### PR TITLE
refactor: consolidate CLI logging with dual console/file output

### DIFF
--- a/src/pynetappfoundry/cli/commands/events/azevents.py
+++ b/src/pynetappfoundry/cli/commands/events/azevents.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import click
 
 from pynetappfoundry.cli.decorators import with_config
-from pynetappfoundry.cli.utils import print_info, print_success
+from pynetappfoundry.cli.utils import print_debug, print_error, print_info, print_success
 from pynetappfoundry.core.config import Config
 from pynetappfoundry.db.azevents import AzEventsDB
 
@@ -81,7 +80,7 @@ def _save_cluster_azure_events(
                             "az_maint_scheduled": event.get("scheduled_time"),
                         }
                         db.upsert_event(db_event)
-                        logging.info(f"Saved event {event_id} for {node_name}")
+                        print_debug(f"Saved event {event_id} for {node_name}")
 
     except Exception as e:
-        logging.error(f"Could not get Azure events for {name}: {e}")
+        print_error(f"Could not get Azure events for {name}: {e}")

--- a/src/pynetappfoundry/cli/commands/events/get.py
+++ b/src/pynetappfoundry/cli/commands/events/get.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import click
@@ -94,5 +93,4 @@ def _get_cluster_events(
             print_info(f"Retrieved {count} events")
 
     except Exception as e:
-        logging.error(f"Could not retrieve events for {name}: {e}")
-        print_error(f"  Error: {e}")
+        print_error(f"Could not retrieve events for {name}: {e}")

--- a/src/pynetappfoundry/cli/commands/licenses/check.py
+++ b/src/pynetappfoundry/cli/commands/licenses/check.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import UTC, datetime
 from typing import Any
 
@@ -152,7 +151,7 @@ def _check_cluster_licenses(
                     )
 
     except Exception as e:
-        logging.error(f"Could not retrieve licenses for {name}: {e}")
+        print_error(f"Could not retrieve licenses for {name}: {e}")
         issues.append(
             {
                 "cluster": name,
@@ -185,7 +184,7 @@ def _send_license_email(
     licensing_settings = config.get_licensing_settings()
 
     if not licensing_settings:
-        logging.warning("Email settings not configured, skipping notification")
+        print_warning("Email settings not configured, skipping notification")
         return
 
     html_body = ["<html><body>"]

--- a/src/pynetappfoundry/cli/commands/licenses/get.py
+++ b/src/pynetappfoundry/cli/commands/licenses/get.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import click
@@ -70,5 +69,4 @@ def _get_cluster_licenses(
             console.print(table)
 
     except Exception as e:
-        logging.error(f"Could not retrieve licenses for {name}: {e}")
-        print_error(f"  Error: {e}")
+        print_error(f"Could not retrieve licenses for {name}: {e}")

--- a/src/pynetappfoundry/cli/commands/licenses/savings.py
+++ b/src/pynetappfoundry/cli/commands/licenses/savings.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import click
@@ -80,5 +79,4 @@ def _analyze_cluster_savings(
             console.print(table)
 
     except Exception as e:
-        logging.error(f"Could not analyze savings for {name}: {e}")
-        print_error(f"  Error: {e}")
+        print_error(f"Could not analyze savings for {name}: {e}")

--- a/src/pynetappfoundry/cli/commands/metrics/dump_dii.py
+++ b/src/pynetappfoundry/cli/commands/metrics/dump_dii.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import click
 
 from pynetappfoundry.cli.decorators import with_config
-from pynetappfoundry.cli.utils import print_exception, print_info, print_success
+from pynetappfoundry.cli.utils import (
+    print_debug,
+    print_error,
+    print_exception,
+    print_info,
+    print_success,
+    print_warning,
+)
 from pynetappfoundry.clients.dii.api import DIIAPIClient
 from pynetappfoundry.core.config import Config
 from pynetappfoundry.db.metrics import MetricDB
@@ -78,7 +84,7 @@ def _dump_cluster_metrics(
         )
 
         if not assets:
-            logging.warning(f"No assets found for {name} in DII")
+            print_warning(f"No assets found for {name} in DII")
             return
 
         # Get metrics for each asset
@@ -109,7 +115,7 @@ def _dump_cluster_metrics(
                 }
                 db.upsert_data(table_name, metric_record)
 
-        logging.info(f"Saved metrics for {name}")
+        print_debug(f"Saved metrics for {name}")
 
     except Exception as e:
-        logging.error(f"Could not dump metrics for {name}: {e}")
+        print_error(f"Could not dump metrics for {name}: {e}")

--- a/src/pynetappfoundry/cli/commands/reports/html.py
+++ b/src/pynetappfoundry/cli/commands/reports/html.py
@@ -11,7 +11,6 @@ This module generates an interactive HTML report with:
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -19,7 +18,7 @@ import click
 from yattag import Doc, indent
 
 from pynetappfoundry.cli.decorators import with_config
-from pynetappfoundry.cli.utils import print_info, print_success
+from pynetappfoundry.cli.utils import print_debug, print_error, print_info, print_success
 from pynetappfoundry.utils.cloud import (
     build_azure_id,
     build_azure_portal_link,
@@ -461,9 +460,9 @@ class HTMLReportBuilder:
                     self.doc.asis(JS_SCRIPT)
 
         result: str = indent(self.doc.getvalue())
-        logging.info(f"Processed {self.counts['ha'] + self.counts['sn']} clusters")
-        logging.info(f"   Single Node : {self.counts['sn']}")
-        logging.info(f"   HA          : {self.counts['ha']}")
+        print_debug(f"Processed {self.counts['ha'] + self.counts['sn']} clusters")
+        print_debug(f"   Single Node : {self.counts['sn']}")
+        print_debug(f"   HA          : {self.counts['ha']}")
         return result
 
     def _format_divisions(self) -> None:
@@ -753,18 +752,18 @@ class ClusterData:
         from netapp_ontap import HostConnection
         from netapp_ontap.resources import CifsService, Cluster, IpInterface, Node, Svm
 
-        logging.info(f"Gathering data for {self.name}")
+        print_debug(f"Gathering data for {self.name}")
         self._build_cloud_info()
 
         ip = getattr(self, "ip", None)
         if not ip:
-            logging.error(f"No IP address for cluster {self.name}")
+            print_error(f"No IP address for cluster {self.name}")
             return
 
         try:
             user, password = self.app_instance.config.get_user("clusters", self.name)
         except Exception as e:
-            logging.error(f"Could not get credentials for {self.name}: {e}")
+            print_error(f"Could not get credentials for {self.name}: {e}")
             return
 
         try:
@@ -793,11 +792,11 @@ class ClusterData:
                 for cifserver in cifsservices:
                     self.fetched_data["cifs"][cifserver["name"]] = cifserver.to_dict()
         except Exception as e:
-            logging.error(f"Could not gather data from {self.name}: {e}")
+            print_error(f"Could not gather data from {self.name}: {e}")
 
     def format(self) -> None:
         """Format the cluster data as HTML."""
-        logging.info(f"Formatting cluster: {self.name}")
+        print_debug(f"Formatting cluster: {self.name}")
         is_active = hasattr(self, "tags") and "active" in getattr(self, "tags", [])
 
         tag = self.app_instance.tag
@@ -958,7 +957,7 @@ class ClusterData:
 
         for svm_name in sorted(self.fetched_data["svms"].keys()):
             svm_data = self.fetched_data["svms"][svm_name]
-            logging.info(f"  SVM: {svm_data.get('name', svm_name)}")
+            print_debug(f"  SVM: {svm_data.get('name', svm_name)}")
 
             state = svm_data.get("state", "")
             state_text = " - State: Stopped" if state == "stopped" else ""

--- a/src/pynetappfoundry/cli/commands/reports/locks.py
+++ b/src/pynetappfoundry/cli/commands/reports/locks.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime
 from typing import Any
 
@@ -10,7 +9,7 @@ import click
 from openpyxl import Workbook
 
 from pynetappfoundry.cli.decorators import with_config
-from pynetappfoundry.cli.utils import print_info, print_success
+from pynetappfoundry.cli.utils import print_debug, print_error, print_info, print_success
 from pynetappfoundry.core.config import Config
 
 
@@ -74,7 +73,7 @@ def _gather_lock_data(
             for lock in ClientLock.get_collection(fields="*"):
                 locks_data.append(lock.to_dict())
 
-            logging.info(f"Locks found: {len(locks_data)}")
+            print_debug(f"Locks found: {len(locks_data)}")
 
             for item in locks_data:
                 try:
@@ -104,11 +103,11 @@ def _gather_lock_data(
                             ]
                         )
                     else:
-                        logging.info(f"Unknown lock type: {lock_type}")
+                        print_debug(f"Unknown lock type: {lock_type}")
                 except Exception as e:
-                    logging.error(f"Lock error: {e}")
+                    print_error(f"Lock error: {e}")
 
     except Exception as e:
-        logging.error(f"Could not gather lock data for {name}: {e}")
+        print_error(f"Could not gather lock data for {name}: {e}")
         ws = wb.create_sheet(name)
         ws.append(["Error", str(e)])

--- a/src/pynetappfoundry/cli/commands/reports/space_usage.py
+++ b/src/pynetappfoundry/cli/commands/reports/space_usage.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime
 from typing import Any
 
@@ -10,7 +9,7 @@ import click
 from openpyxl import Workbook
 
 from pynetappfoundry.cli.decorators import with_config
-from pynetappfoundry.cli.utils import print_info, print_success
+from pynetappfoundry.cli.utils import print_error, print_info, print_success
 from pynetappfoundry.core.config import Config
 
 
@@ -113,6 +112,6 @@ def _gather_space_data(
                 )
 
     except Exception as e:
-        logging.error(f"Could not gather space data for {name}: {e}")
+        print_error(f"Could not gather space data for {name}: {e}")
         ws = wb.create_sheet(name)
         ws.append(["Error", str(e)])

--- a/src/pynetappfoundry/cli/commands/utils/run_cmd.py
+++ b/src/pynetappfoundry/cli/commands/utils/run_cmd.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import click
@@ -64,5 +63,4 @@ def _run_cluster_command(
             console.print(f"  {line}")
 
     except Exception as e:
-        logging.exception(f"Could not run command on {name}: {e}")
-        print_exception(f"  Error: {e}", e)
+        print_exception(f"Could not run command on {name}: {e}", e)

--- a/src/pynetappfoundry/cli/commands/utils/validate.py
+++ b/src/pynetappfoundry/cli/commands/utils/validate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-import traceback
 from typing import Any
 
 import click
@@ -11,7 +9,13 @@ from netapp_ontap import HostConnection
 from netapp_ontap.resources import Cluster, Node, Volume
 
 from pynetappfoundry.cli.decorators import with_config
-from pynetappfoundry.cli.utils import print_error, print_info, print_success, print_warning
+from pynetappfoundry.cli.utils import (
+    print_debug,
+    print_error,
+    print_info,
+    print_success,
+    print_warning,
+)
 from pynetappfoundry.clients.ontap.cli import ONTAPCLI
 from pynetappfoundry.core.config import Config
 
@@ -113,9 +117,9 @@ def _validate_cluster(
             if cluster_name != name:
                 print_warning(f"    Config name {name} does not match cluster name {cluster_name}")
 
-    except Exception:
+    except Exception as e:
         print_error(f"  API: Could not connect to config {name}")
-        logging.debug(traceback.format_exc())
+        print_debug(f"Exception details: {e}")
 
     return node_count, vol_count, success
 
@@ -146,5 +150,5 @@ def _validate_ssh(
         return True
     except Exception as e:
         print_error(f"  SSH: Failed ({e})")
-        logging.debug(traceback.format_exc())
+        print_debug(f"Exception details: {e}")
         return False

--- a/src/pynetappfoundry/cli/utils.py
+++ b/src/pynetappfoundry/cli/utils.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import traceback
 
 import click
 from rich.console import Console
 from rich.table import Table
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 
@@ -46,49 +48,71 @@ def print_table(
 
 
 def print_success(message: str) -> None:
-    """Print a success message.
+    """Print a success message to console and log to file.
 
     Args:
         message: Message to print.
     """
     console.print(f"[green]{message}[/green]")
+    logger.info(message)
 
 
 def print_error(message: str) -> None:
-    """Print an error message.
+    """Print an error message to console and log to file.
 
     Args:
         message: Message to print.
     """
     console.print(f"[red]{message}[/red]")
+    logger.error(message)
 
 
 def print_warning(message: str) -> None:
-    """Print a warning message.
+    """Print a warning message to console and log to file.
 
     Args:
         message: Message to print.
     """
     console.print(f"[yellow]{message}[/yellow]")
+    logger.warning(message)
 
 
 def print_info(message: str) -> None:
-    """Print an info message.
+    """Print an info message to console and log to file.
 
     Args:
         message: Message to print.
     """
     console.print(f"[blue]{message}[/blue]")
+    logger.info(message)
 
 
 def print_exception(message: str, exc: BaseException | None = None) -> None:
     """Print an error message with optional traceback in debug mode.
 
+    Also logs to file - uses exception logging if exc is provided, otherwise error.
+
     Args:
         message: Error message to print.
         exc: Exception to include. If provided and debug mode is enabled,
-             the full traceback will be printed.
+             the full traceback will be printed to console. If provided,
+             logger.exception is used for full traceback in log file.
     """
     console.print(f"[red]{message}[/red]")
+    if exc:
+        logger.exception(message)
+    else:
+        logger.error(message)
     if exc and is_debug_mode():
         console.print("[dim]" + "".join(traceback.format_exception(exc)) + "[/dim]")
+
+
+def print_debug(message: str) -> None:
+    """Print debug message to console (if debug mode) and always log to file.
+
+    Args:
+        message: Debug message to print.
+    """
+    logger.debug(message)
+    if is_debug_mode():
+        console.print(f"[dim]{message}[/dim]")

--- a/tests/unit/cli/test_cli_utils.py
+++ b/tests/unit/cli/test_cli_utils.py
@@ -1,0 +1,190 @@
+"""Tests for CLI utility functions."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pynetappfoundry.cli.utils import (
+    is_debug_mode,
+    print_debug,
+    print_error,
+    print_exception,
+    print_info,
+    print_success,
+    print_warning,
+)
+
+
+class TestIsDebugMode:
+    """Tests for is_debug_mode function."""
+
+    def test_debug_mode_enabled(self) -> None:
+        """Test when debug mode is enabled in context."""
+        with patch("pynetappfoundry.cli.utils.click.get_current_context") as mock_ctx:
+            mock_ctx.return_value = MagicMock(obj={"debug": True})
+            assert is_debug_mode() is True
+
+    def test_debug_mode_disabled(self) -> None:
+        """Test when debug mode is disabled in context."""
+        with patch("pynetappfoundry.cli.utils.click.get_current_context") as mock_ctx:
+            mock_ctx.return_value = MagicMock(obj={"debug": False})
+            assert is_debug_mode() is False
+
+    def test_debug_mode_no_context(self) -> None:
+        """Test when no context is available."""
+        with patch("pynetappfoundry.cli.utils.click.get_current_context") as mock_ctx:
+            mock_ctx.return_value = None
+            assert is_debug_mode() is False
+
+    def test_debug_mode_empty_obj(self) -> None:
+        """Test when context obj is None."""
+        with patch("pynetappfoundry.cli.utils.click.get_current_context") as mock_ctx:
+            mock_ctx.return_value = MagicMock(obj=None)
+            assert is_debug_mode() is False
+
+
+class TestPrintSuccess:
+    """Tests for print_success function."""
+
+    def test_prints_to_console_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that print_success prints to console and logs at INFO level."""
+        with (
+            patch("pynetappfoundry.cli.utils.console") as mock_console,
+            caplog.at_level(logging.INFO),
+        ):
+            print_success("Test message")
+
+            mock_console.print.assert_called_once_with("[green]Test message[/green]")
+            assert "Test message" in caplog.text
+            assert caplog.records[0].levelno == logging.INFO
+
+
+class TestPrintError:
+    """Tests for print_error function."""
+
+    def test_prints_to_console_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that print_error prints to console and logs at ERROR level."""
+        with (
+            patch("pynetappfoundry.cli.utils.console") as mock_console,
+            caplog.at_level(logging.ERROR),
+        ):
+            print_error("Error message")
+
+            mock_console.print.assert_called_once_with("[red]Error message[/red]")
+            assert "Error message" in caplog.text
+            assert caplog.records[0].levelno == logging.ERROR
+
+
+class TestPrintWarning:
+    """Tests for print_warning function."""
+
+    def test_prints_to_console_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that print_warning prints to console and logs at WARNING level."""
+        with (
+            patch("pynetappfoundry.cli.utils.console") as mock_console,
+            caplog.at_level(logging.WARNING),
+        ):
+            print_warning("Warning message")
+
+            mock_console.print.assert_called_once_with("[yellow]Warning message[/yellow]")
+            assert "Warning message" in caplog.text
+            assert caplog.records[0].levelno == logging.WARNING
+
+
+class TestPrintInfo:
+    """Tests for print_info function."""
+
+    def test_prints_to_console_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that print_info prints to console and logs at INFO level."""
+        with (
+            patch("pynetappfoundry.cli.utils.console") as mock_console,
+            caplog.at_level(logging.INFO),
+        ):
+            print_info("Info message")
+
+            mock_console.print.assert_called_once_with("[blue]Info message[/blue]")
+            assert "Info message" in caplog.text
+            assert caplog.records[0].levelno == logging.INFO
+
+
+class TestPrintException:
+    """Tests for print_exception function."""
+
+    def test_with_exception_logs_exception(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that print_exception with exception logs at exception level."""
+        with (
+            patch("pynetappfoundry.cli.utils.console") as mock_console,
+            patch("pynetappfoundry.cli.utils.is_debug_mode", return_value=False),
+            caplog.at_level(logging.ERROR),
+        ):
+            exc = ValueError("Test error")
+            print_exception("Exception message", exc)
+
+            mock_console.print.assert_called_once_with("[red]Exception message[/red]")
+            assert "Exception message" in caplog.text
+
+    def test_without_exception_logs_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that print_exception without exception logs at error level."""
+        with (
+            patch("pynetappfoundry.cli.utils.console") as mock_console,
+            caplog.at_level(logging.ERROR),
+        ):
+            print_exception("Error only message")
+
+            mock_console.print.assert_called_once_with("[red]Error only message[/red]")
+            assert "Error only message" in caplog.text
+            assert caplog.records[0].levelno == logging.ERROR
+
+    def test_with_exception_in_debug_mode_shows_traceback(self) -> None:
+        """Test that traceback is shown on console in debug mode."""
+        with (
+            patch("pynetappfoundry.cli.utils.console") as mock_console,
+            patch("pynetappfoundry.cli.utils.is_debug_mode", return_value=True),
+        ):
+            exc = ValueError("Test error")
+            print_exception("Exception message", exc)
+
+            # Should have two console.print calls: error message and traceback
+            assert mock_console.print.call_count == 2
+
+
+class TestPrintDebug:
+    """Tests for print_debug function."""
+
+    def test_always_logs_to_file(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that print_debug always logs at DEBUG level."""
+        with (
+            patch("pynetappfoundry.cli.utils.console") as mock_console,
+            patch("pynetappfoundry.cli.utils.is_debug_mode", return_value=False),
+            caplog.at_level(logging.DEBUG),
+        ):
+            print_debug("Debug message")
+
+            # Should NOT print to console when debug mode is off
+            mock_console.print.assert_not_called()
+            # Should log to file
+            assert "Debug message" in caplog.text
+            assert caplog.records[0].levelno == logging.DEBUG
+
+    def test_prints_to_console_in_debug_mode(self) -> None:
+        """Test that print_debug prints to console when debug mode is enabled."""
+        with (
+            patch("pynetappfoundry.cli.utils.console") as mock_console,
+            patch("pynetappfoundry.cli.utils.is_debug_mode", return_value=True),
+        ):
+            print_debug("Debug message")
+
+            mock_console.print.assert_called_once_with("[dim]Debug message[/dim]")
+
+    def test_no_console_output_when_not_in_debug_mode(self) -> None:
+        """Test that print_debug does not print to console when debug mode is off."""
+        with (
+            patch("pynetappfoundry.cli.utils.console") as mock_console,
+            patch("pynetappfoundry.cli.utils.is_debug_mode", return_value=False),
+        ):
+            print_debug("Debug message")
+
+            mock_console.print.assert_not_called()


### PR DESCRIPTION
## Description

Consolidates CLI logging by enhancing console print functions in `cli/utils.py` to provide dual-output: Rich-styled console output and file logging at appropriate levels.

## Related Issue

Closes #79

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Enhanced `cli/utils.py` print functions to log to file:
  - `print_success()` - logs at INFO level
  - `print_error()` - logs at ERROR level
  - `print_warning()` - logs at WARNING level
  - `print_info()` - logs at INFO level
  - `print_exception()` - uses `logger.exception()` when exception provided
- Added new `print_debug()` function (console output only in debug mode, always logs to file)
- Converted 11 CLI command files from direct `logging.*` calls to `print_*` functions
- Added comprehensive tests for `cli/utils.py` logging behavior

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

**Scope:** CLI commands only (`cli/commands/*`). Library code (`core/`, `cache/`, `clients/`, `utils/`) continues to use standard logging.

**Files converted:**
- `reports/html.py`, `reports/locks.py`, `reports/space_usage.py`
- `events/azevents.py`, `events/get.py`
- `licenses/check.py`, `licenses/get.py`, `licenses/savings.py`
- `utils/validate.py`, `utils/run_cmd.py`
- `metrics/dump_dii.py`
