### PR TITLE
refactor: add Config accessor methods to reduce tight coupling

### DIFF
--- a/src/pynetappfoundry/cli/commands/licenses/check.py
+++ b/src/pynetappfoundry/cli/commands/licenses/check.py
@@ -182,10 +182,9 @@ def _send_license_email(
     issues: list[dict[str, Any]],
 ) -> None:
     """Send email about license issues."""
-    mailfrom = config.settings.get("settings", {}).get("licensing", {}).get("mailfrom")
-    mailto = config.settings.get("settings", {}).get("licensing", {}).get("mailto")
+    licensing_settings = config.get_licensing_settings()
 
-    if not mailfrom or not mailto:
+    if not licensing_settings:
         logging.warning("Email settings not configured, skipping notification")
         return
 
@@ -205,7 +204,7 @@ def _send_license_email(
         subject=f"{datetime.now().date()} : Licensing issues found",
         body="\n".join(html_body),
         body_type="html",
-        mailfrom=mailfrom,
-        mailto=mailto,
+        mailfrom=licensing_settings.mailfrom,
+        mailto=licensing_settings.mailto,
         high_priority=True,
     )

--- a/src/pynetappfoundry/clients/dii/api.py
+++ b/src/pynetappfoundry/clients/dii/api.py
@@ -22,12 +22,11 @@ class DIIAPIClient(APIWrapper):
         """
         self.config = config
 
+        dii_settings = config.get_dii_api_settings()
         super().__init__(
             api_json_file=str(config.get_schema_location("dii") / "all.json"),
-            base_url=config.settings["diiapi"]["general"]["base_url"],
-            auth_header={
-                "X-CloudInsights-ApiKey": self.config.settings["diiapi"]["general"]["api_ro_token"]
-            },
-            base_api_path=self.config.settings["diiapi"]["general"]["base_api_path"],
+            base_url=dii_settings.base_url,
+            auth_header={"X-CloudInsights-ApiKey": dii_settings.api_ro_token},
+            base_api_path=dii_settings.base_api_path,
             **kwargs,
         )

--- a/src/pynetappfoundry/clients/ontap/api.py
+++ b/src/pynetappfoundry/clients/ontap/api.py
@@ -34,10 +34,11 @@ class ONTAPAPIClient(APIWrapper):
         b64string = base64.b64encode(f"{user}:{enc}".encode("ascii"))
         auth_header = {"authorization": f"Basic {b64string.decode()}"}
 
+        ontap_settings = config.get_ontap_api_settings()
         super().__init__(
             api_json_file=str(config.get_schema_location("ontap") / "all.json"),
             base_url=f"https://{cluster.ip}",
             auth_header=auth_header,
-            base_api_path=self.config.settings["ontapapi"]["general"]["base_api_path"],
+            base_api_path=ontap_settings.base_api_path,
             **kwargs,
         )

--- a/src/pynetappfoundry/core/config.py
+++ b/src/pynetappfoundry/core/config.py
@@ -44,9 +44,18 @@ import logging
 import os
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
+
+from pynetappfoundry.core.models import (
+    DIIAPISettings,
+    LicensingSettings,
+    ONTAPAPISettings,
+    SMTPSettings,
+)
 
 _file_name = Path(__file__).name
+
+T = TypeVar("T")
 
 
 class ConfigurationError(Exception):
@@ -107,6 +116,133 @@ class Config:
             Path to the API schema directory.
         """
         return Path(self.config_dir / "apis" / api_name)
