### PR TITLE
feat: add Pydantic models for type-safe configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pandas>=2.3.3",
     "paramiko>=4.0.0",
     "psutil>=7.1.2",
+    "pydantic>=2.0",
     "xlsxwriter>=3.2.9",
     "requests>=2.31",
     "yattag>=1.15",

--- a/src/pynetappfoundry/core/__init__.py
+++ b/src/pynetappfoundry/core/__init__.py
@@ -1,6 +1,36 @@
 """Core infrastructure modules."""
 
-from pynetappfoundry.core.config import Config
+from pynetappfoundry.core.config import Config, ConfigurationError
 from pynetappfoundry.core.logging import setup_logger
+from pynetappfoundry.core.models import (
+    AIQUMConfig,
+    AzureConfig,
+    BaseResource,
+    CloudInsightsConfig,
+    ClusterConfig,
+    ConnectorConfig,
+    DIIAPISettings,
+    LicensingSettings,
+    ONTAPAPISettings,
+    SearchableKeysConfig,
+    SMTPSettings,
+    UserCredentials,
+)
 
-__all__ = ["Config", "setup_logger"]
+__all__ = [
+    "AIQUMConfig",
+    "AzureConfig",
+    "BaseResource",
+    "CloudInsightsConfig",
+    "ClusterConfig",
+    "Config",
+    "ConfigurationError",
+    "ConnectorConfig",
+    "DIIAPISettings",
+    "LicensingSettings",
+    "ONTAPAPISettings",
+    "SMTPSettings",
+    "SearchableKeysConfig",
+    "UserCredentials",
+    "setup_logger",
+]

