### PR TITLE
fix: isolate CLI tests from NF_CONFIG_DIR environment variable

### DIFF
--- a/tests/unit/test_config_commands.py
+++ b/tests/unit/test_config_commands.py
@@ -114,7 +114,7 @@ class TestConfigShowCommand:
 
             shutil.copytree(temp_config_dir, Path.cwd() / "config")
 
-            result = runner.invoke(nf, ["config", "show"])
+            result = runner.invoke(nf, ["config", "show"], env={"NF_CONFIG_DIR": ""})
             assert result.exit_code == 0
             assert "Configuration from:" in result.output
             assert "clusters" in result.output.lower()
@@ -127,7 +127,9 @@ class TestConfigShowCommand:
 
             shutil.copytree(temp_config_dir, Path.cwd() / "config")
 
-            result = runner.invoke(nf, ["config", "show", "-s", "clusters"])
+            result = runner.invoke(
+                nf, ["config", "show", "-s", "clusters"], env={"NF_CONFIG_DIR": ""}
+            )
             assert result.exit_code == 0
             assert "test-cluster-1" in result.output
 
@@ -139,7 +141,9 @@ class TestConfigShowCommand:
 
             shutil.copytree(temp_config_dir, Path.cwd() / "config")
 
-            result = runner.invoke(nf, ["config", "show", "-s", "nonexistent"])
+            result = runner.invoke(
+                nf, ["config", "show", "-s", "nonexistent"], env={"NF_CONFIG_DIR": ""}
+            )
             assert result.exit_code == 1
             assert "not found" in result.output.lower()
 
@@ -151,7 +155,7 @@ class TestConfigShowCommand:
 
             shutil.copytree(temp_config_dir, Path.cwd() / "config")
 
-            result = runner.invoke(nf, ["config", "show"])
+            result = runner.invoke(nf, ["config", "show"], env={"NF_CONFIG_DIR": ""})
             assert result.exit_code == 0
             # The encoded password should be masked
             assert "encoded_password_123" not in result.output
@@ -165,7 +169,7 @@ class TestConfigShowCommand:
 
             shutil.copytree(temp_config_dir, Path.cwd() / "config")
 
-            result = runner.invoke(nf, ["config", "show", "--unmask"])
+            result = runner.invoke(nf, ["config", "show", "--unmask"], env={"NF_CONFIG_DIR": ""})
             assert result.exit_code == 0
             assert "encoded_password_123" in result.output
 
@@ -173,7 +177,7 @@ class TestConfigShowCommand:
         """Test error when config directory doesn't exist."""
         runner = CliRunner()
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(nf, ["config", "show"])
+            result = runner.invoke(nf, ["config", "show"], env={"NF_CONFIG_DIR": ""})
             assert result.exit_code == 1
             assert "not found" in result.output.lower()
 
@@ -192,7 +196,7 @@ class TestConfigValidateCommand:
         original_cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
-            result = runner.invoke(nf, ["config", "validate"])
+            result = runner.invoke(nf, ["config", "validate"], env={"NF_CONFIG_DIR": ""})
             assert result.exit_code == 0, f"Output: {result.output}"
             assert "valid" in result.output.lower()
         finally:
@@ -204,7 +208,7 @@ class TestConfigValidateCommand:
         original_cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
-            result = runner.invoke(nf, ["config", "validate"])
+            result = runner.invoke(nf, ["config", "validate"], env={"NF_CONFIG_DIR": ""})
             assert result.exit_code == 1
             assert "not found" in result.output.lower()
         finally:
@@ -220,7 +224,7 @@ class TestConfigValidateCommand:
         original_cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
-            result = runner.invoke(nf, ["config", "validate"])
+            result = runner.invoke(nf, ["config", "validate"], env={"NF_CONFIG_DIR": ""})
             assert result.exit_code == 0, f"Output: {result.output}"
             assert "test-cluster-1" in result.output
         finally:


### PR DESCRIPTION
## Description

Tests in `test_config_commands.py` were failing when `NF_CONFIG_DIR` was set in the local environment (e.g., via `.envrc.local`). This fix adds `env={"NF_CONFIG_DIR": ""}` to `runner.invoke()` calls to isolate tests from inherited environment variables.

## Related Issue

Closes #80

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Added `env={"NF_CONFIG_DIR": ""}` to all `runner.invoke()` calls in `TestConfigShowCommand` and `TestConfigValidateCommand`
- This prevents Click's `envvar` feature from picking up `NF_CONFIG_DIR` from the process environment

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Root cause: Click's `envvar` option parameter picks up environment variables from the process. When users have `.envrc.local` setting `NF_CONFIG_DIR`, tests would fail because they expected `config` but the CLI was looking for the value from the env var.