+
+    def get_setting(self, *keys: str, default: T | None = None) -> Any | T | None:
+        """Get a nested setting value with a clear error message if not found.
+
+        This method provides safe access to nested configuration values,
+        avoiding KeyError exceptions with unhelpful messages.
+
+        Args:
+            *keys: Sequence of keys to traverse (e.g., 'ontapapi', 'general', 'base_api_path').
+            default: Value to return if the key path doesn't exist. If None and key is missing,
+                     raises ConfigurationError.
+
+        Returns:
+            The value at the specified key path, or the default value.
+
+        Raises:
+            ConfigurationError: If the key path doesn't exist and no default is provided.
+
+        Example:
+            >>> config.get_setting('ontapapi', 'general', 'base_api_path')
+            '/api'
+            >>> config.get_setting('missing', 'key', default='/default')
+            '/default'
+        """
+        current: Any = self.settings
+        path_so_far: list[str] = []
+
+        for key in keys:
+            path_so_far.append(key)
+            if not isinstance(current, dict):
+                if default is not None:
+                    return default
+                raise ConfigurationError(
+                    f"Cannot access '{key}' in non-dict value at "
+                    f"'{'.'.join(path_so_far[:-1])}'. "
+                    "Check your configuration files."
+                )
+            if key not in current:
+                if default is not None:
+                    return default
+                raise ConfigurationError(
+                    f"Missing configuration key '{'.'.join(path_so_far)}'. "
+                    f"Available keys at '{'.'.join(path_so_far[:-1]) or 'root'}': "
+                    f"{list(current.keys())}. "
+                    "Check your configuration files."
+                )
+            current = current[key]
+
+        return current
+
+    def get_smtp_settings(self) -> SMTPSettings:
+        """Get SMTP settings for sending emails.
+
+        Returns:
+            SMTPSettings object with server configuration.
+
+        Raises:
+            ConfigurationError: If SMTP settings are not configured.
+        """
+        try:
+            smtp_data = self.get_setting("settings", "SMTP")
+            return SMTPSettings.model_validate(smtp_data)
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            raise ConfigurationError(
+                f"Invalid SMTP configuration: {e}. "
+                "Ensure settings.toml has a valid [settings.SMTP] section with "
+                "'server', 'port', 'user', 'password', and 'auth' fields."
+            ) from e
+
+    def get_ontap_api_settings(self) -> ONTAPAPISettings:
+        """Get ONTAP REST API settings.
+
+        Returns:
+            ONTAPAPISettings object with API configuration.
+
+        Raises:
+            ConfigurationError: If ONTAP API settings are not configured.
+        """
+        try:
+            ontap_data = self.get_setting("ontapapi", "general")
+            return ONTAPAPISettings.model_validate(ontap_data)
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            raise ConfigurationError(
+                f"Invalid ONTAP API configuration: {e}. "
+                "Ensure settings.toml has a valid [ontapapi.general] section "
+                "with 'base_api_path' field."
+            ) from e
+
+    def get_dii_api_settings(self) -> DIIAPISettings:
+        """Get Data Infrastructure Insights API settings.
+
+        Returns:
+            DIIAPISettings object with API configuration.
+
+        Raises:
+            ConfigurationError: If DII API settings are not configured.
+        """
+        try:
+            dii_data = self.get_setting("diiapi", "general")
+            return DIIAPISettings.model_validate(dii_data)
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            raise ConfigurationError(
+                f"Invalid DII API configuration: {e}. "
+                "Ensure settings.toml has a valid [diiapi.general] section with "
+                "'api_ro_token', 'base_url', and 'base_api_path' fields."
+            ) from e
+
+    def get_licensing_settings(self) -> LicensingSettings | None:
+        """Get licensing notification settings.
+
+        Returns:
+            LicensingSettings object if configured, None otherwise.
+        """
+        try:
+            licensing_data = self.get_setting("settings", "licensing")
+            return LicensingSettings.model_validate(licensing_data)
+        except ConfigurationError:
+            return None
+        except Exception as e:
+            logging.warning(f"Invalid licensing configuration: {e}")
+            return None
 
     def parse_data(self) -> None:
         """Parse all TOML files in the config directory."""

