### PR TITLE
refactor: move cluster metadata cache to config directory

### DIFF
--- a/docs/decisions/0014-use-sqlite-for-cluster-metadata-caching.md
+++ b/docs/decisions/0014-use-sqlite-for-cluster-metadata-caching.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Decision
 
-Use **SQLite** as the storage backend for caching ONTAP cluster metadata that doesn't change frequently. The cache is stored at `{data_dir}/cache/cluster_metadata.db` and is manually refreshed via CLI commands (`nf cache refresh`).
+Use **SQLite** as the storage backend for caching ONTAP cluster metadata that doesn't change frequently. The cache is stored at `{config_dir}/.cache/cluster_metadata.db` and is manually refreshed via CLI commands (`nf cache refresh`).
 
 ## Rationale
 
@@ -29,6 +29,7 @@ Use **SQLite** as the storage backend for caching ONTAP cluster metadata that do
 ## Related Issues
 
 - Issue #32: feat: add cluster metadata cache for ONTAP clusters
+- Issue #38: refactor: move cluster metadata cache to config directory
 
 ## Related Documentation
 

--- a/src/pynetappfoundry/cache/db.py
+++ b/src/pynetappfoundry/cache/db.py
@@ -65,7 +65,7 @@ class ClusterMetadataDB:
         if db_path:
             self.db_path = db_path
         elif config:
-            cache_dir = config.data_dir / "cache"
+            cache_dir = config.config_dir / ".cache"
             cache_dir.mkdir(parents=True, exist_ok=True)
             self.db_path = cache_dir / "cluster_metadata.db"
         else:

--- a/src/pynetappfoundry/core/models.py
+++ b/src/pynetappfoundry/core/models.py
@@ -163,7 +163,7 @@ class CacheConfig(BaseModel):
 
     Attributes:
         cache_dir: Override cache directory location. If empty, uses default
-                   ({data_dir}/cache).
+                   ({config_dir}/.cache).
         cache_ttl_days: Number of days before cache is considered stale.
                         Used for warnings, not automatic refresh.
         auto_warn_stale: Warn when cached data is stale. Default True.


### PR DESCRIPTION
## Description

Move the cluster metadata cache from `{data_dir}/cache/` to `{config_dir}/.cache/` so each config directory has its own isolated cache.

## Related Issue

Closes #38

## Type of Change

- [x] Code refactoring

## Changes Made

- Change cache location from `{data_dir}/cache` to `{config_dir}/.cache` in `cache/db.py`
- Update `CacheConfig` docstring to reflect new default location
- Update ADR-0001 with new path and link to issue #38

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

Users will need to run `nf cache refresh` after this change to rebuild the cache in the new location.
