### PR TITLE
feat: add response validation and retry logic to APIWrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "paramiko>=4.0.0",
     "psutil>=7.1.2",
     "pydantic>=2.0",
+    "tenacity>=8.2",
     "xlsxwriter>=3.2.9",
     "requests>=2.31",
     "yattag>=1.15",

--- a/src/pynetappfoundry/clients/openapi.py
+++ b/src/pynetappfoundry/clients/openapi.py
@@ -10,6 +10,43 @@ from urllib.parse import urlencode
 
 import requests
 from jsonschema import ValidationError, validate
+from tenacity import (
+    RetryCallState,
+    retry,
+    retry_if_exception_type,
+    retry_if_result,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from pynetappfoundry.core.models import RetryConfig, ValidationConfig
+
+
+class ResponseValidationError(Exception):
+    """Raised when API response fails schema validation in strict mode."""
+
+    def __init__(
+        self,
+        message: str,
+        path_template: str,
+        method: str,
+        status_code: int,
+        validation_error: str,
+    ) -> None:
+        """Initialize the exception.
+
+        Args:
+            message: Error message.
+            path_template: The API path template.
+            method: HTTP method.
+            status_code: Response status code.
+            validation_error: The underlying validation error message.
+        """
+        super().__init__(message)
+        self.path_template = path_template
+        self.method = method
+        self.status_code = status_code
+        self.validation_error = validation_error
 
 
 class APIWrapper:
@@ -24,6 +61,8 @@ class APIWrapper:
         session: requests.Session | None = None,
         base_api_path: str = "",
         verify_ssl: bool = True,
+        retry_config: RetryConfig | None = None,
+        validation_config: ValidationConfig | None = None,
     ) -> None:
         """Initialize the API wrapper.
 
@@ -35,6 +74,8 @@ class APIWrapper:
             session: Existing requests session to use.
             base_api_path: Base path prefix for all API paths.
             verify_ssl: Whether to verify SSL certificates. Default True for security.
+            retry_config: Configuration for retry behavior. Defaults to enabled.
+            validation_config: Configuration for response validation. Defaults to disabled.
         """
         self.verify_ssl = verify_ssl
         # Load the API spec
@@ -63,6 +104,12 @@ class APIWrapper:
 
         self.session.headers.update(default_headers)
         self.session.headers.update(auth_header)
