### PR TITLE
fix: coerce ClusterInfo.model field to string

### DIFF
--- a/src/pynetappfoundry/cache/models.py
+++ b/src/pynetappfoundry/cache/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 def _utcnow() -> datetime:
@@ -54,6 +54,12 @@ class ClusterInfo(BaseModel):
     cluster_uuid: str = ""
     ontap_version: str = ""
     model: str = ""
+
+    @field_validator("model", mode="before")
+    @classmethod
+    def coerce_model_to_str(cls, v: object) -> str:
+        """Coerce model field to string (API sometimes returns int)."""
+        return str(v) if v is not None else ""
 
 
 class NodeInfo(BaseModel):


### PR DESCRIPTION
## Description

Fix ClusterInfo model validation by coercing the `model` field to string, as the ONTAP API sometimes returns an integer.

## Related Issue

Closes #51

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Add `field_validator` to `ClusterInfo.model` field to coerce values to string

## Testing

- [x] All existing tests pass

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests pass (`doit test`)
