### PR TITLE
fix: show exception traceback when --debug is enabled

### DIFF
--- a/src/pynetappfoundry/cli/commands/cache/clear.py
+++ b/src/pynetappfoundry/cli/commands/cache/clear.py
@@ -8,7 +8,7 @@ import click
 from rich.console import Console
 
 from pynetappfoundry.cache import ClusterMetadataDB
-from pynetappfoundry.cli.utils import print_error, print_success, print_warning
+from pynetappfoundry.cli.utils import print_error, print_exception, print_success, print_warning
 from pynetappfoundry.core.config import Config
 
 console = Console()
@@ -53,7 +53,7 @@ def clear(ctx: click.Context, cluster: str | None, clear_all: bool, force: bool)
     try:
         config = Config(config_dir=config_dir, script_name="cache-clear")
     except Exception as e:
-        print_error(f"Failed to load configuration: {e}")
+        print_exception(f"Failed to load configuration: {e}", e)
         ctx.exit(1)
 
     if not cluster and not clear_all:

--- a/src/pynetappfoundry/cli/commands/cache/refresh.py
+++ b/src/pynetappfoundry/cli/commands/cache/refresh.py
@@ -11,7 +11,7 @@ from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from pynetappfoundry.cache import ClusterMetadataDB, MetadataCollector
-from pynetappfoundry.cli.utils import print_error, print_success, print_warning
+from pynetappfoundry.cli.utils import print_error, print_exception, print_success, print_warning
 from pynetappfoundry.clients.ontap import ONTAPCLI, ONTAPAPIClient
 from pynetappfoundry.core.config import Config
 
@@ -50,7 +50,7 @@ def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool) -> None:
     try:
         config = Config(config_dir=config_dir, script_name="cache-refresh")
     except Exception as e:
-        print_error(f"Failed to load configuration: {e}")
+        print_exception(f"Failed to load configuration: {e}", e)
         ctx.exit(1)
 
     # Determine clusters to refresh
@@ -143,7 +143,7 @@ def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool) -> None:
                 success_count += 1
 
             except Exception as e:
-                print_error(f"  {cluster_name}: Failed - {e}")
+                print_exception(f"  {cluster_name}: Failed - {e}", e)
                 error_count += 1
 
             progress.update(task, completed=1)

--- a/src/pynetappfoundry/cli/commands/cache/show.py
+++ b/src/pynetappfoundry/cli/commands/cache/show.py
@@ -10,7 +10,7 @@ from rich.panel import Panel
 from rich.tree import Tree
 
 from pynetappfoundry.cache import ClusterMetadataDB
-from pynetappfoundry.cli.utils import print_error, print_warning
+from pynetappfoundry.cli.utils import print_error, print_exception, print_warning
 from pynetappfoundry.core.config import Config
 
 console = Console()
