### PR TITLE
feat: add config CLI commands and environment variable support

### DIFF
--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -446,6 +446,139 @@ user, enc_password = config.get_user("clusters", "CLUSTER-PROD-01")
 
 ---
 
+## Environment Variables
+
+pynetappfoundry supports environment variables for overriding configuration values, particularly useful for CI/CD pipelines, containers, and secure credential management.
+
+### Available Environment Variables
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `NF_CONFIG_DIR` | Override the config directory path | `NF_CONFIG_DIR=/etc/pynetappfoundry` |
+| `NF_<CLUSTER>_USER` | Override username for a specific cluster | `NF_CLUSTER_PROD_01_USER=admin` |
+| `NF_<CLUSTER>_PASSWORD` | Override password for a specific cluster | `NF_CLUSTER_PROD_01_PASSWORD=base64encoded` |
+
+### Cluster Name Conversion
+
+Cluster names are converted to environment variable format by:
+1. Replacing hyphens (`-`) with underscores (`_`)
+2. Converting to uppercase
+3. Prefixing with `NF_`
+
+| Cluster Name | User Env Var | Password Env Var |
+|--------------|--------------|------------------|
+| `cluster-prod-01` | `NF_CLUSTER_PROD_01_USER` | `NF_CLUSTER_PROD_01_PASSWORD` |
+| `my-cluster` | `NF_MY_CLUSTER_USER` | `NF_MY_CLUSTER_PASSWORD` |
+| `simple` | `NF_SIMPLE_USER` | `NF_SIMPLE_PASSWORD` |
+
+### Credential Resolution Order
+
+Credentials are resolved in the following order (first found wins):
+
+1. **Environment variables** - `NF_<CLUSTER>_USER` and `NF_<CLUSTER>_PASSWORD`
+2. **Object-specific config** - `user` and `enc` fields in the cluster's data file entry
+3. **Default credentials** - `users.toml` defaults for the resource type
+
+### Example Usage
+
+```bash
+# Set credentials via environment variables
+export NF_CLUSTER_PROD_01_USER=admin
+export NF_CLUSTER_PROD_01_PASSWORD=$(echo -n 'mypassword' | base64)
+
+# Override config directory
+export NF_CONFIG_DIR=/path/to/custom/config
+
+# Run command - credentials will be used automatically
+nf licenses get -f '{"name": "cluster-prod-01"}'
+```
+
+### Docker/Container Usage
+
+```dockerfile
+ENV NF_CONFIG_DIR=/app/config
+ENV NF_CLUSTER_PROD_01_USER=admin
+ENV NF_CLUSTER_PROD_01_PASSWORD=YWRtaW5fcGFzc3dvcmQ=
+```
+
+### Security Notes
+
+- Environment variables take precedence over config files, allowing secure injection of credentials
+- Passwords must be base64 encoded (same format as the `enc` field in config files)
+- Use container secrets or CI/CD secret management for production deployments
+
+---
+
+## Configuration CLI Commands
+
+pynetappfoundry provides commands to inspect and validate your configuration.
+
+### nf config show
+
+Display the current loaded configuration.
+
+```bash
+# Show all configuration
+nf config show
+
+# Show only a specific section
+nf config show -s clusters
+nf config show -s settings
+nf config show -s users
+
+# Show with passwords unmasked (use with caution)
+nf config show --unmask
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `-s, --section` | Show only a specific section (clusters, settings, users, etc.) |
+| `--unmask` | Show passwords and tokens unmasked (default: masked with `********`) |
+
+### nf config validate
+
+Validate configuration files and check for common issues.
+
+```bash
+nf config validate
+```
+
+**Checks performed:**
+
+- Configuration directory exists and is readable
+- Cluster definitions are valid against Pydantic models
+- User credentials are properly formatted
+- ONTAP API settings are configured
+- All clusters have valid credentials configured
+- Optional settings (DII API, SMTP, Licensing) are valid if present
+
+**Example output:**
+
+```
+Validating configuration in: /path/to/config
+
+Configuration Validation
+├── Clusters
+│   ├── cluster-prod-01
+│   └── cluster-dev-01
+├── Users
+│   └── clusters
+├── Settings
+│   ├── ONTAP API
+│   ├── DII API: Not configured (optional)
+│   ├── SMTP: Not configured (optional)
+│   └── Licensing: Not configured (optional)
+└── Cluster Credentials
+    ├── cluster-prod-01: admin
+    └── cluster-dev-01: admin
+
+Configuration is valid
+```
+
+---
+
 ## Complete Example
 
 ### Minimal Configuration

--- a/src/pynetappfoundry/cli/commands/config/__init__.py
+++ b/src/pynetappfoundry/cli/commands/config/__init__.py
@@ -1,0 +1,19 @@
+"""Configuration management commands."""
+
+import click
+
+from pynetappfoundry.cli.commands.config.show import show
+from pynetappfoundry.cli.commands.config.validate import validate
+
+
+@click.group()
+def config() -> None:
+    """Configuration management commands.
+
+    Commands for viewing and validating pynetappfoundry configuration.
+    """
+    pass
+
+
+config.add_command(show)
+config.add_command(validate)

--- a/src/pynetappfoundry/cli/commands/config/show.py
+++ b/src/pynetappfoundry/cli/commands/config/show.py
@@ -1,0 +1,206 @@
+"""Config show command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.console import Console
+from rich.panel import Panel
+from rich.tree import Tree
+
+from pynetappfoundry.cli.utils import print_error
+from pynetappfoundry.core.config import Config
+
+console = Console()
+
+# Pattern for detecting sensitive keys
+SENSITIVE_KEYS = {"password", "enc", "token", "secret", "key", "api_key", "api_token"}
+
+
+def _mask_sensitive(data: Any, unmask: bool = False) -> Any:
+    """Recursively mask sensitive values in data.
+
+    Args:
+        data: Data to process.
+        unmask: If True, don't mask values.
+
+    Returns:
+        Data with sensitive values masked.
+    """
+    if unmask:
+        return data
+
+    if isinstance(data, dict):
+        result = {}
+        for key, value in data.items():
+            key_lower = key.lower()
+            if any(sensitive in key_lower for sensitive in SENSITIVE_KEYS):
+                if isinstance(value, str) and value:
+                    result[key] = "********"
+                else:
+                    result[key] = value
+            else:
+                result[key] = _mask_sensitive(value, unmask)
+        return result
+    elif isinstance(data, list):
+        return [_mask_sensitive(item, unmask) for item in data]
+    else:
+        return data
+
+
+def _format_value(value: Any, indent: int = 0) -> str:
+    """Format a value for display.
+
+    Args:
+        value: Value to format.
+        indent: Current indentation level.
+
+    Returns:
+        Formatted string.
+    """
+    prefix = "  " * indent
+    if isinstance(value, dict):
+        if not value:
+            return "{}"
+        lines = []
+        for k, v in value.items():
+            formatted_v = _format_value(v, indent + 1)
+            if isinstance(v, dict) and v:
+                lines.append(f"{prefix}  [cyan]{k}[/cyan]:")
+                lines.append(formatted_v)
+            else:
+                lines.append(f"{prefix}  [cyan]{k}[/cyan]: {formatted_v}")
+        return "\n".join(lines)
+    elif isinstance(value, list):
+        if not value:
+            return "[]"
+        return "[" + ", ".join(str(v) for v in value) + "]"
+    elif isinstance(value, str):
+        if value == "********":
+            return "[dim]********[/dim]"
+        return f"[green]{value}[/green]"
+    elif isinstance(value, bool):
+        return f"[yellow]{value}[/yellow]"
+    elif isinstance(value, (int, float)):
+        return f"[magenta]{value}[/magenta]"
+    else:
+        return str(value)
+
+
+def _build_tree(tree: Tree, data: dict[str, Any], unmask: bool = False) -> None:
+    """Build a Rich tree from configuration data.
+
+    Args:
+        tree: Rich Tree to populate.
+        data: Configuration data.
+        unmask: If True, don't mask sensitive values.
+    """
+    masked_data = _mask_sensitive(data, unmask)
+
+    for key, value in masked_data.items():
+        if isinstance(value, dict) and value:
+            branch = tree.add(f"[bold cyan]{key}[/bold cyan]")
+            _build_tree(branch, value, unmask=True)  # Already masked at top level
+        else:
+            formatted = _format_value(value)
+            tree.add(f"[cyan]{key}[/cyan]: {formatted}")
+
+
+@click.command()
+@click.option(
+    "--section",
+    "-s",
+    type=str,
+    help="Show only a specific section (e.g., 'clusters', 'settings', 'users').",
+)
+@click.option(
+    "--unmask",
+    is_flag=True,
+    default=False,
+    help="Show passwords and tokens unmasked (use with caution).",
+)
+@click.pass_context
+def show(ctx: click.Context, section: str | None, unmask: bool) -> None:
+    """Display current configuration.
+
+    Shows the loaded configuration with sensitive values masked by default.
+    Use --unmask to reveal passwords and tokens (use with caution).
+
+    Examples:
+
+        nf config show                    # Show all config
+        nf config show -s clusters        # Show only clusters
+        nf config show -s settings        # Show only settings
+        nf config show --unmask           # Show with passwords visible
+    """
+    config_dir = ctx.obj.get("config_dir", "config")
+
+    # Check if config directory exists
+    config_path = Path.cwd() / config_dir
+    if not config_path.exists():
+        print_error(f"Configuration directory not found: {config_path}")
+        ctx.exit(1)
+
+    try:
+        config = Config(config_dir=config_dir, script_name="config-show")
+    except Exception as e:
+        print_error(f"Failed to load configuration: {e}")
+        ctx.exit(1)
+
+    console.print(f"\nConfiguration from: [cyan]{config_path}[/cyan]\n")
+
+    if unmask:
+        console.print("[yellow]Warning: Sensitive values are unmasked![/yellow]\n")
+
+    # Determine what to show
+    if section:
+        section_lower = section.lower()
+        # Check in data first (clusters, aiqums, etc.)
+        if section_lower in config.data:
+            tree = Tree(f"[bold blue]{section}[/bold blue]")
+            _build_tree(tree, config.data[section_lower], unmask)
+            console.print(tree)
+        # Check in settings
+        elif section_lower in config.settings:
+            tree = Tree(f"[bold blue]{section}[/bold blue]")
+            _build_tree(tree, config.settings[section_lower], unmask)
+            console.print(tree)
+        else:
+            available = list(config.data.keys()) + list(config.settings.keys())
+            print_error(f"Section '{section}' not found.")
+            console.print(f"Available sections: {', '.join(available)}")
+            ctx.exit(1)
+    else:
+        # Show everything
+        # Data sections
+        if config.data:
+            data_tree = Tree("[bold blue]Data[/bold blue]")
+            for data_type, items in config.data.items():
+                if items:
+                    type_branch = data_tree.add(f"[bold]{data_type}[/bold] ({len(items)} items)")
+                    for name, item_data in items.items():
+                        item_branch = type_branch.add(f"[cyan]{name}[/cyan]")
+                        masked = _mask_sensitive(item_data, unmask)
+                        for k, v in masked.items():
+                            if k != "name":  # Skip redundant name
+                                formatted = _format_value(v)
+                                item_branch.add(f"{k}: {formatted}")
+            console.print(data_tree)
+            console.print()
+
+        # Settings sections
+        if config.settings:
+            settings_tree = Tree("[bold blue]Settings[/bold blue]")
+            _build_tree(settings_tree, config.settings, unmask)
+            console.print(settings_tree)
+
+    # Show summary
+    console.print()
+    summary_lines = [
+        f"Config directory: {config.config_dir}",
+        f"Clusters: {len(config.data.get('clusters', {}))}",
+        f"Settings files: {len(config.settings)}",
+    ]
+    console.print(Panel("\n".join(summary_lines), title="Summary", border_style="dim"))

--- a/src/pynetappfoundry/cli/commands/config/validate.py
+++ b/src/pynetappfoundry/cli/commands/config/validate.py
@@ -1,0 +1,220 @@
+"""Config validation command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from pydantic import ValidationError
+from rich.console import Console
+from rich.panel import Panel
+from rich.tree import Tree
+
+from pynetappfoundry.cli.utils import print_error, print_success
+from pynetappfoundry.core.config import Config, ConfigurationError
+from pynetappfoundry.core.models import (
+    ClusterConfig,
+    UserCredentials,
+)
+
+console = Console()
+
+
+def _validate_clusters(config: Config, tree: Tree) -> list[str]:
+    """Validate cluster configurations.
+
+    Args:
+        config: Config instance to validate.
+        tree: Rich Tree to add results to.
+
+    Returns:
+        List of validation error messages.
+    """
+    errors: list[str] = []
+    clusters_branch = tree.add("[bold]Clusters[/bold]")
+
+    clusters = config.data.get("clusters", {})
+    if not clusters:
+        clusters_branch.add("[yellow]No clusters configured[/yellow]")
+        return errors
+
+    for name, cluster_data in clusters.items():
+        try:
+            ClusterConfig.model_validate(cluster_data)
+            clusters_branch.add(f"[green]{name}[/green]")
+        except ValidationError as e:
+            clusters_branch.add(f"[red]{name}: Invalid[/red]")
+            for err in e.errors():
+                loc = ".".join(str(x) for x in err["loc"])
+                errors.append(f"clusters.{name}.{loc}: {err['msg']}")
+
+    return errors
+
+
+def _validate_users(config: Config, tree: Tree) -> list[str]:
+    """Validate user credential configurations.
+
+    Args:
+        config: Config instance to validate.
+        tree: Rich Tree to add results to.
+
+    Returns:
+        List of validation error messages.
+    """
+    errors: list[str] = []
+    users_branch = tree.add("[bold]Users[/bold]")
+
+    users = config.settings.get("users", {})
+    if not users:
+        users_branch.add("[yellow]No users configured[/yellow]")
+        return errors
+
+    for utype, udata in users.items():
+        if isinstance(udata, dict) and "user" in udata:
+            try:
+                UserCredentials.model_validate(udata)
+                users_branch.add(f"[green]{utype}[/green]")
+            except ValidationError as e:
+                users_branch.add(f"[red]{utype}: Invalid[/red]")
+                for err in e.errors():
+                    loc = ".".join(str(x) for x in err["loc"])
+                    errors.append(f"users.{utype}.{loc}: {err['msg']}")
+
+    return errors
+
+
+def _validate_settings(config: Config, tree: Tree) -> list[str]:
+    """Validate settings configurations.
+
+    Args:
+        config: Config instance to validate.
+        tree: Rich Tree to add results to.
+
+    Returns:
+        List of validation error messages.
+    """
+    errors: list[str] = []
+    settings_branch = tree.add("[bold]Settings[/bold]")
+
+    # Validate ONTAP API settings
+    try:
+        config.get_ontap_api_settings()
+        settings_branch.add("[green]ONTAP API[/green]")
+    except ConfigurationError:
+        settings_branch.add("[yellow]ONTAP API: Not configured[/yellow]")
+    except ValidationError as e:
+        settings_branch.add("[red]ONTAP API: Invalid[/red]")
+        for err in e.errors():
+            loc = ".".join(str(x) for x in err["loc"])
+            errors.append(f"ontapapi.general.{loc}: {err['msg']}")
+
+    # Validate DII API settings (optional)
+    try:
+        config.get_dii_api_settings()
+        settings_branch.add("[green]DII API[/green]")
+    except ConfigurationError:
+        settings_branch.add("[dim]DII API: Not configured (optional)[/dim]")
+    except ValidationError as e:
+        settings_branch.add("[red]DII API: Invalid[/red]")
+        for err in e.errors():
+            loc = ".".join(str(x) for x in err["loc"])
+            errors.append(f"diiapi.general.{loc}: {err['msg']}")
+
+    # Validate SMTP settings (optional)
+    try:
+        config.get_smtp_settings()
+        settings_branch.add("[green]SMTP[/green]")
+    except ConfigurationError:
+        settings_branch.add("[dim]SMTP: Not configured (optional)[/dim]")
+    except ValidationError as e:
+        settings_branch.add("[red]SMTP: Invalid[/red]")
+        for err in e.errors():
+            loc = ".".join(str(x) for x in err["loc"])
+            errors.append(f"settings.SMTP.{loc}: {err['msg']}")
+
+    # Validate licensing settings (optional)
+    licensing = config.get_licensing_settings()
+    if licensing:
+        settings_branch.add("[green]Licensing[/green]")
+    else:
+        settings_branch.add("[dim]Licensing: Not configured (optional)[/dim]")
+
+    return errors
+
+
+def _check_cluster_credentials(config: Config, tree: Tree) -> list[str]:
+    """Check that all clusters have valid credentials.
+
+    Args:
+        config: Config instance to validate.
+        tree: Rich Tree to add results to.
+
+    Returns:
+        List of validation error messages.
+    """
+    errors: list[str] = []
+    creds_branch = tree.add("[bold]Cluster Credentials[/bold]")
+
+    clusters = config.data.get("clusters", {})
+    for name in clusters:
+        try:
+            user, _enc = config.get_user("clusters", name)
+            creds_branch.add(f"[green]{name}: {user}[/green]")
+        except ConfigurationError:
+            creds_branch.add(f"[red]{name}: Missing credentials[/red]")
+            errors.append(f"Cluster '{name}' has no credentials configured")
+
+    return errors
+
+
+@click.command()
+@click.pass_context
+def validate(ctx: click.Context) -> None:
+    """Validate configuration files.
+
+    Checks that all configuration files are properly formatted and contain
+    valid values. Reports any validation errors found.
+    """
+    config_dir = ctx.obj.get("config_dir", "config")
+
+    # Check if config directory exists
+    config_path = Path.cwd() / config_dir
+    if not config_path.exists():
+        print_error(f"Configuration directory not found: {config_path}")
+        ctx.exit(1)
+
+    console.print(f"\nValidating configuration in: [cyan]{config_path}[/cyan]\n")
+
+    try:
+        config = Config(config_dir=config_dir, script_name="config-validate")
+    except Exception as e:
+        print_error(f"Failed to load configuration: {e}")
+        ctx.exit(1)
+
+    # Build validation tree
+    tree = Tree("[bold blue]Configuration Validation[/bold blue]")
+    all_errors: list[str] = []
+
+    # Validate each section
+    all_errors.extend(_validate_clusters(config, tree))
+    all_errors.extend(_validate_users(config, tree))
+    all_errors.extend(_validate_settings(config, tree))
+    all_errors.extend(_check_cluster_credentials(config, tree))
+
+    # Print the tree
+    console.print(tree)
+    console.print()
+
+    # Summary
+    if all_errors:
+        console.print(
+            Panel(
+                "\n".join(f"[red]- {err}[/red]" for err in all_errors),
+                title="[red]Validation Errors[/red]",
+                border_style="red",
+            )
+        )
+        print_error(f"\nValidation failed with {len(all_errors)} error(s)")
+        ctx.exit(1)
+    else:
+        print_success("Configuration is valid")

--- a/src/pynetappfoundry/cli/main.py
+++ b/src/pynetappfoundry/cli/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import click
 
 from pynetappfoundry._version import __version__
+from pynetappfoundry.cli.commands.config import config
 from pynetappfoundry.cli.commands.events import events
 from pynetappfoundry.cli.commands.licenses import licenses
 from pynetappfoundry.cli.commands.metrics import metrics
@@ -47,10 +48,11 @@ def nf(ctx: click.Context, config_dir: str, output_dir: str, debug: bool) -> Non
 
 
 # Explicit registration (infrafoundry pattern)
-nf.add_command(licenses)
-nf.add_command(reports)
+nf.add_command(config)
 nf.add_command(events)
+nf.add_command(licenses)
 nf.add_command(metrics)
+nf.add_command(reports)
 nf.add_command(utils)
 
 

--- a/src/pynetappfoundry/core/config.py
+++ b/src/pynetappfoundry/core/config.py
@@ -65,7 +65,16 @@ class ConfigurationError(Exception):
 
 
 class Config:
-    """Configuration manager for TOML-based config files."""
+    """Configuration manager for TOML-based config files.
+
+    Environment Variables:
+        NF_CONFIG_DIR: Override the default config directory path.
+        NF_<CLUSTER>_USER: Override username for a specific cluster.
+        NF_<CLUSTER>_PASSWORD: Override password (base64 encoded) for a specific cluster.
+
+    The cluster name in environment variables should be uppercase with hyphens
+    replaced by underscores (e.g., cluster-prod -> NF_CLUSTER_PROD_USER).
+    """
 
     def __init__(
         self,
@@ -78,12 +87,18 @@ class Config:
 
         Args:
             config_dir: Directory containing config files (relative to cwd or absolute).
+                        Can be overridden by NF_CONFIG_DIR environment variable.
             output_dir: Directory for output files. If empty, uses data/{script_name}/output.
             script_name: Name of the calling script (used for directory naming).
             args: Optional parsed arguments object.
         """
         self.data: dict[str, dict[str, dict[str, Any]]] = {}
         self.args = args
+        # Check for environment variable override
+        env_config_dir = os.environ.get("NF_CONFIG_DIR")
+        if env_config_dir:
+            logging.debug(f"Using config dir from NF_CONFIG_DIR: {env_config_dir}")
+            config_dir = env_config_dir
         self.config_dir = Path.cwd() / config_dir
         self.data_types = ["aiqums", "connectors", "cloudinsights", "clusters", "azure"]
         self.settings: dict[str, Any] = {}
@@ -281,8 +296,25 @@ class Config:
                 else:
                     self.settings[file.stem].update(data)
 
+    def _get_env_var_name(self, object_name: str) -> str:
+        """Convert object name to environment variable format.
+
+        Args:
+            object_name: Name of the object (e.g., 'cluster-prod').
+
+        Returns:
+            Environment variable prefix (e.g., 'NF_CLUSTER_PROD').
+        """
+        # Replace hyphens with underscores and convert to uppercase
+        return "NF_" + object_name.replace("-", "_").upper()
+
     def get_user(self, utype: str = "clusters", uobject: str = "") -> tuple[str, str]:
         """Get user credentials for a given type and object.
+
+        Credentials are resolved in the following order (first found wins):
+        1. Environment variables: NF_<OBJECT>_USER and NF_<OBJECT>_PASSWORD
+        2. Object-specific config in data files (e.g., clusters.toml)
+        3. Default credentials in users.toml for the type
 
         Args:
             utype: Type of object (e.g., 'clusters').
@@ -297,29 +329,53 @@ class Config:
         user: str | None = None
         enc: str | None = None
 
-        try:
-            user = self.settings["users"][utype]["user"]
-            enc = self.settings["users"][utype]["enc"]
-        except KeyError:
-            pass
+        # 1. Check environment variables first (highest priority)
+        if uobject:
+            env_prefix = self._get_env_var_name(uobject)
+            env_user = os.environ.get(f"{env_prefix}_USER")
+            env_password = os.environ.get(f"{env_prefix}_PASSWORD")
+            if env_user:
+                logging.debug(f"Using user from {env_prefix}_USER")
+                user = env_user
+            if env_password:
+                logging.debug(f"Using password from {env_prefix}_PASSWORD")
+                enc = env_password
 
-        try:
-            user = self.data[utype][uobject]["user"]
-            enc = self.data[utype][uobject]["enc"]
-        except KeyError:
-            pass
+        # 2. Check object-specific config (if not already set by env vars)
+        if not user or not enc:
+            try:
+                if not user:
+                    user = self.data[utype][uobject]["user"]
+                if not enc:
+                    enc = self.data[utype][uobject]["enc"]
+            except KeyError:
+                pass
+
+        # 3. Fall back to default credentials for the type
+        if not user or not enc:
+            try:
+                if not user:
+                    user = self.settings["users"][utype]["user"]
+                if not enc:
+                    enc = self.settings["users"][utype]["enc"]
+            except KeyError:
+                pass
 
         if not user:
             logging.error(f"Could not find user for {utype} and {uobject}")
+            env_prefix = self._get_env_var_name(uobject) if uobject else "NF_<OBJECT>"
             raise ConfigurationError(
                 f"Could not find user for type={utype!r}, object={uobject!r}. "
-                "Ensure credentials are configured in users.toml or the object's data file."
+                f"Set {env_prefix}_USER environment variable, or configure in "
+                "users.toml or the object's data file."
             )
         if not enc:
             logging.error(f"Could not find password for {utype} and {uobject}")
+            env_prefix = self._get_env_var_name(uobject) if uobject else "NF_<OBJECT>"
             raise ConfigurationError(
                 f"Could not find password for type={utype!r}, object={uobject!r}. "
-                "Ensure 'enc' (encoded password) is configured."
+                f"Set {env_prefix}_PASSWORD environment variable (base64 encoded), "
+                "or configure 'enc' in config files."
             )
 
         return user, enc

--- a/tests/unit/test_config_commands.py
+++ b/tests/unit/test_config_commands.py
@@ -1,0 +1,409 @@
+"""Tests for config CLI commands and environment variable support."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from pynetappfoundry.cli.main import nf
+from pynetappfoundry.core.config import Config, ConfigurationError
+
+
+def _create_test_config_files(config_dir: Path) -> None:
+    """Create standard test configuration files in the given directory.
+
+    Note: The file name determines the first-level key in config.settings:
+    - users.toml -> config.settings["users"]
+    - settings.toml -> config.settings["settings"]
+    - ontapapi.toml -> config.settings["ontapapi"]
+
+    So users.toml should have [clusters] not [users.clusters] for
+    config.settings["users"]["clusters"] to work correctly.
+    """
+    # Create a data TOML file (marked with settings.type = "data")
+    data_toml = config_dir / "clusters.toml"
+    data_toml.write_text("""
+[settings]
+type = "data"
+
+[clusters.test-cluster-1]
+name = "test-cluster-1"
+ip = "10.0.0.1"
+bu = "Engineering"
+env = "Dev"
+tags = ["active", "workload"]
+
+[clusters.test-cluster-2]
+name = "test-cluster-2"
+ip = "10.0.0.2"
+bu = "Engineering"
+env = "Prod"
+tags = ["active"]
+user = "cluster2-admin"
+enc = "cluster2-encoded-pass"
+""")
+
+    # Create a settings TOML file
+    # Stored at config.settings["settings"]
+    settings_toml = config_dir / "settings.toml"
+    settings_toml.write_text("""
+[clusters]
+searchable_keys = ["bu", "env", "tags"]
+""")
+
+    # Create ONTAP API settings file
+    # Stored at config.settings["ontapapi"]
+    # Accessed via get_ontap_api_settings() -> get_setting("ontapapi", "general")
+    ontapapi_toml = config_dir / "ontapapi.toml"
+    ontapapi_toml.write_text("""
+[general]
+base_api_path = "/api"
+""")
+
+    # Create a users TOML file
+    # Stored at config.settings["users"]
+    # [clusters] at root means settings["users"]["clusters"] works correctly
+    users_toml = config_dir / "users.toml"
+    users_toml.write_text("""
+[clusters]
+user = "admin"
+enc = "encoded_password_123"
+""")
+
+
+@pytest.fixture
+def temp_config_dir(tmp_path: Path) -> Path:
+    """Create a temporary config directory with test TOML files."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    _create_test_config_files(config_dir)
+    return config_dir
+
+
+@pytest.fixture
+def config_instance(temp_config_dir: Path, tmp_path: Path) -> Config:
+    """Create a Config instance with the temporary config directory."""
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        config = Config(
+            config_dir=str(temp_config_dir),
+            output_dir=str(output_dir),
+            script_name="test_script",
+        )
+    finally:
+        os.chdir(original_cwd)
+    return config
+
+
+class TestConfigShowCommand:
+    """Tests for nf config show command."""
+
+    def test_show_displays_config(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test that config show displays configuration."""
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            # Copy config dir to isolated filesystem
+            import shutil
+
+            shutil.copytree(temp_config_dir, Path.cwd() / "config")
+
+            result = runner.invoke(nf, ["config", "show"])
+            assert result.exit_code == 0
+            assert "Configuration from:" in result.output
+            assert "clusters" in result.output.lower()
+
+    def test_show_section_filter(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test that --section filters output."""
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            import shutil
+
+            shutil.copytree(temp_config_dir, Path.cwd() / "config")
+
+            result = runner.invoke(nf, ["config", "show", "-s", "clusters"])
+            assert result.exit_code == 0
+            assert "test-cluster-1" in result.output
+
+    def test_show_invalid_section(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test that invalid section shows error."""
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            import shutil
+
+            shutil.copytree(temp_config_dir, Path.cwd() / "config")
+
+            result = runner.invoke(nf, ["config", "show", "-s", "nonexistent"])
+            assert result.exit_code == 1
+            assert "not found" in result.output.lower()
+
+    def test_show_masks_passwords(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test that passwords are masked by default."""
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            import shutil
+
+            shutil.copytree(temp_config_dir, Path.cwd() / "config")
+
+            result = runner.invoke(nf, ["config", "show"])
+            assert result.exit_code == 0
+            # The encoded password should be masked
+            assert "encoded_password_123" not in result.output
+            assert "********" in result.output
+
+    def test_show_unmask_reveals_passwords(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test that --unmask reveals passwords."""
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            import shutil
+
+            shutil.copytree(temp_config_dir, Path.cwd() / "config")
+
+            result = runner.invoke(nf, ["config", "show", "--unmask"])
+            assert result.exit_code == 0
+            assert "encoded_password_123" in result.output
+
+    def test_show_missing_config_dir(self, tmp_path: Path) -> None:
+        """Test error when config directory doesn't exist."""
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(nf, ["config", "show"])
+            assert result.exit_code == 1
+            assert "not found" in result.output.lower()
+
+
+class TestConfigValidateCommand:
+    """Tests for nf config validate command."""
+
+    def test_validate_valid_config(self, tmp_path: Path) -> None:
+        """Test that valid config passes validation."""
+        # Create config directory in tmp_path
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        _create_test_config_files(config_dir)
+
+        runner = CliRunner()
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            result = runner.invoke(nf, ["config", "validate"])
+            assert result.exit_code == 0, f"Output: {result.output}"
+            assert "valid" in result.output.lower()
+        finally:
+            os.chdir(original_cwd)
+
+    def test_validate_missing_config_dir(self, tmp_path: Path) -> None:
+        """Test error when config directory doesn't exist."""
+        runner = CliRunner()
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            result = runner.invoke(nf, ["config", "validate"])
+            assert result.exit_code == 1
+            assert "not found" in result.output.lower()
+        finally:
+            os.chdir(original_cwd)
+
+    def test_validate_shows_clusters(self, tmp_path: Path) -> None:
+        """Test that validation shows cluster information."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        _create_test_config_files(config_dir)
+
+        runner = CliRunner()
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            result = runner.invoke(nf, ["config", "validate"])
+            assert result.exit_code == 0, f"Output: {result.output}"
+            assert "test-cluster-1" in result.output
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestEnvironmentVariableSupport:
+    """Tests for environment variable configuration overrides."""
+
+    def test_env_var_config_dir(
+        self, temp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that NF_CONFIG_DIR environment variable overrides config directory."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            monkeypatch.setenv("NF_CONFIG_DIR", str(temp_config_dir))
+            # Use a non-existent default path - env var should override
+            config = Config(
+                config_dir="nonexistent",
+                output_dir=str(output_dir),
+                script_name="test",
+            )
+            assert "clusters" in config.data
+            assert "test-cluster-1" in config.data["clusters"]
+        finally:
+            os.chdir(original_cwd)
+
+    def test_env_var_user_override(
+        self, temp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that NF_<CLUSTER>_USER environment variable overrides user."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            # Create config first, then set env var
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test",
+            )
+            # Set env var AFTER config creation but BEFORE get_user call
+            monkeypatch.setenv("NF_TEST_CLUSTER_1_USER", "env-user")
+            user, enc = config.get_user("clusters", "test-cluster-1")
+            assert user == "env-user"
+            # Password should fall back to config
+            assert enc == "encoded_password_123"
+        finally:
+            os.chdir(original_cwd)
+
+    def test_env_var_password_override(
+        self, temp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that NF_<CLUSTER>_PASSWORD environment variable overrides password."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test",
+            )
+            monkeypatch.setenv("NF_TEST_CLUSTER_1_PASSWORD", "env-encoded-pass")
+            user, enc = config.get_user("clusters", "test-cluster-1")
+            # User should fall back to config
+            assert user == "admin"
+            assert enc == "env-encoded-pass"
+        finally:
+            os.chdir(original_cwd)
+
+    def test_env_var_full_override(
+        self, temp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that both user and password can be overridden via environment."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test",
+            )
+            monkeypatch.setenv("NF_TEST_CLUSTER_1_USER", "env-user")
+            monkeypatch.setenv("NF_TEST_CLUSTER_1_PASSWORD", "env-pass")
+            user, enc = config.get_user("clusters", "test-cluster-1")
+            assert user == "env-user"
+            assert enc == "env-pass"
+        finally:
+            os.chdir(original_cwd)
+
+    def test_env_var_name_conversion(self, config_instance: Config) -> None:
+        """Test that cluster names are properly converted to env var format."""
+        # Test the internal method
+        assert config_instance._get_env_var_name("cluster-prod") == "NF_CLUSTER_PROD"
+        assert config_instance._get_env_var_name("my-cluster-1") == "NF_MY_CLUSTER_1"
+        assert config_instance._get_env_var_name("simple") == "NF_SIMPLE"
+
+    def test_env_var_priority_over_object_config(
+        self, temp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that env vars take priority over object-specific config."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test",
+            )
+            # test-cluster-2 has its own credentials in config
+            monkeypatch.setenv("NF_TEST_CLUSTER_2_USER", "env-override")
+            user, enc = config.get_user("clusters", "test-cluster-2")
+            # Env var should win
+            assert user == "env-override"
+            # Password should come from object config
+            assert enc == "cluster2-encoded-pass"
+        finally:
+            os.chdir(original_cwd)
+
+    def test_credentials_fallback_chain(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test the full credential fallback chain."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test",
+            )
+            # No env vars, no object config -> falls back to default users
+            user, enc = config.get_user("clusters", "test-cluster-1")
+            assert user == "admin"
+            assert enc == "encoded_password_123"
+
+            # Object has config -> uses that
+            user, enc = config.get_user("clusters", "test-cluster-2")
+            assert user == "cluster2-admin"
+            assert enc == "cluster2-encoded-pass"
+        finally:
+            os.chdir(original_cwd)
+
+    def test_error_message_includes_env_var_hint(self, tmp_path: Path) -> None:
+        """Test that error messages mention environment variables."""
+        # Create config without default users
+        config_dir = tmp_path / "config_no_users"
+        config_dir.mkdir()
+        (config_dir / "clusters.toml").write_text("""
+[settings]
+type = "data"
+
+[clusters.orphan-cluster]
+name = "orphan-cluster"
+ip = "10.0.0.99"
+""")
+        (config_dir / "settings.toml").write_text("""
+[ontapapi.general]
+base_api_path = "/api"
+""")
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            config = Config(
+                config_dir=str(config_dir),
+                output_dir=str(output_dir),
+                script_name="test",
+            )
+            with pytest.raises(ConfigurationError) as exc_info:
+                config.get_user("clusters", "orphan-cluster")
+            # Error message should mention the env var
+            assert "NF_ORPHAN_CLUSTER_USER" in str(exc_info.value)
+        finally:
+            os.chdir(original_cwd)


### PR DESCRIPTION
## Description

Add `nf config` command group with user experience improvements for configuration management:

- **`nf config show`** - Display loaded configuration with automatic password masking
- **`nf config validate`** - Validate config structure against Pydantic models

Add environment variable support for secure credential management:
- `NF_CONFIG_DIR` - Override config directory path
- `NF_<CLUSTER>_USER` - Override username for specific cluster
- `NF_<CLUSTER>_PASSWORD` - Override password (base64 encoded)

This addresses item #11 (User Experience) from the first-pass refactor plan.

## Related Issue

Closes #21

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- Create `src/pynetappfoundry/cli/commands/config/` command group
- Add `show.py` - config display with masking and section filtering
- Add `validate.py` - config validation against Pydantic models
- Update `config.py` - add environment variable support in `get_user()` and `__init__()`
- Add 17 comprehensive tests in `tests/unit/test_config_commands.py`
- Update `docs/reference/config-schema.md` with env var and CLI documentation

## Testing

- [x] All existing tests pass (107 tests)
- [x] Added new tests for new functionality (17 tests)
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings