### PR TITLE
feat: add configurable timeout for API clients

### DIFF
--- a/src/pynetappfoundry/clients/dii/api.py
+++ b/src/pynetappfoundry/clients/dii/api.py
@@ -28,5 +28,6 @@ class DIIAPIClient(APIWrapper):
             base_url=dii_settings.base_url,
             auth_header={"X-CloudInsights-ApiKey": dii_settings.api_ro_token},
             base_api_path=dii_settings.base_api_path,
+            timeout=dii_settings.timeout,
             **kwargs,
         )

--- a/src/pynetappfoundry/clients/ontap/api.py
+++ b/src/pynetappfoundry/clients/ontap/api.py
@@ -40,5 +40,6 @@ class ONTAPAPIClient(APIWrapper):
             base_url=f"https://{cluster.ip}",
             auth_header=auth_header,
             base_api_path=ontap_settings.base_api_path,
+            timeout=ontap_settings.timeout,
             **kwargs,
         )

--- a/src/pynetappfoundry/core/models.py
+++ b/src/pynetappfoundry/core/models.py
@@ -96,6 +96,7 @@ class ONTAPAPISettings(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     base_api_path: str = "/api"
+    timeout: float = 30.0
 
 
 class DIIAPISettings(BaseModel):
@@ -106,6 +107,7 @@ class DIIAPISettings(BaseModel):
     api_ro_token: str
     base_url: str
     base_api_path: str = "/rest/v1"
+    timeout: float = 30.0
 
 
 class SearchableKeysConfig(BaseModel):


### PR DESCRIPTION
## Description

Add configurable timeout for API clients (ONTAP and DII) via settings files.

## Related Issue

Closes #27

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **core/models.py**: Added `timeout: float = 30.0` to `ONTAPAPISettings` and `DIIAPISettings`
- **clients/ontap/api.py**: Pass timeout from settings to APIWrapper
- **clients/dii/api.py**: Pass timeout from settings to APIWrapper

## Example Configuration

ontapapi.toml:
```toml
[ontapapi.general]
base_api_path = "/api"
timeout = 60.0
```

diiapi.toml:
```toml
[diiapi]
api_ro_token = "xxx"
base_url = "https://xxx.cloudinsights.netapp.com"
timeout = 30.0
```

## Testing

- [x] All existing tests pass
- [x] Ran `doit check` - all checks pass

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.ai/code)