@@ -113,7 +113,7 @@ def show(ctx: click.Context, cluster: str | None, section: str | None, output_js
     try:
         config = Config(config_dir=config_dir, script_name="cache-show")
     except Exception as e:
-        print_error(f"Failed to load configuration: {e}")
+        print_exception(f"Failed to load configuration: {e}", e)
         ctx.exit(1)
 
     db = ClusterMetadataDB(config=config)

--- a/src/pynetappfoundry/cli/commands/cache/status.py
+++ b/src/pynetappfoundry/cli/commands/cache/status.py
@@ -9,7 +9,7 @@ from rich.console import Console
 from rich.table import Table
 
 from pynetappfoundry.cache import ClusterMetadataDB
-from pynetappfoundry.cli.utils import print_error, print_warning
+from pynetappfoundry.cli.utils import print_error, print_exception, print_warning
 from pynetappfoundry.core.config import Config
 
 console = Console()
@@ -46,7 +46,7 @@ def status(ctx: click.Context, ttl: int) -> None:
     try:
         config = Config(config_dir=config_dir, script_name="cache-status")
     except Exception as e:
-        print_error(f"Failed to load configuration: {e}")
+        print_exception(f"Failed to load configuration: {e}", e)
         ctx.exit(1)
 
     db = ClusterMetadataDB(config=config)

--- a/src/pynetappfoundry/cli/commands/config/show.py
+++ b/src/pynetappfoundry/cli/commands/config/show.py
@@ -10,7 +10,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.tree import Tree
 
-from pynetappfoundry.cli.utils import print_error
+from pynetappfoundry.cli.utils import print_error, print_exception
 from pynetappfoundry.core.config import Config
 
 console = Console()
@@ -146,7 +146,7 @@ def show(ctx: click.Context, section: str | None, unmask: bool) -> None:
     try:
         config = Config(config_dir=config_dir, script_name="config-show")
     except Exception as e:
-        print_error(f"Failed to load configuration: {e}")
+        print_exception(f"Failed to load configuration: {e}", e)
         ctx.exit(1)
 
     console.print(f"\nConfiguration from: [cyan]{config_path}[/cyan]\n")

--- a/src/pynetappfoundry/cli/commands/config/validate.py
+++ b/src/pynetappfoundry/cli/commands/config/validate.py
@@ -10,7 +10,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.tree import Tree
 
-from pynetappfoundry.cli.utils import print_error, print_success
+from pynetappfoundry.cli.utils import print_error, print_exception, print_success
 from pynetappfoundry.core.config import Config, ConfigurationError
 from pynetappfoundry.core.models import (
     ClusterConfig,
@@ -188,7 +188,7 @@ def validate(ctx: click.Context) -> None:
     try:
         config = Config(config_dir=config_dir, script_name="config-validate")
     except Exception as e:
-        print_error(f"Failed to load configuration: {e}")
+        print_exception(f"Failed to load configuration: {e}", e)
         ctx.exit(1)
 
     # Build validation tree

--- a/src/pynetappfoundry/cli/commands/metrics/dump_dii.py
+++ b/src/pynetappfoundry/cli/commands/metrics/dump_dii.py
@@ -8,7 +8,7 @@ from typing import Any
 import click
 
 from pynetappfoundry.cli.decorators import with_config
-from pynetappfoundry.cli.utils import print_error, print_info, print_success
+from pynetappfoundry.cli.utils import print_exception, print_info, print_success
 from pynetappfoundry.clients.dii.api import DIIAPIClient
 from pynetappfoundry.core.config import Config
 from pynetappfoundry.db.metrics import MetricDB
@@ -41,7 +41,7 @@ def dump_dii(
     try:
         dii_client = DIIAPIClient(config)
     except Exception as e:
-        print_error(f"Could not initialize DII client: {e}")
+        print_exception(f"Could not initialize DII client: {e}", e)
         return
 
     db = MetricDB(config)

--- a/src/pynetappfoundry/cli/commands/utils/run_cmd.py
+++ b/src/pynetappfoundry/cli/commands/utils/run_cmd.py
@@ -8,7 +8,7 @@ from typing import Any
 import click
 
 from pynetappfoundry.cli.decorators import with_config
-from pynetappfoundry.cli.utils import console, print_error, print_info
+from pynetappfoundry.cli.utils import console, print_exception, print_info
 from pynetappfoundry.clients.ontap.cli import ONTAPCLI
 from pynetappfoundry.core.config import Config
 
@@ -64,5 +64,5 @@ def _run_cluster_command(
             console.print(f"  {line}")
 
     except Exception as e:
-        logging.error(f"Could not run command on {name}: {e}")
-        print_error(f"  Error: {e}")
+        logging.exception(f"Could not run command on {name}: {e}")
+        print_exception(f"  Error: {e}", e)

--- a/src/pynetappfoundry/cli/commands/utils/sqlite_to_excel.py
+++ b/src/pynetappfoundry/cli/commands/utils/sqlite_to_excel.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import click
 from openpyxl import Workbook
 
-from pynetappfoundry.cli.utils import print_error, print_info, print_success
+from pynetappfoundry.cli.utils import print_error, print_exception, print_info, print_success
 
 
 @click.command("sqlite-to-excel")
@@ -73,4 +73,4 @@ def sqlite_to_excel(db_path: str, output: str | None) -> None:
         print_success(f"Saved to {output_file}")
 
     except Exception as e:
-        print_error(f"Conversion failed: {e}")
+        print_exception(f"Conversion failed: {e}", e)

--- a/src/pynetappfoundry/cli/main.py
+++ b/src/pynetappfoundry/cli/main.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import click
 
 from pynetappfoundry._version import __version__
@@ -43,6 +45,15 @@ def nf(ctx: click.Context, config_dir: str, output_dir: str, debug: bool) -> Non
     A CLI for managing NetApp ONTAP clusters, including license management,
     space reporting, event tracking, and more.
     """
+    # Configure logging based on debug flag
+    if debug:
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
     ctx.ensure_object(dict)
     ctx.obj["config_dir"] = config_dir
     ctx.obj["output_dir"] = output_dir

--- a/src/pynetappfoundry/cli/utils.py
+++ b/src/pynetappfoundry/cli/utils.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
+import traceback
+
+import click
 from rich.console import Console
 from rich.table import Table
 
 console = Console()
+
+
+def is_debug_mode() -> bool:
+    """Check if debug mode is enabled.
+
+    Returns:
+        True if debug mode is enabled in the current Click context.
+    """
+    ctx = click.get_current_context(silent=True)
+    if ctx and ctx.obj:
+        return bool(ctx.obj.get("debug", False))
+    return False
 
 
 def print_table(
@@ -64,3 +79,16 @@ def print_info(message: str) -> None:
         message: Message to print.
     """
     console.print(f"[blue]{message}[/blue]")
+
+
+def print_exception(message: str, exc: BaseException | None = None) -> None:
+    """Print an error message with optional traceback in debug mode.
+
+    Args:
+        message: Error message to print.
+        exc: Exception to include. If provided and debug mode is enabled,
+             the full traceback will be printed.
+    """
+    console.print(f"[red]{message}[/red]")
+    if exc and is_debug_mode():
+        console.print("[dim]" + "".join(traceback.format_exception(exc)) + "[/dim]")


### PR DESCRIPTION
## Description

Wire up the `--debug` flag to show full exception tracebacks when errors occur. This makes debugging much easier.

## Related Issue

Closes #43

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Wire up `--debug` flag to configure logging level (DEBUG when enabled, WARNING otherwise)
- Add `is_debug_mode()` utility to check debug state from Click context
- Add `print_exception()` utility that shows full traceback in debug mode
- Update 10 CLI commands to use `print_exception()` for error handling

## Usage

```bash
# Without debug - shows only error message
nf cache refresh cluster1
# cluster1: Failed - 'utf-8' codec can't decode byte...

# With debug - shows full traceback
nf --debug cache refresh cluster1
# cluster1: Failed - 'utf-8' codec can't decode byte...
# Traceback (most recent call last):
#   File "...", line X, in ...
#   ...
```

## Testing

- [x] All existing tests pass
- [x] Manually verified traceback appears with --debug

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
