### PR TITLE
docs: add project documentation

### DIFF
--- a/docs/decisions/0001-use-uv-for-package-management.md
+++ b/docs/decisions/0001-use-uv-for-package-management.md
@@ -1,0 +1,23 @@
+# ADR-0001: Use uv for package management
+
+## Status
+
+Accepted
+
+## Decision
+
+Use **uv** as the primary package manager for dependency management, virtual environment creation, and package installation.
+
+## Rationale
+
+uv is a modern Python package manager written in Rust by Astral (creators of ruff). It provides 10-100x faster dependency resolution and installation than pip, built-in virtual environment management, and compatibility with `pyproject.toml` standards. Using the same maintainers as ruff ensures aligned tooling philosophy across the project.
+
+## Related Issues
+
+- Issue #166: Block uv add in AI agent hooks/settings
+- Issue #148: dodo.py uses Unix-only shell syntax for UV_CACHE_DIR
+
+## Related Documentation
+
+- [Installation Guide](../getting-started/installation.md)
+- [Tools Reference](../template/tools-reference.md)

--- a/docs/decisions/0002-use-doit-for-task-automation.md
+++ b/docs/decisions/0002-use-doit-for-task-automation.md
@@ -1,0 +1,24 @@
+# ADR-0002: Use doit for task automation
+
+## Status
+
+Accepted
+
+## Decision
+
+Use **doit** as the task automation framework for common operations like testing, linting, building, and deployment.
+
+## Rationale
+
+doit is a Python-based build tool that uses pure Python for task definitions (no DSL to learn), provides automatic task dependency resolution and incremental builds, and encourages modular task organization. Being Python-native means no context switching for developers already working in Python.
+
+## Related Issues
+
+- Issue #170: Rename tools/tasks to tools/doit
+- Issue #87: Add shell completions for doit tasks
+- Issue #80: Add doit issue and doit pr commands for GitHub workflow
+- Issue #65: Promote doit and rich to runtime dependencies
+
+## Related Documentation
+
+- [Tools Reference](../template/tools-reference.md)

--- a/docs/decisions/0003-use-ruff-for-linting-and-formatting.md
+++ b/docs/decisions/0003-use-ruff-for-linting-and-formatting.md
@@ -1,0 +1,21 @@
+# ADR-0003: Use ruff for linting and formatting
+
+## Status
+
+Accepted
+
+## Decision
+
+Use **ruff** as the single tool for both linting and code formatting, replacing flake8, black, isort, and other tools.
+
+## Rationale
+
+ruff is an extremely fast Python linter and formatter written in Rust that consolidates multiple tools into one. It includes linting rules from flake8, pylint, and others, plus a Black-compatible formatter and import sorting. Single configuration in `pyproject.toml` and 10-100x faster execution than traditional Python-based tools.
+
+## Related Issues
+
+- Issue #128: Align pre-commit, CI, and doit check to use consistent checks
+
+## Related Documentation
+
+- [Coding Standards](../development/coding-standards.md)

--- a/docs/decisions/0004-auto-discover-doit-tasks.md
+++ b/docs/decisions/0004-auto-discover-doit-tasks.md
@@ -1,0 +1,21 @@
+# ADR-0004: Auto-discover doit tasks from modules
+
+## Status
+
+Accepted
+
+## Decision
+
+Implement automatic task discovery that scans `tools/doit/` modules and imports all `task_*` functions automatically, rather than requiring manual imports in `dodo.py`.
+
+## Rationale
+
+Manual imports were error-prone - developers would forget to add imports for new tasks, and the import blocks grew unwieldy. Auto-discovery means new tasks are automatically available without editing `dodo.py`, eliminating "forgot to import" errors and keeping `dodo.py` minimal (3 lines instead of 50+).
+
+## Related Issues
+
+- Issue #173: Auto-discover doit tasks from tools/doit modules
+
+## Related Documentation
+
+- [Tools Reference](../template/tools-reference.md)

--- a/docs/decisions/0005-ai-agent-command-restrictions.md
+++ b/docs/decisions/0005-ai-agent-command-restrictions.md
@@ -1,0 +1,27 @@
+# ADR-0005: AI agent command restrictions via hooks
+
+## Status
+
+Accepted
+
+## Decision
+
+Implement tool-level enforcement that blocks dangerous commands (like `--force`, `--admin`, `--no-verify`) before execution via Claude Code PreToolUse hooks, Gemini CLI BeforeTool hooks, and Codex CLI approval policies.
+
+## Rationale
+
+Documentation alone is insufficient - AI agents may violate rules after context compaction or when trying to "help quickly". A real incident occurred where an AI agent attempted to bypass branch protection. Tool-level blocking provides defense in depth, applying restrictions regardless of agent context state.
+
+## Related Issues
+
+- Issue #113: Enforce dangerous command restrictions via hooks and configs
+- Issue #117: Block gh issue create and gh pr create commands for AI agents
+- Issue #163: Add pre-commit hook to block pyproject.toml version changes
+- Issue #164: Block doit release in AI agent hooks
+- Issue #166: Block uv add in AI agent hooks
+
+## Related Documentation
+
+- [AI Command Blocking](../development/ai/command-blocking.md)
+- [AI Enforcement Principles](../development/ai/enforcement-principles.md)
+- [AI Setup Guide](../development/AI_SETUP.md)

--- a/docs/decisions/0006-merge-gate-workflow.md
+++ b/docs/decisions/0006-merge-gate-workflow.md
@@ -1,0 +1,25 @@
+# ADR-0006: Merge-gate workflow requiring ready-to-merge label
+
+## Status
+
+Accepted
+
+## Decision
+
+Implement a merge-gate GitHub Actions workflow that requires the `ready-to-merge` label on PRs before allowing merge, enforced via branch protection rules.
+
+The `ready-to-merge` label is a **pure merge gate** - it signals approval but does not trigger additional CI runs. The default CI matrix provides sufficient coverage for most PRs.
+
+## Rationale
+
+PRs could be merged while CI was still running or without explicit human approval. The merge-gate provides a lightweight mechanism requiring explicit "ready" signal after review, preventing premature merges and AI agents from merging without human review.
+
+## Related Issues
+
+- Issue #149: Add merge-gate workflow to require ready-to-merge label
+- Issue #154: Fix merge-gate to wait for CI completion before allowing merge
+- Issue #168: Add Python 3.14 to CI testing matrix (changed ready-to-merge to pure gate)
+
+## Related Documentation
+
+- [CI/CD Testing Guide](../development/ci-cd-testing.md)

--- a/docs/decisions/0007-use-mypy-for-type-checking.md
+++ b/docs/decisions/0007-use-mypy-for-type-checking.md
@@ -1,0 +1,21 @@
+# ADR-0007: Use mypy for static type checking
+
+## Status
+
+Accepted
+
+## Decision
+
+Use **mypy** in strict mode for static type checking, running as part of `doit check`, pre-commit hooks, and CI.
+
+## Rationale
+
+mypy is the most mature Python type checker with excellent IDE integration. Strict mode catches type errors early, improves code documentation through required type hints, and ensures consistent type safety. Well-integrated with ruff for a complete code quality pipeline.
+
+## Related Issues
+
+- Issue #61: Make doit check use strict mypy mode to match pre-commit hooks
+
+## Related Documentation
+
+- [Coding Standards](../development/coding-standards.md)

