### PR TITLE
fix: remove incorrect base64 decoding of password in cache refresh

### DIFF
--- a/src/pynetappfoundry/cli/commands/cache/refresh.py
+++ b/src/pynetappfoundry/cli/commands/cache/refresh.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import base64
 import contextlib
 from pathlib import Path
 
@@ -91,8 +90,7 @@ def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool) -> None:
                 cluster_data = config.data["clusters"][cluster_name]
 
                 # Get credentials
-                user, enc = config.get_user("clusters", cluster_name)
-                password = base64.b64decode(enc).decode("latin-1")
+                user, password = config.get_user("clusters", cluster_name)
 
                 # Create cluster object for API client
                 class ClusterObj:


### PR DESCRIPTION
## Description

Remove incorrect base64 decoding of password in cache refresh command. The password from `config.get_user()` is already plain text, not base64 encoded.

## Related Issue

Closes #61

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Remove unnecessary `base64.b64decode()` call that was corrupting passwords
- Remove unused `base64` import

## Testing

- [x] All existing tests pass (`doit check`)

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests pass (`doit test`)
