### PR TITLE
docs: add ADR-0001 for cluster metadata cache architecture

### DIFF
--- a/docs/decisions/0014-use-sqlite-for-cluster-metadata-caching.md
+++ b/docs/decisions/0014-use-sqlite-for-cluster-metadata-caching.md
@@ -1,0 +1,36 @@
+# ADR-0014: Use SQLite for cluster metadata caching
+
+## Status
+
+Accepted
+
+## Decision
+
+Use **SQLite** as the storage backend for caching ONTAP cluster metadata that doesn't change frequently. The cache is stored at `{data_dir}/cache/cluster_metadata.db` and is manually refreshed via CLI commands (`nf cache refresh`).
+
+## Rationale
+
+1. **SQLite is reliable and portable**: Single-file database requires no external dependencies or services, works across all platforms (Windows, macOS, Linux).
+
+2. **Consistent with existing patterns**: The project already uses SQLite for metrics and events storage in the `db/` module.
+
+3. **Manual refresh model**: Cluster metadata (instance IDs, node serials, licenses, etc.) changes infrequently. Automatic refresh would add complexity and potential for stale data issues. Manual refresh via `nf cache refresh` gives users explicit control.
+
+4. **REST API first with CLI fallback**: Some metadata (like cloud VM instance info) is only available via CLI. The collector tries REST API first for performance, then falls back to CLI for unavailable endpoints.
+
+5. **Pydantic models for type safety**: All cached data uses Pydantic models ensuring validation and serialization consistency.
+
+### Alternatives Considered
+
+- **JSON files**: Simpler but no query capability, harder to manage multiple clusters
+- **Redis/external cache**: Overkill for local CLI tool, adds deployment complexity
+- **Automatic refresh with TTL**: Adds complexity, harder to reason about data freshness
+
+## Related Issues
+
+- Issue #32: feat: add cluster metadata cache for ONTAP clusters
+
+## Related Documentation
+
+- Cache module: `src/pynetappfoundry/cache/`
+- CLI commands: `nf cache refresh`, `nf cache show`, `nf cache status`, `nf cache clear`


### PR DESCRIPTION
## Description

Add Architecture Decision Record (ADR-0001) documenting the decision to use SQLite for cluster metadata caching with a manual refresh model.

## Related Issue

Closes #33

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add ADR-0001: Use SQLite for cluster metadata caching
- Documents rationale for SQLite storage, manual refresh model, and REST-first approach
- Links to related issue #32 (cluster metadata cache feature)

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
