### PR TITLE
fix: add fields=* parameter to cache collector API calls

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -211,7 +211,7 @@ class MetadataCollector:
         if not self.api_client:
             return ClusterInfo()
 
-        response = self.api_client.call_endpoint("/cluster", method="GET")
+        response = self.api_client.call_endpoint("/cluster?fields=*", method="GET")
         return ClusterInfo(
             cluster_name=response.get("name", ""),
             cluster_uuid=response.get("uuid", ""),
@@ -272,7 +272,7 @@ class MetadataCollector:
         if not self.api_client:
             return []
 
-        response = self.api_client.call_endpoint("/cluster/nodes", method="GET")
+        response = self.api_client.call_endpoint("/cluster/nodes?fields=*", method="GET")
         nodes = []
         for record in response.get("records", []):
             nodes.append(
@@ -343,7 +343,9 @@ class MetadataCollector:
             return NetworkInfo()
 
         # Collect LIFs
-        lifs_response = self.api_client.call_endpoint("/network/ip/interfaces", method="GET")
+        lifs_response = self.api_client.call_endpoint(
+            "/network/ip/interfaces?fields=*", method="GET"
+        )
         intercluster_lifs = []
         data_lifs = []
         management_lifs = []
@@ -374,7 +376,7 @@ class MetadataCollector:
 
         # Collect broadcast domains
         bd_response = self.api_client.call_endpoint(
-            "/network/ethernet/broadcast-domains", method="GET"
+            "/network/ethernet/broadcast-domains?fields=*", method="GET"
         )
         broadcast_domains = []
         for record in bd_response.get("records", []):
@@ -387,7 +389,7 @@ class MetadataCollector:
             broadcast_domains.append(bd)
 
         # Collect IPspaces
-        ipspace_response = self.api_client.call_endpoint("/network/ipspaces", method="GET")
+        ipspace_response = self.api_client.call_endpoint("/network/ipspaces?fields=*", method="GET")
         ipspaces = [r.get("name", "") for r in ipspace_response.get("records", [])]
 
         return NetworkInfo(
@@ -475,7 +477,7 @@ class MetadataCollector:
             return StorageInfo()
 
         # Collect aggregates
-        aggr_response = self.api_client.call_endpoint("/storage/aggregates", method="GET")
+        aggr_response = self.api_client.call_endpoint("/storage/aggregates?fields=*", method="GET")
         aggregates = []
         for record in aggr_response.get("records", []):
             aggr = AggregateInfo(
@@ -489,7 +491,7 @@ class MetadataCollector:
             aggregates.append(aggr)
 
         # Collect SVMs
-        svm_response = self.api_client.call_endpoint("/svm/svms", method="GET")
+        svm_response = self.api_client.call_endpoint("/svm/svms?fields=*", method="GET")
         svms = []
         for record in svm_response.get("records", []):
             svm = SVMInfo(
@@ -569,7 +571,9 @@ class MetadataCollector:
         if not self.api_client:
             return LicenseInfo()
 
-        response = self.api_client.call_endpoint("/cluster/licensing/licenses", method="GET")
+        response = self.api_client.call_endpoint(
+            "/cluster/licensing/licenses?fields=*", method="GET"
+        )
         feature_licenses = []
         capacity_licenses = []
 
@@ -648,7 +652,7 @@ class MetadataCollector:
         if not self.api_client:
             return HAInfo()
 
-        nodes_response = self.api_client.call_endpoint("/cluster/nodes", method="GET")
+        nodes_response = self.api_client.call_endpoint("/cluster/nodes?fields=*", method="GET")
 
         # Check if HA is configured
         ha_configured = len(nodes_response.get("records", [])) > 1
@@ -658,7 +662,9 @@ class MetadataCollector:
         mediator_status = ""
         # Mediator endpoint may not exist on all clusters
         with contextlib.suppress(Exception):
-            mediator_response = self.api_client.call_endpoint("/cluster/mediators", method="GET")
+            mediator_response = self.api_client.call_endpoint(
+                "/cluster/mediators?fields=*", method="GET"
+            )
             mediators = mediator_response.get("records", [])
             if mediators:
                 mediator_address = mediators[0].get("ip_address", "")
@@ -726,7 +732,9 @@ class MetadataCollector:
             return RelationshipsInfo()
 
         # Collect SnapMirror relationships
-        sm_response = self.api_client.call_endpoint("/snapmirror/relationships", method="GET")
+        sm_response = self.api_client.call_endpoint(
+            "/snapmirror/relationships?fields=*", method="GET"
+        )
         snapmirror_destinations = []
         for record in sm_response.get("records", []):
             sm = SnapMirrorRelationship(
@@ -740,7 +748,7 @@ class MetadataCollector:
             snapmirror_destinations.append(sm)
 
         # Collect cluster peers
-        peer_response = self.api_client.call_endpoint("/cluster/peers", method="GET")
+        peer_response = self.api_client.call_endpoint("/cluster/peers?fields=*", method="GET")
         cluster_peers = []
         for record in peer_response.get("records", []):
             peer = ClusterPeer(

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -156,7 +156,7 @@ class TestClusterInfoCollection:
         assert result.cluster_name == "mycluster"
         assert result.cluster_uuid == "abc-123-def-456"
         assert "9.14.1" in result.ontap_version
-        api_client.call_endpoint.assert_called_with("/cluster", method="GET")
+        api_client.call_endpoint.assert_called_with("/cluster?fields=*", method="GET")
 
     def test_collect_cluster_info_fallback_to_cli(
         self, mock_cluster_cli_output: dict[str, dict[str, str]]
@@ -241,7 +241,7 @@ class TestNetworkCollection:
     def mock_network_api_responses(self) -> dict[str, dict[str, Any]]:
         """Mock API responses for network endpoints."""
         return {
-            "/network/ip/interfaces": {
+            "/network/ip/interfaces?fields=*": {
                 "records": [
                     {
                         "name": "data_lif1",
@@ -258,7 +258,7 @@ class TestNetworkCollection:
                     }
                 ]
             },
-            "/network/ethernet/broadcast-domains": {
+            "/network/ethernet/broadcast-domains?fields=*": {
                 "records": [
                     {
                         "name": "Default",
@@ -268,7 +268,7 @@ class TestNetworkCollection:
                     }
                 ]
             },
-            "/network/ipspaces": {"records": [{"name": "Default"}, {"name": "Cluster"}]},
+            "/network/ipspaces?fields=*": {"records": [{"name": "Default"}, {"name": "Cluster"}]},
         }
 
     def test_collect_network_via_api(
@@ -305,7 +305,7 @@ class TestStorageCollection:
     def mock_storage_api_responses(self) -> dict[str, dict[str, Any]]:
         """Mock API responses for storage endpoints."""
         return {
-            "/storage/aggregates": {
+            "/storage/aggregates?fields=*": {
                 "records": [
                     {
                         "name": "aggr1",
@@ -321,7 +321,9 @@ class TestStorageCollection:
                     }
                 ]
             },
-            "/svm/svms": {"records": [{"name": "svm1", "state": "running", "subtype": "default"}]},
+            "/svm/svms?fields=*": {
+                "records": [{"name": "svm1", "state": "running", "subtype": "default"}]
+            },
         }
 
     def test_collect_storage_via_api(
@@ -441,7 +443,7 @@ class TestRelationshipsCollection:
     def mock_relationships_api_responses(self) -> dict[str, dict[str, Any]]:
         """Mock API responses for relationship endpoints."""
         return {
-            "/snapmirror/relationships": {
+            "/snapmirror/relationships?fields=*": {
                 "records": [
                     {
                         "source": {"svm": {"name": "svm1"}, "path": "vol1"},
@@ -453,7 +455,7 @@ class TestRelationshipsCollection:
                     }
                 ]
             },
-            "/cluster/peers": {
+            "/cluster/peers?fields=*": {
                 "records": [
                     {
                         "name": "peer1",


### PR DESCRIPTION
## Description

Add `fields=*` parameter to all ONTAP REST API endpoint calls in the cache collector to ensure complete data retrieval.

## Related Issue

Closes #56

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Add `fields=*` parameter to `/cluster` endpoint
- Add `fields=*` parameter to `/cluster/nodes` endpoint (2 locations)
- Add `fields=*` parameter to `/network/ip/interfaces` endpoint
- Add `fields=*` parameter to `/network/ethernet/broadcast-domains` endpoint
- Add `fields=*` parameter to `/network/ipspaces` endpoint
- Add `fields=*` parameter to `/storage/aggregates` endpoint
- Add `fields=*` parameter to `/svm/svms` endpoint
- Add `fields=*` parameter to `/cluster/licensing/licenses` endpoint
- Add `fields=*` parameter to `/cluster/mediators` endpoint
- Add `fields=*` parameter to `/snapmirror/relationships` endpoint
- Add `fields=*` parameter to `/cluster/peers` endpoint
- Update test fixtures to use new endpoint URLs

## Testing

- [x] All existing tests pass (`doit check`)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