--- a/docs/decisions/0008-pr-based-development-workflow.md
+++ b/docs/decisions/0008-pr-based-development-workflow.md
@@ -1,0 +1,24 @@
+# ADR-0008: PR-based development workflow
+
+## Status
+
+Accepted
+
+## Decision
+
+Adopt a PR-based workflow: Issue → Branch → Commit → PR → Merge. Never commit directly to main. Branch names must follow `<type>/<issue>-<description>` convention. Merge commits must include PR and issue references.
+
+## Rationale
+
+Provides clear audit trail linking issues to PRs to commits, enables code review on every change, ensures CI runs before merge, and makes changes easy to revert (single squash commit per PR). Works well with AI agents due to structured, predictable process.
+
+## Related Issues
+
+- Issue #80: Add doit issue and doit pr commands for GitHub workflow
+- Issue #48: Enforce workflow by blocking direct commits to main
+- Issue #176: Add doit pr_merge task with enforced commit format
+
+## Related Documentation
+
+- [CI/CD Testing Guide](../development/ci-cd-testing.md)
+- [CONTRIBUTING.md](https://github.com/endavis/pynetappfoundry/blob/main/.github/CONTRIBUTING.md)

--- a/docs/decisions/0009-use-pre-commit-hooks-for-quality-gates.md
+++ b/docs/decisions/0009-use-pre-commit-hooks-for-quality-gates.md
@@ -1,0 +1,24 @@
+# ADR-0009: Use pre-commit hooks for quality gates
+
+## Status
+
+Accepted
+
+## Decision
+
+Use the **pre-commit** framework with hooks that run quality checks (ruff, mypy, bandit, codespell) and safety checks (prevent commits to main, protect config files) before every commit.
+
+## Rationale
+
+Ensures bad code never enters the repository, provides fast feedback loop (seconds, not minutes), works offline without CI dependency, and catches issues before PR review. Safety checks prevent dangerous operations at the source.
+
+## Related Issues
+
+- Issue #184: Use project's tool versions in pre-commit hooks
+- Issue #128: Align pre-commit, CI, and doit check to use consistent checks
+- Issue #19: Fix resolve pre-commit hook failures in template files
+
+## Related Documentation
+
+- [Coding Standards](../development/coding-standards.md)
+- [Installation Guide](../getting-started/installation.md)

--- a/docs/decisions/0010-use-conventional-commits-format.md
+++ b/docs/decisions/0010-use-conventional-commits-format.md
@@ -1,0 +1,22 @@
+# ADR-0010: Use conventional commits format
+
+## Status
+
+Accepted
+
+## Decision
+
+Adopt **Conventional Commits** format (`<type>: <subject>`) for all commit messages. Types include feat, fix, docs, refactor, test, chore, ci, perf. Merge commits follow `<type>: <subject> (merges PR #XX, closes #YY)`.
+
+## Rationale
+
+Provides consistent, readable git history, enables automated changelog generation, and allows easy filtering by change type. Works well with semantic versioning for automated version bumps based on commit types.
+
+## Related Issues
+
+- Issue #176: Add doit pr_merge task with enforced commit format
+- Issue #175: Add PR title validation to enforce merge commit format
+
+## Related Documentation
+
+- [CONTRIBUTING.md](https://github.com/endavis/pynetappfoundry/blob/main/.github/CONTRIBUTING.md)

--- a/docs/decisions/0011-use-pytest-for-testing.md
+++ b/docs/decisions/0011-use-pytest-for-testing.md
@@ -1,0 +1,23 @@
+# ADR-0011: Use pytest for testing
+
+## Status
+
+Accepted
+
+## Decision
+
+Use **pytest** as the testing framework with pytest-xdist for parallel execution and pytest-cov for coverage reporting.
+
+## Rationale
+
+pytest minimizes boilerplate (plain functions, no classes required), has a powerful fixture system, excellent assertion introspection, and is the industry standard for Python testing. Parallel execution via xdist speeds up CI significantly.
+
+## Related Issues
+
+- Issue #126: Add tests for template tools and exclude from generated projects
+- Issue #83: Add multi-OS CI testing (Windows, macOS)
+
+## Related Documentation
+
+- [CI/CD Testing Guide](../development/ci-cd-testing.md)
+- [Coding Standards](../development/coding-standards.md)

--- a/docs/decisions/0012-use-mkdocs-with-material-theme-for-documentation.md
+++ b/docs/decisions/0012-use-mkdocs-with-material-theme-for-documentation.md
@@ -1,0 +1,24 @@
+# ADR-0012: Use mkdocs with Material theme for documentation
+
+## Status
+
+Accepted
+
+## Decision
+
+Use **MkDocs** with the **Material for MkDocs** theme for project documentation, hosted on GitHub Pages.
+
+## Rationale
+
+MkDocs uses Markdown (familiar to most developers), Material theme provides modern responsive design with search and dark mode out of the box, and documentation lives alongside code ensuring it stays in sync. Free hosting on GitHub Pages.
+
+## Related Issues
+
+- Issue #169: Auto-generate categorized documentation TOC from frontmatter tags
+- Issue #109: Add comprehensive template tools and workflows documentation
+- Issue #105: Improve GitHub workflows and documentation
+
+## Related Documentation
+
+- [Documentation Index](../index.md)
+- [Extensions Guide](../development/extensions.md)

--- a/docs/decisions/0013-python-version-support-policy.md
+++ b/docs/decisions/0013-python-version-support-policy.md
@@ -1,0 +1,44 @@
+# ADR-0013: Python version support policy with bookend CI strategy
+
+## Status
+
+Accepted
+
+## Decision
+
+Adopt a tiered Python version support policy:
+
+1. **Active support**: Last 3 major Python versions, tested on every PR using bookend strategy (oldest + newest)
+2. **Passive compatibility**: Older versions that still pass CI, tested on-demand via `full-matrix` label
+3. **Deprecation**: Versions removed from CI when tests fail, with final compatible release tagged
+
+CI matrix strategy:
+- **Default (6 jobs)**: Bookend versions (oldest + newest) × 3 OSes
+- **Full matrix (+3 jobs per middle version)**: Middle versions only × 3 OSes, triggered by `full-matrix` label
+
+Version configuration stored in `.github/python-versions.json`:
+```json
+{
+  "oldest": "3.12",
+  "newest": "3.14"
+}
+```
+
+Middle versions are derived automatically. A `ci-complete` summary job aggregates results for branch protection, eliminating the need to update branch protection when versions change.
+
+## Rationale
+
+Testing every Python version on every PR creates excessive CI load without proportional benefit. The bookend strategy (testing oldest and newest supported versions) catches most compatibility issues:
+- If code works on 3.12 and 3.14, it almost certainly works on 3.13
+- Full matrix testing runs only middle versions (bookends already passed)
+- Config-driven approach means no workflow or branch protection changes when versions update
+- Passive compatibility allows supporting older versions without maintenance burden
+- Clear deprecation process with tagged releases protects users on older Python versions
+
+## Related Issues
+
+- Issue #168: Add Python 3.14 to CI testing matrix
+
+## Related Documentation
+
+- [CI/CD Testing Guide - Python Version Support Policy](../development/ci-cd-testing.md#python-version-support-policy)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,75 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for this project.
+
+## What is an ADR?
+
+An ADR documents an architectural decision: what was decided and why. The detailed discussion and specification lives in the GitHub Issue; the ADR provides a summary with links.
+
+## ADR Format
+
+ADRs use a simplified format:
+
+```markdown
+# ADR-NNNN: Title
+
+## Status
+Accepted
+
+## Decision
+Brief summary of what was decided.
+
+## Rationale
+Why this decision was made.
+
+## Related Issues
+- Issue #XX: Description
+
+## Related Documentation
+- [Relevant Doc](../path/to/doc.md)
+```
+
+See [adr-template.md](adr-template.md) for the template.
+
+## Creating a New ADR
+
+```bash
+# Interactive (opens editor)
+doit adr --title="Your decision title"
+
+# Non-interactive (for scripts/AI)
+doit adr --title="Use Redis" --body="## Status\nAccepted\n..."
+doit adr --title="Use Redis" --body-file=adr.md
+```
+
+## When to Create an ADR
+
+Create an ADR when:
+- Introducing a new tool, framework, or library
+- Changing development workflow or processes
+- Making decisions that affect project architecture
+
+The Issue contains the full discussion; the ADR summarizes the outcome.
+
+## ADR Statuses
+
+- **Accepted**: Decision is in effect
+- **Deprecated**: No longer relevant (kept for history)
+- **Superseded**: Replaced by a newer ADR
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-use-uv-for-package-management.md) | Use uv for package management | Accepted |
+| [0002](0002-use-doit-for-task-automation.md) | Use doit for task automation | Accepted |
+| [0003](0003-use-ruff-for-linting-and-formatting.md) | Use ruff for linting and formatting | Accepted |
+| [0004](0004-auto-discover-doit-tasks.md) | Auto-discover doit tasks from modules | Accepted |
+| [0005](0005-ai-agent-command-restrictions.md) | AI agent command restrictions via hooks | Accepted |
+| [0006](0006-merge-gate-workflow.md) | Merge-gate workflow requiring ready-to-merge label | Accepted |
+| [0007](0007-use-mypy-for-type-checking.md) | Use mypy for static type checking | Accepted |
+| [0008](0008-pr-based-development-workflow.md) | PR-based development workflow | Accepted |
+| [0009](0009-use-pre-commit-hooks-for-quality-gates.md) | Use pre-commit hooks for quality gates | Accepted |
+| [0010](0010-use-conventional-commits-format.md) | Use conventional commits format | Accepted |
+| [0011](0011-use-pytest-for-testing.md) | Use pytest for testing | Accepted |
+| [0012](0012-use-mkdocs-with-material-theme-for-documentation.md) | Use mkdocs with Material theme for documentation | Accepted |

--- a/docs/decisions/adr-template.md
+++ b/docs/decisions/adr-template.md
@@ -1,0 +1,25 @@
+# ADR-NNNN: Title
+
+## Status
+<!-- Required -->
+
+Accepted
+
+## Decision
+<!-- Required -->
+
+Brief summary of what was decided.
+
+## Rationale
+<!-- Required -->
+
+Why this decision was made.
+
+## Related Issues
+
+- Issue #XX: Description
+
+## Related Documentation
+
+<!-- Add links to related documentation -->
+<!-- Example: - [Development Guide](../development/coding-standards.md) -->

--- a/docs/deployment/development.md
+++ b/docs/deployment/development.md
@@ -1,0 +1,553 @@
+---
+title: Development Deployment Guide
+description: Guide for setting up and running the application in development environments
+audience:
+  - users
+  - contributors
+tags:
+  - deployment
+  - development
+  - setup
+---
+
+# Development Deployment Guide
+
+This guide covers setting up and running Python applications built with this template in development environments.
+
+## Quick Start
+
+```bash
+# Clone and setup
+git clone <repository-url>
+cd <project-name>
+
+# Install dependencies
+uv sync
+
+# Run tests to verify setup
+doit test
+
+# Start development
+uv run python -m pynetappfoundry
+```
+
+## Environment Setup
+
+### Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Python | 3.12+ | Runtime |
+| uv | Latest | Package management |
+| git | Latest | Version control |
+| Docker | Latest | (Optional) Containerized services |
+
+### Installing uv
+
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+# Verify installation
+uv --version
+```
+
+### Project Setup
+
+```bash
+# Create virtual environment and install dependencies
+uv sync
+
+# Install with development dependencies
+uv sync --all-extras
+
+# Activate the environment (optional, uv run handles this)
+source .venv/bin/activate  # Linux/macOS
+.venv\Scripts\activate     # Windows
+```
+
+## Configuration
+
+### Environment Variables
+
+Create a `.env` file for local configuration:
+
+```bash
+# Copy the example file
+cp .env.example .env
+
+# Edit with your local settings
+```
+
+**Common development variables:**
+
+```bash
+# .env
+APP_ENV=development
+DEBUG=true
+LOG_LEVEL=DEBUG
+DATABASE_URL=sqlite:///./dev.db
+SECRET_KEY=dev-secret-key-not-for-production
+```
+
+### Local Configuration Files
+
+The project supports local configuration overrides:
+
+| File | Purpose | Git Status |
+|------|---------|------------|
+| `.env` | Environment variables | Ignored |
+| `.envrc.local` | direnv local overrides | Ignored |
+| `settings.local.toml` | Local settings | Ignored |
+
+**Important:** Never commit files containing secrets. These local files are in `.gitignore`.
+
+## Running the Application
+
+### Using uv run
+
+The recommended way to run commands:
+
+```bash
+# Run the main module
+uv run python -m pynetappfoundry
+
+# Run a specific script
+uv run python scripts/example.py
+
+# Run with arguments
+uv run python -m pynetappfoundry --verbose
+```
+
+### Using doit Tasks
+
+```bash
+# List all available tasks
+doit list
+
+# Run tests
+doit test
+
+# Run linting and type checks
+doit lint
+doit typecheck
+
+# Run all checks
+doit check
+
+# Format code
+doit fmt
+```
+
+### Direct Python Execution
+
+If you've activated the virtual environment:
+
+```bash
+# Activate first
+source .venv/bin/activate
+
+# Then run directly
+python -m pynetappfoundry
+```
+
+## Development Workflow
+
+### Making Changes
+
+1. **Create a branch** for your work:
+   ```bash
+   git checkout -b feature/my-feature
+   ```
+
+2. **Make changes** and run tests frequently:
+   ```bash
+   doit test
+   ```
+
+3. **Format and lint** before committing:
+   ```bash
+   doit fmt
+   doit check
+   ```
+
+4. **Commit** with conventional commit messages:
+   ```bash
+   git commit -m "feat: add new feature"
+   ```
+
+### Running Tests
+
+```bash
+# Run all tests
+doit test
+
+# Run with coverage
+uv run pytest --cov
+
+# Run specific test file
+uv run pytest tests/test_specific.py
+
+# Run tests matching pattern
+uv run pytest -k "test_feature"
+
+# Run with verbose output
+uv run pytest -v
+```
+
+### Debugging
+
+#### VS Code
+
+Add to `.vscode/launch.json`:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Module",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pynetappfoundry",
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env"
+    },
+    {
+      "name": "Python: Current File",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env"
+    }
+  ]
+}
+```
+
+#### PyCharm
+
+1. Go to **Run > Edit Configurations**
+2. Add new **Python** configuration
+3. Set **Module name**: `pynetappfoundry`
+4. Set **Working directory**: project root
+5. Add **Environment variables** from `.env`
+
+#### Command Line Debugging
+
+```bash
+# Using pdb
+uv run python -m pdb -m pynetappfoundry
+
+# Using breakpoint() in code
+# Add breakpoint() where you want to stop, then run normally
+uv run python -m pynetappfoundry
+```
+
+## Local Services
+
+### Using Docker Compose
+
+For services like databases and caches:
+
+```yaml
+# docker-compose.yml
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: devdb
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+volumes:
+  postgres_data:
+```
+
+```bash
+# Start services
+docker compose up -d
+
+# Stop services
+docker compose down
+
+# View logs
+docker compose logs -f postgres
+```
+
+### SQLite for Development
+
+For simpler setups, use SQLite:
+
+```bash
+# .env
+DATABASE_URL=sqlite:///./dev.db
+```
+
+SQLite requires no external services and is suitable for most development work.
+
+## Code Quality
+
+### Pre-commit Hooks
+
+The project uses pre-commit hooks for quality gates:
+
+```bash
+# Install hooks (done automatically by uv sync)
+uv run pre-commit install
+
+# Run manually
+uv run pre-commit run --all-files
+
+# Skip hooks (use sparingly)
+git commit --no-verify -m "WIP: work in progress"
+```
+
+### Type Checking
+
+```bash
+# Run mypy
+doit typecheck
+
+# Or directly
+uv run mypy src/
+```
+
+### Linting
+
+```bash
+# Run ruff linter
+doit lint
+
+# Auto-fix issues
+uv run ruff check --fix src/
+```
+
+### Formatting
+
+```bash
+# Format code
+doit fmt
+
+# Check format without changing
+uv run ruff format --check src/
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### Virtual Environment Not Found
+
+```bash
+# Recreate the environment
+rm -rf .venv
+uv sync
+```
+
+#### Import Errors
+
+```bash
+# Ensure package is installed in editable mode
+uv sync
+
+# Verify installation
+uv run python -c "import pynetappfoundry; print(pynetappfoundry.__version__)"
+```
+
+#### Permission Denied
+
+```bash
+# Fix script permissions
+chmod +x scripts/*.py
+
+# On Windows, run as administrator or check antivirus
+```
+
+#### Pre-commit Hook Failures
+
+```bash
+# Update hooks
+uv run pre-commit autoupdate
+
+# Run checks to see what's failing
+doit check
+```
+
+### Environment Issues
+
+#### Wrong Python Version
+
+```bash
+# Check current version
+python --version
+
+# Use uv to manage Python
+uv python install 3.12
+uv python use 3.12
+```
+
+#### Dependency Conflicts
+
+```bash
+# Clear cache and reinstall
+uv cache clean
+rm -rf .venv uv.lock
+uv sync
+```
+
+## IDE Setup
+
+### VS Code Extensions
+
+Recommended extensions (`.vscode/extensions.json`):
+
+- `ms-python.python` - Python support
+- `ms-python.vscode-pylance` - Type checking
+- `charliermarsh.ruff` - Ruff linter/formatter
+- `tamasfe.even-better-toml` - TOML support
+- `github.copilot` - AI assistance (optional)
+
+### VS Code Settings
+
+Recommended settings (`.vscode/settings.json`):
+
+```json
+{
+  "python.defaultInterpreterPath": ".venv/bin/python",
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
+    }
+  },
+  "python.analysis.typeCheckingMode": "basic"
+}
+```
+
+### PyCharm Setup
+
+1. **Set interpreter**: File > Settings > Project > Python Interpreter > Add > Existing Environment > `.venv/bin/python`
+2. **Enable ruff**: Install Ruff plugin from marketplace
+3. **Configure mypy**: Install Mypy plugin, set to use project's mypy.ini
+
+## Hot Reloading
+
+For web applications or services that support it:
+
+```bash
+# Using uvicorn with reload
+uv run uvicorn pynetappfoundry.app:app --reload
+
+# Using Flask debug mode
+FLASK_DEBUG=1 uv run flask run
+
+# Using watchfiles for custom scripts
+uv run watchfiles "python -m pynetappfoundry" src/
+```
+
+## Performance Profiling
+
+### CPU Profiling
+
+```bash
+# Using cProfile
+uv run python -m cProfile -o profile.stats -m pynetappfoundry
+
+# Analyze results
+uv run python -c "import pstats; p = pstats.Stats('profile.stats'); p.sort_stats('cumulative').print_stats(20)"
+```
+
+### Memory Profiling
+
+```bash
+# Install memory profiler
+uv add --dev memory-profiler
+
+# Run with profiling
+uv run python -m memory_profiler script.py
+```
+
+## Publishing to TestPyPI
+
+TestPyPI is a separate instance of PyPI for testing package publishing without affecting the real index.
+
+### Why Use TestPyPI?
+
+- Test your publishing workflow before production
+- Verify package metadata and README rendering
+- Catch packaging issues early
+- Safe environment for experimentation
+
+### Configure TestPyPI Credentials
+
+Generate a token at https://test.pypi.org/manage/account/token/
+
+```bash
+# Set TestPyPI token
+export UV_PUBLISH_TOKEN=pypi-xxxxxxxxxxxx
+```
+
+### Build and Publish to TestPyPI
+
+```bash
+# Build distribution packages
+uv build
+
+# Publish to TestPyPI
+uv publish --publish-url https://test.pypi.org/legacy/
+
+# Or with explicit token
+uv publish --publish-url https://test.pypi.org/legacy/ --token pypi-xxxxxxxxxxxx
+```
+
+### Test Installation from TestPyPI
+
+```bash
+# Install from TestPyPI
+uv pip install --index-url https://test.pypi.org/simple/ pynetappfoundry
+
+# If your package has dependencies from real PyPI, use both indexes
+uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pynetappfoundry
+```
+
+### Verify Package
+
+```bash
+# Check the package page
+# https://test.pypi.org/project/pynetappfoundry/
+
+# Verify installation works
+uv venv /tmp/test-install
+uv pip install --python /tmp/test-install --index-url https://test.pypi.org/simple/ pynetappfoundry
+```
+
+### Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| Version already exists | Increment version, TestPyPI doesn't allow re-uploads |
+| Missing dependencies | Use `--extra-index-url https://pypi.org/simple/` |
+| README not rendering | Check pyproject.toml `readme` field, validate markdown |
+| Authentication failed | Regenerate token, check URL is correct |
+
+## See Also
+
+- [Installation Guide](../getting-started/installation.md) - Initial project setup
+- [Usage Guide](../usage/basics.md) - Package usage patterns
+- [Production Deployment Guide](production.md) - Deploying to production
+- [CI/CD Testing Guide](../development/ci-cd-testing.md) - Automated pipelines

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -1,0 +1,719 @@
+---
+title: Production Deployment Guide
+description: Comprehensive guide for deploying Python applications to production
+audience:
+  - users
+  - contributors
+tags:
+  - deployment
+  - production
+  - operations
+---
+
+# Production Deployment Guide
+
+This guide covers best practices for deploying Python applications built with this template to production environments.
+
+## Pre-deployment Checklist
+
+Before deploying to production, verify the following:
+
+- [ ] All tests passing (`doit test`)
+- [ ] Security scan clean (`doit security` or `bandit`)
+- [ ] Dependencies audited (`uv pip audit` or `pip-audit`)
+- [ ] Environment variables documented
+- [ ] Secrets management configured
+- [ ] Logging configured for production
+- [ ] Health check endpoints implemented
+- [ ] Error reporting configured
+
+## Environment Configuration
+
+### Production vs Development Settings
+
+Use environment variables to distinguish between environments:
+
+```python
+import os
+
+# Environment detection
+ENV = os.getenv("APP_ENV", "development")
+DEBUG = ENV == "development"
+
+# Environment-specific settings
+if ENV == "production":
+    LOG_LEVEL = "INFO"
+    DATABASE_POOL_SIZE = 20
+else:
+    LOG_LEVEL = "DEBUG"
+    DATABASE_POOL_SIZE = 5
+```
+
+### Environment Variable Management
+
+**Required variables for production:**
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `APP_ENV` | Environment identifier | `production` |
+| `DATABASE_URL` | Database connection string | `postgresql://...` |
+| `SECRET_KEY` | Application secret | (generated) |
+| `LOG_LEVEL` | Logging verbosity | `INFO` |
+
+**Best practices:**
+
+- Never commit `.env` files with secrets
+- Use `.env.example` to document required variables
+- Validate all required variables on startup
+
+```python
+def validate_environment() -> None:
+    """Validate required environment variables are set."""
+    required = ["DATABASE_URL", "SECRET_KEY"]
+    missing = [var for var in required if not os.getenv(var)]
+    if missing:
+        raise RuntimeError(f"Missing required environment variables: {missing}")
+```
+
+### Secret Injection Patterns
+
+#### HashiCorp Vault
+
+```python
+import hvac
+
+def get_vault_secret(path: str, key: str) -> str:
+    """Retrieve secret from HashiCorp Vault."""
+    client = hvac.Client(url=os.getenv("VAULT_ADDR"))
+    client.token = os.getenv("VAULT_TOKEN")
+    secret = client.secrets.kv.v2.read_secret_version(path=path)
+    return secret["data"]["data"][key]
+```
+
+#### AWS Secrets Manager
+
+```python
+import boto3
+import json
+
+def get_aws_secret(secret_name: str) -> dict:
+    """Retrieve secret from AWS Secrets Manager."""
+    client = boto3.client("secretsmanager")
+    response = client.get_secret_value(SecretId=secret_name)
+    return json.loads(response["SecretString"])
+```
+
+#### Kubernetes Secrets
+
+Mount secrets as environment variables or files:
+
+```yaml
+# kubernetes/deployment.yaml
+env:
+  - name: DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: app-secrets
+        key: database-url
+```
+
+### Configuration Validation on Startup
+
+```python
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    """Application settings with validation."""
+
+    app_env: str = "development"
+    database_url: str
+    secret_key: str
+    log_level: str = "INFO"
+
+    class Config:
+        env_file = ".env"
+
+# Validate on import
+settings = Settings()
+```
+
+## Logging & Monitoring
+
+### Structured Logging (JSON Format)
+
+```python
+import logging
+import json
+from datetime import datetime
+
+class JSONFormatter(logging.Formatter):
+    """Format log records as JSON for aggregation systems."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_data = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "module": record.module,
+            "function": record.funcName,
+            "line": record.lineno,
+        }
+        if record.exc_info:
+            log_data["exception"] = self.formatException(record.exc_info)
+        if hasattr(record, "correlation_id"):
+            log_data["correlation_id"] = record.correlation_id
+        return json.dumps(log_data)
+```
+
+### Log Levels for Production
+
+| Level | Use Case |
+|-------|----------|
+| `ERROR` | Failures requiring immediate attention |
+| `WARNING` | Unexpected behavior, potential issues |
+| `INFO` | Key business events, request/response summaries |
+| `DEBUG` | Detailed diagnostic info (disabled in production) |
+
+**Recommendation:** Use `INFO` as the default production log level.
+
+### Correlation IDs for Tracing
+
+```python
+import uuid
+from contextvars import ContextVar
+
+correlation_id: ContextVar[str] = ContextVar("correlation_id", default="")
+
+def set_correlation_id(request_id: str | None = None) -> str:
+    """Set correlation ID for the current request context."""
+    cid = request_id or str(uuid.uuid4())
+    correlation_id.set(cid)
+    return cid
+
+def get_correlation_id() -> str:
+    """Get the current correlation ID."""
+    return correlation_id.get()
+```
+
+### Integration Points
+
+#### DataDog
+
+```python
+from ddtrace import tracer
+
+tracer.configure(
+    hostname=os.getenv("DD_AGENT_HOST", "localhost"),
+    port=8126,
+)
+```
+
+#### Prometheus
+
+```python
+from prometheus_client import Counter, Histogram, start_http_server
+
+REQUEST_COUNT = Counter(
+    "app_requests_total",
+    "Total request count",
+    ["method", "endpoint", "status"]
+)
+
+REQUEST_LATENCY = Histogram(
+    "app_request_latency_seconds",
+    "Request latency in seconds",
+    ["method", "endpoint"]
+)
+
+# Start metrics server
+start_http_server(8000)
+```
+
+### Health Check Endpoints
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class HealthStatus:
+    status: str
+    database: str
+    cache: str
+
+async def health_check() -> HealthStatus:
+    """Comprehensive health check for all dependencies."""
+    db_status = await check_database()
+    cache_status = await check_cache()
+
+    overall = "healthy" if all([
+        db_status == "healthy",
+        cache_status == "healthy"
+    ]) else "unhealthy"
+
+    return HealthStatus(
+        status=overall,
+        database=db_status,
+        cache=cache_status
+    )
+```
+
+## Error Handling
+
+### Exception Reporting
+
+#### Sentry Integration
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn=os.getenv("SENTRY_DSN"),
+    environment=os.getenv("APP_ENV"),
+    traces_sample_rate=0.1,  # 10% of transactions
+)
+```
+
+#### Rollbar Integration
+
+```python
+import rollbar
+
+rollbar.init(
+    access_token=os.getenv("ROLLBAR_TOKEN"),
+    environment=os.getenv("APP_ENV"),
+)
+```
+
+### Graceful Degradation Patterns
+
+```python
+from functools import wraps
+from typing import TypeVar, Callable, Any
+
+T = TypeVar("T")
+
+def with_fallback(fallback_value: T) -> Callable:
+    """Decorator that returns fallback value on failure."""
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            try:
+                return func(*args, **kwargs)
+            except Exception as e:
+                logger.warning(f"{func.__name__} failed, using fallback: {e}")
+                return fallback_value
+        return wrapper
+    return decorator
+
+@with_fallback(fallback_value=[])
+def get_recommendations(user_id: str) -> list:
+    """Get personalized recommendations with fallback to empty list."""
+    return recommendation_service.get(user_id)
+```
+
+### Circuit Breaker Pattern
+
+```python
+import time
+from enum import Enum
+from dataclasses import dataclass, field
+
+class CircuitState(Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+@dataclass
+class CircuitBreaker:
+    """Circuit breaker for external service calls."""
+
+    failure_threshold: int = 5
+    recovery_timeout: float = 30.0
+
+    _failure_count: int = field(default=0, init=False)
+    _last_failure_time: float = field(default=0.0, init=False)
+    _state: CircuitState = field(default=CircuitState.CLOSED, init=False)
+
+    def call(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        """Execute function with circuit breaker protection."""
+        if self._state == CircuitState.OPEN:
+            if time.time() - self._last_failure_time > self.recovery_timeout:
+                self._state = CircuitState.HALF_OPEN
+            else:
+                raise CircuitOpenError("Circuit is open")
+
+        try:
+            result = func(*args, **kwargs)
+            self._on_success()
+            return result
+        except Exception as e:
+            self._on_failure()
+            raise
+
+    def _on_success(self) -> None:
+        self._failure_count = 0
+        self._state = CircuitState.CLOSED
+
+    def _on_failure(self) -> None:
+        self._failure_count += 1
+        self._last_failure_time = time.time()
+        if self._failure_count >= self.failure_threshold:
+            self._state = CircuitState.OPEN
+```
+
+## Performance
+
+### Connection Pooling
+
+```python
+from sqlalchemy import create_engine
+from sqlalchemy.pool import QueuePool
+
+engine = create_engine(
+    os.getenv("DATABASE_URL"),
+    poolclass=QueuePool,
+    pool_size=20,
+    max_overflow=10,
+    pool_pre_ping=True,  # Verify connections before use
+    pool_recycle=3600,   # Recycle connections after 1 hour
+)
+```
+
+### Caching Strategies
+
+```python
+import redis
+from functools import wraps
+import json
+from typing import Callable, Any
+
+redis_client = redis.Redis.from_url(os.getenv("REDIS_URL"))
+
+def cached(ttl: int = 300) -> Callable:
+    """Cache function results in Redis."""
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            cache_key = f"{func.__name__}:{hash((args, tuple(kwargs.items())))}"
+
+            cached_value = redis_client.get(cache_key)
+            if cached_value:
+                return json.loads(cached_value)
+
+            result = func(*args, **kwargs)
+            redis_client.setex(cache_key, ttl, json.dumps(result))
+            return result
+        return wrapper
+    return decorator
+```
+
+### Async Workers
+
+#### Celery
+
+```python
+from celery import Celery
+
+app = Celery(
+    "tasks",
+    broker=os.getenv("CELERY_BROKER_URL"),
+    backend=os.getenv("CELERY_RESULT_BACKEND"),
+)
+
+app.conf.update(
+    task_serializer="json",
+    result_serializer="json",
+    accept_content=["json"],
+    task_acks_late=True,
+    worker_prefetch_multiplier=1,
+)
+```
+
+#### arq (Async)
+
+```python
+from arq import create_pool
+from arq.connections import RedisSettings
+
+async def startup() -> None:
+    redis = await create_pool(
+        RedisSettings.from_dsn(os.getenv("REDIS_URL"))
+    )
+```
+
+### Resource Limits
+
+Set appropriate limits in your deployment configuration:
+
+```yaml
+# kubernetes/deployment.yaml
+resources:
+  requests:
+    memory: "256Mi"
+    cpu: "250m"
+  limits:
+    memory: "512Mi"
+    cpu: "500m"
+```
+
+## Security Hardening
+
+### Non-root Containers
+
+```dockerfile
+# Dockerfile
+FROM python:3.12-slim
+
+# Create non-root user
+RUN useradd --create-home --shell /bin/bash appuser
+
+WORKDIR /app
+COPY --chown=appuser:appuser . .
+
+USER appuser
+
+CMD ["python", "-m", "pynetappfoundry"]
+```
+
+### Read-only Filesystems
+
+```yaml
+# kubernetes/deployment.yaml
+securityContext:
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+volumeMounts:
+  - name: tmp
+    mountPath: /tmp
+
+volumes:
+  - name: tmp
+    emptyDir: {}
+```
+
+### Network Policies
+
+```yaml
+# kubernetes/network-policy.yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: app-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: myapp
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              role: database
+      ports:
+        - protocol: TCP
+          port: 5432
+```
+
+### Secrets Rotation
+
+Implement periodic secret rotation:
+
+```python
+import schedule
+import time
+
+def rotate_database_credentials() -> None:
+    """Rotate database credentials from secrets manager."""
+    new_creds = get_vault_secret("database", "credentials")
+    update_connection_pool(new_creds)
+    logger.info("Database credentials rotated successfully")
+
+# Schedule rotation
+schedule.every().day.at("03:00").do(rotate_database_credentials)
+```
+
+## Deployment Strategies
+
+### Blue-Green Deployment
+
+Maintain two identical production environments:
+
+1. **Blue** (current): Serving live traffic
+2. **Green** (new): Updated version ready for switch
+
+```bash
+# Switch traffic from blue to green
+kubectl patch service myapp -p '{"spec":{"selector":{"version":"green"}}}'
+```
+
+### Canary Releases
+
+Gradually roll out changes to a subset of users:
+
+```yaml
+# kubernetes/canary-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-canary
+spec:
+  replicas: 1  # Small percentage of traffic
+  selector:
+    matchLabels:
+      app: myapp
+      track: canary
+```
+
+### Rolling Updates
+
+Default Kubernetes strategy for zero-downtime updates:
+
+```yaml
+# kubernetes/deployment.yaml
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+```
+
+### Rollback Procedures
+
+```bash
+# Kubernetes rollback
+kubectl rollout undo deployment/myapp
+
+# View rollout history
+kubectl rollout history deployment/myapp
+
+# Rollback to specific revision
+kubectl rollout undo deployment/myapp --to-revision=2
+```
+
+## Publishing to PyPI
+
+Publishing your package to PyPI makes it available for installation via `pip install`.
+
+### Pre-publish Checklist
+
+- [ ] Version updated (via `doit release` or git tag)
+- [ ] All tests passing (`doit test`)
+- [ ] CHANGELOG updated
+- [ ] README accurate and up-to-date
+- [ ] License file present
+- [ ] No secrets in source code
+
+### Configure PyPI Credentials
+
+#### Using API Tokens (Recommended)
+
+Generate a token at https://pypi.org/manage/account/token/
+
+```bash
+# Configure uv with PyPI token
+export UV_PUBLISH_TOKEN=pypi-xxxxxxxxxxxx
+
+# Or use keyring
+uv run keyring set https://upload.pypi.org/legacy/ __token__
+```
+
+#### Using Trusted Publishing (GitHub Actions)
+
+Configure OIDC in your PyPI project settings, then in your workflow:
+
+```yaml
+# .github/workflows/release.yml
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+```
+
+### Build and Publish
+
+```bash
+# Build distribution packages
+uv build
+
+# This creates:
+# - dist/pynetappfoundry-x.y.z.tar.gz (source distribution)
+# - dist/pynetappfoundry-x.y.z-py3-none-any.whl (wheel)
+
+# Publish to PyPI
+uv publish
+
+# Or with explicit token
+uv publish --token pypi-xxxxxxxxxxxx
+```
+
+### Verify Publication
+
+```bash
+# Check package on PyPI
+pip index versions pynetappfoundry
+
+# Test installation in clean environment
+uv venv /tmp/test-install
+uv pip install --python /tmp/test-install pynetappfoundry
+```
+
+### Version Management
+
+This template uses git tags as the source of truth for versions:
+
+```bash
+# Create a release (updates version from git tag)
+doit release
+
+# Version is automatically determined from git tags
+# Never manually edit version in pyproject.toml
+```
+
+## Quick Reference
+
+### Deployment Checklist
+
+| Step | Command/Action |
+|------|----------------|
+| Run tests | `doit test` |
+| Security scan | `doit security` |
+| Audit deps | `uv pip audit` |
+| Build image | `docker build -t myapp:version .` |
+| Push image | `docker push registry/myapp:version` |
+| Deploy | `kubectl apply -f kubernetes/` |
+| Verify | `kubectl rollout status deployment/myapp` |
+
+### Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| Container OOMKilled | Increase memory limits |
+| Connection pool exhausted | Increase pool size or fix connection leaks |
+| Slow startup | Add readiness probes, optimize imports |
+| High latency | Check database queries, add caching |
+
+## See Also
+
+- [Development Deployment Guide](development.md) - Local development setup
+- [CI/CD Testing Guide](../development/ci-cd-testing.md) - Automated testing pipelines
+- [Release Automation](../development/release-and-automation.md) - Versioning and releases

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -1,0 +1,305 @@
+---
+title: AI Agent Setup Guide
+description: Configure Claude, Gemini, and Codex for this project
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - setup
+  - configuration
+---
+
+# AI Agent Setup Guide
+
+This template includes pre-configured settings for multiple AI coding assistants.
+
+## Supported AI Agents
+
+### 1. Codex CLI (OpenAI)
+
+**Configuration:** `.codex/config.toml`
+
+Codex CLI directly reads `AGENTS.md` from the project root. The configuration file whitelists common development commands.
+
+**Whitelisted commands:**
+- `git` - All git operations
+- `gh` - GitHub CLI
+- `uv` - UV package manager
+- `doit` - Task automation
+- File operations: `ls`, `cat`, `tree`, `find`, `grep`, `wc`, `mkdir`
+
+**Setup:**
+```bash
+# Codex CLI will automatically use .codex/config.toml if present
+# Or copy to global config:
+cp .codex/config.toml ~/.codex/config.toml
+
+# Initialize or regenerate AGENTS.md with Codex:
+codex
+/init
+```
+
+**Documentation:**
+- [Codex CLI Documentation](https://developers.openai.com/codex/cli/)
+- [Configuring Codex](https://developers.openai.com/codex/local-config/)
+- [Codex Security Guide](https://developers.openai.com/codex/security/)
+
+### 2. Gemini CLI (Google)
+
+**Configuration:** `.gemini/settings.json`
+
+Gemini CLI can read `AGENTS.md` (or `GEMINI.md`) from the project root. The configuration file uses allowlists for tools and shell commands, and configures lifecycle hooks.
+
+**Allowlisted commands:**
+- `git`, `gh`, `uv`, `doit` - Development tools
+- `python`, `pytest`, `ruff`, `mypy` - Python tools
+- File operations: `ls`, `cat`, `tree`, `find`, `grep`, `wc`, `mkdir`
+
+**Core tools enabled:**
+- `ShellTool` - Execute shell commands
+- `ReadFileTool`, `WriteFileTool` - File operations
+- `LSTool`, `GrepTool` - File exploration
+
+**Setup:**
+```bash
+# Gemini CLI automatically uses .gemini/settings.json if present
+# Or copy to global config:
+cp .gemini/settings.json ~/.gemini/settings.json
+
+# Ensure hooks are enabled in settings.json:
+# {
+#   "hooks": { "enabled" : true }
+# }
+
+# Use YOLO mode to skip all permission prompts (use with caution):
+gemini --yolo
+# Or toggle auto-approve with Ctrl+Y during a session
+```
+
+**Documentation:**
+- [Gemini CLI Configuration](https://geminicli.com/docs/get-started/configuration/)
+- [Gemini CLI Hooks](https://geminicli.com/docs/hooks/)
+- [Provide Context with GEMINI.md Files](https://google-gemini.github.io/gemini-cli/docs/cli/gemini-md.html)
+- [Sandboxing in Gemini CLI](https://geminicli.com/docs/cli/sandbox/)
+- [Gemini CLI Settings](https://geminicli.com/docs/cli/settings/)
+
+### 3. Claude Code (Anthropic)
+
+**Configuration:** `.claude/` directory
+
+Claude Code uses a reference file (`.claude/claude.md`) that imports `AGENTS.md`.
+
+**Whitelisted commands:**
+- `git:*` - All git commands
+- `gh:*` - All GitHub CLI commands
+- `uv:*` - All uv commands
+- `doit:*` - All doit commands
+- File operations: `ls`, `cat`, `tree`, `find`, `grep`, `wc`, `mkdir`
+
+**Setup:**
+```bash
+# Claude Code automatically detects .claude/ directory
+# No additional setup needed
+```
+
+**Files:**
+- `.claude/claude.md` - Imports AGENTS.md
+- `.claude/settings.local.json` - Command permissions
+- `.claude/settings.json` - Status line and PreToolUse hooks
+
+**LSP Support (Recommended):**
+
+Claude Code supports Language Server Protocol for enhanced code intelligence:
+- Document symbols (functions, classes, variables)
+- Go to definition / find references
+- Hover information and type checking
+- Call hierarchy navigation
+
+**Quick LSP Setup:**
+```bash
+# 1. Install the LSP plugin from marketplace
+/install-plugin @anthropic-ai/claude-code-lsp
+
+# 2. Install development dependencies (includes language server)
+doit install_dev
+
+# 3. Enable LSP tool in .envrc.local
+echo 'export ENABLE_LSP_TOOL=1' >> .envrc.local
+direnv allow
+
+# 4. Start Claude Code
+claude
+```
+
+For complete setup instructions and troubleshooting, see `.claude/lsp-setup.md` in the repository root.
+
+### 4. Other AI Tools
+
+The `AGENTS.md` file serves as general-purpose documentation for any AI coding assistant:
+
+- **GitHub Copilot**: Reference in `.github/copilot-instructions.md`
+- **Cursor**: Reference in `.cursorrules`
+- **Codeium**: Reference in project settings
+- **Tabnine**: Reference in configuration
+
+## AGENTS.md - Universal Context File
+
+The `AGENTS.md` file provides comprehensive project context including:
+
+- Repository structure and architecture
+- Development workflows and commands
+- Code style and conventions
+- Testing expectations
+- CI/CD workflows
+- Troubleshooting guides
+
+This file is:
+- **Read directly** by Codex CLI and Gemini CLI
+- **Imported** by Claude Code via `.claude/claude.md`
+- **Referenceable** by other AI tools
+
+## Customization
+
+### For Your Project
+
+When using this template for a new project:
+
+1. **Update AGENTS.md**: Customize project-specific details
+2. **Adjust permissions**: Modify `.codex/config.toml` and `.claude/settings.local.json` as needed
+3. **Add project commands**: Include any custom scripts or tools
+
+### Adding New Commands
+
+**Codex CLI** (`.codex/config.toml`):
+```toml
+[[approval_policy]]
+type = "command"
+pattern = "^your-command\\b"
+action = "allow"
+reason = "Description of command"
+```
+
+**Gemini CLI** (`.gemini/settings.json`):
+```json
+{
+  "tools": {
+    "allowed": [
+      "run_shell_command(your-command)"
+    ]
+  }
+}
+```
+
+**Claude Code** (`.claude/settings.local.json`):
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(your-command:*)"
+    ]
+  }
+}
+```
+
+## Security Considerations
+
+All configuration files are set up with security in mind.
+
+> **Note**: This template enforces security rules in code and settings, not just instructions. See [AI Enforcement Principles](ai/enforcement-principles.md) for details.
+
+**Whitelisted Operations:**
+- Read-only file operations
+- Safe git operations (status, diff, log, add, commit, push, pull)
+- Package management (uv)
+- Testing and linting (pytest, ruff, mypy)
+- Task automation (doit)
+
+**Protected Information:**
+- API keys and tokens are excluded from environment variables
+- No dangerous operations (rm -rf, format, etc.) are pre-approved
+- Network operations require approval in some modes
+
+## Troubleshooting
+
+### Codex CLI
+
+**Commands still prompt for approval:**
+```bash
+# Check current config
+cat ~/.codex/config.toml
+
+# Copy project config to global
+cp .codex/config.toml ~/.codex/config.toml
+
+# Or use project-specific config
+codex --config .codex/config.toml
+```
+
+**Regenerate AGENTS.md:**
+```bash
+codex
+/init
+```
+
+### Claude Code
+
+**Permissions not working:**
+- Ensure `.claude/settings.local.json` exists
+- Check file is valid JSON
+- Restart Claude Code
+
+**Context not loading:**
+- Verify `.claude/claude.md` contains `@AGENTS.md`
+- Check `AGENTS.md` exists in project root
+
+### Gemini CLI
+
+**Commands still prompt for approval:**
+```bash
+# Check current config
+cat ~/.gemini/settings.json
+
+# Copy project config to global
+cp .gemini/settings.json ~/.gemini/settings.json
+
+# Or use YOLO mode (auto-approve all)
+gemini --yolo
+
+# Or toggle auto-approve during session
+# Press Ctrl+Y
+```
+
+**Context not loading:**
+- Ensure `AGENTS.md` or `GEMINI.md` exists in project root
+- Check `.gemini/settings.json` has `"context": {"files": ["AGENTS.md"]}`
+- Verify settings.json is valid JSON
+
+## Resources
+
+### Codex CLI
+- [Codex CLI](https://developers.openai.com/codex/cli/)
+- [Codex Configuration](https://developers.openai.com/codex/local-config/)
+- [Codex Security Guide](https://developers.openai.com/codex/security/)
+- [Codex CLI Reference](https://developers.openai.com/codex/cli/reference/)
+
+### Gemini CLI
+- [Gemini CLI Documentation](https://geminicli.com/docs/get-started/configuration/)
+- [Gemini CLI Hooks](https://geminicli.com/docs/hooks/)
+- [GEMINI.md Context Files](https://google-gemini.github.io/gemini-cli/docs/cli/gemini-md.html)
+- [Sandboxing in Gemini CLI](https://geminicli.com/docs/cli/sandbox/)
+- [Gemini CLI Settings](https://geminicli.com/docs/cli/settings/)
+- [Gemini CLI GitHub](https://github.com/google-gemini/gemini-cli)
+
+### Claude Code
+- [Claude Code Documentation](https://claude.com/claude-code)
+- [Claude Agent SDK](https://github.com/anthropics/claude-code)
+
+### General AI Coding
+- [GitHub Copilot](https://github.com/features/copilot)
+- [Cursor](https://cursor.sh/)
+- [Codeium](https://codeium.com/)
+
+---
+
+**Note**: The `.codex/`, `.gemini/`, and `.claude/` directories should be committed to version control to share consistent AI assistant configuration across the team. .local files should not be committed.

--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -1,0 +1,224 @@
+---
+title: AI Command Blocking
+description: Hooks that block dangerous commands from AI agents
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - security
+  - hooks
+---
+
+# AI CLI Hooks
+
+The `tools/hooks/ai/` directory contains hooks for AI coding assistants (Claude Code, Gemini CLI).
+
+## Block Dangerous Commands
+
+### Purpose
+
+AI agents can sometimes attempt dangerous operations like:
+
+- `--admin` - bypasses branch protection
+- `--no-verify` - skips pre-commit hooks
+- `git reset --hard` - loses uncommitted changes
+- `rm -rf /` or `rm -rf ~` - destructive deletions
+- Force push to `main`/`master` - overwrites shared history
+- Deleting protected branches
+- Merge commits on protected branches - violates linear history
+
+These hooks intercept commands before execution and block dangerous patterns, even if the agent doesn't follow the rules in `AGENTS.md`.
+
+### How It Works
+
+The hook uses Python's `shlex` module to properly parse shell quoting:
+
+1. **Tokenize** the command with `shlex.split()`
+2. **Check** for dangerous flags as standalone tokens
+3. **Check** for dangerous token sequences (e.g., `rm -rf ~`)
+4. **Check** for force push to protected branches (main/master)
+5. **Check** for deletion of protected branches
+6. **Check** for merge commits on protected branches (linear history)
+7. **Block** (exit code 2) or **Allow** (exit code 0)
+
+#### Key Feature: Quote-Aware Parsing
+
+The hook correctly distinguishes between:
+
+```bash
+# BLOCKED - actual dangerous flag
+gh pr merge --admin
+
+# ALLOWED - flag is just text in a commit message
+git commit -m "The --admin flag is dangerous"
+
+# ALLOWED - flag mentioned in heredoc content
+doit pr --body="$(cat <<'EOF'
+Do not use --force
+EOF
+)"
+```
+
+### Files
+
+| File | Description |
+|------|-------------|
+| [`block-dangerous-commands.py`](https://github.com/endavis/pynetappfoundry/blob/main/tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude and Gemini) |
+| [`test_hook.py`](https://github.com/endavis/pynetappfoundry/blob/main/tools/hooks/ai/test_hook.py) | Test suite to verify hook behavior |
+
+### Configuration
+
+#### Claude Code
+
+`.claude/settings.json`:
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/block-dangerous-commands.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Gemini CLI
+
+`.gemini/settings.json`:
+```json
+{
+  "hooks": {
+    "enabled" : true,
+    "BeforeTool": [
+      {
+        "matcher": "run_shell_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $GEMINI_PROJECT_DIR/tools/hooks/ai/block-dangerous-commands.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Codex CLI
+
+Codex uses approval policies instead of hooks. See `.codex/config.toml` for deny rules.
+
+### Testing
+
+Run the test suite after making changes:
+
+```bash
+python3 tools/hooks/ai/test_hook.py
+```
+
+Output shows green for passing tests, red for failures:
+
+```
+Testing hook: /path/to/block-dangerous-commands.py
+
+================================================================================
++ ALLOW (expected ALLOW) | safe command              | git status
++ ALLOW (expected ALLOW) | double quoted             | git commit -m "text with --admin"
++ BLOCK (expected BLOCK) | actual --admin flag       | gh pr merge --admin
+================================================================================
+
+Results: 14 passed, 0 failed
+```
+
+### Blocked Patterns
+
+#### Dangerous Flags (always blocked)
+
+| Flag | Reason |
+|------|--------|
+| `--admin` | Bypasses branch protection rules |
+| `--no-verify` | Skips pre-commit/pre-push hooks |
+| `--hard` | Hard reset - can lose uncommitted changes |
+
+#### Dangerous Sequences (consecutive tokens)
+
+| Sequence | Reason |
+|----------|--------|
+| `rm -rf /` | Destructive: removes root filesystem |
+| `rm -rf ~` | Destructive: removes home directory |
+| `sudo rm` | Privileged deletion |
+
+#### Protected Branch Operations
+
+Force push, delete, and merge operations are only blocked when targeting protected branches (`main`, `master`).
+
+| Command | Result |
+|---------|--------|
+| `git push --force origin main` | BLOCKED |
+| `git push --force origin feat/branch` | ALLOWED |
+| `git push -f origin master` | BLOCKED |
+| `git push --force` (no branch) | BLOCKED (safer default) |
+| `git push origin --delete main` | BLOCKED |
+| `git push origin :main` | BLOCKED |
+| `git branch -D main` | BLOCKED |
+| `git branch -D feat/old` | ALLOWED |
+| `git merge branch` (on main) | BLOCKED (creates merge commit) |
+| `git merge --ff-only branch` (on main) | ALLOWED (fast-forward only) |
+| `git merge branch` (on feature) | ALLOWED |
+
+#### Blocked Workflow Commands
+
+These commands should use `doit` wrappers or require user approval:
+
+| Command | Use Instead | Reason |
+|---------|-------------|--------|
+| `gh issue create` | `doit issue --type=<type>` | Ensures proper template and labels |
+| `gh pr create` | `doit pr` | Ensures proper template format |
+| `gh pr merge` | `doit pr_merge` | Enforces merge commit format: `<type>: <subject> (merges PR #XX, closes #YY)` |
+| `uv add` | User runs manually | Dependencies require human approval - suggest package, let user run command |
+| `doit release*` | User runs manually | Releases require human approval - AI can help prepare but not execute |
+
+#### Governance Labels
+
+Some labels are governance controls that require human approval. AI agents are blocked from adding these labels:
+
+| Label | Reason |
+|-------|--------|
+| `ready-to-merge` | Signals human approval that PR is ready for merge. Add manually via `gh pr edit --add-label ready-to-merge` or GitHub web UI. |
+
+### Adding New Patterns
+
+Edit `tools/hooks/ai/block-dangerous-commands.py`:
+
+```python
+# Add a new always-blocked flag
+DANGEROUS_FLAGS = {
+    "--admin": "Bypasses branch protection rules",
+    "--new-flag": "Description of why it's dangerous",
+}
+
+# Add a new dangerous sequence
+DANGEROUS_SEQUENCES = [
+    (["rm", "-rf", "/"], "Destructive: removes root filesystem"),
+    (["new", "dangerous", "sequence"], "Why it's dangerous"),
+]
+
+# Add a new protected branch
+PROTECTED_BRANCHES = {"main", "master", "production"}
+```
+
+Then run the test suite to verify.
+
+## Related
+
+- [AI Enforcement Principles](enforcement-principles.md) - Why and how we enforce rules in code
+- [AGENTS.md](https://github.com/endavis/pynetappfoundry/blob/main/AGENTS.md) - AI agent rules including "When Blocked Protocol"
+- [AI Agent Setup](../AI_SETUP.md) - Setting up AI coding assistants

--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -1,0 +1,291 @@
+---
+title: AI Enforcement Principles
+description: How we enforce AI agent behavior in code and settings
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - enforcement
+  - hooks
+---
+
+# AI Enforcement Principles
+
+## Core Principle
+
+> **All processes are enforced in code or settings as much as possible.**
+
+AI agents do not follow `AGENTS.md` consistently. Instructions alone are insufficient for reliable behavior - enforcement must be automated.
+
+### Why Instructions Alone Are Insufficient
+
+Even when `AGENTS.md` explicitly states "use `doit pr` instead of `gh pr create`", AI agents frequently ignore this guidance. The reasons include:
+
+- **Context window limitations**: Instructions may fall out of context during long conversations
+- **Training data bias**: Models default to commonly-used patterns from their training
+- **Ambiguous interpretation**: Agents may rationalize exceptions ("this is just a quick fix")
+- **No consequences**: Without enforcement, violations go unnoticed
+
+**Solution**: Shift from "tell the agent what to do" to "prevent the agent from doing the wrong thing."
+
+## Enforcement Options
+
+Listed in order of preference:
+
+### 1. GitHub Repository Settings (Most Universal)
+
+GitHub-level enforcement applies to **all** contributors - humans and AI agents alike. This is the strongest form of enforcement because it cannot be bypassed locally.
+
+**Branch Rulesets** (Settings → Rules → Rulesets):
+- Require pull request before merging
+- Require status checks to pass (CI, merge-gate)
+- Require linear history (no merge commits)
+- Restrict force pushes and deletions
+- Require signed commits
+
+**Example**: Required status checks ensure CI passes before merge:
+```
+Branch protection for 'main':
+├─ Require status checks: ci, merge-gate
+├─ Require branches to be up to date
+└─ Restrict who can push: (none - all changes via PR)
+```
+
+Use GitHub settings when:
+- The rule applies to all contributors (not just AI)
+- You need server-side enforcement that can't be bypassed
+- The rule maps to a GitHub-native feature
+
+### 2. Pre-commit Hooks (Local Git Enforcement)
+
+Pre-commit hooks run locally before commits are created. They enforce rules for all local development but can be bypassed with `--no-verify` (which AI hooks block).
+
+**Example**: Branch naming and commit message enforcement (`.pre-commit-config.yaml`):
+```yaml
+- repo: local
+  hooks:
+    - id: no-commit-to-main
+      name: Prevent commits to main branch
+      entry: bash -c 'if [[ "$(git branch --show-current)" == "main" ]]; then exit 1; fi'
+      language: system
+
+- repo: https://github.com/compilerla/conventional-pre-commit
+  hooks:
+    - id: conventional-pre-commit
+      stages: [commit-msg]
+```
+
+Use pre-commit hooks when:
+- The rule should apply to all local development
+- Immediate feedback is valuable (before push)
+- The rule can be expressed as a file or commit check
+
+### 3. AI Agent Hooks (PreToolUse/BeforeTool)
+
+Hooks intercept AI tool calls before execution, allowing custom logic to block dangerous patterns. Use when:
+- You need to block AI-specific behaviors
+- You need pattern matching (not just exact commands)
+- You need context-aware decisions (e.g., checking current git branch)
+
+**Example**: Block dangerous commands (`.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/block-dangerous-commands.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+See [AI Command Blocking](command-blocking.md) for implementation details.
+
+### 4. AI Agent Settings (Allowlists/Denylists)
+
+Settings-based enforcement in agent config files:
+- Is declarative and version-controlled
+- Works across AI tools that support the setting format
+- Requires no custom code
+
+**Example**: Gemini CLI allowed tools list (`.gemini/settings.json`):
+
+```json
+{
+  "tools": {
+    "allowed": [
+      "run_shell_command(git)",
+      "run_shell_command(gh)",
+      "run_shell_command(uv)",
+      "run_shell_command(doit)"
+    ]
+  }
+}
+```
+
+This implicitly blocks any command not in the allowlist.
+
+### 5. Agent-Specific Configuration (Last Resort)
+
+When hooks aren't available for a particular agent, fall back to agent-specific configuration files. This is the least maintainable because:
+- Each agent requires separate configuration
+- Patterns may need different syntax per agent
+- Changes must be replicated across all agent configs
+
+**Example**: Codex CLI deny rules (`.codex/config.toml`):
+
+```toml
+[[approval_policy]]
+type = "command"
+pattern = "gh\\s+pr\\s+create"
+action = "deny"
+reason = "BLOCKED: Use 'doit pr' instead of 'gh pr create'. See AGENTS.md."
+```
+
+## Currently Enforced Processes
+
+### By GitHub Repository Settings
+
+| Rule | Setting | Effect |
+|------|---------|--------|
+| All changes via PR | Branch ruleset | Direct push to `main` blocked server-side |
+| CI must pass | Required status check | Merge blocked until `ci` workflow succeeds |
+| Merge gate label | Required status check | Merge blocked until `merge-gate` succeeds |
+| Linear history | Branch ruleset | Merge commits rejected |
+
+> **Note**: GitHub settings require repository admin access to configure. See Settings → Rules → Rulesets.
+
+### By AI Agent Enforcement (Claude, Gemini, Codex)
+
+These patterns are blocked across all AI agents. Claude and Gemini use the shared hook at `tools/hooks/ai/block-dangerous-commands.py`. Codex uses approval policies in `.codex/config.toml` (no hook support).
+
+| Pattern | Command | Claude | Gemini | Codex |
+|---------|---------|--------|--------|-------|
+| `--admin` flag | `gh pr merge --admin` | Hook | Hook | Config |
+| `--no-verify` flag | `git commit --no-verify`, `git push --no-verify` | Hook | Hook | Config |
+| `--hard` flag | `git reset --hard` | Hook | Hook | Config |
+| `rm -rf /` or `rm -rf ~` | Any shell | Hook | Hook | Config |
+| `sudo rm` | Any shell | Hook | Hook | Config |
+| Force push to protected branch | `git push --force origin main` | Hook | Hook | Config |
+| Delete protected branch | `git push origin --delete main`, `git branch -D main` | Hook | Hook | — |
+| Merge commit on protected branch | `git merge` (without `--ff-only`) on `main` | Hook | Hook | — |
+| `gh pr create` | Use `doit pr` instead | Hook | Hook | Config |
+| `gh issue create` | Use `doit issue` instead | Hook | Hook | Config |
+| `uv add` | User runs manually | Hook | Hook | Config |
+| `doit release*` | User runs manually | Hook | Hook | Config |
+
+> **Note**: "Hook" = `block-dangerous-commands.py`, "Config" = `.codex/config.toml` approval policy, "—" = not enforced for this agent.
+
+### By Pre-commit Hooks (All Developers and Agents)
+
+| Rule | Hook | Effect |
+|------|------|--------|
+| No commits to `main` | `no-commit-to-main` | Blocks commit with guidance message |
+| Branch naming convention | `check-branch-name` | Requires `<type>/<issue#>-<description>` format |
+| No local config files | `no-local-config` | Blocks `*.local` and `*.local.*` files (allows `*.local.example`) |
+| Protect dynamic version | `protect-dynamic-version` | Blocks changes to `dynamic =` in pyproject.toml |
+| Conventional commits | `conventional-pre-commit` | Requires `<type>: <subject>` format |
+| Code formatting | `ruff-format` | Auto-fixes formatting issues |
+| Linting | `ruff` | Auto-fixes linting issues |
+| Type checking | `mypy` | Blocks commits with type errors |
+| Security scan | `bandit` | Blocks commits with security issues |
+| Spelling | `codespell` | Blocks commits with spelling errors |
+| Private key detection | `detect-private-key` | Blocks commits containing secrets |
+| Large file prevention | `check-added-large-files` | Blocks commits with large files |
+
+### By GitHub Workflows (CI/CD)
+
+| Rule | Workflow | Effect |
+|------|----------|--------|
+| All CI checks must pass | `ci.yml` | Required status check for merge |
+| `ready-to-merge` label required | `merge-gate.yml` | Blocks merge without label |
+| Full test matrix on merge | `ci.yml` | Runs all Python versions when labeled |
+| Minimum 80% test coverage | `ci.yml` + `pyproject.toml` | `fail_under = 80` fails CI if coverage drops |
+
+### By Settings (Agent-Specific)
+
+| Rule | Setting | Agent |
+|------|---------|-------|
+| Allowed shell commands only | `.gemini/settings.json` tools.allowed | Gemini |
+| Deny dangerous patterns | `.codex/config.toml` approval_policy | Codex |
+| Block dangerous env vars | `.codex/config.toml` shell_env_policy | Codex |
+
+## Selecting an Enforcement Method
+
+```
+Does the rule apply to ALL contributors (humans + AI)?
+├─ Yes
+│  ├─ Can GitHub enforce it? (branch rules, status checks)
+│  │  └─ Yes → Use GitHub settings (Option 1)
+│  └─ Is it a commit/file check?
+│     └─ Yes → Use pre-commit hooks (Option 2)
+└─ No (AI-specific rule)
+   ├─ Does it need pattern matching or context?
+   │  └─ Yes → Use AI hooks (Option 3)
+   └─ Can agent settings handle it?
+      ├─ Yes → Use agent settings (Option 4)
+      └─ No → Use agent-specific config (Option 5)
+```
+
+**Principles**:
+
+| # | Principle | Description |
+|---|-----------|-------------|
+| 1 | Prefer universal enforcement | GitHub settings > pre-commit > AI hooks |
+| 2 | Prefer shared enforcement | One hook for multiple agents is better than separate configs |
+| 3 | Block by default | Allowlists are safer than denylists |
+| 4 | Fail closed | If enforcement fails, block the action rather than allow it |
+| 5 | Test enforcement | Run `tools/hooks/ai/test_hook.py` after AI hook changes |
+
+## Block and Redirect Pattern
+
+When blocking a command, provide an approved alternative when possible. This project uses `doit` wrappers that enforce rules the raw commands don't:
+
+| Blocked Command | Alternative | What the Alternative Enforces |
+|-----------------|-------------|-------------------------------|
+| `gh issue create` | `doit issue --type=<type>` | Issue template format, required sections, auto-labeling |
+| `gh pr create` | `doit pr` | PR template format, proper description structure |
+| `doit release` | User runs manually | Human approval for releases |
+| `uv add` | User runs manually | Human approval for new dependencies |
+
+**Why wrappers instead of just blocking?**
+
+1. **Enforces structure**: `doit issue` validates required sections, `doit pr` ensures proper format
+2. **Reduces friction**: Agents can still complete tasks, just through compliant paths
+3. **Consistent output**: All issues/PRs follow the same template regardless of who creates them
+4. **Audit trail**: Wrapper can add metadata, logging, or additional checks
+
+**When to use "user runs manually" instead of a wrapper:**
+
+- High-consequence operations (releases, dependency changes)
+- Operations that should be rare and deliberate
+- When human judgment is required that can't be encoded in a wrapper
+
+## TODO: Potential Future Enforcement
+
+The following AGENTS.md rules are currently instruction-only and could benefit from automated enforcement:
+
+### Low Priority / Difficult to Automate
+
+| Rule | Current State | Why Difficult |
+|------|---------------|---------------|
+| "One logical change per commit" | Instruction only | Requires human judgment to define "logical." Conventional commits enforcement ensures message describes one change type. |
+| "Stop on error" | Instruction only | Requires understanding agent intent |
+| "Questions != Instructions" | Instruction only | Requires natural language understanding |
+| "Summary before commit" | Instruction only | Requires conversation context analysis |
+| "Pre-commit validation before staging" | Instruction only | Would require tracking agent's intended workflow |
+
+## Related Documentation
+
+- [AI Command Blocking](command-blocking.md) - Hook implementation details
+- [AGENTS.md](https://github.com/endavis/pynetappfoundry/blob/main/AGENTS.md) - Full AI agent instructions
+- [AI Setup Guide](../AI_SETUP.md) - Setting up AI coding assistants

--- a/docs/development/ai/statusline.md
+++ b/docs/development/ai/statusline.md
@@ -1,0 +1,104 @@
+---
+title: Claude Code Statusline
+description: Custom statusline showing git branch, Python version, and project info
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - claude
+  - configuration
+---
+
+# Claude Code Statusline
+
+The template includes a custom statusline for Claude Code sessions that provides useful context at a glance.
+
+## Example Output
+
+```
+📁 project-name | 🐍 .venv | Python: 3.12.12
+@endavis | 🔀 main (0 files uncommitted, synced 5m ago)
+Claude Opus 4.5 | ▓▓░░░░░░░░ ~10% of 200k tokens
+💬 work on issue #130
+```
+
+## Features
+
+- **Current directory** and Python virtual environment name
+- **Python version** currently active
+- **GitHub endavis** (from `gh` CLI)
+- **Git branch** with uncommitted file count
+- **Sync status** showing ahead/behind commits and last fetch time
+- **Model name** with context usage bar (visual + percentage)
+- **Last user message** preview for quick context
+
+## Configuration
+
+The statusline is configured in `.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash $CLAUDE_PROJECT_DIR/.claude/statusline-command.sh"
+  }
+}
+```
+
+## Customization
+
+### Color Theme
+
+Edit `.claude/statusline-command.sh` and change the `COLOR` variable at the top:
+
+```bash
+# Available themes: gray, orange, blue, teal, green, lavender, rose, gold, slate, cyan
+COLOR="blue"
+```
+
+### Color Reference
+
+| Theme    | ANSI Code | Description |
+|----------|-----------|-------------|
+| gray     | 245       | Monochrome, subtle |
+| orange   | 173       | Warm, energetic |
+| blue     | 74        | Default, calm |
+| teal     | 66        | Cool, professional |
+| green    | 71        | Fresh, nature |
+| lavender | 139       | Soft, creative |
+| rose     | 132       | Warm pink |
+| gold     | 136       | Rich, elegant |
+| slate    | 60        | Dark blue-gray |
+| cyan     | 37        | Bright, tech |
+
+### Removing Features
+
+Comment out or remove lines in the "Build output" section of the script:
+
+```bash
+# Build output: Model | Dir | Branch (uncommitted) | Context
+output="📁 ${dir}"
+[[ -n "$venv_name" ]] && output+=" | 🐍 ${venv_name}"
+[[ -n "$python_version" ]] && output+=" | Python: ${python_version}"
+# [[ -n "$gh_user" ]] && output+="\n@${gh_user}"  # Remove GitHub endavis
+[[ -n "$branch" ]] && output+=" | 🔀 ${branch} ${git_status}"
+```
+
+## Requirements
+
+- `jq` - JSON processor (used for parsing Claude's input)
+- `gh` - GitHub CLI (optional, for endavis display)
+- `git` - For branch and status information
+
+## Troubleshooting
+
+### Statusline not appearing
+
+1. Ensure the script is executable: `chmod +x .claude/statusline-command.sh`
+2. Check `jq` is installed: `which jq`
+3. Test manually: `echo '{}' | bash .claude/statusline-command.sh`
+
+### Colors not displaying
+
+Some terminals may not support 256-color mode. Try setting `COLOR="gray"` for basic output.

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -1,0 +1,641 @@
+---
+title: CI/CD Testing Guide
+description: GitHub Actions pipelines for testing, linting, and coverage
+audience:
+  - contributors
+tags:
+  - ci-cd
+  - testing
+  - github-actions
+---
+
+# CI/CD Testing Guide
+
+## Overview
+
+CI runs lint/format, tests, coverage, and quality checks to guard against regressions. GitHub Actions pipelines target multiple Python versions and publish coverage artifacts/comments.
+
+## Audience and Prerequisites
+
+- **Audience:** Contributors and reviewers ensuring CI health
+- **Prerequisites:** GitHub Actions access; local tools (`uv`, `doit`, pytest, ruff, mypy) to replicate checks
+
+## When to Use This
+
+- Before opening/merging PRs to mirror CI locally
+- Understanding pipeline stages and coverage expectations
+- Expanding tests or adjusting quality thresholds
+
+## Quick Start
+
+Local commands:
+```bash
+doit format && doit lint
+uv run pytest
+doit coverage
+```
+
+## Python Version Support Policy
+
+### Active Support
+
+Only the **last 3 major Python versions** are actively supported. This means:
+- Bug fixes and new features are tested against these versions
+- CI runs these versions on every PR (using bookend strategy - oldest + newest)
+- Documentation and examples target these versions
+
+**Current active versions:** Python 3.12, 3.13, 3.14
+
+### Passive Compatibility
+
+Older Python versions may continue to work but are not actively maintained:
+- We continue testing previous versions in CI via the `full-matrix` label
+- Once a version fails CI tests, it is removed from the matrix and marked incompatible
+- Users on older Python versions can use version-tagged releases (e.g., `v1.2.3-py310-final`)
+
+### Version Lifecycle
+
+| Stage | Description | CI Testing |
+|-------|-------------|------------|
+| **Active** | Last 3 major versions | Every PR (bookend strategy) |
+| **Passive** | Older versions still passing | On-demand (`full-matrix` label) |
+| **Deprecated** | Fails CI tests | Removed from matrix |
+
+### CI Matrix Strategy
+
+To balance test coverage with CI efficiency:
+
+| PR State | Python Versions Tested | Jobs |
+|----------|----------------------|------|
+| Default | Bookends only (oldest + newest) × 3 OSes | 6 |
+| `full-matrix` label | Middle versions only × 3 OSes | 3 per middle version |
+
+The **bookend strategy** tests the oldest and newest supported versions. If both pass, intermediate versions are assumed compatible. Use the `full-matrix` label when:
+- Making changes that might affect version compatibility
+- Preparing a release
+- Investigating compatibility issues
+
+### Configuration
+
+Python versions are configured in `.github/python-versions.json`:
+
+```json
+{
+  "oldest": "3.12",
+  "newest": "3.14"
+}
+```
+
+The CI workflow automatically derives:
+- **Bookends**: oldest + newest (tested on every PR)
+- **Middle versions**: everything between (tested when `full-matrix` label is added)
+
+When updating supported versions, edit this config file - no workflow changes needed.
+
+### Deprecation Process
+
+When a Python version starts failing CI:
+
+1. **Assess**: Determine if the failure is fixable without significant effort
+2. **Decide**: Fix compatibility or deprecate the version
+3. **Tag**: If deprecating, tag the last compatible release (e.g., `v1.2.3-py310-final`)
+4. **Update**: Remove version from CI matrix and update `pyproject.toml` classifiers
+5. **Document**: Update this documentation and release notes
+
+## Pipeline Details (GitHub Actions)
+
+### Recommended Workflow Structure
+
+Create `.github/workflows/tests.yml`:
+
+```yaml
+name: Tests
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.14"]  # Bookend strategy: oldest + newest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          uv sync --dev
+
+      - name: Run format check
+        run: uv run doit format_check
+
+      - name: Run linter
+        run: uv run doit lint
+
+      - name: Run type checker
+        run: uv run doit type_check
+        continue-on-error: true  # Optional: make non-blocking
+
+      - name: Run tests with coverage
+        run: uv run pytest --cov=src --cov-report=xml --cov-report=html
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        if: matrix.python-version == '3.12'
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: true
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        if: matrix.python-version == '3.12'
+        with:
+          name: coverage-report
+          path: htmlcov/
+```
+
+### Pipeline Jobs
+
+#### Code Quality Job
+
+```yaml
+code-quality:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v1
+    - name: Install dependencies
+      run: uv sync --dev
+    - name: Format check
+      run: uv run doit format_check
+    - name: Lint check
+      run: uv run doit lint
+    - name: Type check
+      run: uv run doit type_check
+      continue-on-error: true
+```
+
+#### Security Scan Job
+
+```yaml
+security:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v1
+    - name: Install security tools
+      run: uv sync --extra security
+    - name: Run security audit
+      run: uv run doit audit
+    - name: Run bandit scan
+      run: uv run doit security
+```
+
+### Coverage Requirements
+
+- **Recommended threshold**: ≥70%
+- **Configuration**: Set in `pyproject.toml` and pytest command
+- **Artifacts**: Upload HTML coverage reports for review
+- **Integration**: Use Codecov or similar service for tracking
+
+**Example pytest configuration in `pyproject.toml`:**
+```toml
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "--cov=src",
+    "--cov-report=term-missing",
+    "--cov-report=html",
+    "--cov-report=xml",
+    "--cov-fail-under=70",
+]
+```
+
+### PR Comments
+
+Add coverage comments to PRs using GitHub Actions:
+
+```yaml
+- name: Coverage comment
+  uses: py-cov-action/python-coverage-comment-action@v3
+  with:
+    GITHUB_TOKEN: ${{ github.token }}
+    MINIMUM_GREEN: 80
+    MINIMUM_ORANGE: 70
+```
+
+## Local Development Workflow
+
+### Running Tests Locally
+
+```bash
+# Run all tests
+uv run pytest
+
+# Run specific test file
+uv run pytest tests/test_config.py
+
+# Run specific test
+uv run pytest tests/test_config.py::test_load_config
+
+# Run with verbose output
+uv run pytest -v
+
+# Run with coverage
+uv run pytest --cov=src
+
+# Generate HTML coverage report
+uv run pytest --cov=src --cov-report=html
+xdg-open htmlcov/index.html  # Open in browser
+```
+
+### Quality Checks
+
+```bash
+# Format code
+doit format
+
+# Check formatting (CI mode)
+doit format_check
+
+# Lint code
+doit lint
+
+# Type check
+doit type_check
+
+# Run all quality checks
+doit check
+```
+
+### Coverage Analysis
+
+```bash
+# Run with coverage
+doit coverage
+
+# View coverage report
+xdg-open tmp/htmlcov/index.html
+
+# Check coverage threshold
+pytest --cov=src --cov-fail-under=70
+```
+
+## Validation and Checks
+
+### Pre-commit Integration
+
+The template includes pre-commit hooks that run automatically:
+
+```bash
+# Install hooks
+uv run pre-commit install
+
+# Run manually on all files
+uv run pre-commit run --all-files
+
+# Update hook versions
+uv run pre-commit autoupdate
+```
+
+**Pre-commit configuration (`.pre-commit-config.yaml`):**
+```yaml
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.0
+    hooks:
+      - id: ruff-format
+      - id: ruff
+        args: [--fix]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.0.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-all]
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: uv run pytest
+        language: system
+        pass_filenames: false
+        always_run: true
+```
+
+### Continuous Integration Checklist
+
+Before pushing to CI:
+- [ ] Run `doit format` to format code
+- [ ] Run `doit lint` to check for issues
+- [ ] Run `doit type_check` to verify types
+- [ ] Run `uv run pytest` to ensure tests pass
+- [ ] Run `doit coverage` to check coverage threshold
+- [ ] Review changes and commit messages
+
+## Testing Best Practices
+
+### Test Organization
+
+```
+tests/
+├── unit/           # Unit tests (fast, isolated)
+│   ├── test_config.py
+│   ├── test_utils.py
+│   └── test_models.py
+├── integration/    # Integration tests (slower, with dependencies)
+│   ├── test_api.py
+│   └── test_database.py
+├── fixtures/       # Test data and fixtures
+│   └── sample_config.json
+└── conftest.py     # Shared pytest fixtures
+```
+
+### Writing Good Tests
+
+```python
+import pytest
+from myproject import Config, ConfigError
+
+@pytest.fixture
+def temp_config_file(tmp_path):
+    """Create a temporary config file."""
+    config_file = tmp_path / "config.json"
+    config_file.write_text('{"key": "value"}')
+    return config_file
+
+def test_config_load_success(temp_config_file):
+    """Test successful config loading."""
+    config = Config.load(str(temp_config_file))
+    assert config.get("key") == "value"
+
+def test_config_load_file_not_found():
+    """Test config loading with missing file."""
+    with pytest.raises(ConfigError, match="not found"):
+        Config.load("nonexistent.json")
+
+@pytest.mark.parametrize("value,expected", [
+    ("true", True),
+    ("false", False),
+    ("1", True),
+    ("0", False),
+])
+def test_parse_bool(value, expected):
+    """Test boolean parsing with various inputs."""
+    assert parse_bool(value) == expected
+```
+
+### Mocking External Dependencies
+
+```python
+from unittest.mock import Mock, patch
+import pytest
+
+def test_api_call_success():
+    """Test successful API call."""
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.json.return_value = {"status": "ok"}
+        mock_get.return_value.status_code = 200
+
+        result = fetch_data("https://api.example.com/data")
+        assert result["status"] == "ok"
+        mock_get.assert_called_once_with("https://api.example.com/data")
+
+def test_api_call_failure():
+    """Test API call failure handling."""
+    with patch("requests.get") as mock_get:
+        mock_get.side_effect = ConnectionError("Network error")
+
+        with pytest.raises(APIError, match="Network error"):
+            fetch_data("https://api.example.com/data")
+```
+
+## Examples
+
+### Running Specific Tests
+
+```bash
+# Run all tests in a file
+pytest tests/unit/test_config.py
+
+# Run a specific test class
+pytest tests/unit/test_config.py::TestConfigManager
+
+# Run a specific test method
+pytest tests/unit/test_config.py::TestConfigManager::test_load_config
+
+# Run tests matching a pattern
+pytest -k "test_config"
+
+# Run tests with markers
+pytest -m "slow"  # Run only tests marked as slow
+pytest -m "not slow"  # Skip slow tests
+```
+
+### Coverage Analysis
+
+```bash
+# Generate coverage report
+doit coverage
+
+# View HTML coverage report
+xdg-open tmp/htmlcov/index.html
+
+# Check specific module coverage
+pytest --cov=src/myproject/config --cov-report=term-missing
+
+# Generate XML coverage for CI
+pytest --cov=src --cov-report=xml
+```
+
+### Testing Multiple Python Versions
+
+Using `tox`:
+
+```ini
+# tox.ini
+[tox]
+envlist = py312,py313,py314
+
+[testenv]
+deps =
+    pytest
+    pytest-cov
+commands = pytest {posargs}
+```
+
+```bash
+# Run tests on all environments
+tox
+
+# Run on specific environment
+tox -e py314
+```
+
+## Merge Gate Workflow
+
+The repository uses a merge gate to ensure PRs are only merged after explicit approval.
+
+### How It Works
+
+The merge gate is implemented in `.github/workflows/merge-gate.yml`:
+
+```yaml
+name: Merge Gate
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, labeled, unlabeled, synchronize, reopened]
+
+jobs:
+  require-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for ready-to-merge label
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ready-to-merge') }}" != "true" ]]; then
+            echo "::error::PR requires 'ready-to-merge' label before merging"
+            exit 1
+          fi
+```
+
+### The `ready-to-merge` Label
+
+This label is a **pure merge gate** - it signals that a PR is approved for merge but does not trigger additional CI runs. The default CI matrix (6 jobs) provides sufficient coverage.
+
+**When to add the label:**
+- All CI checks have passed
+- Code review is complete and approved
+- All review feedback has been addressed
+
+**Adding the label:**
+```bash
+# Via GitHub CLI
+gh pr edit <PR-NUMBER> --add-label "ready-to-merge"
+
+# Or via GitHub web UI: PR page → Labels → ready-to-merge
+```
+
+### The `full-matrix` Label
+
+Use this label to trigger comprehensive compatibility testing across all supported Python versions:
+
+**When to use:**
+- Changes that might affect Python version compatibility
+- Preparing a release
+- Investigating compatibility issues reported by users
+
+```bash
+# Add full-matrix label for comprehensive testing
+gh pr edit <PR-NUMBER> --add-label "full-matrix"
+```
+
+### Branch Protection Integration
+
+Configure branch protection rules to require the merge gate:
+
+1. Go to **Settings** → **Branches** → **Branch protection rules**
+2. Select or create rule for `main`
+3. Enable **Require status checks to pass before merging**
+4. Add `require-label` to required status checks
+
+This ensures PRs cannot be merged until:
+- The `ready-to-merge` label is present
+- All CI checks pass (default 6-job matrix)
+
+### Interaction with Approval Workflows
+
+The merge gate works alongside GitHub's approval requirement:
+
+| Check | Type | Purpose |
+|-------|------|---------|
+| Approvals | GitHub built-in | Ensures code review is complete |
+| CI checks | GitHub Actions | Tests code on bookend Python versions × all OSes |
+| Merge gate | Custom workflow | Explicit "ready" signal via label |
+
+**Recommended merge flow:**
+
+```
+PR opened → CI runs (6 jobs) → Review/Approval → Add ready-to-merge label → Merge
+```
+
+**Optional full compatibility check:**
+
+```
+PR opened → CI runs → Add full-matrix label → Full CI runs (9-15 jobs) → Review → Add ready-to-merge → Merge
+```
+
+## Troubleshooting
+
+### Coverage Below Threshold
+
+**Symptom**: `pytest --cov-fail-under=70` fails
+**Fix**:
+- Add tests for new/changed code paths
+- Use `pytest --cov=src --cov-report=html` to see uncovered lines
+- Review coverage report: `xdg-open tmp/htmlcov/index.html`
+
+### Ruff/Format Failures
+
+**Symptom**: Formatting or linting errors in CI
+**Fix**:
+- Run `doit format` locally to auto-format
+- Run `doit lint` to see all violations
+- Address violations or add exceptions to `pyproject.toml`
+
+### Mypy Type Errors
+
+**Symptom**: Type checking fails
+**Fix**:
+- Add proper type annotations
+- Use `# type: ignore[error-code]` sparingly with explanatory comments
+- Review mypy output for specific issues
+- Consider making mypy non-blocking initially (`continue-on-error: true`)
+
+### Tests Fail in CI but Pass Locally
+
+**Symptom**: Tests pass locally but fail in CI
+**Fix**:
+- Check for environment-specific dependencies
+- Ensure all test dependencies are in `pyproject.toml`
+- Look for timing issues or race conditions
+- Check for file system or path differences
+
+### Pre-commit Hooks Too Slow
+
+**Symptom**: Pre-commit hooks take too long
+**Fix**:
+- Skip test hook for routine commits: `git commit --no-verify`
+- Run tests manually before pushing
+- Consider running only fast unit tests in pre-commit
+- Move integration tests to CI only
+
+## Related Documentation
+
+- [Coding Standards](coding-standards.md)
+- [Release Automation](release-and-automation.md)
+
+---
+
+[Back to Documentation Index](../index.md)

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -1,0 +1,617 @@
+---
+title: Python Project Coding Standards
+description: Guidelines for exceptions, typing, structure, testing, and documentation
+audience:
+  - contributors
+tags:
+  - coding-standards
+  - python
+  - best-practices
+---
+
+# Python Project Coding Standards
+
+## Overview
+
+Guidelines for exceptions, typing, structure, testing, and documentation to keep your Python project code consistent and safe.
+
+## Audience and Prerequisites
+
+- **Audience:** Contributors writing or reviewing code
+- **Prerequisites:** Python 3.12+, familiarity with the repo layout, access to local tooling (`uv`, `doit`, ruff, pytest)
+
+## When to Use This
+
+- Implementing new features or refactors
+- Reviewing PRs for compliance and safety
+- Adding tests or updating typing/structure
+
+## Quick Start
+
+- Use typed functions with explicit return types
+- Prefer specific exceptions over generic ones
+- Run `doit format && doit lint && uv run pytest` before submitting
+
+## Coding Standards
+
+### Exception Handling
+
+- Use specific exceptions first (e.g., `ValueError`, `TypeError`, `FileNotFoundError`)
+- Create custom exception classes for domain-specific errors
+- Only catch generic `Exception` as a last resort
+- Include context in error messages for debugging
+- For CLI tools: use proper error reporting for user-facing errors
+
+**Example:**
+```python
+class ConfigError(Exception):
+    """Raised when configuration is invalid."""
+    pass
+
+def load_config(path: str) -> dict[str, Any]:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError as exc:
+        raise ConfigError(f"Config file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"Invalid JSON in config: {path}") from exc
+```
+
+### Typing
+
+- **Full annotations**: Add type hints to all function parameters and return values
+- **Avoid `Any`**: Use specific types; `Any` should be rare and documented
+- **Modern syntax**: Use `list[str]`, `dict[str, int]`, `X | None` (Python 3.10+ syntax)
+- **Protocols**: Use `typing.Protocol` for structural typing
+- **Generic types**: Use `TypeVar` and `Generic` for reusable generic code
+- **Override decorator**: Use `@override` (from `typing` in Python 3.12+) on method implementations
+
+**Example:**
+```python
+from typing import Protocol
+
+class Validator(Protocol):
+    """Protocol for validation strategies."""
+    def validate(self, data: dict[str, Any]) -> bool: ...
+
+def process_data(
+    data: dict[str, Any],
+    validator: Validator | None = None
+) -> list[str]:
+    """Process data with optional validation.
+
+    Args:
+        data: Input data to process
+        validator: Optional validator instance
+
+    Returns:
+        List of processed items
+    """
+    if validator and not validator.validate(data):
+        raise ValueError("Validation failed")
+    return [str(v) for v in data.values()]
+```
+
+### Project Structure
+
+- **Organization**: Follow consistent package organization
+  - `core/`: Core functionality
+  - `utils/`: Utility functions
+  - `cli/`: Command-line interface
+  - `models/`: Data models
+- **Public APIs**: Re-export public APIs via `__init__.py` for clean imports
+- **Private modules**: Prefix internal modules with `_` (e.g., `_internal.py`)
+
+**Example `__init__.py`:**
+```python
+"""Public API for myproject."""
+
+from myproject.core.config import Config
+from myproject.core.processor import Processor
+
+__all__ = ["Config", "Processor"]
+```
+
+### Base Classes and Mixins
+
+- **Inheritance**: Call `super().__init__()` in constructors
+- **Mixins**: Use mixins to share common functionality
+- **Abstract base classes**: Use `abc.ABC` and `@abstractmethod` for interfaces
+
+**Example:**
+```python
+from abc import ABC, abstractmethod
+
+class BaseManager(ABC):
+    """Base class for all managers."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @abstractmethod
+    def initialize(self) -> None:
+        """Initialize the manager."""
+        pass
+
+class ConfigMixin:
+    """Mixin for configuration loading."""
+
+    def load_config(self, path: str) -> dict[str, Any]:
+        """Load configuration from file."""
+        # Implementation here
+        pass
+
+class AppManager(BaseManager, ConfigMixin):
+    """Application manager with config support."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self.config: dict[str, Any] = {}
+
+    def initialize(self) -> None:
+        self.config = self.load_config("config.json")
+```
+
+### Error Patterns
+
+- **Defensive catches**: Use try-except blocks to prevent crashes in non-critical paths
+- **Re-raise**: Re-raise exceptions after logging when appropriate
+- **Context preservation**: Use `raise ... from exc` to preserve exception chains
+- **Logging**: Log errors with appropriate context before re-raising
+
+**Example:**
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+def safe_operation(data: dict[str, Any]) -> bool:
+    """Perform operation with defensive error handling."""
+    try:
+        process_data(data)
+        return True
+    except ValueError as exc:
+        logger.warning("Validation failed: %s", exc)
+        return False
+    except Exception as exc:
+        logger.error("Unexpected error: %s", exc, exc_info=True)
+        raise
+```
+
+### Logging
+
+- Use the `logging` module, not `print()` in library code
+- Use appropriate log levels (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+- Include context in log messages
+- Use structured logging when possible
+
+**Example:**
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+def process_file(path: str) -> None:
+    logger.info("Processing file: %s", path)
+    try:
+        # ... processing ...
+        logger.debug("File processed successfully: %s", path)
+    except Exception as exc:
+        logger.error("Failed to process file %s: %s", path, exc, exc_info=True)
+        raise
+```
+
+## Testing
+
+### Coverage Requirements
+
+- **Minimum coverage target**: ≥70%
+- **Commands**: `uv run pytest` or `doit test`
+- **Coverage report**: `doit coverage`
+
+### Testing Guidelines
+
+- Add/adjust tests when changing behavior
+- Use fixtures for test setup and teardown
+- Use mocks/stubs for external dependencies
+- Test edge cases and error conditions
+- Keep tests focused and independent
+
+**Example:**
+```python
+import pytest
+from myproject.core import Processor
+
+@pytest.fixture
+def processor() -> Processor:
+    """Create a test processor instance."""
+    return Processor(config={"mode": "test"})
+
+def test_processor_success(processor: Processor) -> None:
+    """Test successful processing."""
+    result = processor.process({"key": "value"})
+    assert result == ["value"]
+
+def test_processor_validation_error(processor: Processor) -> None:
+    """Test validation error handling."""
+    with pytest.raises(ValueError, match="Validation failed"):
+        processor.process({})
+```
+
+## Documentation
+
+### Docstring Standards
+
+Docstrings are automatically extracted into the [API Reference](../reference/api.md)
+using [mkdocstrings](https://mkdocstrings.github.io/).
+
+**Requirements:**
+
+- Use **Google-style docstrings** for consistency
+- Document all public functions, classes, and modules
+- Include Args, Returns, Raises, Examples sections as appropriate
+- Type hints go in signatures, not duplicated in docstrings
+- End descriptions with periods for consistency
+- Keep line length ≤100 characters
+
+**Example:**
+```python
+def calculate_score(
+    values: list[float],
+    weights: list[float] | None = None
+) -> float:
+    """Calculate weighted score from values.
+
+    Args:
+        values: List of numeric values to score
+        weights: Optional weights for each value. If None, uses equal weights.
+
+    Returns:
+        The calculated weighted score
+
+    Raises:
+        ValueError: If values is empty or lengths don't match
+
+    Example:
+        >>> calculate_score([1.0, 2.0, 3.0])
+        2.0
+        >>> calculate_score([1.0, 2.0], weights=[0.3, 0.7])
+        1.7
+    """
+    if not values:
+        raise ValueError("values cannot be empty")
+    if weights and len(values) != len(weights):
+        raise ValueError("values and weights must have same length")
+
+    if weights is None:
+        return sum(values) / len(values)
+    return sum(v * w for v, w in zip(values, weights))
+```
+
+### Comments
+
+- Use inline comments sparingly, only when code intent isn't clear
+- Prefer self-documenting code (clear variable/function names)
+- Update comments when code changes
+
+### Documentation Maintenance
+
+- Update relevant docs when public behavior changes
+- Keep documentation in sync with code
+- Use examples to illustrate complex concepts
+
+## Validation and Checks
+
+### Pre-commit Checks
+
+Run these before every commit:
+
+```bash
+# Format code
+doit format
+
+# Lint code
+doit lint
+
+# Type check
+doit type_check
+
+# Run tests
+uv run pytest
+```
+
+### CI/CD Integration
+
+All checks should pass in CI:
+- Code formatting (ruff format)
+- Linting (ruff check)
+- Type checking (mypy)
+- Test suite (pytest)
+- Coverage threshold (pytest-cov)
+
+### Import Compatibility
+
+When refactoring imports:
+- Update `__init__.py` re-exports
+- Verify dependent imports still work
+- Consider deprecation warnings for breaking changes
+
+## Code Style
+
+### Ruff Configuration
+
+This template uses Ruff for linting and formatting:
+
+- **Line length**: 100 characters
+- **Target version**: Python 3.12+
+- **Rules**: See `pyproject.toml` for enabled rule sets
+  - E/F: pycodestyle and pyflakes
+  - I: isort (import sorting)
+  - N: pep8-naming
+  - UP: pyupgrade
+  - ANN: type annotations
+  - B: bugbear
+  - C4: comprehensions
+  - RUF: Ruff-specific rules
+
+### Example: Good Code Style
+
+```python
+"""User management module."""
+
+import logging
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class UserStore(Protocol):
+    """Protocol for user storage backends."""
+
+    def get_user(self, user_id: int) -> dict[str, Any] | None: ...
+    def save_user(self, user: dict[str, Any]) -> None: ...
+
+
+class UserManager:
+    """Manages user operations with pluggable storage."""
+
+    def __init__(self, store: UserStore) -> None:
+        """Initialize manager with storage backend.
+
+        Args:
+            store: Storage backend implementing UserStore protocol
+        """
+        self.store = store
+        logger.info("UserManager initialized")
+
+    def create_user(self, name: str, email: str) -> int:
+        """Create a new user.
+
+        Args:
+            name: User's full name
+            email: User's email address
+
+        Returns:
+            ID of created user
+
+        Raises:
+            ValueError: If email is invalid
+        """
+        if "@" not in email:
+            raise ValueError(f"Invalid email: {email}")
+
+        user = {
+            "id": self._generate_id(),
+            "name": name,
+            "email": email,
+        }
+        self.store.save_user(user)
+        logger.info("Created user: %s", user["id"])
+        return user["id"]
+
+    def _generate_id(self) -> int:
+        """Generate unique user ID."""
+        # Implementation details...
+        return 42
+```
+
+## Dead Code Detection
+
+### Overview
+
+This template uses [vulture](https://github.com/jendrikseipp/vulture) to detect unused code. Dead code accumulates over time and wastes maintenance effort.
+
+### Running Dead Code Analysis
+
+```bash
+# Run dead code detection
+doit deadcode
+```
+
+### What Vulture Detects
+
+- Unused functions and methods
+- Unused variables and attributes
+- Unused imports
+- Unused classes
+- Unreachable code
+
+### Configuration
+
+Vulture is configured in `pyproject.toml` under `[tool.vulture]`:
+
+```toml
+[tool.vulture]
+min_confidence = 80          # Only report high-confidence findings
+paths = ["src", "tests"]     # Directories to scan
+ignore_names = ["test_*"]    # Patterns to ignore
+ignore_decorators = ["@pytest.fixture"]  # Decorators to ignore
+```
+
+### Handling False Positives
+
+Vulture may report false positives for code that's used dynamically. Common examples:
+
+| Pattern | Why It's a False Positive |
+|---------|--------------------------|
+| Pytest fixtures | Used by name injection |
+| Click/Typer commands | Called via decorators |
+| `__all__` exports | Used for public API |
+| Abstract methods | Implemented in subclasses |
+| Logging formatters | Called by logging framework |
+
+**To handle false positives:**
+
+1. **Add to `ignore_names`** in `pyproject.toml`:
+   ```toml
+   ignore_names = [
+       "my_special_function",
+       "fixture_*",
+   ]
+   ```
+
+2. **Add to `ignore_decorators`**:
+   ```toml
+   ignore_decorators = [
+       "@my_framework.command",
+   ]
+   ```
+
+3. **Use a whitelist file** (for complex cases):
+   ```bash
+   # Generate whitelist from current findings
+   uv run vulture src/ --make-whitelist > vulture_whitelist.py
+
+   # Edit the whitelist to keep only intentional items
+   # Then run with whitelist
+   uv run vulture src/ vulture_whitelist.py
+   ```
+
+### Best Practices
+
+- Run `doit deadcode` periodically during development
+- Remove genuinely unused code promptly
+- Document why code is kept if it appears unused but is needed
+- Keep the confidence threshold at 80+ to avoid noise
+
+## Code Complexity Metrics
+
+### Overview
+
+This template uses [radon](https://radon.readthedocs.io/) to analyze code complexity. Complex code is harder to understand, test, and maintain.
+
+### Running Complexity Analysis
+
+```bash
+# Analyze cyclomatic complexity (A-F grades)
+doit complexity
+
+# Analyze maintainability index (A-F grades)
+doit maintainability
+```
+
+### Metrics Explained
+
+#### Cyclomatic Complexity (CC)
+
+Measures the number of independent paths through a function. Lower is better.
+
+| Grade | CC Score | Risk Level |
+|-------|----------|------------|
+| A | 1-5 | Low - simple, easy to test |
+| B | 6-10 | Low - slightly complex |
+| C | 11-20 | Moderate - more difficult to test |
+| D | 21-30 | High - difficult to test |
+| E | 31-40 | Very high - untestable |
+| F | 41+ | Extremely high - error-prone |
+
+**Target:** Keep all functions at grade B or better (CC ≤ 10).
+
+#### Maintainability Index (MI)
+
+A composite score based on cyclomatic complexity, lines of code, and Halstead volume. Higher is better.
+
+| Grade | MI Score | Meaning |
+|-------|----------|---------|
+| A | 20-100 | Highly maintainable |
+| B | 10-19 | Moderately maintainable |
+| C | 0-9 | Difficult to maintain |
+
+**Target:** Keep all modules at grade A (MI ≥ 20).
+
+### Reducing Complexity
+
+If a function has high complexity:
+
+1. **Extract helper functions** - Break large functions into smaller, focused ones
+2. **Use early returns** - Reduce nesting with guard clauses
+3. **Simplify conditionals** - Use lookup tables instead of long if-else chains
+4. **Apply design patterns** - Strategy pattern can replace complex switches
+
+**Example - Before (CC=8):**
+```python
+def process(data, mode):
+    if mode == "a":
+        if data.valid:
+            return handle_a(data)
+        else:
+            return error_a()
+    elif mode == "b":
+        if data.valid:
+            return handle_b(data)
+        else:
+            return error_b()
+    # ... more branches
+```
+
+**Example - After (CC=2):**
+```python
+HANDLERS = {"a": handle_a, "b": handle_b}
+ERRORS = {"a": error_a, "b": error_b}
+
+def process(data, mode):
+    handler = HANDLERS.get(mode)
+    if not handler:
+        raise ValueError(f"Unknown mode: {mode}")
+    return handler(data) if data.valid else ERRORS[mode]()
+```
+
+### Best Practices
+
+- Run `doit complexity` before submitting PRs
+- Refactor functions with CC > 10
+- Document exceptions where high complexity is justified
+- Use maintainability index to identify modules needing attention
+
+## Related Documentation
+
+- [Release Automation](release-and-automation.md)
+- [CI/CD Testing](ci-cd-testing.md)
+- [Extensions](extensions.md)
+
+## Troubleshooting
+
+### Lint/Format Failures
+
+**Symptom**: Ruff reports violations
+**Fix**: Run `doit format && doit lint` and address the violations
+
+### Coverage Drop
+
+**Symptom**: Coverage below threshold
+**Fix**: Add/adjust tests for new code paths; use `doit coverage` to see coverage report
+
+### Import Breakage After Refactor
+
+**Symptom**: Imports fail after moving modules
+**Fix**: Update `__init__.py` re-exports and verify dependent imports
+
+### Type Checking Errors
+
+**Symptom**: mypy reports type errors
+**Fix**: Add proper type annotations; use `# type: ignore[error-code]` sparingly with comments
+
+---
+
+[Back to Documentation Index](../index.md)

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -1,0 +1,945 @@
+---
+title: Doit Tasks Reference
+description: Complete reference for all doit automation tasks
+audience:
+  - users
+  - contributors
+tags:
+  - doit
+  - automation
+  - reference
+---
+
+# Doit Tasks Reference
+
+Complete reference for all available `doit` tasks in this project template.
+
+## Quick Reference
+
+```bash
+# List all available tasks
+doit list
+
+# Get help for a specific task
+doit help <task_name>
+
+# Run a task
+doit <task_name>
+```
+
+## Task Categories
+
+| Category | Tasks | Description |
+|----------|-------|-------------|
+| [Testing](#testing-tasks) | `test`, `coverage` | Run tests and coverage |
+| [Code Quality](#code-quality-tasks) | `format`, `lint`, `type_check`, `check` | Code formatting and linting |
+| [Code Analysis](#code-analysis-tasks) | `complexity`, `maintainability`, `deadcode` | Code metrics and analysis |
+| [Security](#security-tasks) | `security`, `audit`, `licenses` | Security scanning |
+| [Documentation](#documentation-tasks) | `docs_serve`, `docs_build`, `docs_deploy`, `docs_toc` | Documentation management |
+| [Dependencies](#dependency-tasks) | `install`, `install_dev`, `update_deps` | Package management |
+| [GitHub Workflow](#github-workflow-tasks) | `issue`, `pr`, `pr_merge`, `adr` | Issue and PR management |
+| [Release](#release-tasks) | `release`, `release_dev`, `release_pr`, `release_tag`, `publish` | Version and release management |
+| [Version](#version-tasks) | `bump`, `changelog` | Version bumping and changelog |
+| [Setup](#setup-tasks) | `pre_commit_install`, `completions`, `install_direnv` | Development environment |
+| [Maintenance](#maintenance-tasks) | `cleanup`, `template_clean` | Project cleanup |
+
+---
+
+## Testing Tasks
+
+### `test`
+
+Run pytest with parallel execution for faster test runs.
+
+```bash
+doit test
+```
+
+**What it does:**
+- Runs `pytest -n auto -v` for parallel test execution
+- Uses all available CPU cores
+
+**Equivalent command:**
+```bash
+uv run pytest -n auto -v
+```
+
+### `coverage`
+
+Run tests with coverage reporting.
+
+```bash
+doit coverage
+```
+
+**What it does:**
+- Runs pytest with coverage tracking (parallel execution disabled for accuracy)
+- Generates terminal, HTML, and XML coverage reports
+- Reports are saved to `tmp/` directory
+
+**Equivalent command:**
+```bash
+uv run pytest --cov=src --cov-report=term-missing --cov-report=html:tmp/htmlcov --cov-report=xml:tmp/coverage.xml -v
+```
+
+**Output locations:**
+- Terminal: Shows coverage summary with missing lines
+- HTML: `tmp/htmlcov/index.html`
+- XML: `tmp/coverage.xml`
+
+---
+
+## Code Quality Tasks
+
+### `format`
+
+Format code with ruff.
+
+```bash
+doit format
+```
+
+**What it does:**
+- Runs `ruff format` to format Python code
+- Runs `ruff check --fix` to auto-fix linting issues
+
+**Equivalent command:**
+```bash
+uv run ruff format src/ tests/
+uv run ruff check --fix src/ tests/
+```
+
+### `format_check`
+
+Check code formatting without making changes.
+
+```bash
+doit format_check
+```
+
+**What it does:**
+- Checks if code is properly formatted (CI mode)
+- Returns non-zero exit code if formatting is needed
+
+**Equivalent command:**
+```bash
+uv run ruff format --check src/ tests/
+```
+
+### `lint`
+
+Run ruff linting checks.
+
+```bash
+doit lint
+```
+
+**What it does:**
+- Runs ruff linter on source and test code
+- Reports violations without auto-fixing
+
+**Equivalent command:**
+```bash
+uv run ruff check src/ tests/
+```
+
+### `type_check`
+
+Run mypy type checking.
+
+```bash
+doit type_check
+```
+
+**What it does:**
+- Runs mypy on `src/` directory
+- Uses configuration from `pyproject.toml`
+
+**Equivalent command:**
+```bash
+uv run mypy src/
+```
+
+### `check`
+
+Run all quality checks in sequence.
+
+```bash
+doit check
+```
+
+**What it does:**
+- Runs format check, lint, type check, security, spelling, and tests
+- Stops on first failure
+
+**Task dependencies:**
+- `format_check`
+- `lint`
+- `type_check`
+- `security` (if available)
+- `spell_check`
+- `test`
+
+### `spell_check`
+
+Check spelling in code and documentation.
+
+```bash
+doit spell_check
+```
+
+**What it does:**
+- Runs codespell on all text files
+- Uses configuration from `pyproject.toml` `[tool.codespell]`
+
+**Configuration example:**
+```toml
+[tool.codespell]
+skip = ".git,*.lock,tmp,htmlcov"
+ignore-words-list = "crate"
+```
+
+### `fmt_pyproject`
+
+Format `pyproject.toml` with pyproject-fmt.
+
+```bash
+doit fmt_pyproject
+```
+
+**What it does:**
+- Formats and validates pyproject.toml structure
+- Sorts dependencies alphabetically
+- Standardizes formatting
+
+---
+
+## Code Analysis Tasks
+
+### `complexity`
+
+Analyze cyclomatic complexity with radon.
+
+```bash
+doit complexity
+```
+
+**What it does:**
+- Analyzes all Python files for cyclomatic complexity
+- Reports functions/methods with complexity grades (A-F)
+- Grade A (1-5) is best, F (41+) indicates highly complex code
+
+**Interpretation:**
+
+| Grade | CC Score | Risk Level |
+|-------|----------|------------|
+| A | 1-5 | Low - simple, easy to test |
+| B | 6-10 | Low - slightly complex |
+| C | 11-20 | Moderate - more difficult to test |
+| D | 21-30 | High - difficult to test |
+| E | 31-40 | Very high - untestable |
+| F | 41+ | Extremely high - error-prone |
+
+**Target:** Keep all functions at grade B or better (CC ≤ 10).
+
+**Equivalent command:**
+```bash
+uv run radon cc src/ -a -s
+```
+
+### `maintainability`
+
+Analyze maintainability index with radon.
+
+```bash
+doit maintainability
+```
+
+**What it does:**
+- Calculates maintainability index for all modules
+- Higher scores indicate more maintainable code
+
+**Interpretation:**
+
+| Grade | MI Score | Meaning |
+|-------|----------|---------|
+| A | 20-100 | Highly maintainable |
+| B | 10-19 | Moderately maintainable |
+| C | 0-9 | Difficult to maintain |
+
+**Target:** Keep all modules at grade A (MI ≥ 20).
+
+**Equivalent command:**
+```bash
+uv run radon mi src/ -s
+```
+
+### `deadcode`
+
+Detect unused code with vulture.
+
+```bash
+doit deadcode
+```
+
+**What it does:**
+- Scans for unused functions, variables, imports, and classes
+- Uses configuration from `pyproject.toml` `[tool.vulture]`
+- Reports findings with confidence scores
+
+**Configuration example:**
+```toml
+[tool.vulture]
+min_confidence = 80
+paths = ["src", "tests"]
+ignore_names = ["test_*"]
+ignore_decorators = ["@pytest.fixture"]
+```
+
+**Handling false positives:**
+- Add to `ignore_names` in pyproject.toml
+- Add to `ignore_decorators` for framework-specific patterns
+- Use a whitelist file for complex cases
+
+See [Coding Standards - Dead Code Detection](coding-standards.md#dead-code-detection) for details.
+
+---
+
+## Security Tasks
+
+### `security`
+
+Run static security analysis with bandit.
+
+```bash
+doit security
+```
+
+**What it does:**
+- Scans Python code for security vulnerabilities
+- Uses configuration from `pyproject.toml` `[tool.bandit]`
+- Excludes tests, tmp, and .venv directories
+
+**Requires:** `[security]` extras installed (`uv sync --extra security`)
+
+### `audit`
+
+Run dependency vulnerability audit with pip-audit.
+
+```bash
+doit audit
+```
+
+**What it does:**
+- Scans all dependencies for known CVE vulnerabilities
+- Reports any security advisories
+
+**Requires:** `[security]` extras installed (`uv sync --extra security`)
+
+### `licenses`
+
+Check licenses of all dependencies.
+
+```bash
+doit licenses
+```
+
+**What it does:**
+- Lists all dependency licenses for compliance review
+- Outputs in markdown table format
+
+**Requires:** `[security]` extras installed (`uv sync --extra security`)
+
+---
+
+## Documentation Tasks
+
+### `docs_serve`
+
+Serve documentation locally with live reload.
+
+```bash
+doit docs_serve
+```
+
+**What it does:**
+- Starts MkDocs development server
+- Watches for file changes and auto-reloads
+- Available at http://127.0.0.1:8000
+
+**Equivalent command:**
+```bash
+uv run mkdocs serve
+```
+
+### `docs_build`
+
+Build static documentation site.
+
+```bash
+doit docs_build
+```
+
+**What it does:**
+- Builds documentation to `site/` directory
+- Ready for deployment
+
+**Equivalent command:**
+```bash
+uv run mkdocs build
+```
+
+### `docs_deploy`
+
+Deploy documentation to GitHub Pages.
+
+```bash
+doit docs_deploy
+```
+
+**What it does:**
+- Builds documentation
+- Pushes to `gh-pages` branch
+- Requires GitHub Pages enabled in repository settings
+
+**Equivalent command:**
+```bash
+uv run mkdocs gh-deploy
+```
+
+### `docs_toc`
+
+Generate documentation table of contents.
+
+```bash
+doit docs_toc
+```
+
+**What it does:**
+- Runs `tools/generate_doc_toc.py`
+- Generates `docs/TABLE_OF_CONTENTS.md` from frontmatter
+- Automatically runs as a pre-commit hook when docs change
+
+---
+
+## Dependency Tasks
+
+### `install`
+
+Install package with dependencies.
+
+```bash
+doit install
+```
+
+**What it does:**
+- Syncs dependencies from lock file
+- Installs package in editable mode
+
+**Equivalent command:**
+```bash
+uv sync
+```
+
+### `install_dev`
+
+Install package with development dependencies.
+
+```bash
+doit install_dev
+```
+
+**What it does:**
+- Syncs all dependencies including dev extras
+- Installs pre-commit hooks
+
+**Equivalent command:**
+```bash
+uv sync --all-extras --dev
+uv run pre-commit install
+```
+
+### `update_deps`
+
+Update dependencies and verify with tests.
+
+```bash
+doit update_deps
+```
+
+**What it does:**
+1. Updates all dependencies to latest compatible versions
+2. Regenerates lock file
+3. Runs test suite to verify nothing broke
+
+**When to use:**
+- Periodically to get security updates
+- Before releases to ensure latest dependencies work
+- After adding new dependencies
+
+**Equivalent commands:**
+```bash
+uv lock --upgrade
+uv sync --all-extras --dev
+uv run pytest
+```
+
+---
+
+## GitHub Workflow Tasks
+
+### `issue`
+
+Create a GitHub issue from a template.
+
+```bash
+# Interactive mode (opens $EDITOR)
+doit issue --type=feature
+
+# Non-interactive mode (for scripts/AI)
+doit issue --type=feature --title="Add feature" --body="## Problem\n..."
+doit issue --type=bug --title="Fix bug" --body-file=issue.md
+```
+
+**Issue types:**
+- `feature` - New feature request
+- `bug` - Bug report
+- `refactor` - Code refactoring
+- `doc` - Documentation improvement
+- `chore` - Maintenance task
+
+**Options:**
+- `--type` (required): Issue type
+- `--title`: Issue title (non-interactive)
+- `--body`: Issue body content (non-interactive)
+- `--body-file`: File containing issue body (non-interactive)
+
+### `pr`
+
+Create a pull request from a template.
+
+```bash
+# Interactive mode (opens $EDITOR)
+doit pr
+
+# Non-interactive mode
+doit pr --title="feat: add feature" --body="## Description\n..."
+doit pr --title="fix: bug fix" --body-file=pr.md
+
+# Create draft PR
+doit pr --draft
+```
+
+**Features:**
+- Auto-detects issue number from branch name (e.g., `feat/42-add-feature`)
+- Pre-fills template with branch information
+- Validates required fields
+
+**Options:**
+- `--title`: PR title (non-interactive)
+- `--body`: PR body content (non-interactive)
+- `--body-file`: File containing PR body (non-interactive)
+- `--draft`: Create as draft PR
+
+### `pr_merge`
+
+Merge a pull request with properly formatted commit message.
+
+```bash
+# Merge PR for current branch
+doit pr_merge
+
+# Merge specific PR
+doit pr_merge --pr=123
+```
+
+**What it does:**
+1. Finds PR associated with current branch (or uses `--pr`)
+2. Validates PR is approved and checks pass
+3. Merges with conventional commit format: `<type>: <subject> (merges PR #XX, closes #YY)`
+
+**Options:**
+- `--pr`: PR number to merge (defaults to PR for current branch)
+
+### `adr`
+
+Create an Architecture Decision Record.
+
+```bash
+# Interactive mode
+doit adr
+
+# Non-interactive mode
+doit adr --title="Use Redis for caching" --body="## Status\nAccepted\n..."
+doit adr --title="Use Redis" --body-file=adr.md
+```
+
+**What it does:**
+- Creates a new ADR in `docs/decisions/`
+- Auto-numbers based on existing ADRs
+- Uses ADR template format
+
+**Options:**
+- `--title`: ADR title (non-interactive)
+- `--body`: ADR body content (non-interactive)
+- `--body-file`: File containing ADR body (non-interactive)
+
+See [ADR Documentation](../decisions/README.md) for more information.
+
+---
+
+## Release Tasks
+
+### `release`
+
+Create a production release (full workflow).
+
+```bash
+doit release
+```
+
+**What it does:**
+1. Verifies you're on `main` branch
+2. Checks for uncommitted changes
+3. Pulls latest changes
+4. Runs governance validations (merge commit format, issue links)
+5. Runs all quality checks (`doit check`)
+6. Uses commitizen to bump version and update CHANGELOG.md
+7. Creates git tag
+8. Pushes commits and tags to trigger CI/CD
+
+**Requirements:**
+- Must be on `main` branch
+- No uncommitted changes
+- All checks must pass
+
+See [Release Automation](release-and-automation.md) for details.
+
+### `release_dev`
+
+Create a pre-release for TestPyPI testing.
+
+```bash
+# Create alpha (default)
+doit release_dev
+
+# Create beta
+doit release_dev --type=beta
+
+# Create release candidate
+doit release_dev --type=rc
+```
+
+**What it does:**
+1. Verifies branch (warns if not on main)
+2. Runs quality checks
+3. Creates pre-release tag (e.g., `v1.0.0-alpha.1`)
+4. Pushes to trigger TestPyPI publish
+
+**Options:**
+- `--type`: Pre-release type (`alpha`, `beta`, `rc`)
+
+### `release_pr`
+
+Create a release PR with changelog updates.
+
+```bash
+doit release_pr
+```
+
+**What it does:**
+- Creates a PR that includes version bump and changelog updates
+- Used for PR-based release workflows
+- Alternative to direct `doit release`
+
+### `release_tag`
+
+Tag a release after a release PR is merged.
+
+```bash
+doit release_tag
+```
+
+**What it does:**
+- Creates the release tag after `release_pr` is merged
+- Triggers CI/CD to build and publish
+
+### `publish`
+
+Build and publish package to PyPI.
+
+```bash
+doit publish
+```
+
+**What it does:**
+1. Builds package (`uv build`)
+2. Publishes to PyPI (`uv publish`)
+
+**Requirements:**
+- PyPI credentials configured
+- Package must build successfully
+
+**Note:** Typically triggered by CI/CD after release tag is pushed, not run manually.
+
+---
+
+## Version Tasks
+
+### `bump`
+
+Bump version based on conventional commits.
+
+```bash
+doit bump
+```
+
+**What it does:**
+- Analyzes commits since last tag
+- Determines version bump (major/minor/patch) from commit types
+- Updates version according to semantic versioning
+
+**Commit type → Version bump:**
+- `feat!` or `BREAKING CHANGE` → Major
+- `feat` → Minor
+- `fix`, `refactor`, `perf` → Patch
+
+### `changelog`
+
+Generate CHANGELOG from conventional commits.
+
+```bash
+doit changelog
+```
+
+**What it does:**
+- Generates/updates `CHANGELOG.md` from commit history
+- Groups changes by type (Features, Bug Fixes, etc.)
+- Uses commitizen for generation
+
+---
+
+## Setup Tasks
+
+### `pre_commit_install`
+
+Install pre-commit hooks.
+
+```bash
+doit pre_commit_install
+```
+
+**What it does:**
+- Installs pre-commit hooks to `.git/hooks/`
+- Hooks run automatically on `git commit`
+
+**Equivalent command:**
+```bash
+uv run pre-commit install
+```
+
+### `pre_commit_run`
+
+Run pre-commit on all files.
+
+```bash
+doit pre_commit_run
+```
+
+**What it does:**
+- Runs all pre-commit hooks on all files
+- Useful for checking entire codebase
+
+**Equivalent command:**
+```bash
+uv run pre-commit run --all-files
+```
+
+### `completions`
+
+Generate shell completion scripts.
+
+```bash
+doit completions
+```
+
+**What it does:**
+- Generates completion scripts in `completions/` directory
+- Creates `doit.bash` and `doit.zsh`
+
+**Output:**
+- `completions/doit.bash` - Bash completions
+- `completions/doit.zsh` - Zsh completions
+
+### `completions_install`
+
+Install shell completions to your shell config.
+
+```bash
+doit completions_install
+```
+
+**What it does:**
+1. Generates completion scripts
+2. Adds source lines to `~/.bashrc` and/or `~/.zshrc`
+3. Completions activate on next shell session
+
+**After installation:**
+```bash
+source ~/.bashrc   # For Bash
+source ~/.zshrc    # For Zsh
+```
+
+### `install_direnv`
+
+Install direnv for automatic environment loading.
+
+```bash
+doit install_direnv
+```
+
+**What it does:**
+- Installs direnv if not present
+- Provides instructions for shell integration
+
+**After installation:**
+```bash
+# Add to shell config (one-time)
+echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+
+# Allow direnv in project
+direnv allow
+```
+
+### `commit`
+
+Interactive commit with commitizen.
+
+```bash
+doit commit
+```
+
+**What it does:**
+- Opens interactive commit prompt
+- Ensures conventional commit format
+- Guides through commit message creation
+
+**Equivalent command:**
+```bash
+uv run cz commit
+```
+
+---
+
+## Maintenance Tasks
+
+### `cleanup`
+
+Clean build and cache artifacts (deep clean).
+
+```bash
+doit cleanup
+```
+
+**What it does:**
+- Removes `build/`, `dist/`, `*.egg-info/`
+- Removes `__pycache__/` directories
+- Removes `tmp/` directory
+- Removes `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`
+
+### `template_clean`
+
+Remove template-specific files after project setup.
+
+```bash
+# Remove setup files only (keep update checking)
+doit template_clean --setup
+
+# Remove all template files
+doit template_clean --all
+
+# Preview what would be deleted
+doit template_clean --dry-run
+```
+
+**Setup mode (`--setup`)** removes:
+- `bootstrap.py`
+- `tools/pyproject_template/setup_repo.py`
+- `tools/pyproject_template/migrate_existing_project.py`
+- `docs/template/new-project.md`
+- `docs/template/migration.md`
+
+**All mode (`--all`)** removes:
+- All setup files (above)
+- `tools/pyproject_template/` directory
+- `docs/template/` directory
+- `.config/pyproject_template/` directory
+
+**Options:**
+- `--setup`: Remove setup files only
+- `--all`: Remove all template files
+- `--dry-run`: Show what would be deleted
+
+See [Template Tools Reference](../template/tools-reference.md#cleanuppy) for details.
+
+### `build`
+
+Build the package.
+
+```bash
+doit build
+```
+
+**What it does:**
+- Builds source distribution and wheel
+- Output in `dist/` directory
+
+**Equivalent command:**
+```bash
+uv build
+```
+
+---
+
+## Pre-commit Hooks
+
+The following hooks run automatically on `git commit`:
+
+| Hook | Purpose |
+|------|---------|
+| `ruff` | Lint and auto-fix Python code |
+| `ruff-format` | Format Python code |
+| `mypy` | Type checking |
+| `bandit` | Security scanning (if installed) |
+| `codespell` | Spell checking |
+| `check-branch-name` | Enforce branch naming convention |
+| `generate-doc-toc` | Update documentation TOC |
+| `no-commit-to-main` | Prevent direct commits to main |
+| `no-local-config` | Prevent committing local config files |
+| `protect-dynamic-version` | Protect version configuration |
+| `conventional-pre-commit` | Enforce conventional commit format |
+
+### Dynamic Version Protection
+
+The `protect-dynamic-version` hook prevents accidental changes to the `dynamic` field in `pyproject.toml`. This ensures version management remains git-tag-based.
+
+**What it blocks:**
+- Any changes to the `dynamic = ["version"]` line
+
+**Why this matters:**
+- Version is derived from git tags via hatch-vcs
+- Modifying this breaks automated versioning
+- See [Release Automation](release-and-automation.md#automated-versioning) for details
+
+---
+
+## See Also
+
+- [Usage Guide](../usage/basics.md) - Development workflows
+- [Release Automation](release-and-automation.md) - Release process details
+- [Coding Standards](coding-standards.md) - Code quality guidelines
+- [CI/CD Testing](ci-cd-testing.md) - Continuous integration
+
+---
+
+[Back to Documentation Index](../index.md)

--- a/docs/development/extensions.md
+++ b/docs/development/extensions.md
@@ -1,0 +1,179 @@
+---
+title: Extensions
+description: How to extend pynetappfoundry
+audience:
+  - contributors
+tags:
+  - development
+  - extensions
+---
+
+# Extensions
+
+This guide covers how to extend pynetappfoundry with custom functionality.
+
+## Adding New CLI Commands
+
+### Create a New Command Group
+
+```python
+# src/pynetappfoundry/cli/custom.py
+import click
+from pynetappfoundry.cli import nf
+
+@nf.group()
+def custom():
+    """Custom commands."""
+    pass
+
+@custom.command()
+@click.option("--name", required=True, help="Name to greet")
+def greet(name: str):
+    """Greet someone."""
+    click.echo(f"Hello, {name}!")
+```
+
+### Register the Command
+
+Add the import to `src/pynetappfoundry/cli.py`:
+
+```python
+from pynetappfoundry.cli.custom import custom  # noqa: F401
+```
+
+## Adding New Clients
+
+### Create a Custom Client
+
+```python
+# src/pynetappfoundry/clients/custom/api.py
+from pynetappfoundry.clients.openapi import APIWrapper
+from pynetappfoundry.core.config import Config
+
+class CustomAPIClient(APIWrapper):
+    """Client for custom API."""
+
+    def __init__(self, config: Config, name: str):
+        super().__init__(config, name)
+        self.base_url = config.get_endpoint(name)
+
+    def get_resources(self) -> list[dict]:
+        """Get resources from API."""
+        return self._get("/resources")
+
+    def create_resource(self, data: dict) -> dict:
+        """Create a new resource."""
+        return self._post("/resources", data)
+```
+
+### Export from Package
+
+Add to `src/pynetappfoundry/__init__.py`:
+
+```python
+from pynetappfoundry.clients.custom.api import CustomAPIClient
+
+__all__ = [
+    # ... existing exports
+    "CustomAPIClient",
+]
+```
+
+## Adding New Database Models
+
+### Create a Database Class
+
+```python
+# src/pynetappfoundry/db/custom.py
+import sqlite3
+from pathlib import Path
+
+class CustomDB:
+    """Database for custom data."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self._init_db()
+
+    def _init_db(self):
+        """Initialize database schema."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute('''
+                CREATE TABLE IF NOT EXISTS custom_data (
+                    id INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    value TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            ''')
+
+    def store(self, name: str, value: str) -> int:
+        """Store data."""
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "INSERT INTO custom_data (name, value) VALUES (?, ?)",
+                (name, value)
+            )
+            return cursor.lastrowid
+
+    def get(self, name: str) -> list[dict]:
+        """Get data by name."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                "SELECT * FROM custom_data WHERE name = ?",
+                (name,)
+            )
+            return [dict(row) for row in cursor.fetchall()]
+```
+
+## Adding New Report Types
+
+### Create a Report Generator
+
+```python
+# src/pynetappfoundry/reports/custom.py
+from pathlib import Path
+from pynetappfoundry.core.config import Config
+
+class CustomReport:
+    """Generate custom reports."""
+
+    def __init__(self, config: Config):
+        self.config = config
+
+    def generate(self, data: list[dict], output: Path) -> None:
+        """Generate report from data."""
+        # Implementation here
+        pass
+```
+
+## Testing Extensions
+
+### Write Tests for Custom Code
+
+```python
+# tests/test_custom.py
+import pytest
+from pynetappfoundry.clients.custom.api import CustomAPIClient
+
+@pytest.fixture
+def mock_config(tmp_path):
+    """Create mock configuration."""
+    # Setup mock config
+    pass
+
+def test_custom_client_get_resources(mock_config):
+    """Test getting resources."""
+    client = CustomAPIClient(mock_config, "test")
+    # Add test assertions
+    pass
+```
+
+## Best Practices
+
+1. **Follow existing patterns** - Look at existing code for examples
+2. **Add type hints** - All public functions should have type annotations
+3. **Write tests** - Aim for high test coverage
+4. **Document public APIs** - Add docstrings to all public functions
+5. **Handle errors gracefully** - Use appropriate exception types

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -1,0 +1,703 @@
+---
+title: Release Automation & Security
+description: Automated versioning, release management, and security tooling
+audience:
+  - contributors
+  - maintainers
+tags:
+  - release
+  - security
+  - automation
+---
+
+# Release Automation & Security
+
+This guide covers automated versioning, release management, governance validation, and security tooling available in this Python project template.
+
+## Table of Contents
+- [Automated Versioning](#automated-versioning)
+- [Release Management](#release-management)
+- [PR Merging](#pr-merging)
+- [Security & Quality Tasks](#security-quality-tasks)
+- [Governance Validation](#governance-validation)
+- [Environment Configuration](#environment-configuration)
+
+## Automated Versioning
+
+This template uses **hatch-vcs** for automated, git tag-based versioning. Version numbers are derived from git tags - no manual edits to `pyproject.toml` or `_version.py` are required.
+
+### How It Works
+
+- **Git Tags**: Version source of truth (e.g., `v0.1.0`, `v1.0.0`)
+- **Automatic Generation**: The `_version.py` file is auto-generated during builds
+- **Dynamic Versioning**: Version is set to `dynamic = ["version"]` in `pyproject.toml`
+
+### Version Formats
+
+```bash
+# Production releases
+v1.0.0         # Major release
+v1.1.0         # Minor release (new features)
+v1.1.1         # Patch release (bug fixes)
+
+# Pre-releases (for TestPyPI)
+v1.0.0-alpha.1   # Alpha release
+v1.0.0-beta.1    # Beta release
+v1.0.0-rc.1      # Release candidate
+```
+
+### Checking Current Version
+
+```bash
+# From installed package (replace 'your-package' with your package name)
+uv run python -c "from importlib.metadata import version; print(version('your-package'))"
+
+# Development version (shows git-based dev version)
+# Example output: 0.0.1.dev519+g295cc7b6b.d20251229
+```
+
+## Release Management
+
+This template provides two automated release workflows powered by **commitizen**:
+
+### 1. Production Release (`doit release`)
+
+Creates a stable release for PyPI with full governance validation.
+
+```bash
+uv run doit release
+```
+
+**What it does:**
+1. ✅ Verifies you're on the `main` branch
+2. ✅ Checks for uncommitted changes
+3. ✅ Pulls latest changes from remote
+4. ✅ **Runs governance validations** (merge commit format, issue links)
+5. ✅ Runs all quality checks (`doit check`)
+6. ✅ Uses commitizen to:
+   - Analyze conventional commits since last tag
+   - Determine next version number (MAJOR, MINOR, PATCH)
+   - Update CHANGELOG.md (merges pre-release entries)
+   - Create git tag
+7. ✅ Pushes commits and tags to GitHub
+8. ✅ Triggers CI/CD to build and publish to PyPI
+
+**Example Output:**
+```
+======================================================================
+Starting automated release process...
+======================================================================
+
+Pulling latest changes...
+✓ Git pull successful.
+
+Running governance validations...
+
+Validating merge commit format...
+✓ All merge commits follow required format.
+
+Validating issue links in commits...
+✓ All non-docs commits reference issues.
+
+✓ Governance validations complete.
+
+Running all pre-release checks...
+✓ All checks passed.
+
+Bumping version and generating CHANGELOG with commitizen...
+✓ Version bumped and CHANGELOG updated (merged pre-releases).
+
+Pushing commits and tags to GitHub...
+✓ Pushed new commits and tags to GitHub.
+
+======================================================================
+✓ Automated release 1.0.0 complete!
+======================================================================
+
+Next steps:
+1. Monitor GitHub Actions for build and publish.
+2. Check PyPI: https://pypi.org/project/your-package/
+3. Verify the updated CHANGELOG.md in the repository.
+```
+
+### 2. Pre-release (`doit release_dev`)
+
+Creates alpha/beta/rc releases for TestPyPI testing.
+
+```bash
+# Create alpha pre-release (default)
+uv run doit release_dev
+
+# Create beta pre-release
+uv run doit release_dev --type=beta
+
+# Create release candidate
+uv run doit release_dev --type=rc
+```
+
+**What it does:**
+1. ✅ Verifies you're on the `main` branch (with warning option to continue)
+2. ✅ Checks for uncommitted changes
+3. ✅ Pulls latest changes
+4. ✅ Runs all quality checks
+5. ✅ Uses commitizen to create pre-release tag
+6. ✅ Pushes tag to trigger TestPyPI publish
+
+**No governance validation** - this is for testing only.
+
+### Release Workflow Best Practices
+
+```bash
+# 1. Develop features with conventional commits
+git commit -m "feat: add new feature"
+git commit -m "fix: resolve bug"
+
+# 2. Create alpha for testing
+uv run doit release_dev --type=alpha
+# --> Creates v0.2.0-alpha.1, publishes to TestPyPI
+
+# 3. Test the alpha release
+pip install --index-url https://test.pypi.org/simple/ your-package==0.2.0a1
+
+# 4. Fix issues, create beta
+git commit -m "fix: address alpha feedback"
+uv run doit release_dev --type=beta
+# --> Creates v0.2.0-beta.1
+
+# 5. Final testing, then production release
+uv run doit release
+# --> Creates v0.2.0, updates CHANGELOG, publishes to PyPI
+```
+
+## PR Merging
+
+Use `doit pr_merge` to merge pull requests with properly formatted commit messages. This task enforces the merge commit format and provides a consistent workflow.
+
+### Basic Usage
+
+```bash
+# Merge PR for current branch
+doit pr_merge
+
+# Merge specific PR by number
+doit pr_merge --pr=123
+
+# Keep the branch after merge (default deletes it)
+doit pr_merge --delete-branch=false
+```
+
+### What It Does
+
+1. **Validates PR title** - Ensures the title follows conventional commit format (`<type>: <subject>`)
+2. **Extracts linked issues** - Parses PR body for `closes #XX`, `fixes #XX`, or `part of #XX`
+3. **Formats merge commit** - Creates a standardized commit message with PR and issue references
+4. **Squash merges** - Uses squash merge to maintain clean history
+5. **Deletes branch** - Removes the source branch after merge (default behavior)
+6. **Reminds to close issues** - Displays commands to manually close linked issues
+
+### Merge Commit Format
+
+The task automatically formats the merge commit subject:
+
+```
+<type>: <subject> (merges PR #XX, closes #YY)
+<type>: <subject> (merges PR #XX, part of #YY)
+<type>: <subject> (merges PR #XX)
+```
+
+**Examples:**
+```
+feat: add user authentication (merges PR #102, closes #99)
+fix: resolve parsing error (merges PR #103, closes #100, #101)
+docs: update installation guide (merges PR #104)
+refactor: extract helper functions (merges PR #105, part of #50)
+```
+
+### Linking Issues in PRs
+
+In your PR body, use these keywords to link issues:
+
+| Keyword | Effect | Use When |
+|---------|--------|----------|
+| `closes #XX`, `fixes #XX`, `resolves #XX` | Included as `closes #XX` in merge commit | PR fully completes the issue |
+| `part of #XX` | Included as `part of #XX` in merge commit | Issue requires multiple PRs |
+
+**Example PR body:**
+```markdown
+## Summary
+- Add login form component
+- Implement session management
+
+Closes #99
+
+## Test Plan
+- [ ] Test login flow
+```
+
+For multi-PR issues:
+```markdown
+## Summary
+First part of the authentication system refactor.
+
+Part of #50
+
+## Test Plan
+- [ ] Existing tests pass
+```
+
+### Closing Issues After Merge
+
+Issues are **not automatically closed** by GitHub when using squash merge with custom commit messages. After merging, manually close linked issues:
+
+```bash
+# The task displays these commands after merge
+gh issue close 99 --comment "Fixed in PR #102"
+gh issue close 100 --comment "Fixed in PR #103"
+```
+
+This ensures issues are explicitly closed with a reference to the PR that fixed them.
+
+### Why Use `doit pr_merge`?
+
+| Direct `gh pr merge` | `doit pr_merge` |
+|---------------------|-----------------|
+| Default commit message | Enforced format with PR/issue links |
+| May not validate title | Validates conventional commit format |
+| Manual issue tracking | Extracts and displays linked issues |
+| No post-merge guidance | Reminds to close issues |
+
+## Security & Quality Tasks
+
+This template includes comprehensive security scanning and code quality tools.
+
+### Security Tasks
+
+```bash
+# Run dependency vulnerability audit (pip-audit)
+uv run doit audit
+
+# Run static security analysis (bandit)
+uv run doit security
+
+# Check all dependency licenses
+uv run doit licenses
+```
+
+**Installing Security Tools:**
+```bash
+# Security tools are optional to keep dev environment lean
+uv sync --extra security
+```
+
+### Quality Tasks
+
+```bash
+# Check spelling in code and docs (codespell)
+uv run doit spell_check
+
+# Format pyproject.toml (pyproject-fmt)
+uv run doit fmt_pyproject
+```
+
+### Task Details
+
+#### `doit audit`
+- **Tool**: pip-audit
+- **Purpose**: Scans dependencies for known CVE vulnerabilities
+- **When**: Run before releases, periodically in CI
+- **Example**:
+  ```bash
+  $ uv run doit audit
+  No known vulnerabilities found
+  ```
+
+#### `doit security`
+- **Tool**: bandit
+- **Purpose**: Static security analysis of Python code
+- **Configuration**: See `[tool.bandit]` in `pyproject.toml`
+- **Excludes**: tests/, tmp/, .venv/
+- **Example**:
+  ```bash
+  $ uv run doit security
+  [main]  INFO    profile include tests: None
+  [main]  INFO    profile exclude tests: None
+  [main]  INFO    running on Python 3.12.0
+  Run started
+  ...
+  Code scanned:
+          Total lines of code: 5234
+          Total lines skipped: 123
+  ```
+
+#### `doit spell_check`
+- **Tool**: codespell
+- **Purpose**: Catches typos in code, tests, docs, README
+- **Configuration**: See `[tool.codespell]` in `pyproject.toml`
+- **Example**:
+  ```bash
+  $ uv run doit spell_check
+  # Checks all files for common typos and suggests corrections
+  ```
+
+#### `doit fmt_pyproject`
+- **Tool**: pyproject-fmt
+- **Purpose**: Formats and validates pyproject.toml structure
+- **Auto-fixes**: Sorts dependencies, standardizes formatting
+- **Example**:
+  ```bash
+  $ uv run doit fmt_pyproject
+  Formatted pyproject.toml
+  ```
+
+#### `doit licenses`
+- **Tool**: pip-licenses
+- **Purpose**: Lists all dependency licenses for compliance
+- **Output**: Markdown table by license type
+- **Example**:
+  ```bash
+  $ uv run doit licenses
+  | Name         | Version | License     |
+  |--------------|---------|-------------|
+  | click        | 8.1.7   | BSD-3-Clause|
+  | pydantic     | 2.5.0   | MIT         |
+  ```
+
+### Integrating into CI
+
+Add security checks to your CI pipeline:
+
+```yaml
+# .github/workflows/security.yml
+name: Security Scan
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly
+  workflow_dispatch:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v1
+      - name: Run security audit
+        run: uv run doit audit
+      - name: Run bandit scan
+        run: uv run doit security
+```
+
+## Governance Validation
+
+This template enforces governance rules to ensure code quality and traceability.
+
+### Validation Functions
+
+#### 1. Merge Commit Format Validation
+
+**Purpose**: Ensures all merge commits follow conventional format with PR/issue links.
+
+**Required Format**:
+```
+<type>: <subject> (merges PR #XX, closes #YY)
+<type>: <subject> (merges PR #XX, part of #YY)
+<type>: <subject> (merges PR #XX)
+```
+
+**Examples**:
+```
+✅ feat: add new feature (merges PR #102, closes #99)
+✅ fix: resolve bug (merges PR #103, closes #100)
+✅ docs: update guide (merges PR #104)
+✅ refactor: extract utils (merges PR #105, part of #50)
+
+❌ Add new feature                    # Missing type
+❌ feat: add feature                  # Missing PR reference
+❌ feat: add feature (PR #102)        # Wrong format
+```
+
+Use `closes` when the PR fully resolves an issue. Use `part of` when an issue requires multiple PRs to complete. See [PR Merging](#pr-merging) for details.
+
+**Valid Types**: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf`
+
+**When It Runs**: During `doit release` (blocks on failure)
+
+#### 2. Issue Link Validation
+
+**Purpose**: Encourages linking commits to issues for better tracking.
+
+**Checks**: All non-docs, non-merge commits should reference an issue (`#123`)
+
+**Examples**:
+```
+✅ feat: add new feature (#99)
+✅ fix: resolve bug closes #100
+✅ docs: update README                # Docs exempt
+
+⚠️ feat: add new feature             # Warning only
+```
+
+**When It Runs**: During `doit release` (warning only, doesn't block)
+
+### Pre-commit Hooks
+
+The template includes pre-commit hooks that run on every commit:
+
+```yaml
+# .pre-commit-config.yaml
+hooks:
+  - ruff-format: Auto-format Python code
+  - ruff-check: Lint and auto-fix issues
+  - mypy: Type checking (strict mode)
+  - tests: Run test suite
+  - check-branch-name: Enforce branch naming convention
+```
+
+**Branch Naming Convention**:
+```
+✅ issue/99-feature-name
+✅ feat/102-add-feature
+✅ fix/103-resolve-bug
+✅ docs/installation-guide
+✅ hotfix/critical-fix
+✅ release/v1.0.0
+✅ main
+✅ develop
+
+❌ my-feature-branch
+❌ fix-bug
+❌ random-name
+```
+
+### Conventional Commits
+
+All commits should follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+**Format**:
+```
+<type>[(scope)]: <subject>
+
+[optional body]
+
+[optional footer]
+```
+
+**Types**:
+- `feat`: New feature (triggers MINOR version bump)
+- `fix`: Bug fix (triggers PATCH version bump)
+- `refactor`: Code refactoring (triggers PATCH version bump)
+- `perf`: Performance improvement (triggers PATCH version bump)
+- `docs`: Documentation only
+- `test`: Adding/updating tests
+- `chore`: Maintenance tasks
+- `ci`: CI/CD changes
+
+**Breaking Changes** (triggers MAJOR version bump):
+```
+feat!: redesign API
+
+BREAKING CHANGE: API interface has changed. See migration guide.
+```
+
+**Examples**:
+```bash
+# Feature commit
+git commit -m "feat: add new capability (#99)"
+
+# Bug fix commit
+git commit -m "fix: resolve parsing issue (#100)"
+
+# Documentation commit
+git commit -m "docs: add release guide"
+
+# Breaking change
+git commit -m "feat!: redesign plugin system
+
+BREAKING CHANGE: Plugin registration API has changed.
+Plugins must now implement the new PluginProtocol interface.
+See docs/template/migration.md for upgrade instructions."
+```
+
+## Environment Configuration
+
+### Using direnv (Recommended)
+
+This template supports `direnv` for automatic environment management:
+
+```bash
+# Install direnv
+uv run doit install_direnv
+
+# Hook into your shell (one-time)
+echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+source ~/.bashrc
+
+# Allow direnv in this directory
+direnv allow
+```
+
+Once configured, direnv automatically:
+- Activates the virtual environment
+- Sets cache directories (UV_CACHE_DIR, RUFF_CACHE_DIR, etc.)
+- Loads project-specific environment variables
+- Creates tmp/ directory structure
+
+### Manual Environment Setup
+
+Without direnv:
+
+```bash
+# Activate virtual environment
+source .venv/bin/activate
+
+# Set cache directories (optional but recommended)
+export UV_CACHE_DIR="$(pwd)/tmp/.uv_cache"
+export RUFF_CACHE_DIR="$(pwd)/tmp/.ruff_cache"
+export MYPY_CACHE_DIR="$(pwd)/tmp/.mypy_cache"
+export COVERAGE_FILE="$(pwd)/tmp/.coverage"
+
+# Create tmp directory
+mkdir -p tmp
+```
+
+### Cache Management
+
+All cache files are stored in `tmp/` to keep the project root clean:
+
+```
+tmp/
+├── .uv_cache/         # uv package cache
+├── .ruff_cache/       # ruff linter cache
+├── .mypy_cache/       # mypy type checker cache
+├── .coverage          # coverage data
+└── htmlcov/           # coverage HTML reports
+```
+
+The `tmp/` directory is gitignored and can be safely deleted:
+
+```bash
+# Clean all caches
+rm -rf tmp/
+doit cleanup  # Also removes build artifacts
+```
+
+## Quick Reference
+
+### Common Tasks
+
+```bash
+# Development
+uv run doit format          # Format code
+uv run doit lint            # Run linter
+uv run doit type_check      # Run mypy
+uv run doit test            # Run tests
+uv run doit check           # Run all checks
+
+# Security & Quality
+uv run doit audit           # Vulnerability scan
+uv run doit security        # Security analysis
+uv run doit spell_check     # Spell checking
+uv run doit licenses        # License compliance
+
+# Releases
+uv run doit release_dev     # Create pre-release (TestPyPI)
+uv run doit release         # Create production release (PyPI)
+```
+
+### Installation Options
+
+```bash
+# Standard development setup
+uv sync --dev
+
+# Include security tools
+uv sync --dev --extra security
+
+# Include all extras
+uv sync --dev --all-extras
+```
+
+### Pre-commit
+
+```bash
+# Install hooks
+uv run pre-commit install
+
+# Run manually on all files
+uv run pre-commit run --all-files
+
+# Skip hooks (emergency only)
+git commit --no-verify
+```
+
+## Troubleshooting
+
+### Release Fails: "Not on main branch"
+
+**Problem**: `doit release` requires main branch
+
+**Solution**:
+```bash
+git checkout main
+git pull
+uv run doit release
+```
+
+### Release Fails: "Uncommitted changes"
+
+**Problem**: Working directory has uncommitted changes
+
+**Solution**:
+```bash
+git status
+git add .
+git commit -m "feat: finalize changes before release"
+uv run doit release
+```
+
+### Governance Validation Fails
+
+**Problem**: Merge commit format doesn't match required pattern
+
+**Solution**: Use `doit pr_merge` which automatically formats the commit message:
+```bash
+# Merge the PR with proper format
+doit pr_merge --pr=102
+```
+
+If you need to fix an existing merge commit, use interactive rebase (advanced):
+```bash
+git rebase -i HEAD~1
+# Change 'pick' to 'reword', then edit the message to:
+# feat: add new feature (merges PR #102, closes #99)
+```
+
+### Security Task Fails: "pip-audit not installed"
+
+**Problem**: Security tools are optional dependencies
+
+**Solution**:
+```bash
+uv sync --extra security
+uv run doit audit
+```
+
+### Spell Check Finds False Positives
+
+**Problem**: Technical terms flagged as typos
+
+**Solution**: Add to ignore list in `pyproject.toml`:
+```toml
+[tool.codespell]
+ignore-words-list = "crate,kubernetes,terraform"
+```
+
+## See Also
+
+- [Coding Standards](coding-standards.md) - Code style guidelines
+- [CI/CD Testing](ci-cd-testing.md) - Continuous integration setup
+
+---
+
+[Back to Documentation Index](../index.md)

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,113 @@
+---
+title: Examples
+description: Code examples for pynetappfoundry
+audience:
+  - users
+tags:
+  - examples
+  - tutorial
+---
+
+# Examples
+
+This section contains example code demonstrating common use cases for pynetappfoundry.
+
+## Quick Examples
+
+### Connect to a Cluster
+
+```python
+from pynetappfoundry import Config, ONTAPAPIClient
+
+# Load configuration
+config = Config()
+
+# Create client
+client = ONTAPAPIClient(config, "cluster1")
+
+# Get cluster info
+info = client.get_cluster_info()
+print(f"Cluster: {info['name']}")
+```
+
+### Run CLI Commands
+
+```python
+from pynetappfoundry import Config, ONTAPCLI
+
+config = Config()
+cli = ONTAPCLI(config, "cluster1")
+
+# Run a command
+output = cli.run_command("volume show -fields size,used")
+print(output)
+```
+
+### Collect Metrics
+
+```python
+from pynetappfoundry import MetricDB, ONTAPAPIClient, Config
+
+config = Config()
+client = ONTAPAPIClient(config, "cluster1")
+db = MetricDB("metrics.db")
+
+# Collect volume metrics
+volumes = client.get_volumes()
+for vol in volumes:
+    db.store_metric("cluster1", f"volume_{vol['name']}_used", vol['used'])
+```
+
+### Monitor Events
+
+```python
+from pynetappfoundry import EmsEventsDB, ONTAPAPIClient, Config
+
+config = Config()
+client = ONTAPAPIClient(config, "cluster1")
+db = EmsEventsDB("events.db")
+
+# Fetch and store events
+events = client.get_ems_events(hours=24)
+for event in events:
+    db.store_event(event)
+
+# Query errors
+errors = db.get_events(severity="error")
+```
+
+## CLI Examples
+
+### License Management
+
+```bash
+# List all licenses
+nf licenses list
+
+# Export to Excel
+nf licenses export --format xlsx -o licenses.xlsx
+```
+
+### Report Generation
+
+```bash
+# Generate space report
+nf reports space --all-clusters
+
+# Generate volume report for specific SVM
+nf reports volume --cluster cluster1 --svm svm1 -o volumes.html
+```
+
+### Event Monitoring
+
+```bash
+# Fetch recent events
+nf events fetch --hours 24 --all-clusters
+
+# Export error events
+nf events export --severity error --format csv -o errors.csv
+```
+
+## More Examples
+
+- [API Examples](api.md) - Detailed API usage examples

--- a/docs/examples/api.md
+++ b/docs/examples/api.md
@@ -1,0 +1,198 @@
+---
+title: API Examples
+description: Detailed Python API usage examples
+audience:
+  - users
+tags:
+  - examples
+  - api
+---
+
+# API Examples
+
+Detailed examples for using the pynetappfoundry Python API.
+
+## Configuration Examples
+
+### Custom Configuration Directory
+
+```python
+from pynetappfoundry import Config
+
+# Use custom config directory
+config = Config(config_dir="/path/to/config")
+```
+
+### Multiple Clusters
+
+```python
+from pynetappfoundry import Config, ONTAPAPIClient
+
+config = Config()
+
+# Create clients for multiple clusters
+clusters = ["cluster1", "cluster2", "cluster3"]
+clients = {name: ONTAPAPIClient(config, name) for name in clusters}
+
+# Query all clusters
+for name, client in clients.items():
+    info = client.get_cluster_info()
+    print(f"{name}: {info['version']}")
+```
+
+## ONTAP API Examples
+
+### Get Volume Information
+
+```python
+from pynetappfoundry import Config, ONTAPAPIClient
+
+config = Config()
+client = ONTAPAPIClient(config, "cluster1")
+
+# Get all volumes
+volumes = client.get_volumes()
+for vol in volumes:
+    print(f"Volume: {vol['name']}, Size: {vol['size']}, Used: {vol['used']}")
+
+# Get volumes for specific SVM
+svm_volumes = client.get_volumes(svm="svm1")
+```
+
+### Get Aggregate Information
+
+```python
+# Get all aggregates
+aggregates = client.get_aggregates()
+for aggr in aggregates:
+    pct_used = (aggr['used'] / aggr['size']) * 100
+    print(f"Aggregate: {aggr['name']}, Used: {pct_used:.1f}%")
+```
+
+### Get LIF Information
+
+```python
+# Get all network interfaces
+lifs = client.get_lifs()
+for lif in lifs:
+    print(f"LIF: {lif['name']}, IP: {lif['ip']}, Status: {lif['status']}")
+```
+
+## CLI Examples
+
+### Run ONTAP CLI Commands
+
+```python
+from pynetappfoundry import Config, ONTAPCLI
+
+config = Config()
+cli = ONTAPCLI(config, "cluster1")
+
+# Run system commands
+output = cli.run_command("system node show")
+print(output)
+
+# Run volume commands
+output = cli.run_command("volume show -fields size,used,available")
+print(output)
+```
+
+### Parse CLI Output
+
+```python
+# Run command and parse output
+output = cli.run_command("df -h")
+lines = output.strip().split('\n')
+for line in lines[1:]:  # Skip header
+    parts = line.split()
+    if len(parts) >= 4:
+        print(f"Filesystem: {parts[0]}, Used: {parts[2]}")
+```
+
+## Database Examples
+
+### Metrics Collection and Querying
+
+```python
+from pynetappfoundry import MetricDB
+from datetime import datetime, timedelta
+
+db = MetricDB("metrics.db")
+
+# Store metrics
+db.store_metric("cluster1", "volume_count", 150)
+db.store_metric("cluster1", "aggregate_used_pct", 75.5)
+
+# Query recent metrics
+metrics = db.get_metrics(
+    cluster="cluster1",
+    start_time=datetime.now() - timedelta(hours=24)
+)
+
+for metric in metrics:
+    print(f"{metric['name']}: {metric['value']} at {metric['timestamp']}")
+```
+
+### Event Storage and Querying
+
+```python
+from pynetappfoundry import EmsEventsDB
+
+db = EmsEventsDB("events.db")
+
+# Store events (usually from API fetch)
+event = {
+    "cluster": "cluster1",
+    "time": "2024-01-15T10:30:00Z",
+    "severity": "error",
+    "message": "Disk failed in aggregate aggr1"
+}
+db.store_event(event)
+
+# Query events
+errors = db.get_events(severity="error", limit=100)
+for error in errors:
+    print(f"[{error['time']}] {error['message']}")
+```
+
+## Error Handling
+
+### Handle Connection Errors
+
+```python
+from pynetappfoundry import Config, ONTAPAPIClient
+from pynetappfoundry.clients.ontap.cli import CLICommandError
+
+config = Config()
+
+try:
+    client = ONTAPAPIClient(config, "cluster1")
+    volumes = client.get_volumes()
+except ConnectionError as e:
+    print(f"Failed to connect: {e}")
+except CLICommandError as e:
+    print(f"CLI command failed: {e}")
+```
+
+### Retry Logic
+
+```python
+import time
+from pynetappfoundry import Config, ONTAPAPIClient
+
+config = Config()
+
+def get_volumes_with_retry(cluster, max_retries=3):
+    for attempt in range(max_retries):
+        try:
+            client = ONTAPAPIClient(config, cluster)
+            return client.get_volumes()
+        except ConnectionError:
+            if attempt < max_retries - 1:
+                time.sleep(5 * (attempt + 1))
+            else:
+                raise
+    return []
+
+volumes = get_volumes_with_retry("cluster1")
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,156 @@
+---
+title: Installation Guide
+description: How to install and set up your project
+audience:
+  - users
+  - contributors
+tags:
+  - getting-started
+  - setup
+---
+
+# Installation Guide
+
+> **Setting up from the template?** See the [New Project Setup](../template/new-project.md) guide instead.
+
+## Requirements
+
+- Python 3.12 or higher
+- pip or uv
+
+## Install from PyPI
+
+### Using pip
+
+```bash
+pip install pynetappfoundry
+```
+
+### Using uv (recommended)
+
+```bash
+uv pip install pynetappfoundry
+```
+
+## Install from Source
+
+### Clone the Repository
+
+```bash
+git clone https://github.com/endavis/pynetappfoundry.git
+cd pynetappfoundry
+```
+
+### Install in Development Mode
+
+```bash
+# Using uv (recommended)
+uv venv
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+
+# Using pip
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+## Optional Dependencies
+
+### Security Auditing
+
+Install security audit tools:
+
+```bash
+uv pip install -e ".[security]"
+```
+
+This adds:
+- `pip-audit` - Security vulnerability scanner
+- `bandit` - Security issue detector in Python code
+
+### All Optional Dependencies
+
+```bash
+uv pip install -e ".[dev,security]"
+```
+
+## Verify Installation
+
+Check that the package is installed correctly:
+
+```python
+import pynetappfoundry
+print(pynetappfoundry.__version__)
+```
+
+Or from the command line:
+
+```bash
+nf --version
+```
+
+## Upgrading
+
+### From PyPI
+
+```bash
+pip install --upgrade pynetappfoundry
+```
+
+### From Source
+
+```bash
+cd pynetappfoundry
+git pull
+uv pip install -e ".[dev]"
+```
+
+## Uninstallation
+
+```bash
+pip uninstall pynetappfoundry
+```
+
+## Troubleshooting
+
+### Python Version Issues
+
+Ensure you're using Python 3.12 or higher:
+
+```bash
+python --version
+```
+
+If you have multiple Python versions:
+
+```bash
+python3.12 -m pip install pynetappfoundry
+```
+
+### Virtual Environment Issues
+
+If you encounter issues, try creating a fresh virtual environment:
+
+```bash
+rm -rf .venv
+uv venv
+source .venv/bin/activate
+uv pip install pynetappfoundry
+```
+
+### Permission Errors
+
+If you get permission errors, use a virtual environment instead of installing globally:
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install pynetappfoundry
+```
+
+## Next Steps
+
+- Read the [Usage Guide](../usage/basics.md) to learn how to use the package
+- Check the [API Reference](../reference/api.md) for detailed documentation
+- See [Examples](../examples/README.md) for usage examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,85 @@
+---
+title: pynetappfoundry Documentation
+description: ONTAP administration library and CLI tools
+audience:
+  - users
+  - contributors
+tags:
+  - overview
+  - getting-started
+---
+
+# pynetappfoundry Documentation
+
+ONTAP administration library and CLI tools for NetApp storage management.
+
+## Overview
+
+pynetappfoundry provides a comprehensive Python library and command-line interface for managing NetApp ONTAP clusters. It supports both REST API and SSH CLI access for flexible administration tasks.
+
+## Quick Links
+
+- [Installation Guide](getting-started/installation.md)
+- [Usage Guide](usage/basics.md)
+- [CLI Reference](reference/cli.md)
+- [API Reference](reference/api.md)
+- [Contributing](https://github.com/endavis/pynetappfoundry/blob/main/.github/CONTRIBUTING.md)
+
+## Features
+
+- **License Management** - Track and report on cluster licenses
+- **Space Reporting** - Generate detailed storage capacity reports
+- **Event Tracking** - Monitor and analyze EMS events
+- **Metrics Collection** - Gather performance and usage metrics
+- **Multi-cluster Support** - Manage multiple ONTAP clusters
+- **REST API Support** - Full ONTAP REST API integration via netapp-ontap SDK
+- **SSH CLI Support** - Direct CLI access via Paramiko
+
+## Quick Start
+
+```bash
+# Install from PyPI
+pip install pynetappfoundry
+
+# Or install with uv
+uv add pynetappfoundry
+
+# Run CLI
+nf --help
+```
+
+```python
+from pynetappfoundry import ONTAPAPIClient, Config
+
+# Initialize configuration
+config = Config()
+
+# Connect to ONTAP cluster
+client = ONTAPAPIClient(config, "cluster1")
+```
+
+## Documentation Sections
+
+### For Users
+
+- **[Installation](getting-started/installation.md)** - How to install the package
+- **[Usage Guide](usage/basics.md)** - How to use the package
+- **[CLI Reference](reference/cli.md)** - Command-line interface documentation
+- **[API Reference](reference/api.md)** - Python API documentation
+
+### For Contributors
+
+- **[Contributing Guide](https://github.com/endavis/pynetappfoundry/blob/main/.github/CONTRIBUTING.md)** - Development workflow, coding standards, and best practices
+- **[Code of Conduct](https://github.com/endavis/pynetappfoundry/blob/main/.github/CODE_OF_CONDUCT.md)** - Community guidelines
+- **[AI Agent Setup](development/AI_SETUP.md)** - Setup guide for AI coding assistants
+- **[Development Tasks](development/doit-tasks-reference.md)** - doit task runner reference
+
+## Support
+
+- **Issues:** [GitHub Issues](https://github.com/endavis/pynetappfoundry/issues)
+- **Discussions:** [GitHub Discussions](https://github.com/endavis/pynetappfoundry/discussions)
+- **Security:** See [SECURITY.md](https://github.com/endavis/pynetappfoundry/blob/main/.github/SECURITY.md)
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/endavis/pynetappfoundry/blob/main/LICENSE) file for details.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,135 @@
+---
+title: API Reference
+description: Python API documentation
+audience:
+  - users
+  - contributors
+tags:
+  - reference
+  - api
+---
+
+# API Reference
+
+Python API documentation for pynetappfoundry.
+
+## Core Classes
+
+### Config
+
+Configuration management for cluster connections.
+
+::: pynetappfoundry.core.config.Config
+    options:
+      show_root_heading: true
+      show_source: false
+
+### setup_logger
+
+Logging configuration.
+
+::: pynetappfoundry.core.logging.setup_logger
+    options:
+      show_root_heading: true
+      show_source: false
+
+## ONTAP Clients
+
+### ONTAPAPIClient
+
+REST API client for ONTAP clusters.
+
+::: pynetappfoundry.clients.ontap.api.ONTAPAPIClient
+    options:
+      show_root_heading: true
+      show_source: false
+
+### ONTAPCLI
+
+SSH CLI client for ONTAP clusters.
+
+::: pynetappfoundry.clients.ontap.cli.ONTAPCLI
+    options:
+      show_root_heading: true
+      show_source: false
+
+### CLICommandError
+
+Exception raised when CLI commands fail.
+
+::: pynetappfoundry.clients.ontap.cli.CLICommandError
+    options:
+      show_root_heading: true
+      show_source: false
+
+## Database Classes
+
+### MetricDB
+
+Database for storing cluster metrics.
+
+::: pynetappfoundry.db.metrics.MetricDB
+    options:
+      show_root_heading: true
+      show_source: false
+
+### EmsEventsDB
+
+Database for storing EMS events.
+
+::: pynetappfoundry.db.ems.EmsEventsDB
+    options:
+      show_root_heading: true
+      show_source: false
+
+### AzEventsDB
+
+Database for storing Azure events.
+
+::: pynetappfoundry.db.azevents.AzEventsDB
+    options:
+      show_root_heading: true
+      show_source: false
+
+## Utility Classes
+
+### APIWrapper
+
+Generic OpenAPI wrapper for REST APIs.
+
+::: pynetappfoundry.clients.openapi.APIWrapper
+    options:
+      show_root_heading: true
+      show_source: false
+
+### DIIAPIClient
+
+DII API client.
+
+::: pynetappfoundry.clients.dii.api.DIIAPIClient
+    options:
+      show_root_heading: true
+      show_source: false
+
+## Module Structure
+
+```
+pynetappfoundry/
+├── __init__.py          # Package exports
+├── _version.py          # Version (generated)
+├── cli.py               # Click CLI entry point
+├── core/
+│   ├── config.py        # Configuration management
+│   └── logging.py       # Logging setup
+├── clients/
+│   ├── openapi.py       # Generic API wrapper
+│   ├── ontap/
+│   │   ├── api.py       # REST API client
+│   │   └── cli.py       # SSH CLI client
+│   └── dii/
+│       └── api.py       # DII API client
+└── db/
+    ├── metrics.py       # Metrics database
+    ├── ems.py           # EMS events database
+    └── azevents.py      # Azure events database
+```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,187 @@
+---
+title: CLI Reference
+description: Command-line interface documentation
+audience:
+  - users
+tags:
+  - reference
+  - cli
+---
+
+# CLI Reference
+
+Complete reference for the `nf` command-line interface.
+
+## Global Options
+
+All commands support these global options:
+
+| Option | Description |
+|--------|-------------|
+| `--version` | Show version and exit |
+| `-c, --config-dir PATH` | Configuration directory path |
+| `-o, --output-dir PATH` | Output directory path |
+| `--debug / --no-debug` | Enable debug logging |
+| `--help` | Show help and exit |
+
+## Commands
+
+### licenses
+
+License management commands.
+
+```bash
+nf licenses [OPTIONS] COMMAND [ARGS]...
+```
+
+**Subcommands:**
+
+| Command | Description |
+|---------|-------------|
+| `list` | List licenses for clusters |
+| `export` | Export licenses to file |
+| `check` | Check license compliance |
+
+### reports
+
+Report generation commands.
+
+```bash
+nf reports [OPTIONS] COMMAND [ARGS]...
+```
+
+**Subcommands:**
+
+| Command | Description |
+|---------|-------------|
+| `space` | Generate space utilization report |
+| `aggregate` | Generate aggregate report |
+| `volume` | Generate volume report |
+| `performance` | Generate performance report |
+
+### events
+
+Event management commands.
+
+```bash
+nf events [OPTIONS] COMMAND [ARGS]...
+```
+
+**Subcommands:**
+
+| Command | Description |
+|---------|-------------|
+| `fetch` | Fetch events from clusters |
+| `list` | List stored events |
+| `export` | Export events to file |
+| `clear` | Clear event database |
+
+### metrics
+
+Metrics collection commands.
+
+```bash
+nf metrics [OPTIONS] COMMAND [ARGS]...
+```
+
+**Subcommands:**
+
+| Command | Description |
+|---------|-------------|
+| `collect` | Collect metrics from clusters |
+| `query` | Query stored metrics |
+| `export` | Export metrics to file |
+
+### utils
+
+Utility commands.
+
+```bash
+nf utils [OPTIONS] COMMAND [ARGS]...
+```
+
+**Subcommands:**
+
+| Command | Description |
+|---------|-------------|
+| `config` | Configuration management |
+| `test-connection` | Test cluster connectivity |
+| `version` | Show detailed version info |
+
+## Examples
+
+### License Management
+
+```bash
+# List all licenses
+nf licenses list
+
+# List licenses for specific cluster
+nf licenses list --cluster cluster1
+
+# Export to Excel
+nf licenses export --format xlsx -o licenses.xlsx
+
+# Check compliance
+nf licenses check --cluster cluster1
+```
+
+### Report Generation
+
+```bash
+# Space report for all clusters
+nf reports space --all-clusters
+
+# Volume report with filtering
+nf reports volume --cluster cluster1 --svm svm1
+
+# Export report to HTML
+nf reports space --format html -o space-report.html
+```
+
+### Event Monitoring
+
+```bash
+# Fetch last 24 hours of events
+nf events fetch --hours 24
+
+# Fetch events for specific cluster
+nf events fetch --cluster cluster1 --hours 48
+
+# List error events
+nf events list --severity error
+
+# Export to CSV
+nf events export --format csv -o events.csv
+```
+
+### Metrics Collection
+
+```bash
+# Collect all metrics
+nf metrics collect --all-clusters
+
+# Query specific metric
+nf metrics query --metric volume_used --cluster cluster1
+
+# Export metrics
+nf metrics export --format json -o metrics.json
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `NF_CONFIG_DIR` | Default configuration directory |
+| `NF_OUTPUT_DIR` | Default output directory |
+| `NF_DEBUG` | Enable debug mode (1/true) |
+
+## Exit Codes
+
+| Code | Description |
+|------|-------------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Configuration error |
+| 3 | Connection error |
+| 4 | Authentication error |

--- a/docs/template/ai-sync-checklist.md
+++ b/docs/template/ai-sync-checklist.md
@@ -1,0 +1,253 @@
+---
+title: AI Agent Sync Checklist
+description: Step-by-step checklist for AI agents synchronizing downstream projects with pyproject-template
+audience:
+  - ai-agents
+tags:
+  - template
+  - sync
+  - ai
+---
+
+# AI Agent Checklist: Synchronize with pyproject-template
+
+This checklist guides an AI agent through synchronizing a downstream project with the latest pyproject-template. It uses the official `manage.py` tooling documented in [Template Manager](manage.md), [Keeping Up to Date](updates.md), and [Tools Reference](tools-reference.md).
+
+**Prerequisites:**
+
+- Downstream project already uses pyproject-template structure (doit tasks, CI workflows, pre-commit, etc.)
+- Template repo: `endavis/pyproject-template`
+
+---
+
+## Pre-Flight
+
+- [ ] Verify on `main` branch and clean working tree (`git status`)
+- [ ] Run `doit check` to confirm current state passes
+- [ ] Create a GitHub Issue for the sync work:
+  ```bash
+  doit issue --type=chore --title="chore: synchronize with latest pyproject-template" \
+    --body="## Description\nSynchronize project with latest pyproject-template improvements."
+  ```
+- [ ] Create branch linked to the issue (e.g., `chore/<issue#>-sync-pyproject-template`)
+
+---
+
+## Phase 1: Install Template Management Tools (First-Time Only)
+
+If the project does NOT yet have `tools/pyproject_template/manage.py`, install it using the bootstrap script. Skip this phase if already present.
+
+```bash
+curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py | python3 - --sync
+```
+
+This will:
+
+1. Download the management suite to `tools/pyproject_template/`:
+    - `__init__.py`, `utils.py`, `settings.py`, `check_template_updates.py`, `manage.py`, `configure.py`, `cleanup.py`
+2. Detect project settings from `pyproject.toml`
+3. Create `.config/pyproject_template/settings.toml` with detected values
+4. Verify the installation
+
+After installation:
+
+- [ ] Review `.config/pyproject_template/settings.toml` and correct any values
+- [ ] Decide: Track `.config/pyproject_template/` in git or add to `.gitignore`
+- [ ] Verify: `python tools/pyproject_template/manage.py --dry-run check`
+
+---
+
+## Phase 2: Run Template Update Check
+
+Per [Template Manager](manage.md) "Workflow: Staying Up to Date":
+
+```bash
+python tools/pyproject_template/manage.py check
+```
+
+This will (per [Tools Reference](tools-reference.md)):
+
+1. Fetch the latest template release (or specified version via `--template-version`)
+2. Compare all files - categorized as **Modified**, **Missing** (new in template), or **Extra** (project-specific)
+3. Keep the template at `tmp/extracted/pyproject-template-main/` for diff commands
+4. Show GitHub compare URL for commit history since last sync
+5. Save commit info to `.template_commit` for later `sync` marking
+
+**Diff commands** (per documentation):
+
+```bash
+diff <file> tmp/extracted/pyproject-template-main/<file>
+```
+
+Review the output and proceed with Phases 3-7 to selectively apply changes.
+
+---
+
+## Phase 3: GitHub Workflows (`.github/workflows/`)
+
+For each workflow file flagged as **Modified** or **Missing**:
+
+- [ ] Compare each workflow against the template version
+- [ ] Apply updates (new permissions, action version bumps, new features)
+- [ ] **Preserve project-specific divergences** (e.g., custom OS matrix, extra setup steps, project-specific env vars)
+- [ ] Verify workflows still reference the correct package name
+
+**Files typically synchronized:**
+
+- `ci.yml` - Test matrix, action versions, triggers
+- `breaking-change-detection.yml` - Permissions, PR comment reporting
+- `release.yml` - Release automation
+- `testpypi.yml` - Pre-release testing
+- `pr-checks.yml` - PR validation
+- `merge-gate.yml` - Merge requirements
+
+**Check for ADRs:** If the project has ADRs documenting intentional divergences from template workflows, respect those decisions.
+
+---
+
+## Phase 4: Doit Tasks (`tools/doit/`)
+
+### 4.1 Core Task Infrastructure
+
+- [ ] Compare `tools/doit/__init__.py` for discovery mechanism updates
+- [ ] Compare `tools/doit/base.py` for configuration changes (DOIT_CONFIG, helpers)
+
+### 4.2 Quality Tasks
+
+- [ ] Compare `tools/doit/quality.py` - check for new tasks:
+    - `task_deadcode()` (uses vulture)
+    - `task_complexity()` (uses radon cc)
+    - `task_maintainability()` (uses radon mi)
+    - Any new linting/formatting improvements
+
+### 4.3 All Other Task Files
+
+- [ ] Compare each of: `github.py`, `testing.py`, `security.py`, `maintenance.py`, `release.py`, `build.py`, `docs.py`, `git.py`, `install.py`, `adr.py`, `templates.py`
+- [ ] Apply differences that are template improvements (not project-specific)
+- [ ] Skip `template_clean.py` unless cleanup capability is desired
+
+---
+
+## Phase 5: pyproject.toml Tool Configuration
+
+### 5.1 Add Missing Tool Sections
+
+Check template's pyproject.toml for sections not present in the project:
+
+- [ ] `[tool.vulture]` - Dead code detection configuration
+- [ ] `[tool.pyright]` - LSP/type checking for AI code editors
+
+### 5.2 Update Existing Sections
+
+Compare each `[tool.*]` section and apply template improvements:
+
+- [ ] `[tool.ruff]` - New rules, updated ignores
+- [ ] `[tool.mypy]` - Configuration updates
+- [ ] `[tool.pytest.ini_options]` - Version bumps, new options
+- [ ] `[tool.coverage]` - Threshold changes, exclude patterns
+- [ ] `[tool.bandit]` - New skips, exclude patterns
+- [ ] `[tool.commitizen]` - Format updates
+
+**Decision points (ask user):**
+
+- Coverage `fail_under` threshold (project may intentionally differ)
+- Cache directory locations (template uses defaults, project may customize)
+- Extended ignores/excludes (project-specific suppressions should be preserved)
+
+### 5.3 Dev Dependencies
+
+Add any new dev dependencies required by new doit tasks:
+
+- [ ] `vulture` (for `task_deadcode()`)
+- [ ] `radon` (for `task_complexity()` and `task_maintainability()`)
+- [ ] `pyright` (for `[tool.pyright]`)
+- [ ] Any other new tools referenced by updated doit tasks
+
+---
+
+## Phase 6: AGENTS.md Updates
+
+- [ ] Compare AGENTS.md between project and template
+- [ ] Add new sections from template (e.g., Pre-Action Checks, Reasoning Examples)
+- [ ] Update workflow commands and examples to match latest template patterns
+- [ ] **Preserve all project-specific sections** (architecture, CLI, patterns, etc.)
+
+---
+
+## Phase 7: Pre-commit & Other Config
+
+- [ ] Compare `.pre-commit-config.yaml` - hook versions, new hooks
+- [ ] Compare `.github/CONTRIBUTING.md` for updated processes
+- [ ] Compare `.github/pull_request_template.md` for new checklist items
+- [ ] Compare `.github/ISSUE_TEMPLATE/*.yml` for template updates
+- [ ] Compare `.github/python-versions.json` for version support changes
+
+---
+
+## Phase 8: Validation
+
+- [ ] Run `doit check` - all checks must pass
+- [ ] Run `uv run pytest` - all tests must pass
+- [ ] Run `uv run pre-commit run --all-files` - all hooks must pass
+- [ ] Run `doit lint` - no new linting issues
+- [ ] Run `doit type_check` - no new type errors
+- [ ] If new quality tasks added: run them and verify output is reasonable
+
+---
+
+## Phase 9: Mark as Synced
+
+Per [Template Manager](manage.md) step [5]:
+
+```bash
+python tools/pyproject_template/manage.py sync
+```
+
+This:
+
+1. Reads the reviewed commit from `tmp/extracted/pyproject-template-main/.template_commit` (saved during Phase 2)
+2. Updates `.config/pyproject_template/settings.toml` with the template commit SHA and date
+3. Cleans up the `tmp/extracted/` directory
+4. Future runs of `manage.py check` will compare from this sync point
+
+---
+
+## Phase 10: Commit & PR
+
+- [ ] Stage all changes
+- [ ] Commit with conventional format:
+  ```
+  chore: synchronize with pyproject-template
+
+  Syncs the following template improvements:
+  - endavis/pyproject-template#<PR1> (description)
+  - endavis/pyproject-template#<PR2> (description)
+  - <additional changes summary>
+  ```
+- [ ] Create PR: `doit pr --title="chore: synchronize with pyproject-template" --body-file=<body>`
+- [ ] PR body should reference the issue and list all synced template PRs
+
+---
+
+## Future Updates
+
+Once `tools/pyproject_template/manage.py` is installed and sync state is tracked, future updates follow this simplified workflow:
+
+1. **Check:** `python tools/pyproject_template/manage.py check`
+2. **Review:** Inspect diffs for Modified/Missing files
+3. **Apply:** Manually merge relevant changes
+4. **Validate:** `doit check`
+5. **Mark synced:** `python tools/pyproject_template/manage.py sync`
+6. **Commit:** Follow issue → branch → PR workflow
+
+---
+
+## Key Principles
+
+- **Selective merging:** Not all template changes apply to every project - review diffs carefully
+- **Preserve divergences:** Projects may intentionally differ from template (document with ADRs)
+- **Replace placeholders:** Any `pynetappfoundry` references in copied template content must be replaced with the actual package name
+- **Validate before commit:** Always run `doit check` before staging - mandatory per project workflow
+- **One PR per sync:** Keep all template synchronization changes in a single PR unless scope is too large
+- **manage.py is the official tool:** Use it for checking updates and marking sync state
+- **Read the CHANGELOG:** Review template CHANGELOG to understand why changes were made before applying

--- a/docs/template/index.md
+++ b/docs/template/index.md
@@ -1,0 +1,80 @@
+---
+title: Using This Template
+description: Overview of using pyproject-template for your Python projects
+audience:
+  - users
+tags:
+  - template
+  - getting-started
+---
+
+# Using This Template
+
+This section covers how to use the pyproject-template for your Python projects.
+
+## Quick Start: Template Manager
+
+The easiest way to work with the template is through the unified **[Template Manager](manage.md)**:
+
+```bash
+python tools/pyproject_template/manage.py
+```
+
+This interactive menu provides access to all template operations - creating projects, configuring, checking for updates, and more.
+
+## Choose Your Path
+
+### Starting Fresh?
+
+**[New Project Setup](new-project.md)** - Create a new Python project from this template.
+
+- **Automated setup** (recommended): One command creates and configures everything
+- **Manual setup**: Clone the template and configure it yourself
+
+### Have an Existing Project?
+
+**[Migration Guide](migration.md)** - Bring your existing Python project into this template.
+
+- Preserves your code while adopting template tooling
+- Step-by-step checklist for a smooth migration
+
+### Already Using This Template?
+
+**[Keeping Up to Date](updates.md)** - Stay in sync with template improvements.
+
+- Compare your project against the latest template
+- Selectively merge updates you want
+
+**[AI Sync Checklist](ai-sync-checklist.md)** - Structured guide for AI agents performing synchronization.
+
+- Step-by-step phases from pre-flight through commit
+- Decision points where AI should ask for user input
+
+## Template Tools
+
+All template tools are located in `tools/pyproject_template/`:
+
+| Tool | Purpose |
+|------|---------|
+| **`manage.py`** | **Unified interface for all operations (recommended)** |
+| `bootstrap.py` | Remote setup script (curl and run) |
+| `setup_repo.py` | Full repository setup orchestration |
+| `configure.py` | Replace placeholders with your project info |
+| `migrate_existing_project.py` | Copy template files to existing project |
+| `check_template_updates.py` | Compare project against latest template |
+| `cleanup.py` | Remove template files after setup |
+
+See the **[Template Manager](manage.md)** for the recommended interactive interface, or the **[Tools Reference](tools-reference.md)** for detailed CLI documentation of individual tools.
+
+## What the Template Provides
+
+When you use this template, you get:
+
+- **Modern Python packaging** with `pyproject.toml` and `uv`
+- **Task automation** with `doit` (format, lint, test, release)
+- **Code quality** with `ruff` (linting + formatting) and `mypy` (type checking)
+- **Testing** with `pytest` and coverage reporting
+- **CI/CD** with GitHub Actions (test, release to PyPI)
+- **Documentation** with MkDocs and Material theme
+- **Pre-commit hooks** enforcing code quality and conventional commits
+- **AI agent support** with pre-configured settings for Claude, Codex, and Gemini

--- a/docs/template/manage.md
+++ b/docs/template/manage.md
@@ -1,0 +1,226 @@
+---
+title: Template Management
+description: Unified interface for creating projects, checking updates, and syncing
+audience:
+  - users
+tags:
+  - template
+  - tooling
+---
+
+# Template Management
+
+The `manage.py` script provides a unified interface for all template operations. It auto-detects your project context and recommends appropriate actions.
+
+## Quick Start
+
+```bash
+# Interactive mode (recommended)
+python tools/pyproject_template/manage.py
+
+# Or use quick commands
+python tools/pyproject_template/manage.py create     # Create new project
+python tools/pyproject_template/manage.py check      # Check for updates
+python tools/pyproject_template/manage.py sync       # Mark as synced
+```
+
+## Menu Options
+
+### [1] Create new project from template
+
+Creates a new GitHub repository from the template:
+
+1. Creates the repository on GitHub
+2. Configures repository settings
+3. Clones locally and configures placeholders
+4. Sets up development environment (dependencies, pre-commit hooks)
+5. Configures branch protection and other GitHub settings
+6. Saves template sync state
+
+**When to use:** You're starting a brand new project and don't have a repository yet.
+
+### [2] Configure project
+
+Re-runs the configuration script to update placeholders:
+
+- Project name, package name, PyPI name
+- Author information
+- GitHub user/repo
+- Description
+
+**When to use:** You cloned the template manually and need to configure it, or you want to update project metadata.
+
+### [3] Check for template updates
+
+Compares your project against the latest template:
+
+1. Downloads the latest template
+2. Shows files that differ from the template
+3. Provides diff commands for reviewing changes
+4. Shows GitHub compare URL for commit history
+
+**When to use:** You want to see what improvements have been made to the template since you last synced.
+
+**Important:** This does NOT automatically apply changes. You must manually review and apply changes you want.
+
+### [4] Update repository settings
+
+Configures GitHub repository settings:
+
+- Repository description and features
+- Branch protection rulesets
+- Labels
+- GitHub Pages
+- CodeQL code scanning
+
+**When to use:** You want to update GitHub settings to match the latest template configuration.
+
+### [5] Mark as synced to latest template
+
+After reviewing and applying template changes, marks your project as synced:
+
+1. Updates `.config/pyproject_template/settings.toml` with the reviewed commit
+2. Cleans up the downloaded template directory
+
+**When to use:** After running "Check for template updates" and applying the changes you want.
+
+### [6] Clean up template files
+
+Removes template-specific files that are no longer needed after project setup:
+
+**Setup only mode:** Removes files only needed for initial setup:
+
+- `bootstrap.py` - Remote setup script
+- `tools/pyproject_template/setup_repo.py` - Repository creation
+- `tools/pyproject_template/migrate_existing_project.py` - Migration tool
+- `docs/template/new-project.md` - New project instructions
+- `docs/template/migration.md` - Migration guide
+
+This keeps the template update checking capability intact.
+
+**All mode:** Removes all template files:
+
+- All setup files (above)
+- `tools/pyproject_template/` directory (entire)
+- `docs/template/` directory (entire)
+- `.config/pyproject_template/` directory
+
+⚠️ **Warning:** After removing all template files, you won't be able to check for template updates.
+
+**When to use:** After setting up your project, to clean up files you no longer need.
+
+You can also use the doit task:
+
+```bash
+doit template_clean              # Interactive mode
+doit template_clean --setup      # Remove setup files only
+doit template_clean --all        # Remove all template files
+doit template_clean --dry-run    # Preview what would be deleted
+```
+
+## Workflow: Staying Up to Date
+
+The recommended workflow for keeping your project in sync with template improvements:
+
+### 1. Check for updates
+
+```bash
+python tools/pyproject_template/manage.py
+# Select [3] Check for template updates
+```
+
+This downloads the latest template and shows what's different. The template files are kept at `tmp/extracted/pyproject-template-main/` for review.
+
+### 2. Review changes
+
+Use the provided diff commands to compare files:
+
+```bash
+diff .github/workflows/ci.yml tmp/extracted/pyproject-template-main/.github/workflows/ci.yml
+```
+
+Or view the commit history on GitHub using the provided compare URL.
+
+### 3. Apply changes you want
+
+Manually copy or merge changes from the template into your project. Be selective - not all template changes may apply to your project.
+
+### 4. Mark as synced
+
+```bash
+python tools/pyproject_template/manage.py
+# Select [5] Mark as synced to latest template
+```
+
+This updates your sync state and cleans up the template directory.
+
+### 5. Commit the sync state
+
+Follow the Issue → Branch → PR workflow:
+
+```bash
+# Create an issue
+doit issue --type=chore --title='Sync template state'
+
+# Create branch and commit
+git checkout -b chore/<issue#>-sync-template-state
+git add .config/pyproject_template/settings.toml
+git commit -m 'chore: sync template state'
+git push -u origin HEAD
+
+# Create PR
+doit pr --title='chore: sync template state'
+```
+
+## Settings File
+
+The template sync state is stored in `.config/pyproject_template/settings.toml`:
+
+```toml
+[template]
+commit = "7dc4dba86601ebb2a63fb9b60138af2da1d8d4be"
+commit_date = "2025-01-15"
+```
+
+This tracks which template commit your project was last synced with.
+
+## CLI Options
+
+```bash
+# Quick actions
+python tools/pyproject_template/manage.py create     # Create new project
+python tools/pyproject_template/manage.py configure  # Re-run configuration
+python tools/pyproject_template/manage.py check      # Check for updates
+python tools/pyproject_template/manage.py repo       # Update repo settings
+python tools/pyproject_template/manage.py sync       # Mark as synced
+
+# Flags
+python tools/pyproject_template/manage.py --dry-run  # Preview without changes
+python tools/pyproject_template/manage.py --yes      # Non-interactive mode
+```
+
+## Project Detection
+
+The script auto-detects your project context:
+
+| Context | Recommended Action |
+|---------|-------------------|
+| No git repository | Create new project |
+| Has git but unconfigured | Configure project |
+| Template downloaded, not synced | Mark as synced |
+| Template outdated | Check for updates |
+| Up to date | No action needed |
+
+## Troubleshooting
+
+### "No reviewed template found"
+
+Run "Check for template updates" first to download and review the template before marking as synced.
+
+### Settings file not committed
+
+Branch protection prevents direct commits to main. Follow the Issue → Branch → PR workflow shown after marking as synced.
+
+### Package name validation fails
+
+Python package names must be PEP 8 compliant: lowercase letters, numbers, and underscores only. The script will suggest a valid name.

--- a/docs/template/migration.md
+++ b/docs/template/migration.md
@@ -1,0 +1,91 @@
+---
+title: Migration Guide
+description: Migrate existing Python projects to use this template
+audience:
+  - users
+tags:
+  - template
+  - migration
+---
+
+# Migration Guide
+
+Bring your existing Python project into the pyproject-template.
+
+> **Automated Option:** Use `migrate_existing_project.py` to copy template files automatically:
+> ```bash
+> python tools/pyproject_template/migrate_existing_project.py --target /path/to/your/project
+> ```
+> See [Tools Reference](tools-reference.md#migrate_existing_projectpy) for details.
+
+## Manual Migration Checklist
+
+Use this checklist for a manual migration. The flow assumes hatch-vcs for versioning, commitizen for tagging/changelog, uv for deps, and doit for tasks.
+
+### 1) Inventory & Prep
+- Note current package import name, supported Python versions, dependencies (runtime/dev/extras), scripts/entry points, CI/release setup.
+- Ensure current tests pass before migrating.
+
+### 2) Bring in the Template
+- **Backup:** Rename your existing `README.md`, `LICENSE`, and `pyproject.toml` (e.g., to `*.old`) so you don't lose content.
+- **Copy Files:** Copy template files into your repo:
+    - **Config:** `pyproject.toml`, `dodo.py`, `.envrc`, `.pre-commit-config.yaml`, `.python-version`, `mkdocs.yml`.
+    - **Docs & Guides:** `AGENTS.md`, `AI_SETUP.md`, `docs/*`, `examples/*`, `CHANGELOG.md`.
+    - **Hidden Configs:** `.github/workflows/*`, `.vscode/`, `.devcontainer/`, `.claude/`, `.codex/`, `.gemini/`, `tmp/.gitkeep`.
+- **Keep your code:** You’ll move it in step 4.
+
+### 3) Run the Template Manager
+- From the template root: `python tools/pyproject_template/manage.py`.
+- Select **[2] Configure project** to run the configurator.
+- Provide project name, package name (import), PyPI name, author, GitHub user, description.
+- **What it does:** Rewrites placeholders (badges/links/docs/workflows), renames `src/pynetappfoundry → src/<your_package>`.
+
+See [Template Management](manage.md) for full documentation on the management script.
+
+### 4) Move Your Code
+- Move your existing package source into the newly renamed `src/<your_package>/`.
+- **Cleanup:** Delete the template's default `core.py` if not needed.
+- **Type Hinting:** Ensure `py.typed` exists in `src/<your_package>/` to mark your package as typed.
+- **Versioning:** Leave `_version.py` as the stub; hatch-vcs generates it at build time from git tags.
+
+### 5) Update pyproject.toml
+- **Merge, don't overwrite:** Copy your dependencies and metadata *into* the new `pyproject.toml`. Preserve the `[tool]` sections (hatch, ruff, mypy, doit) provided by the template.
+- Update `[project.dependencies]`.
+- Add dev tools to `[project.optional-dependencies]` (keep the template's defaults like `ruff`, `pytest` if possible).
+- Define entry points under `[project.scripts]` if you have a CLI.
+
+### 6) Tests & Coverage
+- Move your tests to `tests/`.
+- If moving from a flat layout to `src/`, you may need to adjust imports in your tests.
+- Ensure `dodo.py` and workflows point coverage to the correct package (handled by `configure.py`, but worth double-checking).
+
+### 7) Regenerate Lockfile
+- Run `uv lock` to refresh `uv.lock` with your merged dependencies.
+
+### 8) Tasks and CI
+- Local tasks: `doit check` runs format (ruff), lint, mypy, tests.
+- Workflows: `ci.yml` runs checks; `release.yml` triggers on stable `v*` tags; `testpypi.yml` triggers on prerelease `v*-<pre>` tags.
+
+### 9) Docs & Badges
+- Check `README.md`: Restore your project description, but keep the new badges (links were updated by `configure.py`).
+- Update docs (`docs/installation.md`, `docs/usage.md`, `docs/api.md`) with your specific details.
+
+### 10) Verify Locally
+- Install environment: `uv sync --all-extras --dev`
+- Install hooks: `doit pre_commit_install`
+- Run checks: `doit check`
+- Run tests: `doit test`
+
+### 11) Release Flow
+- **Prerelease:** `doit release_dev` → bumps version (e.g., alpha) → tags → triggers `testpypi.yml`.
+- **Production:** `doit release` → bumps version (stable) → tags → triggers `release.yml`.
+- **Important:** No manual edits to `pyproject.toml` version or `_version.py`; the git tag is the source of truth.
+
+### 12) Clean Up & Commit
+- Remove old CI configs/Makefiles you no longer need.
+- `direnv allow` to load `.envrc`.
+- Commit and push. Monitor CI actions to ensure the migration was successful.
+
+## Staying Updated
+
+After migration, use [Keeping Up to Date](updates.md) to stay in sync with template improvements.

--- a/docs/template/new-project.md
+++ b/docs/template/new-project.md
@@ -1,0 +1,224 @@
+---
+title: New Project Setup
+description: Create a new Python project from this template
+audience:
+  - users
+tags:
+  - template
+  - getting-started
+  - setup
+---
+
+# New Project Setup
+
+Create a new Python project from this template using either the automated or manual approach.
+
+> **Tip:** For an interactive experience, use the [Template Manager](manage.md):
+> ```bash
+> python tools/pyproject_template/manage.py
+> ```
+> Select option **[1] Create new project from template** to be guided through the process.
+
+## Automated Setup (Recommended)
+
+The fastest way to create a new project:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py | python3
+```
+
+### What It Does
+
+The bootstrap script (`setup_repo.py`) automates the entire setup:
+
+1. **Creates GitHub repository** from the template
+2. **Configures repository settings**:
+   - Disables wiki and projects (optional features)
+   - Enables issues and discussions
+   - Sets merge options (squash, delete branch on merge)
+3. **Sets up branch protection** for `main`:
+   - Requires PR reviews
+   - Requires status checks to pass
+   - Prevents force pushes
+4. **Replicates labels** from the template repository
+5. **Runs placeholder replacement** (`configure.py`)
+6. **Clones the repository** locally
+7. **Prints next steps** checklist
+
+### Requirements
+
+- [GitHub CLI](https://cli.github.com/) installed and authenticated (`gh auth login`)
+- Git installed
+- Python 3.12+
+
+### Interactive Prompts
+
+The script will ask for:
+
+| Prompt | Description | Example |
+|--------|-------------|---------|
+| Repository name | Name for your new repo | `my-python-project` |
+| Description | Short project description | `A utility for processing data` |
+| Visibility | Public or private | `public` |
+| Package name | Python import name (snake_case) | `my_python_project` |
+| Author name | Your name | `Jane Doe` |
+| Author email | Your email | `jane@example.com` |
+
+### Post-Setup Manual Steps
+
+After the script completes, you'll need to:
+
+1. **Add PyPI tokens** (for package publishing):
+   - Go to Settings → Secrets → Actions
+   - Add `PYPI_API_TOKEN` for production releases
+   - Add `TEST_PYPI_API_TOKEN` for test releases
+
+2. **Add Codecov token** (optional, for coverage reports):
+   - Sign up at [codecov.io](https://codecov.io)
+   - Add `CODECOV_TOKEN` to repository secrets
+
+3. **Configure collaborators** if needed:
+   - Settings → Collaborators and teams
+
+4. **Enable GitHub Pages** (for documentation):
+   - Settings → Pages → Deploy from branch `gh-pages`
+
+## Manual Setup
+
+If you prefer more control, set up the template manually.
+
+### Step 1: Create Repository from Template
+
+**Option A: Use GitHub's template feature**
+
+1. Go to [pyproject-template](https://github.com/endavis/pyproject-template)
+2. Click "Use this template" → "Create a new repository"
+3. Fill in repository details
+4. Clone your new repository locally
+
+**Option B: Clone directly**
+
+```bash
+# Clone the template
+git clone https://github.com/endavis/pyproject-template.git my-project
+cd my-project
+
+# Remove template's git history and start fresh
+rm -rf .git
+git init
+git add .
+git commit -m "feat: initial commit from pyproject-template"
+
+# Create GitHub repo and push
+gh repo create my-project --public --source=. --push
+```
+
+### Step 2: Run Configuration
+
+Replace all placeholder values with your project information:
+
+```bash
+python tools/pyproject_template/configure.py
+```
+
+The script will prompt for:
+
+- Project name (display name)
+- Package name (import name, snake_case)
+- PyPI name (package name on PyPI, typically with hyphens)
+- Author name and email
+- GitHub endavis
+- Project description
+
+### What Configure Does
+
+The `configure.py` script:
+
+1. **Replaces placeholders** in all relevant files:
+   - `pyproject.toml` - Package metadata
+   - `README.md` - Badges and links
+   - `mkdocs.yml` - Documentation site
+   - `.github/workflows/*` - CI/CD configuration
+   - `docs/*` - Documentation content
+
+2. **Renames the source directory**:
+   - `src/pynetappfoundry/` → `src/your_pynetappfoundry/`
+
+3. **Updates badge URLs** for CI, coverage, and PyPI
+
+### Step 3: Set Up Development Environment
+
+```bash
+# Allow direnv (if installed)
+direnv allow
+
+# Or manually set up
+uv sync --all-extras --dev
+uv run pre-commit install
+```
+
+#### Enable Shell Completions (Optional)
+
+Enable tab completion for `doit` commands:
+
+```bash
+# Generate and install completions to your shell config
+doit completions_install
+```
+
+This will:
+- Generate completion scripts in `completions/`
+- Add source lines to `~/.bashrc` (Bash) and/or `~/.zshrc` (Zsh)
+
+After installation, reload your shell:
+```bash
+source ~/.bashrc   # For Bash
+source ~/.zshrc    # For Zsh
+```
+
+### Step 4: Verify Setup
+
+```bash
+# Run all checks
+doit check
+
+# Should see:
+# ✓ format_check
+# ✓ lint
+# ✓ type_check
+# ✓ test
+# ✓ All checks passed!
+```
+
+### Step 5: Configure GitHub Repository
+
+Manually configure what the automated setup does automatically:
+
+1. **Repository settings** (Settings → General):
+   - Enable/disable features as needed
+   - Set merge options
+
+2. **Branch protection** (Settings → Branches):
+   - Add rule for `main`
+   - Require pull request reviews
+   - Require status checks
+
+3. **Secrets** (Settings → Secrets → Actions):
+   - Add `PYPI_API_TOKEN`
+   - Add `TEST_PYPI_API_TOKEN`
+   - Add `CODECOV_TOKEN` (optional)
+
+4. **Labels**:
+   - The template includes standard labels
+   - Add custom labels as needed via Settings → Labels
+
+## Next Steps
+
+After setup is complete:
+
+1. **Start coding** in `src/your_pynetappfoundry/`
+2. **Write tests** in `tests/`
+3. **Update documentation** in `docs/`
+4. **Follow the workflow**: Issue → Branch → Commit → PR → Merge
+
+See [CONTRIBUTING.md](https://github.com/endavis/pyproject-template/blob/main/.github/CONTRIBUTING.md) for the development workflow.

--- a/docs/template/tools-reference.md
+++ b/docs/template/tools-reference.md
@@ -1,0 +1,414 @@
+---
+title: Template Tools Reference
+description: Complete reference for all template tools in tools/pyproject_template/
+audience:
+  - users
+  - contributors
+tags:
+  - template
+  - reference
+  - tooling
+---
+
+# Template Tools Reference
+
+Complete reference for all template tools in `tools/pyproject_template/`.
+
+> **Note:** For most use cases, the **[Template Manager](manage.md)** (`manage.py`) provides a unified, interactive interface to all these tools. Use this reference for advanced usage, scripting, or understanding the underlying CLI options.
+
+## bootstrap.py
+
+Remote bootstrap script for one-command setup.
+
+### Usage
+
+```bash
+curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py | python3
+```
+
+### Description
+
+This is a thin wrapper that downloads and runs `setup_repo.py`. It's designed to be fetched and executed directly from the template repository.
+
+### Requirements
+
+- Python 3.12+
+- Internet connection
+
+---
+
+## setup_repo.py
+
+Full repository setup orchestration from the template.
+
+### Usage
+
+```bash
+python tools/pyproject_template/setup_repo.py
+```
+
+### Description
+
+Automates the complete process of creating a new GitHub repository from this template:
+
+1. Creates repository from template on GitHub
+2. Configures repository settings
+3. Sets up branch protection rules
+4. Replicates labels from template
+5. Runs `configure.py` for placeholder replacement
+6. Clones repository locally
+7. Displays post-setup checklist
+
+### Interactive Prompts
+
+| Prompt | Description |
+|--------|-------------|
+| Repository name | Name for the new GitHub repository |
+| Description | Short project description |
+| Visibility | Public or private repository |
+| Package name | Python import name (snake_case) |
+| Author name | Your name for package metadata |
+| Author email | Your email for package metadata |
+
+### Requirements
+
+- GitHub CLI (`gh`) installed and authenticated
+- Git installed
+- Python 3.12+
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Error (missing requirements, API failure, etc.) |
+
+---
+
+## configure.py
+
+Replace placeholder values with your project information.
+
+### Usage
+
+```bash
+python tools/pyproject_template/configure.py
+```
+
+### Description
+
+Interactively prompts for project information and replaces all placeholder values throughout the template files.
+
+### Interactive Prompts
+
+| Prompt | Default | Description |
+|--------|---------|-------------|
+| Project name | pynetappfoundry | Display name for the project |
+| Package name | pynetappfoundry | Python import name (snake_case) |
+| PyPI name | pynetappfoundry | Name on PyPI (typically hyphenated) |
+| Author name | Your Name | Author for package metadata |
+| Author email | your.email@example.com | Contact email |
+| GitHub endavis | endavis | Your GitHub endavis |
+| Description | A short description... | One-line project description |
+
+### Files Modified
+
+- `pyproject.toml`
+- `README.md`
+- `mkdocs.yml`
+- `dodo.py`
+- `AGENTS.md`
+- `CHANGELOG.md`
+- `.github/workflows/*`
+- `.github/SECURITY.md`
+- `docs/*`
+- `examples/*`
+
+### Actions Performed
+
+1. Replaces placeholder strings with provided values
+2. Renames `src/pynetappfoundry/` to `src/your_pynetappfoundry/`
+3. Updates all URLs and badge links
+4. Updates documentation references
+
+### Requirements
+
+- Python 3.12+
+- Must be run from template root directory
+
+---
+
+## migrate_existing_project.py
+
+Copy template scaffolding into an existing repository.
+
+### Usage
+
+```bash
+python tools/pyproject_template/migrate_existing_project.py --target /path/to/your/project
+```
+
+### Description
+
+Copies template tooling, configuration, and documentation into an existing Python project. Creates backups of any files it overwrites.
+
+### CLI Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `--target` | Yes | - | Path to your existing repository |
+| `--template` | No | Script's repo | Path to template root |
+| `--download` | No | False | Download template instead of using local |
+| `--archive-url` | No | GitHub main.zip | URL to template archive |
+
+### Examples
+
+```bash
+# Use local template checkout
+python tools/pyproject_template/migrate_existing_project.py --target ~/projects/myapp
+
+# Download fresh template
+python tools/pyproject_template/migrate_existing_project.py --target ~/projects/myapp --download
+
+# Use specific template archive
+python tools/pyproject_template/migrate_existing_project.py \
+  --target ~/projects/myapp \
+  --archive-url https://github.com/endavis/pyproject-template/archive/refs/tags/v2.0.0.zip
+```
+
+### Files Copied
+
+The script copies these template files/directories:
+
+**Configuration & Tooling:**
+- `pyproject.toml`
+- `dodo.py`
+- `.envrc`, `.envrc.local.example`
+- `.pre-commit-config.yaml`
+- `.python-version`
+- `mkdocs.yml`
+- `.editorconfig`
+- `.gitignore`
+
+**Documentation & Guides:**
+- `AGENTS.md`
+- `CHANGELOG.md`
+- `docs/`
+- `examples/`
+
+**Project Scaffolding:**
+- `.github/` (workflows, templates)
+- `.vscode/`
+- `.devcontainer/`
+- `.claude/`, `.codex/`, `.gemini/`
+- `tools/pyproject_template/`
+- `src/pynetappfoundry/` (template source)
+- `tests/` (template tests)
+
+### Backup Behavior
+
+- Creates timestamped backup directory: `backup_YYYYMMDD_HHMMSS/`
+- Backs up any existing files before overwriting
+- Prints summary of backed up files
+
+### Post-Migration Steps
+
+After running the script:
+
+1. Run `python tools/pyproject_template/configure.py`
+2. Move your code into `src/your_pynetappfoundry/`
+3. Merge your dependencies into `pyproject.toml`
+4. Run `uv lock` to regenerate lock file
+5. Run `doit check` to verify
+
+See [Migration Guide](migration.md) for detailed steps.
+
+---
+
+## check_template_updates.py
+
+Compare your project against the latest template version.
+
+### Usage
+
+```bash
+python tools/pyproject_template/check_template_updates.py
+```
+
+### Description
+
+Fetches the latest template release (or specified version), compares it against your project, and shows what files differ.
+
+### CLI Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--template-version` | Latest release | Compare against specific version (e.g., `v2.2.0`) |
+| `--skip-changelog` | False | Don't open CHANGELOG.md in editor |
+| `--keep-template` | False | Keep downloaded template after comparison |
+
+### Examples
+
+```bash
+# Compare against latest release
+python tools/pyproject_template/check_template_updates.py
+
+# Compare against specific version
+python tools/pyproject_template/check_template_updates.py --template-version v2.2.0
+
+# Quick comparison without changelog review
+python tools/pyproject_template/check_template_updates.py --skip-changelog
+
+# Keep template for manual inspection
+python tools/pyproject_template/check_template_updates.py --keep-template
+```
+
+### Output Categories
+
+| Category | Description |
+|----------|-------------|
+| Modified | Files that exist in both but have different content |
+| Missing | Files in template that don't exist in your project |
+| Extra | Files in your project that don't exist in template |
+
+### Skipped Paths
+
+The comparison automatically skips:
+
+- `.git/`
+- `.venv/`, `venv/`
+- `__pycache__/`
+- `tmp/`
+- `*.pyc`, `*.pyo`
+- `*.egg-info/`
+- `.coverage`, `htmlcov/`
+- Project-specific source files
+
+### Requirements
+
+- Python 3.12+
+- Internet connection (to fetch template)
+- `$EDITOR` environment variable (for changelog viewing)
+
+---
+
+## cleanup.py
+
+Remove template-specific files after project setup.
+
+### Usage
+
+```bash
+python tools/pyproject_template/cleanup.py
+python tools/pyproject_template/cleanup.py --setup
+python tools/pyproject_template/cleanup.py --all
+python tools/pyproject_template/cleanup.py --dry-run
+```
+
+Or use the doit task:
+
+```bash
+doit template_clean
+doit template_clean --setup
+doit template_clean --all
+doit template_clean --dry-run
+```
+
+### Description
+
+Removes template-specific files that are no longer needed after project setup. Two cleanup modes are available:
+
+**Setup only mode (`--setup`):** Removes files only needed for initial setup:
+
+- `bootstrap.py` - Remote setup script
+- `tools/pyproject_template/setup_repo.py` - Repository creation
+- `tools/pyproject_template/migrate_existing_project.py` - Migration tool
+- `docs/template/new-project.md` - New project instructions
+- `docs/template/migration.md` - Migration guide
+
+This mode keeps the template update checking capability intact.
+
+**All mode (`--all`):** Removes all template files:
+
+- All setup files (above)
+- `tools/pyproject_template/` directory (entire)
+- `docs/template/` directory (entire)
+- `.config/pyproject_template/` directory
+
+### CLI Options
+
+| Option | Description |
+|--------|-------------|
+| `--setup` | Remove setup files only (keep update checking) |
+| `--all` | Remove all template files (no future updates) |
+| `--dry-run` | Show what would be deleted without deleting |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Error (conflicting flags, deletion failure) |
+
+---
+
+## repo_settings.py
+
+GitHub repository settings configuration functions.
+
+### Description
+
+Internal module providing functions to configure GitHub repository settings. Used by both `setup_repo.py` (initial setup) and `manage.py` (updating existing repositories).
+
+### Functions
+
+| Function | Description |
+|----------|-------------|
+| `configure_repository_settings()` | Configure repo description, features, security settings |
+| `configure_branch_protection()` | Set up branch protection rulesets |
+| `replicate_labels()` | Copy labels from template repository |
+| `enable_github_pages()` | Enable GitHub Pages for documentation |
+| `configure_codeql()` | Configure CodeQL code scanning |
+| `update_all_repo_settings()` | Convenience function to run all configuration steps |
+
+### Usage
+
+This module is not meant to be run directly. It's imported by other template tools:
+
+```python
+from tools.pyproject_template.repo_settings import update_all_repo_settings
+
+update_all_repo_settings(
+    repo_full="user/repo",
+    description="My project description",
+)
+```
+
+---
+
+## utils.py
+
+Shared utilities used by other template tools.
+
+### Description
+
+Internal module providing common functionality:
+
+- `Colors` - ANSI color codes for terminal output
+- `Logger` - Formatted logging (info, success, warning, error)
+- `GitHubCLI` - Wrapper for `gh` CLI commands
+- `prompt()` - Interactive input with defaults
+- `prompt_confirm()` - Yes/no confirmation prompts
+- `update_file()` - Safe file content replacement
+- `download_and_extract_archive()` - Download and extract zip/tar archives
+
+### Usage
+
+This module is not meant to be run directly. It's imported by other template tools:
+
+```python
+from tools.pyproject_template.utils import Logger, prompt
+
+Logger.info("Starting process...")
+name = prompt("Enter name", default="default_value")
+```

--- a/docs/template/updates.md
+++ b/docs/template/updates.md
@@ -1,0 +1,210 @@
+---
+title: Keeping Up to Date
+description: Stay in sync with improvements to the pyproject-template
+audience:
+  - users
+tags:
+  - template
+  - updates
+---
+
+# Keeping Up to Date
+
+Stay in sync with improvements to the pyproject-template.
+
+> **Tip:** The easiest way to check for updates is through the [Template Manager](manage.md):
+> ```bash
+> python tools/pyproject_template/manage.py
+> ```
+> Select option **[3] Check for template updates** to compare your project against the latest template, then **[5] Mark as synced** after applying changes.
+
+## When to Update
+
+Consider checking for template updates when:
+
+- A new template version is released
+- You want new tooling or workflow improvements
+- You're starting a new phase of development
+- Security updates are announced
+
+## Using check_template_updates.py
+
+The `check_template_updates.py` script compares your project against the latest template and shows what's different.
+
+### Basic Usage
+
+```bash
+python tools/pyproject_template/check_template_updates.py
+```
+
+### What It Does
+
+1. **Fetches the latest template** (or specified version)
+2. **Opens CHANGELOG.md** so you can review what changed
+3. **Compares files** and categorizes them:
+   - **Modified**: Files that exist in both but differ
+   - **Missing**: Files in template but not in your project
+   - **Extra**: Files in your project but not in template
+4. **Generates a diff** for each modified file
+5. **Cleans up** temporary files
+
+### CLI Options
+
+```bash
+# Compare against specific version
+python tools/pyproject_template/check_template_updates.py --template-version v2.2.0
+
+# Skip opening CHANGELOG in editor
+python tools/pyproject_template/check_template_updates.py --skip-changelog
+
+# Keep downloaded template for manual inspection
+python tools/pyproject_template/check_template_updates.py --keep-template
+```
+
+### Example Output
+
+```
+Comparing your project against the latest pyproject-template...
+
+Latest template release: v2.3.0
+Template extracted to tmp/pyproject-template-2.3.0
+
+Opening CHANGELOG.md for review...
+(Close the editor when you're done)
+
+=== Comparison Results ===
+
+Modified files (differ from template):
+  - .github/workflows/ci.yml
+  - dodo.py
+  - .pre-commit-config.yaml
+
+Missing files (in template, not in project):
+  - .github/ISSUE_TEMPLATE/chore.yml
+  - docs/template/updates.md
+
+Your project-specific files (not in template):
+  - src/mypackage/custom_module.py
+  - tests/test_custom.py
+
+Would you like to see diffs for modified files? [y/N]
+```
+
+## Reviewing Changes
+
+### Understanding the Categories
+
+| Category | Meaning | Action |
+|----------|---------|--------|
+| **Modified** | File exists in both but content differs | Review diff, merge selectively |
+| **Missing** | New file in template you don't have | Consider adding if useful |
+| **Extra** | Your project-specific files | Keep as-is (expected) |
+
+### Files to Usually Update
+
+These files typically should be kept in sync:
+
+- `.github/workflows/*.yml` - CI/CD improvements
+- `.pre-commit-config.yaml` - New hooks or version bumps
+- `dodo.py` - New tasks or improvements
+- `tools/pyproject_template/*.py` - Template tooling
+
+### Files to Review Carefully
+
+These may have project-specific customizations:
+
+- `pyproject.toml` - Your dependencies differ
+- `mkdocs.yml` - Your navigation differs
+- `README.md` - Your content differs
+- `.github/CONTRIBUTING.md` - May have project-specific rules
+
+### Files to Usually Skip
+
+These are project-specific:
+
+- `src/your_package/*` - Your code
+- `tests/*` - Your tests
+- `docs/*.md` - Your documentation content
+- `CHANGELOG.md` - Your release history
+
+## Merging Updates
+
+### Manual Merge Process
+
+1. **Run the comparison**:
+   ```bash
+   python tools/pyproject_template/check_template_updates.py --keep-template
+   ```
+
+2. **Review the CHANGELOG** to understand what changed and why
+
+3. **For each modified file**, decide:
+   - **Accept template version**: Copy from `tmp/pyproject-template-*/`
+   - **Keep your version**: No action needed
+   - **Merge selectively**: Manually combine changes
+
+4. **For missing files**, decide:
+   - **Add the file**: Copy from template
+   - **Skip**: Not needed for your project
+
+5. **Test your changes**:
+   ```bash
+   doit check
+   ```
+
+6. **Commit the updates**:
+   ```bash
+   git add -A
+   git commit -m "chore: update from pyproject-template vX.Y.Z"
+   ```
+
+### Using Git Diff Tools
+
+For complex merges, use your preferred diff tool:
+
+```bash
+# Compare specific file
+diff -u your_file.py tmp/pyproject-template-*/your_file.py
+
+# Use visual diff tool
+code --diff your_file.py tmp/pyproject-template-*/your_file.py
+```
+
+## AI Agent Workflow
+
+If you're using an AI agent (Claude, Codex, etc.) to perform the synchronization, see the **[AI Sync Checklist](ai-sync-checklist.md)** for a structured, step-by-step guide covering all phases from pre-flight through commit.
+
+## Best Practices
+
+1. **Update regularly** - Small, frequent updates are easier than large ones
+
+2. **Read the CHANGELOG** - Understand what changed before merging
+
+3. **Test after updating** - Always run `doit check` after merging changes
+
+4. **Commit updates separately** - Keep template updates in their own commits
+
+5. **Document deviations** - If you intentionally differ from template, note why
+
+## Troubleshooting
+
+### Script Can't Fetch Template
+
+If you're behind a proxy or have network issues:
+
+```bash
+# Download template manually
+wget https://github.com/endavis/pyproject-template/archive/refs/heads/main.zip
+unzip main.zip -d tmp/
+
+# Compare manually
+diff -r your_project/ tmp/pyproject-template-main/
+```
+
+### Too Many Differences
+
+If your project has diverged significantly:
+
+1. Focus on critical files first (CI, pre-commit)
+2. Skip content files (docs, README)
+3. Consider a fresh migration if heavily outdated

--- a/docs/usage/basics.md
+++ b/docs/usage/basics.md
@@ -1,0 +1,152 @@
+---
+title: Basic Usage
+description: Getting started with pynetappfoundry
+audience:
+  - users
+tags:
+  - usage
+  - tutorial
+---
+
+# Basic Usage
+
+This guide covers the basic usage patterns for pynetappfoundry.
+
+## Configuration
+
+pynetappfoundry uses a configuration directory to store cluster credentials and settings.
+
+### Default Locations
+
+- **Linux/macOS:** `~/.config/pynetappfoundry/`
+- **Windows:** `%APPDATA%\pynetappfoundry\`
+
+### Configuration Files
+
+```
+~/.config/pynetappfoundry/
+├── config.json          # Main configuration
+├── clusters/            # Cluster-specific configs
+│   ├── cluster1.json
+│   └── cluster2.json
+└── output/              # Default output directory
+```
+
+## Command Line Interface
+
+The `nf` command provides access to all CLI functionality.
+
+### Global Options
+
+```bash
+nf --help                    # Show help
+nf --version                 # Show version
+nf --config-dir PATH         # Custom config directory
+nf --output-dir PATH         # Custom output directory
+nf --debug                   # Enable debug logging
+```
+
+### Available Commands
+
+```bash
+nf licenses                  # License management
+nf reports                   # Report generation
+nf events                    # Event management
+nf metrics                   # Metrics collection
+nf utils                     # Utility commands
+```
+
+## Python API
+
+### Basic Client Usage
+
+```python
+from pynetappfoundry import Config, ONTAPAPIClient
+
+# Load configuration
+config = Config()
+
+# Create API client for a cluster
+client = ONTAPAPIClient(config, "cluster1")
+
+# Use the client
+volumes = client.get_volumes()
+```
+
+### CLI Client for SSH Access
+
+```python
+from pynetappfoundry import Config, ONTAPCLI
+
+# Load configuration
+config = Config()
+
+# Create CLI client
+cli = ONTAPCLI(config, "cluster1")
+
+# Run CLI commands
+output = cli.run_command("volume show")
+```
+
+### Event Database
+
+```python
+from pynetappfoundry import EmsEventsDB
+
+# Initialize events database
+db = EmsEventsDB("events.db")
+
+# Query events
+events = db.get_events(cluster="cluster1", severity="error")
+```
+
+### Metrics Collection
+
+```python
+from pynetappfoundry import MetricDB
+
+# Initialize metrics database
+db = MetricDB("metrics.db")
+
+# Store and query metrics
+db.store_metric("cluster1", "volume_used", 1024)
+metrics = db.get_metrics("cluster1")
+```
+
+## Common Workflows
+
+### License Reporting
+
+```bash
+# List licenses for all clusters
+nf licenses list
+
+# Export licenses to Excel
+nf licenses export --format xlsx --output licenses.xlsx
+```
+
+### Space Reporting
+
+```bash
+# Generate space report
+nf reports space --cluster cluster1
+
+# Generate aggregate report
+nf reports aggregate --all-clusters
+```
+
+### Event Monitoring
+
+```bash
+# Fetch recent events
+nf events fetch --hours 24
+
+# List events by severity
+nf events list --severity error
+```
+
+## Next Steps
+
+- [CLI Reference](../reference/cli.md) - Complete CLI documentation
+- [API Reference](../reference/api.md) - Python API documentation
+- [Examples](../examples/README.md) - More usage examples


### PR DESCRIPTION
## Description

Add comprehensive project documentation using MkDocs with Material theme. Includes user guides, API reference, development documentation, and Architecture Decision Records.

## Related Issue

Closes #2

## Type of Change

- [x] Documentation update

## Changes Made

- Added documentation index and project overview (docs/index.md)
- Added getting-started installation guide
- Added usage basics and CLI reference
- Added API reference with mkdocstrings integration
- Added development documentation (coding standards, doit tasks, CI/CD, release process)
- Added AI agent setup and command blocking documentation
- Added 13 Architecture Decision Records (ADRs) for tooling choices
- Added template management documentation
- Added examples documentation with API usage examples
- Added deployment guides (development, production)

## Testing

- [x] `mkdocs build --strict` passes without warnings
- [x] All documentation pages render correctly
- [x] Navigation is complete

## Checklist

- [x] I have updated the documentation accordingly