### PR TITLE
fix: handle non-UTF-8 characters in ONTAP CLI output

### DIFF
--- a/src/pynetappfoundry/clients/ontap/cli.py
+++ b/src/pynetappfoundry/clients/ontap/cli.py
@@ -184,7 +184,11 @@ class ONTAPCLI:
 
         stdin, stdout, _stderr = self.cli.exec_command(f"{cmd} {arguments}")
 
-        for line in stdout:
+        # Read raw bytes and decode with error handling for non-UTF-8 characters
+        raw_output = stdout.read()
+        decoded_output = raw_output.decode("utf-8", errors="replace")
+
+        for line in decoded_output.splitlines():
             line = line.rstrip()
             logging.info(line)
             if not line or line == "\x07":


### PR DESCRIPTION
## Description

Fix UTF-8 decoding error when ONTAP CLI output contains non-UTF-8 characters (e.g., Latin-1 encoded pound sign `£`).

## Related Issue

Closes #41

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Read stdout as raw bytes and decode with `errors='replace'` to gracefully handle non-UTF-8 characters
- Undecodable bytes are replaced with the Unicode replacement character (`�`) instead of crashing

## Testing

- [x] All existing tests pass
- [x] Manually tested with cluster that previously caused the error

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
