### PR TITLE
fix: handle non-dict membership field in nodes collection

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -275,14 +275,17 @@ class MetadataCollector:
         response = self.api_client.call_endpoint("/cluster/nodes?fields=*", method="GET")
         nodes = []
         for record in response.get("records", []):
+            # membership may be a dict or other type depending on API version
+            membership = record.get("membership")
+            is_epsilon = membership.get("epsilon", False) if isinstance(membership, dict) else False
             nodes.append(
                 NodeInfo(
                     name=record.get("name", ""),
                     serial_number=record.get("serial_number", ""),
-                    system_id=record.get("system_id", ""),
-                    model=record.get("model", ""),
+                    system_id=str(record.get("system_id", "")),
+                    model=str(record.get("model", "")),
                     uptime=record.get("uptime", 0),
-                    is_epsilon=record.get("membership", {}).get("epsilon", False),
+                    is_epsilon=is_epsilon,
                 )
             )
         return nodes


### PR DESCRIPTION
## Description

Fix nodes collection failing when `fields=*` parameter returns membership field in unexpected format.

## Related Issue

Closes #58

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Check if `membership` field is a dict before calling `.get()` on it
- Convert `system_id` and `model` to strings explicitly for safety

## Testing

- [x] All existing tests pass (`doit check`)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] All new and existing tests pass (`doit test`)