--- a/src/pynetappfoundry/core/models.py
+++ b/src/pynetappfoundry/core/models.py
@@ -1,0 +1,124 @@
+"""Pydantic models for type-safe configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class BaseResource(BaseModel):
+    """Base model for searchable resources.
+
+    All fields are optional with empty string defaults to allow partial
+    configuration. The 'name' field is typically set from the TOML key
+    after parsing.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = ""
+    ip: str = ""
+    div: str = ""
+    bu: str = ""
+    env: str = ""
+
+
+class ClusterConfig(BaseResource):
+    """Configuration for an ONTAP cluster."""
+
+    app: str = ""
+    subapp: str = ""
+    tags: list[str] = Field(default_factory=list)
+    region: str = ""
+    cloud: str = ""
+    # Optional per-cluster credentials (override global)
+    user: str | None = None
+    enc: str | None = None
+
+
+class AIQUMConfig(BaseResource):
+    """Configuration for an Active IQ Unified Manager instance."""
+
+    pass
+
+
+class ConnectorConfig(BaseResource):
+    """Configuration for a Cloud Insights connector."""
+
+    pass
+
+
+class CloudInsightsConfig(BaseResource):
+    """Configuration for a Cloud Insights tenant."""
+
+    pass
+
+
+class AzureConfig(BaseResource):
+    """Configuration for Azure resources."""
+
+    subscription_id: str = ""
+    resource_group: str = ""
+
+
+class UserCredentials(BaseModel):
+    """Credentials for a resource type."""
+
+    model_config = ConfigDict(extra="allow")
+
+    user: str
+    enc: str
+
+
+class SMTPSettings(BaseModel):
+    """SMTP server configuration."""
+
+    model_config = ConfigDict(extra="allow")
+
+    server: str
+    user: str = ""
+    password: str = ""
+    auth: str = "False"
+    port: int = 25
+
+
+class LicensingSettings(BaseModel):
+    """Licensing notification settings."""
+
+    model_config = ConfigDict(extra="allow")
+
+    mailfrom: str
+    mailto: str
+
+
+class ONTAPAPISettings(BaseModel):
+    """ONTAP REST API settings."""
+
+    model_config = ConfigDict(extra="allow")
+
+    base_api_path: str = "/api"
+
+
+class DIIAPISettings(BaseModel):
+    """Data Infrastructure Insights API settings."""
+
+    model_config = ConfigDict(extra="allow")
+
+    api_ro_token: str
+    base_url: str
+    base_api_path: str = "/rest/v1"
+
+
+class SearchableKeysConfig(BaseModel):
+    """Searchable keys configuration for a resource type."""
+
+    model_config = ConfigDict(extra="allow")
+
+    searchable_keys: list[str] = Field(default_factory=list)
+
+
+# Type aliases for collections
+ClusterCollection = dict[str, ClusterConfig]
+AIQUMCollection = dict[str, AIQUMConfig]
+ConnectorCollection = dict[str, ConnectorConfig]
+CloudInsightsCollection = dict[str, CloudInsightsConfig]
+AzureCollection = dict[str, AzureConfig]

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,320 @@
+"""Tests for Pydantic configuration models."""
+
+from __future__ import annotations
+
+import pytest
+
+from pynetappfoundry.core.models import (
+    AIQUMConfig,
+    AzureConfig,
+    BaseResource,
+    CloudInsightsConfig,
+    ClusterConfig,
+    ConnectorConfig,
+    DIIAPISettings,
+    LicensingSettings,
+    ONTAPAPISettings,
+    SearchableKeysConfig,
+    SMTPSettings,
+    UserCredentials,
+)
+
+
+class TestBaseResource:
+    """Tests for BaseResource model."""
+
+    def test_default_values(self) -> None:
+        """Test that all fields have empty string defaults."""
+        resource = BaseResource()
+        assert resource.name == ""
+        assert resource.ip == ""
+        assert resource.div == ""
+        assert resource.bu == ""
+        assert resource.env == ""
+
+    def test_with_values(self) -> None:
+        """Test creating resource with values."""
+        resource = BaseResource(
+            name="test-resource",
+            ip="192.168.1.1",
+            div="ITS",
+            bu="LAR",
+            env="Prod",
+        )
+        assert resource.name == "test-resource"
+        assert resource.ip == "192.168.1.1"
+        assert resource.div == "ITS"
+        assert resource.bu == "LAR"
+        assert resource.env == "Prod"
+
+    def test_extra_fields_allowed(self) -> None:
+        """Test that extra fields are allowed."""
+        resource = BaseResource(
+            name="test",
+            custom_field="custom_value",
+        )
+        assert resource.name == "test"
+        assert resource.custom_field == "custom_value"  # type: ignore[attr-defined]
+
+
+class TestClusterConfig:
+    """Tests for ClusterConfig model."""
+
+    def test_default_values(self) -> None:
+        """Test default values for cluster config."""
+        cluster = ClusterConfig()
+        assert cluster.app == ""
+        assert cluster.subapp == ""
+        assert cluster.tags == []
+        assert cluster.region == ""
+        assert cluster.cloud == ""
+        assert cluster.user is None
+        assert cluster.enc is None
+
+    def test_full_cluster_config(self) -> None:
+        """Test creating a full cluster config."""
+        cluster = ClusterConfig(
+            name="CLUSTER-PROD-01",
+            ip="192.168.1.173",
+            div="ITS",
+            bu="LAR",
+            app="Storage",
+            env="Prod",
+            subapp="PD1",
+            tags=["active", "nfs"],
+            region="USCU",
+        )
+        assert cluster.name == "CLUSTER-PROD-01"
+        assert cluster.ip == "192.168.1.173"
+        assert cluster.tags == ["active", "nfs"]
+        assert cluster.region == "USCU"
+
+    def test_cluster_with_credentials(self) -> None:
+        """Test cluster with per-cluster credentials."""
+        cluster = ClusterConfig(
+            name="CLUSTER-01",
+            ip="10.0.0.1",
+            user="admin",
+            enc="encrypted_password",
+        )
+        assert cluster.user == "admin"
+        assert cluster.enc == "encrypted_password"
+
+    def test_from_toml_dict(self) -> None:
+        """Test creating cluster from TOML-style dict."""
+        toml_data = {
+            "ip": "192.168.1.173",
+            "div": "ITS",
+            "bu": "LAR",
+            "app": "Storage",
+            "env": "PD",
+            "subapp": "PD1",
+            "tags": ["active", "nfs"],
+            "region": "USCU",
+        }
+        cluster = ClusterConfig(**toml_data)
+        cluster.name = "CLUSTER-PROD-01"  # Set from TOML key
+
+        assert cluster.name == "CLUSTER-PROD-01"
+        assert cluster.ip == "192.168.1.173"
+        assert cluster.tags == ["active", "nfs"]
+
+
+class TestAIQUMConfig:
+    """Tests for AIQUMConfig model."""
+
+    def test_inherits_base_resource(self) -> None:
+        """Test that AIQUMConfig inherits from BaseResource."""
+        aiqum = AIQUMConfig(
+            name="AIQUM-Prod",
+            ip="192.168.1.150",
+            div="ITS",
+            bu="LAR",
+            env="Prod",
+        )
+        assert aiqum.name == "AIQUM-Prod"
+        assert aiqum.ip == "192.168.1.150"
+
+
+class TestConnectorConfig:
+    """Tests for ConnectorConfig model."""
+
+    def test_inherits_base_resource(self) -> None:
+        """Test that ConnectorConfig inherits from BaseResource."""
+        connector = ConnectorConfig(
+            name="CONNECTOR-PROD-01",
+            ip="192.168.1.132",
+            div="ITS",
+            bu="LAR",
+            env="Prod",
+        )
+        assert connector.name == "CONNECTOR-PROD-01"
+        assert connector.ip == "192.168.1.132"
+
+
+class TestCloudInsightsConfig:
+    """Tests for CloudInsightsConfig model."""
+
+    def test_inherits_base_resource(self) -> None:
+        """Test that CloudInsightsConfig inherits from BaseResource."""
+        ci = CloudInsightsConfig(
+            name="CI-Tenant-01",
+            env="Prod",
+        )
+        assert ci.name == "CI-Tenant-01"
+
+
+class TestAzureConfig:
+    """Tests for AzureConfig model."""
+
+    def test_azure_specific_fields(self) -> None:
+        """Test Azure-specific fields."""
+        azure = AzureConfig(
+            name="Azure-Prod",
+            subscription_id="sub-123",
+            resource_group="rg-storage",
+        )
+        assert azure.subscription_id == "sub-123"
+        assert azure.resource_group == "rg-storage"
+
+
+class TestUserCredentials:
+    """Tests for UserCredentials model."""
+
+    def test_required_fields(self) -> None:
+        """Test that user and enc are required."""
+        creds = UserCredentials(user="admin", enc="encrypted_pass")
+        assert creds.user == "admin"
+        assert creds.enc == "encrypted_pass"
+
+    def test_missing_required_field_raises(self) -> None:
+        """Test that missing required fields raise ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            UserCredentials(user="admin")  # type: ignore[call-arg]
+
+
+class TestSMTPSettings:
+    """Tests for SMTPSettings model."""
+
+    def test_default_values(self) -> None:
+        """Test SMTP default values."""
+        smtp = SMTPSettings(server="smtp.example.com")
+        assert smtp.server == "smtp.example.com"
+        assert smtp.user == ""
+        assert smtp.password == ""
+        assert smtp.auth == "False"
+        assert smtp.port == 25
+
+    def test_full_config(self) -> None:
+        """Test full SMTP configuration."""
+        smtp = SMTPSettings(
+            server="smtp.example.com",
+            user="smtp_user",
+            password="smtp_pass",
+            auth="True",
+            port=587,
+        )
+        assert smtp.server == "smtp.example.com"
+        assert smtp.user == "smtp_user"
+        assert smtp.port == 587
+
+
+class TestLicensingSettings:
+    """Tests for LicensingSettings model."""
+
+    def test_required_fields(self) -> None:
+        """Test licensing required fields."""
+        licensing = LicensingSettings(
+            mailfrom="netapp-licensing@example.com",
+            mailto="netapp-team@example.com",
+        )
+        assert licensing.mailfrom == "netapp-licensing@example.com"
+        assert licensing.mailto == "netapp-team@example.com"
+
+
+class TestONTAPAPISettings:
+    """Tests for ONTAPAPISettings model."""
+
+    def test_default_base_path(self) -> None:
+        """Test default base API path."""
+        settings = ONTAPAPISettings()
+        assert settings.base_api_path == "/api"
+
+    def test_custom_base_path(self) -> None:
+        """Test custom base API path."""
+        settings = ONTAPAPISettings(base_api_path="/api/v2")
+        assert settings.base_api_path == "/api/v2"
+
+
+class TestDIIAPISettings:
+    """Tests for DIIAPISettings model."""
+
+    def test_required_fields(self) -> None:
+        """Test DII API required fields."""
+        settings = DIIAPISettings(
+            api_ro_token="token123",
+            base_url="https://client.cloudinsights.netapp.com",
+        )
+        assert settings.api_ro_token == "token123"
+        assert settings.base_url == "https://client.cloudinsights.netapp.com"
+        assert settings.base_api_path == "/rest/v1"
+
+    def test_custom_base_path(self) -> None:
+        """Test custom base API path."""
+        settings = DIIAPISettings(
+            api_ro_token="token123",
+            base_url="https://client.cloudinsights.netapp.com",
+            base_api_path="/rest/v2",
+        )
+        assert settings.base_api_path == "/rest/v2"
+
+
+class TestSearchableKeysConfig:
+    """Tests for SearchableKeysConfig model."""
+
+    def test_default_empty_list(self) -> None:
+        """Test default empty searchable keys."""
+        config = SearchableKeysConfig()
+        assert config.searchable_keys == []
+
+    def test_with_keys(self) -> None:
+        """Test with searchable keys."""
+        config = SearchableKeysConfig(
+            searchable_keys=["div", "bu", "env", "app", "region"],
+        )
+        assert "div" in config.searchable_keys
+        assert "bu" in config.searchable_keys
+        assert len(config.searchable_keys) == 5
+
+
+class TestModelSerialization:
+    """Tests for model serialization."""
+
+    def test_model_dump(self) -> None:
+        """Test converting model to dict."""
+        cluster = ClusterConfig(
+            name="CLUSTER-01",
+            ip="10.0.0.1",
+            tags=["active"],
+        )
+        data = cluster.model_dump()
+        assert data["name"] == "CLUSTER-01"
+        assert data["ip"] == "10.0.0.1"
+        assert data["tags"] == ["active"]
+
+    def test_model_dump_exclude_unset(self) -> None:
+        """Test excluding unset fields."""
+        cluster = ClusterConfig(name="CLUSTER-01", ip="10.0.0.1")
+        data = cluster.model_dump(exclude_unset=True)
+        assert "name" in data
+        assert "ip" in data
+        # Default values are still included because they were set
+
+    def test_model_json(self) -> None:
+        """Test JSON serialization."""
+        cluster = ClusterConfig(name="CLUSTER-01", ip="10.0.0.1")
+        json_str = cluster.model_dump_json()
+        assert '"name":"CLUSTER-01"' in json_str
+        assert '"ip":"10.0.0.1"' in json_str

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1448,6 +1457,92 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1516,6 +1611,7 @@ dependencies = [
     { name = "pandas" },
     { name = "paramiko" },
     { name = "psutil" },
+    { name = "pydantic" },
     { name = "requests" },
     { name = "rich" },
     { name = "xlsxwriter" },
@@ -1566,6 +1662,7 @@ requires-dist = [
     { name = "pip-licenses", marker = "extra == 'security'", specifier = ">=4.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },
     { name = "psutil", specifier = ">=7.1.2" },
+    { name = "pydantic", specifier = ">=2.0" },
     { name = "pyproject-fmt", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -2068,6 +2165,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds Pydantic models for type-safe configuration, providing validation, IDE autocompletion, and clear documentation of data shapes.

## Related Issue

Closes #13

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Add `pydantic>=2.0` dependency
- Create `src/pynetappfoundry/core/models.py` with:
  - **Resource models**: `BaseResource`, `ClusterConfig`, `AIQUMConfig`, `ConnectorConfig`, `CloudInsightsConfig`, `AzureConfig`
  - **Settings models**: `UserCredentials`, `SMTPSettings`, `LicensingSettings`, `ONTAPAPISettings`, `DIIAPISettings`, `SearchableKeysConfig`
- Add 25 tests in `tests/unit/test_models.py`
- Export all models from `pynetappfoundry.core`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (25 tests)
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Usage Example

```python
from pynetappfoundry.core import ClusterConfig, UserCredentials

# Create a cluster config with validation
cluster = ClusterConfig(
    name="CLUSTER-PROD-01",
    ip="192.168.1.173",
    div="ITS",
    bu="LAR",
    tags=["active", "nfs"],
)

# IDE autocompletion works!
print(cluster.ip)  # 192.168.1.173
print(cluster.tags)  # ['active', 'nfs']

# Serialize to dict
data = cluster.model_dump()
```

🤖 Generated with [Claude Code](https://claude.ai/code)