+
+        # Retry and validation configuration
+        self.retry_config = retry_config if retry_config is not None else RetryConfig()
+        self.validation_config = (
+            validation_config if validation_config is not None else ValidationConfig()
+        )
 
     def _get_operation(self, api_path: str, method: str) -> dict[str, Any]:
         """Get the operation for an API path.
@@ -318,6 +365,218 @@ class APIWrapper:
             "body_sample": body_sample,
         }
 
+    def _get_response_schema(
+        self, path_template: str, method: str, status_code: int
+    ) -> dict[str, Any] | None:
+        """Extract response schema from the OpenAPI spec for a given status code.
+
+        Args:
+            path_template: The API path template.
+            method: HTTP method.
+            status_code: The response status code to get schema for.
+
+        Returns:
+            Resolved JSON Schema dict for the response, or None if not found.
+        """
+        op = self._get_operation(path_template, method)
+        responses = op.get("responses", {})
+
+        # Try exact status code first, then wildcard (e.g., "2XX"), then "default"
+        status_str = str(status_code)
+        response_spec = responses.get(status_str)
+
+        if not response_spec:
+            # Try wildcard like "2XX"
+            wildcard = f"{status_str[0]}XX"
+            response_spec = responses.get(wildcard)
+
+        if not response_spec:
+            response_spec = responses.get("default")
+
+        if not response_spec:
+            return None
+
+        # OpenAPI 3.x style
+        content = response_spec.get("content", {}).get("application/json", {})
+        schema = content.get("schema")
+
+        if schema:
+            resolved: dict[str, Any] = self._resolve_refs(schema)
+            return resolved
+
+        return None
+
+    def validate_response(
+        self,
+        path_template: str,
+        method: str,
+        status_code: int,
+        response_data: Any,
+        validation_config: ValidationConfig | None = None,
+    ) -> bool:
+        """Validate response data against the OpenAPI schema.
+
+        Args:
+            path_template: The API path template.
+            method: HTTP method.
+            status_code: The response status code.
+            response_data: The response data to validate.
+            validation_config: Optional override for validation config.
+
+        Returns:
+            True if validation passes or is disabled, False otherwise.
+
+        Raises:
+            ResponseValidationError: If strict mode is enabled and validation fails.
+        """
+        config = validation_config if validation_config is not None else self.validation_config
+
+        if not config.enabled:
+            return True
+
+        # Only validate success responses if configured
+        if config.validate_success_only and not (200 <= status_code < 300):
+            return True
+
+        schema = self._get_response_schema(path_template, method, status_code)
+        if not schema:
+            logging.debug(
+                f"No response schema found for {method} {path_template} status {status_code}"
+            )
+            return True
+
+        try:
+            validate(instance=response_data, schema=schema)
+            return True
+        except ValidationError as e:
+            error_msg = (
+                f"Response validation failed for {method} {path_template} "
+                f"status {status_code}: {e.message}"
+            )
+            if config.strict:
+                raise ResponseValidationError(
+                    message=error_msg,
+                    path_template=path_template,
+                    method=method,
+                    status_code=status_code,
+                    validation_error=e.message,
+                ) from e
+            logging.warning(error_msg)
+            return False
+
+    def _should_retry_response(
+        self, response: requests.Response, retry_config: RetryConfig
+    ) -> bool:
+        """Determine if a response should trigger a retry.
+
+        Args:
+            response: The HTTP response.
+            retry_config: Retry configuration.
+
+        Returns:
+            True if the response status code is in the retryable list.
+        """
+        return response.status_code in retry_config.retryable_status_codes
+
+    def _create_retry_callback(self, retry_config: RetryConfig) -> Any:
+        """Create a callback for logging retry attempts.
+
+        Args:
+            retry_config: Retry configuration.
+
+        Returns:
+            A callback function for tenacity.
+        """
+
+        def log_retry(retry_state: RetryCallState) -> None:
+            if retry_state.attempt_number > 1:
+                outcome = retry_state.outcome
+                if outcome is not None:
+                    exception = outcome.exception()
+                    result = outcome.result() if exception is None else None
+                    if exception:
+                        logging.warning(
+                            f"Retry attempt {retry_state.attempt_number} "
+                            f"after exception: {exception}"
+                        )
+                    elif result is not None and hasattr(result, "status_code"):
+                        logging.warning(
+                            f"Retry attempt {retry_state.attempt_number} "
+                            f"after status code: {result.status_code}"
+                        )
+
+        return log_retry
+
+    def _execute_request_with_retry(
+        self,
+        method: str,
+        url: str,
+        body: dict[str, Any] | None,
+        headers: dict[str, str | bytes],
+        retry_config: RetryConfig | None = None,
+    ) -> requests.Response:
+        """Execute an HTTP request with retry logic.
+
+        Args:
+            method: HTTP method.
+            url: Full URL to request.
+            body: Request body (JSON).
+            headers: Request headers.
+            retry_config: Optional override for retry config.
+
+        Returns:
+            The HTTP response.
+
+        Raises:
+            requests.RequestException: If all retries are exhausted.
+        """
+        config = retry_config if retry_config is not None else self.retry_config
+
+        if not config.enabled:
+            return self.session.request(
+                method,
+                url,
+                json=body,
+                headers=headers,
+                timeout=self.timeout,
+                verify=self.verify_ssl,
+            )
+
+        # Build retry conditions
+        def should_retry_result(response: requests.Response) -> bool:
+            return self._should_retry_response(response, config)
+
+        retry_conditions: Any = retry_if_result(should_retry_result)
+
+        if config.retry_on_connection_error:
+            retry_conditions = retry_conditions | retry_if_exception_type(
+                (requests.ConnectionError, requests.Timeout)
+            )
+
+        # Create the retry decorator dynamically
+        @retry(
+            stop=stop_after_attempt(config.max_attempts),
+            wait=wait_exponential(
+                multiplier=config.initial_wait,
+                max=config.max_wait,
+                exp_base=config.exponential_base,
+            ),
+            retry=retry_conditions,
+            before_sleep=self._create_retry_callback(config),
+            reraise=True,
+        )
+        def make_request() -> requests.Response:
+            return self.session.request(
+                method,
+                url,
+                json=body,
+                headers=headers,
+                timeout=self.timeout,
+                verify=self.verify_ssl,
+            )
+
+        return make_request()
+
     def call_endpoint(
         self,
         path_template: str,
@@ -326,10 +585,13 @@ class APIWrapper:
         query_params: dict[str, Any] | None = None,
         body: dict[str, Any] | None = None,
         additional_headers: dict[str, str] | None = None,
+        retry_config: RetryConfig | None = None,
+        validation_config: ValidationConfig | None = None,
     ) -> Any:
         """Make the HTTP call.
 
