### PR TITLE
fix: disable SSL verification for ONTAP API client

### DIFF
--- a/src/pynetappfoundry/clients/ontap/api.py
+++ b/src/pynetappfoundry/clients/ontap/api.py
@@ -41,5 +41,6 @@ class ONTAPAPIClient(APIWrapper):
             auth_header=auth_header,
             base_api_path=ontap_settings.base_api_path,
             timeout=ontap_settings.timeout,
+            verify_ssl=False,  # ONTAP clusters typically use self-signed certs
             **kwargs,
         )


### PR DESCRIPTION
## Description

Disable SSL verification for ONTAP API client to allow connections to clusters with self-signed certificates.

## Related Issue

Closes #49

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Add `verify_ssl=False` to `ONTAPAPIClient.__init__()` when calling `APIWrapper`

## Testing

- [x] All existing tests pass

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests pass (`doit test`)
