### PR TITLE
feat: add NF_CONFIG_DIR environment variable support for CLI

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -21,6 +21,9 @@ export PRE_COMMIT_HOME=${PRE_COMMIT_HOME:-"$(pwd)/tmp/.pre-commit"}
 export PATH="$PWD/.venv/bin:$PATH"
 
 # Project-specific environment variables
+# Default config directory for nf CLI (override in .envrc.local)
+export NF_CONFIG_DIR=${NF_CONFIG_DIR:-"config"}
+
 # Uncomment and customize as needed:
 # export DEBUG=${DEBUG:-false}
 # export LOG_LEVEL=${LOG_LEVEL:-INFO}

--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -2,6 +2,9 @@
 # Copy this file to .envrc.local and customize as needed
 # .envrc.local is git-ignored and will not be committed
 
+# Example: Use a different config directory for nf CLI
+# export NF_CONFIG_DIR="/path/to/my/config"
+
 # Example: Enable debug mode
 # export DEBUG=true
 

--- a/src/pynetappfoundry/cli/main.py
+++ b/src/pynetappfoundry/cli/main.py
@@ -21,7 +21,8 @@ from pynetappfoundry.cli.commands.utils import utils
     "-c",
     type=click.Path(),
     default="config",
-    help="Configuration directory path.",
+    envvar="NF_CONFIG_DIR",
+    help="Configuration directory path. Can also be set via NF_CONFIG_DIR env var.",
 )
 @click.option(
     "--output-dir",

--- a/src/pynetappfoundry/core/config.py
+++ b/src/pynetappfoundry/core/config.py
@@ -68,12 +68,14 @@ class Config:
     """Configuration manager for TOML-based config files.
 
     Environment Variables:
-        NF_CONFIG_DIR: Override the default config directory path.
         NF_<CLUSTER>_USER: Override username for a specific cluster.
         NF_<CLUSTER>_PASSWORD: Override password (base64 encoded) for a specific cluster.
 
     The cluster name in environment variables should be uppercase with hyphens
     replaced by underscores (e.g., cluster-prod -> NF_CLUSTER_PROD_USER).
+
+    Note: The NF_CONFIG_DIR environment variable is handled by the CLI layer,
+    not this class. Use `nf --config-dir` or set NF_CONFIG_DIR before running.
     """
 
     def __init__(
@@ -94,11 +96,6 @@ class Config:
         """
         self.data: dict[str, dict[str, dict[str, Any]]] = {}
         self.args = args
-        # Check for environment variable override
-        env_config_dir = os.environ.get("NF_CONFIG_DIR")
-        if env_config_dir:
-            logging.debug(f"Using config dir from NF_CONFIG_DIR: {env_config_dir}")
-            config_dir = env_config_dir
         self.config_dir = Path.cwd() / config_dir
         self.data_types = ["aiqums", "connectors", "cloudinsights", "clusters", "azure"]
         self.settings: dict[str, Any] = {}

--- a/tests/unit/test_config_commands.py
+++ b/tests/unit/test_config_commands.py
@@ -229,24 +229,19 @@ class TestConfigValidateCommand:
 class TestEnvironmentVariableSupport:
     """Tests for environment variable configuration overrides."""
 
-    def test_env_var_config_dir(
-        self, temp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_env_var_config_dir(self, temp_config_dir: Path, tmp_path: Path) -> None:
         """Test that NF_CONFIG_DIR environment variable overrides config directory."""
-        output_dir = tmp_path / "output"
-        output_dir.mkdir()
+        runner = CliRunner()
         original_cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
-            monkeypatch.setenv("NF_CONFIG_DIR", str(temp_config_dir))
-            # Use a non-existent default path - env var should override
-            config = Config(
-                config_dir="nonexistent",
-                output_dir=str(output_dir),
-                script_name="test",
+            # Set env var to point to valid config, don't pass --config-dir
+            # CLI should use env var as default
+            result = runner.invoke(
+                nf, ["config", "validate"], env={"NF_CONFIG_DIR": str(temp_config_dir)}
             )
-            assert "clusters" in config.data
-            assert "test-cluster-1" in config.data["clusters"]
+            assert result.exit_code == 0, f"Output: {result.output}"
+            assert "test-cluster-1" in result.output
         finally:
             os.chdir(original_cwd)
 


### PR DESCRIPTION
## Description

Add support for `NF_CONFIG_DIR` environment variable to specify the default config directory for the `nf` CLI.

## Related Issue

Closes #37

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Add `envvar="NF_CONFIG_DIR"` to `--config-dir` CLI option in `main.py`
- Remove redundant env var handling from `Config` class (CLI now handles it via Click)
- Add default `NF_CONFIG_DIR` in `.envrc`
- Add example override in `.envrc.local.example`
- Update test to use CLI runner for env var testing

## Priority Order

1. CLI `--config-dir` flag (highest)
2. `NF_CONFIG_DIR` environment variable
3. Built-in default "config" (lowest)

## Testing

- [x] All existing tests pass
- [x] Updated test to verify CLI env var behavior

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