-        Validates body (if schema exists) and raises for HTTP errors.
+        Validates body (if schema exists), applies retry logic, validates response,
+        and raises for HTTP errors.
 
         Args:
             path_template: API path template.
@@ -338,6 +600,8 @@ class APIWrapper:
             query_params: Query string parameters.
             body: Request body (JSON).
             additional_headers: Extra headers to include.
+            retry_config: Optional per-call retry configuration override.
+            validation_config: Optional per-call validation configuration override.
 
         Returns:
             Response JSON or text.
@@ -345,6 +609,7 @@ class APIWrapper:
         Raises:
             ValueError: If request body validation fails.
             requests.HTTPError: If the request fails.
+            ResponseValidationError: If response validation fails in strict mode.
         """
         method = method.upper()
 
@@ -368,15 +633,33 @@ class APIWrapper:
             headers.update(additional_headers)
 
         logging.debug(f"Calling {method} {url} {headers}")
-        resp = self.session.request(
-            method, url, json=body, headers=headers, timeout=self.timeout, verify=self.verify_ssl
+
+        # Execute request with retry logic
+        resp = self._execute_request_with_retry(
+            method=method,
+            url=url,
+            body=body,
+            headers=headers,
+            retry_config=retry_config,
         )
+
         logging.debug(f"Response Status Code: {resp.status_code}")
         resp.raise_for_status()
 
         # Try JSON, else return text
         try:
             logging.debug(f"Response Text: {resp.text}")
-            return resp.json()
+            response_data = resp.json()
         except ValueError:
-            return resp.text
+            response_data = resp.text
+
+        # Validate response if enabled
+        self.validate_response(
+            path_template=path_template,
+            method=method,
+            status_code=resp.status_code,
+            response_data=response_data,
+            validation_config=validation_config,
+        )
+
+        return response_data

--- a/src/pynetappfoundry/core/models.py
+++ b/src/pynetappfoundry/core/models.py
@@ -116,6 +116,46 @@ class SearchableKeysConfig(BaseModel):
     searchable_keys: list[str] = Field(default_factory=list)
 
 
+class RetryConfig(BaseModel):
+    """Configuration for HTTP retry behavior.
+
+    Attributes:
+        enabled: Whether retry is enabled. Default True.
+        max_attempts: Maximum number of retry attempts (1-10). Default 3.
+        initial_wait: Initial wait time in seconds before first retry. Default 1.0.
+        max_wait: Maximum wait time in seconds between retries. Default 60.0.
+        exponential_base: Base for exponential backoff calculation. Default 2.
+        retryable_status_codes: HTTP status codes that trigger a retry.
+        retry_on_connection_error: Whether to retry on connection errors. Default True.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    max_attempts: int = Field(default=3, ge=1, le=10)
+    initial_wait: float = Field(default=1.0, ge=0.1)
+    max_wait: float = Field(default=60.0, ge=1.0)
+    exponential_base: int = Field(default=2, ge=2)
+    retryable_status_codes: list[int] = Field(default_factory=lambda: [429, 500, 502, 503, 504])
+    retry_on_connection_error: bool = True
+
+
+class ValidationConfig(BaseModel):
+    """Configuration for response validation behavior.
+
+    Attributes:
+        enabled: Whether validation is enabled. Default False (opt-in).
+        strict: If True, raise exception on validation failure. If False, log warning.
+        validate_success_only: Only validate 2xx responses. Default True.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    strict: bool = False
+    validate_success_only: bool = True
+
+
 # Type aliases for collections
 ClusterCollection = dict[str, ClusterConfig]
 AIQUMCollection = dict[str, AIQUMConfig]

--- a/tests/unit/test_openapi.py
+++ b/tests/unit/test_openapi.py
@@ -9,8 +9,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
+from tenacity import RetryError
 
-from pynetappfoundry.clients.openapi import APIWrapper
+from pynetappfoundry.clients.openapi import APIWrapper, ResponseValidationError
+from pynetappfoundry.core.models import RetryConfig, ValidationConfig
 
 
 @pytest.fixture
@@ -517,3 +519,494 @@ class TestGetRequestSchemaForEndpoint:
         """Test None returned when no request body."""
         result = api_wrapper.get_request_schema_for_endpoint("/users", "GET")
         assert result is None
+
+
+class TestRetryConfig:
+    """Tests for RetryConfig model."""
+
+    def test_default_values(self) -> None:
+        """Test default configuration values."""
+        config = RetryConfig()
+        assert config.enabled is True
+        assert config.max_attempts == 3
+        assert config.initial_wait == 1.0
+        assert config.max_wait == 60.0
+        assert config.exponential_base == 2
+        assert config.retryable_status_codes == [429, 500, 502, 503, 504]
+        assert config.retry_on_connection_error is True
+
+    def test_custom_values(self) -> None:
+        """Test custom configuration values."""
+        config = RetryConfig(
+            enabled=False,
+            max_attempts=5,
+            initial_wait=0.5,
+            max_wait=30.0,
+            exponential_base=3,
+            retryable_status_codes=[500, 503],
+            retry_on_connection_error=False,
+        )
+        assert config.enabled is False
+        assert config.max_attempts == 5
+        assert config.initial_wait == 0.5
+        assert config.max_wait == 30.0
+        assert config.exponential_base == 3
+        assert config.retryable_status_codes == [500, 503]
+        assert config.retry_on_connection_error is False
+
+    def test_max_attempts_bounds(self) -> None:
+        """Test max_attempts validation bounds."""
+        with pytest.raises(ValueError):
+            RetryConfig(max_attempts=0)  # below minimum
+        with pytest.raises(ValueError):
+            RetryConfig(max_attempts=11)  # above maximum
+
+    def test_initial_wait_minimum(self) -> None:
+        """Test initial_wait validation minimum."""
+        with pytest.raises(ValueError):
+            RetryConfig(initial_wait=0.05)  # below 0.1
+
+    def test_max_wait_minimum(self) -> None:
+        """Test max_wait validation minimum."""
+        with pytest.raises(ValueError):
+            RetryConfig(max_wait=0.5)  # below 1.0
+
+    def test_exponential_base_minimum(self) -> None:
+        """Test exponential_base validation minimum."""
+        with pytest.raises(ValueError):
+            RetryConfig(exponential_base=1)  # below 2
+
+
+class TestValidationConfig:
+    """Tests for ValidationConfig model."""
+
+    def test_default_values(self) -> None:
+        """Test default configuration values."""
+        config = ValidationConfig()
+        assert config.enabled is False
+        assert config.strict is False
+        assert config.validate_success_only is True
+
+    def test_custom_values(self) -> None:
+        """Test custom configuration values."""
+        config = ValidationConfig(
+            enabled=True,
+            strict=True,
+            validate_success_only=False,
+        )
+        assert config.enabled is True
+        assert config.strict is True
+        assert config.validate_success_only is False
+
+
+class TestResponseValidation:
+    """Tests for response validation."""
+
+    @pytest.fixture
+    def spec_with_response_schema(self, tmp_path: Path) -> Path:
+        """Create a spec with response schemas."""
+        spec = {
+            "swagger": "2.0",
+            "basePath": "/api/v1",
+            "paths": {
+                "/users": {
+                    "get": {
+                        "summary": "List users",
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "required": ["users"],
+                                            "properties": {
+                                                "users": {
+                                                    "type": "array",
+                                                    "items": {"type": "object"},
+                                                },
+                                                "count": {"type": "integer"},
+                                            },
+                                        }
+                                    }
+                                }
+                            },
+                            "default": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {"error": {"type": "string"}},
+                                        }
+                                    }
+                                }
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        spec_path = tmp_path / "spec_with_response.json"
+        spec_path.write_text(json.dumps(spec))
+        return spec_path
+
+    @pytest.fixture
+    def wrapper_with_response_schema(self, spec_with_response_schema: Path) -> APIWrapper:
+        """Create wrapper with response schema spec."""
+        return APIWrapper(
+            api_json_file=str(spec_with_response_schema),
+            base_url="https://api.example.com",
+            validation_config=ValidationConfig(enabled=True),
+        )
+
+    def test_validate_response_valid_data(self, wrapper_with_response_schema: APIWrapper) -> None:
+        """Test validation passes for valid response data."""
+        result = wrapper_with_response_schema.validate_response(
+            "/users", "GET", 200, {"users": [], "count": 0}
+        )
+        assert result is True
+
+    def test_validate_response_invalid_data_warning(
+        self, wrapper_with_response_schema: APIWrapper
+    ) -> None:
+        """Test validation fails with warning for invalid data (non-strict)."""
+        result = wrapper_with_response_schema.validate_response(
+            "/users",
+            "GET",
+            200,
+            {"invalid": "data"},  # missing required 'users'
+        )
+        assert result is False
+
+    def test_validate_response_invalid_data_strict(self, spec_with_response_schema: Path) -> None:
+        """Test validation raises exception for invalid data in strict mode."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_with_response_schema),
+            base_url="https://api.example.com",
+            validation_config=ValidationConfig(enabled=True, strict=True),
+        )
+        with pytest.raises(ResponseValidationError) as exc_info:
+            wrapper.validate_response("/users", "GET", 200, {"invalid": "data"})
+        assert exc_info.value.status_code == 200
+        assert exc_info.value.method == "GET"
+        assert exc_info.value.path_template == "/users"
+
+    def test_validate_response_disabled(self, spec_with_response_schema: Path) -> None:
+        """Test validation skipped when disabled."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_with_response_schema),
+            base_url="https://api.example.com",
+            validation_config=ValidationConfig(enabled=False),
+        )
+        result = wrapper.validate_response("/users", "GET", 200, {"invalid": "data"})
+        assert result is True  # Skipped, returns True
+
+    def test_validate_response_success_only(self, wrapper_with_response_schema: APIWrapper) -> None:
+        """Test validation skips non-2xx when validate_success_only is True."""
+        # 404 response should not be validated with validate_success_only=True (default)
+        result = wrapper_with_response_schema.validate_response(
+            "/users", "GET", 404, {"any": "data"}
+        )
+        assert result is True
+
+    def test_validate_response_all_status_codes(self, spec_with_response_schema: Path) -> None:
+        """Test validation applies to all status codes when validate_success_only=False."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_with_response_schema),
+            base_url="https://api.example.com",
+            validation_config=ValidationConfig(enabled=True, validate_success_only=False),
+        )
+        # Uses "default" schema for non-200 responses
+        result = wrapper.validate_response("/users", "GET", 404, {"error": "not found"})
+        assert result is True
+
+    def test_validate_response_no_schema(self, api_wrapper: APIWrapper) -> None:
+        """Test validation passes when no schema defined."""
+        result = api_wrapper.validate_response("/items", "GET", 200, {"any": "data"})
+        assert result is True
+
+    def test_get_response_schema_exact_status(
+        self, wrapper_with_response_schema: APIWrapper
+    ) -> None:
+        """Test getting response schema by exact status code."""
+        schema = wrapper_with_response_schema._get_response_schema("/users", "GET", 200)
+        assert schema is not None
+        assert "properties" in schema
+        assert "users" in schema["properties"]
+
+    def test_get_response_schema_default(self, wrapper_with_response_schema: APIWrapper) -> None:
+        """Test getting default response schema."""
+        schema = wrapper_with_response_schema._get_response_schema("/users", "GET", 500)
+        assert schema is not None
+        assert "properties" in schema
+        assert "error" in schema["properties"]
+
+
+class TestRetryLogic:
+    """Tests for retry logic."""
+
+    def test_retry_on_503(self, spec_file: Path) -> None:
+        """Test retry on 503 status code."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            retry_config=RetryConfig(max_attempts=3, initial_wait=0.1, max_wait=1.0),
+        )
+        with patch.object(wrapper.session, "request") as mock_request:
+            # First two calls return 503, third succeeds
+            mock_503 = MagicMock()
+            mock_503.status_code = 503
+
+            mock_200 = MagicMock()
+            mock_200.status_code = 200
+            mock_200.json.return_value = {"users": []}
+
+            mock_request.side_effect = [mock_503, mock_503, mock_200]
+
+            result = wrapper.call_endpoint("/users", "GET")
+
+            assert result == {"users": []}
+            assert mock_request.call_count == 3
+
+    def test_retry_exhausted(self, spec_file: Path) -> None:
+        """Test that RetryError is raised when retries are exhausted."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            retry_config=RetryConfig(max_attempts=2, initial_wait=0.1, max_wait=1.0),
+        )
+        with patch.object(wrapper.session, "request") as mock_request:
+            mock_503 = MagicMock()
+            mock_503.status_code = 503
+
+            mock_request.return_value = mock_503
+
+            # tenacity raises RetryError when max attempts reached with retryable result
+            with pytest.raises(RetryError):
+                wrapper.call_endpoint("/users", "GET")
+
+            # Should have tried max_attempts times
+            assert mock_request.call_count == 2
+
+    def test_retry_disabled(self, spec_file: Path) -> None:
+        """Test that retry can be disabled."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            retry_config=RetryConfig(enabled=False),
+        )
+        with patch.object(wrapper.session, "request") as mock_request:
+            mock_503 = MagicMock()
+            mock_503.status_code = 503
+            mock_503.raise_for_status.side_effect = requests.HTTPError("Service Unavailable")
+
+            mock_request.return_value = mock_503
+
+            with pytest.raises(requests.HTTPError):
+                wrapper.call_endpoint("/users", "GET")
+
+            # No retry, only one call
+            assert mock_request.call_count == 1
+
+    def test_retry_on_connection_error(self, spec_file: Path) -> None:
+        """Test retry on connection error."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            retry_config=RetryConfig(
+                max_attempts=3, initial_wait=0.1, max_wait=1.0, retry_on_connection_error=True
+            ),
+        )
+        with patch.object(wrapper.session, "request") as mock_request:
+            mock_200 = MagicMock()
+            mock_200.status_code = 200
+            mock_200.json.return_value = {"data": []}
+
+            mock_request.side_effect = [
+                requests.ConnectionError("Connection failed"),
+                requests.ConnectionError("Connection failed"),
+                mock_200,
+            ]
+
+            result = wrapper.call_endpoint("/users", "GET")
+
+            assert result == {"data": []}
+            assert mock_request.call_count == 3
+
+    def test_no_retry_on_connection_error_when_disabled(self, spec_file: Path) -> None:
+        """Test no retry on connection error when disabled."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            retry_config=RetryConfig(
+                max_attempts=3, initial_wait=0.1, retry_on_connection_error=False
+            ),
+        )
+        with patch.object(wrapper.session, "request") as mock_request:
+            mock_request.side_effect = requests.ConnectionError("Connection failed")
+
+            with pytest.raises(requests.ConnectionError):
+                wrapper.call_endpoint("/users", "GET")
+
+            # Only one call, no retry
+            assert mock_request.call_count == 1
+
+    def test_no_retry_on_success(self, spec_file: Path) -> None:
+        """Test no retry on successful response."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            retry_config=RetryConfig(max_attempts=3),
+        )
+        with patch.object(wrapper.session, "request") as mock_request:
+            mock_200 = MagicMock()
+            mock_200.status_code = 200
+            mock_200.json.return_value = {"users": []}
+
+            mock_request.return_value = mock_200
+
+            result = wrapper.call_endpoint("/users", "GET")
+
+            assert result == {"users": []}
+            assert mock_request.call_count == 1
+
+    def test_no_retry_on_4xx(self, spec_file: Path) -> None:
+        """Test no retry on 4xx client errors (not in default retryable list)."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            retry_config=RetryConfig(max_attempts=3, initial_wait=0.1),
+        )
+        with patch.object(wrapper.session, "request") as mock_request:
+            mock_400 = MagicMock()
+            mock_400.status_code = 400
+            mock_400.raise_for_status.side_effect = requests.HTTPError("Bad Request")
+
+            mock_request.return_value = mock_400
+
+            with pytest.raises(requests.HTTPError):
+                wrapper.call_endpoint("/users", "GET")
+
+            # Only one call, no retry for 400
+            assert mock_request.call_count == 1
+
+
+class TestPerCallOverrides:
+    """Tests for per-call configuration overrides."""
+
+    def test_per_call_retry_config(self, spec_file: Path) -> None:
+        """Test per-call retry configuration override."""
+        # Instance-level: retry enabled
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            retry_config=RetryConfig(enabled=True, max_attempts=5),
+        )
+        with patch.object(wrapper.session, "request") as mock_request:
+            mock_503 = MagicMock()
+            mock_503.status_code = 503
+            mock_503.raise_for_status.side_effect = requests.HTTPError("Service Unavailable")
+
+            mock_request.return_value = mock_503
+
+            # Per-call: disable retry
+            with pytest.raises(requests.HTTPError):
+                wrapper.call_endpoint("/users", "GET", retry_config=RetryConfig(enabled=False))
+
+            # Only one call because per-call config disabled retry
+            assert mock_request.call_count == 1
+
+    def test_per_call_validation_config(self, tmp_path: Path) -> None:
+        """Test per-call validation configuration override."""
+        spec = {
+            "swagger": "2.0",
+            "basePath": "/api/v1",
+            "paths": {
+                "/users": {
+                    "get": {
+                        "summary": "List users",
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "required": ["users"],
+                                            "properties": {
+                                                "users": {"type": "array"},
+                                            },
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                    }
+                }
+            },
+        }
+        spec_path = tmp_path / "spec.json"
+        spec_path.write_text(json.dumps(spec))
+
+        # Instance-level: validation disabled
+        wrapper = APIWrapper(
+            api_json_file=str(spec_path),
+            base_url="https://api.example.com",
+            validation_config=ValidationConfig(enabled=False),
+            retry_config=RetryConfig(enabled=False),
+        )
+        with patch.object(wrapper.session, "request") as mock_request:
+            mock_200 = MagicMock()
+            mock_200.status_code = 200
+            mock_200.json.return_value = {"invalid": "data"}
+
+            mock_request.return_value = mock_200
+
+            # Per-call: enable strict validation
+            with pytest.raises(ResponseValidationError):
+                wrapper.call_endpoint(
+                    "/users",
+                    "GET",
+                    validation_config=ValidationConfig(enabled=True, strict=True),
+                )
+
+
+class TestAPIWrapperWithConfigs:
+    """Tests for APIWrapper initialization with configs."""
+
+    def test_default_retry_config(self, spec_file: Path) -> None:
+        """Test default retry config is enabled."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+        )
+        assert wrapper.retry_config.enabled is True
+        assert wrapper.retry_config.max_attempts == 3
+
+    def test_default_validation_config(self, spec_file: Path) -> None:
+        """Test default validation config is disabled."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+        )
+        assert wrapper.validation_config.enabled is False
+
+    def test_custom_retry_config(self, spec_file: Path) -> None:
+        """Test custom retry config."""
+        config = RetryConfig(enabled=False, max_attempts=5)
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            retry_config=config,
+        )
+        assert wrapper.retry_config.enabled is False
+        assert wrapper.retry_config.max_attempts == 5
+
+    def test_custom_validation_config(self, spec_file: Path) -> None:
+        """Test custom validation config."""
+        config = ValidationConfig(enabled=True, strict=True)
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            validation_config=config,
+        )
+        assert wrapper.validation_config.enabled is True
+        assert wrapper.validation_config.strict is True

--- a/uv.lock
+++ b/uv.lock
@@ -1614,6 +1614,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
     { name = "rich" },
+    { name = "tenacity" },
     { name = "xlsxwriter" },
     { name = "yattag" },
 ]
@@ -1672,6 +1673,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
+    { name = "tenacity", specifier = ">=8.2" },
     { name = "types-paramiko", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31" },
@@ -2042,6 +2044,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/5b/496f8abebd10c3301129abba7ddafd46c71d799a70c44ab080323987c4c9/stevedore-5.6.0.tar.gz", hash = "sha256:f22d15c6ead40c5bbfa9ca54aa7e7b4a07d59b36ae03ed12ced1a54cf0b51945", size = 516074, upload-time = "2025-11-20T10:06:07.264Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/40/8561ce06dc46fd17242c7724ab25b257a2ac1b35f4ebf551b40ce6105cfa/stevedore-5.6.0-py3-none-any.whl", hash = "sha256:4a36dccefd7aeea0c70135526cecb7766c4c84c473b1af68db23d541b6dc1820", size = 54428, upload-time = "2025-11-20T10:06:05.946Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Add resilience features to the OpenAPI wrapper with configurable retry logic and response validation.

## Related Issue

Closes #23

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **pyproject.toml**: Added `tenacity>=8.2` dependency
- **core/models.py**: Added `RetryConfig` and `ValidationConfig` Pydantic models with validation
- **clients/openapi.py**:
  - Added `ResponseValidationError` exception
  - Added `_get_response_schema()`, `validate_response()` methods
  - Added `_execute_request_with_retry()` with tenacity integration
  - Updated `call_endpoint()` with retry and validation support
- **tests/unit/test_openapi.py**: Added 30+ tests for retry and validation functionality

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

**Behavior Defaults:**
- Retry is enabled by default (improves reliability)
- Validation is disabled by default (backward compatible)

**New Configuration Models:**
- `RetryConfig`: max_attempts, initial_wait, max_wait, exponential_base, retryable_status_codes
- `ValidationConfig`: enabled, strict, validate_success_only

🤖 Generated with [Claude Code](https://claude.ai/code)
