### PR TITLE
refactor: make find_closest key order configurable

### DIFF
--- a/src/pynetappfoundry/core/config.py
+++ b/src/pynetappfoundry/core/config.py
@@ -413,6 +413,36 @@ class Config:
                         if key not in self.data[data_type][item]:
                             self.data[data_type][item][key] = ""
 
+    def get_relaxation_order(self, data_type: str) -> list[str]:
+        """Get the key relaxation order for find_closest searches.
+
+        The relaxation order determines which keys to remove first when
+        progressively relaxing search criteria in find_closest().
+
+        Priority:
+        1. Explicit 'relaxation_order' in settings for the data type
+        2. Reverse of 'searchable_keys' for the data type
+        3. Default fallback order
+
+        Args:
+            data_type: The data type to get relaxation order for.
+
+        Returns:
+            List of keys in order of relaxation (first key removed first).
+        """
+        default_order = ["region", "subapp", "cloud", "env", "app", "bu", "div"]
+        settings = self.settings.get("settings", {}).get(data_type, {})
+
+        # Check for explicit relaxation_order
+        if "relaxation_order" in settings:
+            return list(settings["relaxation_order"])
+
+        # Fall back to reverse of searchable_keys
+        if "searchable_keys" in settings:
+            return list(reversed(settings["searchable_keys"]))
+
+        return default_order
+
     def load_data(self, data: dict[str, Any]) -> None:
         """Load data sections from a parsed TOML.
 
@@ -544,6 +574,11 @@ class Config:
     def find_closest(self, data_type: str, tree: dict[str, str]) -> dict[str, Any] | None:
         """Find the closest matching item by progressively relaxing search criteria.
 
+        The order in which keys are relaxed (removed) is determined by:
+        1. Explicit 'relaxation_order' in settings for the data type
+        2. Reverse of 'searchable_keys' for the data type
+        3. Default fallback order
+
         Args:
             data_type: Type of data to search.
             tree: Dictionary of hierarchical search criteria.
@@ -555,8 +590,7 @@ class Config:
         logging.debug(f"{_file_name} :  {data_type = }")
         logging.debug(f"{_file_name} :  {tree = }")
         tree = tree.copy()
-        key_order = ["div", "bu", "app", "env", "subapp", "cloud", "region"]
-        key_order.reverse()
+        key_order = self.get_relaxation_order(data_type)
         found: dict[str, Any] | None = None
 
         # remove empty keys

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -696,3 +696,115 @@ key = "value"
             assert result is None
         finally:
             os.chdir(original_cwd)
+
+
+class TestGetRelaxationOrder:
+    """Tests for get_relaxation_order method."""
+
+    def test_explicit_relaxation_order(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test that explicit relaxation_order in settings is used."""
+        settings_file = temp_config_dir / "settings.toml"
+        settings_file.write_text("""
+[clusters]
+searchable_keys = ['div', 'bu', 'env']
+relaxation_order = ['env', 'bu', 'div']
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            result = config.get_relaxation_order("clusters")
+            assert result == ["env", "bu", "div"]
+        finally:
+            os.chdir(original_cwd)
+
+    def test_falls_back_to_reversed_searchable_keys(
+        self, temp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Test that reversed searchable_keys is used when relaxation_order not set."""
+        settings_file = temp_config_dir / "settings.toml"
+        settings_file.write_text("""
+[clusters]
+searchable_keys = ['div', 'bu', 'env', 'app']
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            result = config.get_relaxation_order("clusters")
+            # Should be reversed searchable_keys
+            assert result == ["app", "env", "bu", "div"]
+        finally:
+            os.chdir(original_cwd)
+
+    def test_falls_back_to_default_order(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test that default order is used when no settings exist."""
+        settings_file = temp_config_dir / "settings.toml"
+        settings_file.write_text("""
+[other]
+key = "value"
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            result = config.get_relaxation_order("clusters")
+            # Should be the default fallback order
+            assert result == ["region", "subapp", "cloud", "env", "app", "bu", "div"]
+        finally:
+            os.chdir(original_cwd)
+
+    def test_different_data_types_can_have_different_orders(
+        self, temp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Test that different data types can have different relaxation orders."""
+        settings_file = temp_config_dir / "settings.toml"
+        settings_file.write_text("""
+[clusters]
+relaxation_order = ['region', 'env', 'bu']
+
+[connectors]
+relaxation_order = ['cloud', 'app', 'div']
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            clusters_order = config.get_relaxation_order("clusters")
+            connectors_order = config.get_relaxation_order("connectors")
+            assert clusters_order == ["region", "env", "bu"]
+            assert connectors_order == ["cloud", "app", "div"]
+        finally:
+            os.chdir(original_cwd)


### PR DESCRIPTION
## Description

Make the key relaxation order in `find_closest()` configurable per data type instead of hardcoded.

## Related Issue

Closes #25

## Type of Change

- [x] Code refactoring

## Changes Made

- **core/config.py**: Added `get_relaxation_order()` method with priority:
  1. Explicit `relaxation_order` setting in settings.toml
  2. Reverse of `searchable_keys` for the data type
  3. Default fallback order
- **core/config.py**: Updated `find_closest()` to use the new configurable order
- **tests/unit/test_config.py**: Added 4 tests for `TestGetRelaxationOrder`

## Example Configuration

```toml
# settings.toml
[clusters]
searchable_keys = ['div', 'bu', 'cloud', 'app', 'env', 'subapp', 'region']
relaxation_order = ['region', 'subapp', 'cloud', 'env', 'app', 'bu', 'div']
```

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Ran `doit check` - all checks pass

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.ai/code)