--- a/src/pynetappfoundry/utils/email.py
+++ b/src/pynetappfoundry/utils/email.py
@@ -36,11 +36,12 @@ def send_email(
         high_priority: If True, mark email as high priority.
     """
     # Email configuration
-    smtp_server = config.settings["settings"]["SMTP"]["server"]
-    smtp_port = int(config.settings["settings"]["SMTP"]["port"])
-    smtp_user = config.settings["settings"]["SMTP"]["user"]
-    smtp_password = config.settings["settings"]["SMTP"]["password"]
-    auth = config.settings["settings"]["SMTP"]["auth"]
+    smtp_settings = config.get_smtp_settings()
+    smtp_server = smtp_settings.server
+    smtp_port = smtp_settings.port
+    smtp_user = smtp_settings.user
+    smtp_password = smtp_settings.password
+    auth = smtp_settings.auth
 
     if not mailto:
         logging.error(f"{_file_name} : No To Email address specified")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -7,6 +7,12 @@ from pathlib import Path
 import pytest
 
 from pynetappfoundry.core.config import Config, ConfigurationError
+from pynetappfoundry.core.models import (
+    DIIAPISettings,
+    LicensingSettings,
+    ONTAPAPISettings,
+    SMTPSettings,
+)
 
 
 @pytest.fixture
@@ -382,3 +388,311 @@ class TestCount:
         count = config_instance.count("clusters", "bu")
         # Engineering and Finance = 2 unique values
         assert count == 2
+
+
+class TestGetSetting:
+    """Tests for get_setting accessor method."""
+
+    def test_get_setting_single_key(self, config_instance: Config) -> None:
+        """Test get_setting with a single key."""
+        result = config_instance.get_setting("settings")
+        assert isinstance(result, dict)
+        assert "ontapapi" in result
+
+    def test_get_setting_nested_keys(self, config_instance: Config) -> None:
+        """Test get_setting with nested keys."""
+        result = config_instance.get_setting("settings", "ontapapi", "general", "base_api_path")
+        assert result == "/api"
+
+    def test_get_setting_with_default(self, config_instance: Config) -> None:
+        """Test get_setting returns default for missing key."""
+        result = config_instance.get_setting("nonexistent", default="default_value")
+        assert result == "default_value"
+
+    def test_get_setting_missing_key_raises(self, config_instance: Config) -> None:
+        """Test get_setting raises ConfigurationError for missing key."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            config_instance.get_setting("nonexistent", "key")
+        assert "Missing configuration key" in str(exc_info.value)
+        assert "nonexistent" in str(exc_info.value)
+
+    def test_get_setting_nested_missing_key_raises(self, config_instance: Config) -> None:
+        """Test get_setting raises ConfigurationError for missing nested key."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            config_instance.get_setting("settings", "nonexistent")
+        assert "Missing configuration key" in str(exc_info.value)
+        assert "settings.nonexistent" in str(exc_info.value)
+
+    def test_get_setting_non_dict_access_raises(
+        self, temp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Test get_setting raises ConfigurationError when accessing non-dict."""
+        # Create a settings file with a scalar value
+        settings_toml = temp_config_dir / "scalar.toml"
+        settings_toml.write_text("""
+value = "scalar_string"
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            with pytest.raises(ConfigurationError) as exc_info:
+                config.get_setting("scalar", "value", "nested")
+            assert "Cannot access" in str(exc_info.value)
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestGetSmtpSettings:
+    """Tests for get_smtp_settings accessor method."""
+
+    def test_get_smtp_settings_success(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test get_smtp_settings returns SMTPSettings object."""
+        # SMTP settings go in settings.toml under [SMTP] section
+        # which becomes config.settings["settings"]["SMTP"]
+        smtp_toml = temp_config_dir / "settings.toml"
+        smtp_toml.write_text("""
+[SMTP]
+server = "smtp.example.com"
+port = 587
+user = "smtp_user"
+password = "smtp_pass"
+auth = "True"
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            result = config.get_smtp_settings()
+            assert isinstance(result, SMTPSettings)
+            assert result.server == "smtp.example.com"
+            assert result.port == 587
+            assert result.user == "smtp_user"
+            assert result.password == "smtp_pass"
+            assert result.auth == "True"
+        finally:
+            os.chdir(original_cwd)
+
+    def test_get_smtp_settings_missing_raises(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test get_smtp_settings raises ConfigurationError when not configured."""
+        # Remove settings.toml to ensure no SMTP config exists
+        settings_file = temp_config_dir / "settings.toml"
+        settings_file.write_text("""
+[other]
+key = "value"
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            with pytest.raises(ConfigurationError) as exc_info:
+                config.get_smtp_settings()
+            assert "SMTP" in str(exc_info.value) or "Missing configuration" in str(exc_info.value)
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestGetOntapApiSettings:
+    """Tests for get_ontap_api_settings accessor method."""
+
+    def test_get_ontap_api_settings_success(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test get_ontap_api_settings returns ONTAPAPISettings object."""
+        # ONTAP API settings go in ontapapi.toml under [general] section
+        # which becomes config.settings["ontapapi"]["general"]
+        ontapapi_toml = temp_config_dir / "ontapapi.toml"
+        ontapapi_toml.write_text("""
+[general]
+base_api_path = "/api"
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            result = config.get_ontap_api_settings()
+            assert isinstance(result, ONTAPAPISettings)
+            assert result.base_api_path == "/api"
+        finally:
+            os.chdir(original_cwd)
+
+    def test_get_ontap_api_settings_missing_raises(
+        self, temp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Test get_ontap_api_settings raises ConfigurationError when not configured."""
+        # Create config without ontapapi settings
+        settings_file = temp_config_dir / "settings.toml"
+        settings_file.write_text("""
+[other]
+key = "value"
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            with pytest.raises(ConfigurationError) as exc_info:
+                config.get_ontap_api_settings()
+            assert "ontapapi" in str(exc_info.value) or "Missing configuration" in str(
+                exc_info.value
+            )
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestGetDiiApiSettings:
+    """Tests for get_dii_api_settings accessor method."""
+
+    def test_get_dii_api_settings_success(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test get_dii_api_settings returns DIIAPISettings object."""
+        # DII API settings go in diiapi.toml under [general] section
+        # which becomes config.settings["diiapi"]["general"]
+        diiapi_toml = temp_config_dir / "diiapi.toml"
+        diiapi_toml.write_text("""
+[general]
+api_ro_token = "test_token"
+base_url = "https://dii.example.com"
+base_api_path = "/rest/v1"
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            result = config.get_dii_api_settings()
+            assert isinstance(result, DIIAPISettings)
+            assert result.api_ro_token == "test_token"
+            assert result.base_url == "https://dii.example.com"
+            assert result.base_api_path == "/rest/v1"
+        finally:
+            os.chdir(original_cwd)
+
+    def test_get_dii_api_settings_missing_raises(
+        self, temp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Test get_dii_api_settings raises ConfigurationError when not configured."""
+        settings_file = temp_config_dir / "settings.toml"
+        settings_file.write_text("""
+[other]
+key = "value"
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            with pytest.raises(ConfigurationError) as exc_info:
+                config.get_dii_api_settings()
+            assert "diiapi" in str(exc_info.value) or "Missing configuration" in str(exc_info.value)
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestGetLicensingSettings:
+    """Tests for get_licensing_settings accessor method."""
+
+    def test_get_licensing_settings_success(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test get_licensing_settings returns LicensingSettings object."""
+        # Licensing settings go in settings.toml under [licensing] section
+        # which becomes config.settings["settings"]["licensing"]
+        settings_toml = temp_config_dir / "settings.toml"
+        settings_toml.write_text("""
+[licensing]
+mailfrom = "from@example.com"
+mailto = "to@example.com"
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            result = config.get_licensing_settings()
+            assert isinstance(result, LicensingSettings)
+            assert result.mailfrom == "from@example.com"
+            assert result.mailto == "to@example.com"
+        finally:
+            os.chdir(original_cwd)
+
+    def test_get_licensing_settings_missing_returns_none(
+        self, temp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Test get_licensing_settings returns None when not configured."""
+        settings_file = temp_config_dir / "settings.toml"
+        settings_file.write_text("""
+[other]
+key = "value"
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            result = config.get_licensing_settings()
+            assert result is None
+        finally:
+            os.chdir(original_cwd)


### PR DESCRIPTION
## Description

Add typed accessor methods to `Config` class for safe nested configuration access. This replaces direct `config.settings["a"]["b"]["c"]` access patterns that can cause unhelpful `KeyError` exceptions with accessor methods that provide clear error messages and type-safe returns using existing Pydantic models.

## Related Issue

Closes #15

## Type of Change

- [x] Code refactoring
- [x] Test improvement

## Changes Made

- Add `get_setting(*keys, default)` - Generic safe nested dict access with clear error messages
- Add `get_smtp_settings() -> SMTPSettings` - Returns validated SMTP configuration
- Add `get_ontap_api_settings() -> ONTAPAPISettings` - Returns validated ONTAP API configuration
- Add `get_dii_api_settings() -> DIIAPISettings` - Returns validated DII API configuration
- Add `get_licensing_settings() -> LicensingSettings | None` - Returns licensing settings or None
- Update `email.py` to use `get_smtp_settings()`
- Update `ontap/api.py` to use `get_ontap_api_settings()`
- Update `dii/api.py` to use `get_dii_api_settings()`
- Update `licenses/check.py` to use `get_licensing_settings()`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (12 new tests across 5 test classes)
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)