### PR TITLE
feat: integrate cache metadata into Config.get_clusters()

### DIFF
--- a/src/pynetappfoundry/core/config.py
+++ b/src/pynetappfoundry/core/config.py
@@ -44,7 +44,7 @@ import logging
 import os
 import tomllib
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from pynetappfoundry.core.models import (
     DIIAPISettings,
@@ -52,6 +52,9 @@ from pynetappfoundry.core.models import (
     ONTAPAPISettings,
     SMTPSettings,
 )
+
+if TYPE_CHECKING:
+    from pynetappfoundry.cache.db import ClusterMetadataDB
 
 _file_name = Path(__file__).name
 
@@ -282,7 +285,71 @@ class Config:
             f"{_file_name} :loaded the"
             f" following files: {', '.join([str(path) for path in loaded_tomls])}"
         )
+        self._enrich_with_cache()
         self.add_searchable_keys()
+
+    def _enrich_with_cache(self) -> None:
+        """Enrich cluster data with cached cloud metadata.
+
+        Adds cloud metadata fields to all clusters in self.data["clusters"].
+        Clusters with cached data get actual values; clusters without cache
+        get default values (empty strings for all cloud fields).
+
+        This method runs BEFORE add_searchable_keys() so cloud fields
+        can be included in searchable keys.
+        """
+        from pynetappfoundry.cache.db import ClusterMetadataDB
+        from pynetappfoundry.cache.models import CloudMetadata
+
+        # Define which cloud fields to add (with cloud_ prefix)
+        cloud_fields = [
+            "instance_id",
+            "account_id",
+            "instance_type",
+            "region",
+            "provider",
+            "primary_ip",
+            "availability_zone",
+            "resource_group_name",
+        ]
+
+        # Get default values from CloudMetadata model
+        default_cloud = CloudMetadata()
+        defaults = {f"cloud_{field}": getattr(default_cloud, field) for field in cloud_fields}
+
+        clusters = self.data.get("clusters", {})
+        if not clusters:
+            logging.debug(f"{_file_name} : no clusters to enrich with cache")
+            return
+
+        # Try to open the cache database
+        cache_db: ClusterMetadataDB | None = None
+        try:
+            cache_db = ClusterMetadataDB(config=self)
+        except Exception as e:
+            logging.debug(f"{_file_name} : could not open cache database: {e}")
+
+        for cluster_name, cluster_data in clusters.items():
+            # Add default values for all cloud fields
+            for field, default_value in defaults.items():
+                if field not in cluster_data:
+                    cluster_data[field] = default_value
+
+            # Try to get cached data and override defaults
+            if cache_db:
+                try:
+                    cached = cache_db.get(cluster_name)
+                    if cached and cached.cloud:
+                        for field in cloud_fields:
+                            cache_value = getattr(cached.cloud, field, "")
+                            if cache_value:  # Only override if cache has a value
+                                cluster_data[f"cloud_{field}"] = cache_value
+                        logging.debug(f"{_file_name} : enriched {cluster_name} with cache data")
+                except Exception as e:
+                    logging.debug(f"{_file_name} : could not get cache for {cluster_name}: {e}")
+
+        if cache_db:
+            cache_db.close()
 
     def parse_toml(self, file: Path) -> None:
         """Parse a single TOML file.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -808,3 +808,182 @@ relaxation_order = ['cloud', 'app', 'div']
             assert connectors_order == ["cloud", "app", "div"]
         finally:
             os.chdir(original_cwd)
+
+
+class TestCacheEnrichment:
+    """Tests for cache metadata enrichment."""
+
+    def test_clusters_have_cloud_fields_with_defaults(
+        self, temp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Test that clusters get cloud fields with default values when no cache."""
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+
+            # All clusters should have cloud fields with default empty values
+            for cluster_name in config.data.get("clusters", {}):
+                cluster = config.data["clusters"][cluster_name]
+                assert "cloud_provider" in cluster
+                assert "cloud_region" in cluster
+                assert "cloud_instance_id" in cluster
+                assert "cloud_account_id" in cluster
+                assert "cloud_resource_group_name" in cluster
+                # Default should be empty string
+                assert cluster["cloud_provider"] == ""
+                assert cluster["cloud_region"] == ""
+        finally:
+            os.chdir(original_cwd)
+
+    def test_cloud_fields_are_searchable(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test that cloud fields can be used in search queries."""
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+
+            # Search for clusters by cloud_provider (all have default "")
+            results = config.get_clusters({"cloud_provider": ""})
+            assert len(results) == 3  # All clusters have empty cloud_provider
+
+            # Search for non-existent provider should return nothing
+            results = config.get_clusters({"cloud_provider": "Azure"})
+            assert len(results) == 0
+        finally:
+            os.chdir(original_cwd)
+
+    def test_cached_data_enriches_cluster(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test that cached cloud data is merged into cluster."""
+        import os
+
+        from pynetappfoundry.cache.db import ClusterMetadataDB
+        from pynetappfoundry.cache.models import CachedClusterMetadata, CloudMetadata
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+
+            # First create a config to set up the cache directory
+            config1 = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+
+            # Now populate cache for one cluster
+            db = ClusterMetadataDB(config=config1)
+            cached_metadata = CachedClusterMetadata(
+                cluster_name="test-cluster-1",
+                cloud=CloudMetadata(
+                    provider="Azure",
+                    region="eastus",
+                    account_id="sub-12345",
+                    resource_group_name="rg-test",
+                    instance_type="Standard_E20ds_v5",
+                ),
+            )
+            db.set("test-cluster-1", cached_metadata)
+            db.close()
+
+            # Now create a new config - it should enrich from cache
+            config2 = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+
+            # Check enriched cluster
+            cluster1 = config2.data["clusters"]["test-cluster-1"]
+            assert cluster1["cloud_provider"] == "Azure"
+            assert cluster1["cloud_region"] == "eastus"
+            assert cluster1["cloud_account_id"] == "sub-12345"
+            assert cluster1["cloud_resource_group_name"] == "rg-test"
+            assert cluster1["cloud_instance_type"] == "Standard_E20ds_v5"
+
+            # Check non-cached cluster still has defaults
+            cluster2 = config2.data["clusters"]["test-cluster-2"]
+            assert cluster2["cloud_provider"] == ""
+            assert cluster2["cloud_region"] == ""
+        finally:
+            os.chdir(original_cwd)
+
+    def test_cached_data_is_searchable(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Test that cached cloud data can be used for searching."""
+        import os
+
+        from pynetappfoundry.cache.db import ClusterMetadataDB
+        from pynetappfoundry.cache.models import CachedClusterMetadata, CloudMetadata
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+
+            # Create config and populate cache
+            config1 = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+
+            db = ClusterMetadataDB(config=config1)
+            # Add Azure cluster
+            db.set(
+                "test-cluster-1",
+                CachedClusterMetadata(
+                    cluster_name="test-cluster-1",
+                    cloud=CloudMetadata(provider="Azure", region="eastus"),
+                ),
+            )
+            # Add AWS cluster
+            db.set(
+                "test-cluster-2",
+                CachedClusterMetadata(
+                    cluster_name="test-cluster-2",
+                    cloud=CloudMetadata(provider="AWS", region="us-east-1"),
+                ),
+            )
+            db.close()
+
+            # New config should have enriched data
+            config2 = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+
+            # Search by cloud provider
+            azure_clusters = config2.get_clusters({"cloud_provider": "Azure"})
+            assert len(azure_clusters) == 1
+            assert "test-cluster-1" in azure_clusters
+
+            aws_clusters = config2.get_clusters({"cloud_provider": "AWS"})
+            assert len(aws_clusters) == 1
+            assert "test-cluster-2" in aws_clusters
+
+            # Search by cloud region
+            eastus_clusters = config2.get_clusters({"cloud_region": "eastus"})
+            assert len(eastus_clusters) == 1
+            assert "test-cluster-1" in eastus_clusters
+        finally:
+            os.chdir(original_cwd)


### PR DESCRIPTION
## Description

Config now enriches cluster data with cached cloud metadata during initialization.
Cloud fields are added to ALL clusters with default values, and clusters with
cached data get the actual values from the cache. This enables searching clusters
by cloud metadata fields.

## Related Issue

Closes #75

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `_enrich_with_cache()` method to Config class
- Enrichment runs BEFORE `add_searchable_keys()` so cloud fields are searchable
- Cloud fields added: cloud_instance_id, cloud_account_id, cloud_instance_type, cloud_region, cloud_provider, cloud_primary_ip, cloud_availability_zone, cloud_resource_group_name
- Clusters with cache get actual values; clusters without cache get empty string defaults

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This feature enables searching for clusters by cloud provider, region, etc:
- `config.get_clusters({"cloud_provider": "Azure"})`
- `config.get_clusters({"cloud_region": "eastus"})`
