### PR TITLE
fix: add database migration for azevents schema changes

### DIFF
--- a/src/pynetappfoundry/db/azevents.py
+++ b/src/pynetappfoundry/db/azevents.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from pynetappfoundry.db.base import adapt_datetime, convert_datetime
 
@@ -34,6 +34,33 @@ sqlite3.register_converter("aggr_giveback_complete", convert_datetime)
 class AzEventsDB:
     """SQLite database for storing Azure maintenance events."""
 
+    # Schema definition: (column_name, column_type)
+    # Order matters for table creation
+    SCHEMA: ClassVar[list[tuple[str, str]]] = [
+        ("event_id", "TEXT PRIMARY KEY"),
+        ("cluster", "TEXT DEFAULT 'Unknown'"),
+        ("node", "TEXT DEFAULT 'Unknown'"),
+        ("type", "TEXT DEFAULT 'Unknown'"),
+        ("az_maint_not_before", "TEXT"),
+        ("az_maint_scheduled", "TEXT"),
+        ("az_maint_started", "TEXT"),
+        ("az_maint_complete", "TEXT"),
+        ("node_takeover_complete", "TEXT"),
+        ("node_reboot_starts", "TEXT"),
+        ("node_reboot_complete", "TEXT"),
+        ("node_ready_for_giveback", "TEXT"),
+        ("node_giveback_starts", "TEXT"),
+        ("node_giveback_complete", "TEXT"),
+        # SMB client impact tracking fields (added in v2)
+        ("lif_failover_start", "TEXT"),
+        ("lif_failover_complete", "TEXT"),
+        ("cifs_transition_ms", "INTEGER"),
+        ("cifs_witness_time", "TEXT"),
+        ("cifs_witness_clients", "INTEGER"),
+        ("aggr_giveback_start", "TEXT"),
+        ("aggr_giveback_complete", "TEXT"),
+    ]
+
     def __init__(self, config: Config, db_name: str = "azevents.db") -> None:
         """Initialize the Azure events database.
 
@@ -44,45 +71,39 @@ class AzEventsDB:
         db_location = config.db_dir / db_name
         self.conn = sqlite3.connect(db_location, detect_types=sqlite3.PARSE_DECLTYPES)
         self.conn.row_factory = sqlite3.Row  # Enables dictionary-like access
-        self.create_table()
+        self._init_schema()
 
-    def create_table(self) -> None:
-        """Create the maintenance_events table if it doesn't exist."""
+    def _init_schema(self) -> None:
+        """Initialize database schema, creating table or migrating as needed."""
         cur = self.conn.cursor()
         cur.execute(
-            """
-            SELECT name FROM sqlite_master WHERE type='table' AND name='maintenance_events'
-        """
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='maintenance_events'"
         )
         if cur.fetchone() is None:
-            with self.conn:
-                self.conn.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS maintenance_events (
-                        event_id TEXT PRIMARY KEY,
-                        cluster TEXT DEFAULT 'Unknown',
-                        node TEXT DEFAULT 'Unknown',
-                        type TEXT DEFAULT 'Unknown',
-                        az_maint_not_before TEXT,
-                        az_maint_scheduled TEXT,
-                        az_maint_started TEXT,
-                        az_maint_complete TEXT,
-                        node_takeover_complete TEXT,
-                        node_reboot_starts TEXT,
-                        node_reboot_complete TEXT,
-                        node_ready_for_giveback TEXT,
-                        node_giveback_starts TEXT,
-                        node_giveback_complete TEXT,
-                        lif_failover_start TEXT,
-                        lif_failover_complete TEXT,
-                        cifs_transition_ms INTEGER,
-                        cifs_witness_time TEXT,
-                        cifs_witness_clients INTEGER,
-                        aggr_giveback_start TEXT,
-                        aggr_giveback_complete TEXT
+            self._create_table()
+        else:
+            self._migrate_schema()
+
+    def _create_table(self) -> None:
+        """Create the maintenance_events table."""
+        columns = ", ".join(f"{name} {col_type}" for name, col_type in self.SCHEMA)
+        with self.conn:
+            self.conn.execute(f"CREATE TABLE maintenance_events ({columns})")
+
+    def _migrate_schema(self) -> None:
+        """Add any missing columns to existing table."""
+        cur = self.conn.cursor()
+        cur.execute("PRAGMA table_info(maintenance_events)")
+        existing_columns = {row[1] for row in cur.fetchall()}
+
+        with self.conn:
+            for col_name, col_type in self.SCHEMA:
+                if col_name not in existing_columns:
+                    # For ALTER TABLE, we need simpler type (no PRIMARY KEY, no DEFAULT)
+                    simple_type = col_type.split()[0]  # Gets TEXT, INTEGER, etc.
+                    self.conn.execute(
+                        f"ALTER TABLE maintenance_events ADD COLUMN {col_name} {simple_type}"
                     )
-                """
-                )
 
     def upsert_event(self, event: dict[str, Any]) -> None:
         """Insert or update a maintenance event.

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from pynetappfoundry.db.azevents import AzEventsDB
 from pynetappfoundry.db.base import adapt_datetime, convert_datetime
 from pynetappfoundry.db.metrics import MetricDB, _validate_table_name
 
@@ -327,3 +328,162 @@ class TestMetricDB:
         assert "timestamp" in keys_list
         assert "read_ops" in keys_list
         db.conn.close()
+
+
+class TestAzEventsDB:
+    """Tests for AzEventsDB class."""
+
+    def test_creates_table_on_init(self, mock_config: MagicMock) -> None:
+        """Test that AzEventsDB creates table on initialization."""
+        db = AzEventsDB(mock_config)
+
+        cur = db.conn.cursor()
+        cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='maintenance_events'"
+        )
+        result = cur.fetchone()
+        assert result is not None
+        db.conn.close()
+
+    def test_creates_all_schema_columns(self, mock_config: MagicMock) -> None:
+        """Test that all schema columns are created."""
+        db = AzEventsDB(mock_config)
+
+        cur = db.conn.cursor()
+        cur.execute("PRAGMA table_info(maintenance_events)")
+        columns = {row[1] for row in cur.fetchall()}
+
+        expected_columns = {col_name for col_name, _ in AzEventsDB.SCHEMA}
+        assert columns == expected_columns
+        db.conn.close()
+
+    def test_migrates_missing_columns(self, mock_config: MagicMock) -> None:
+        """Test that missing columns are added to existing table."""
+        import sqlite3
+
+        # Create an old-style table without SMB columns
+        db_location = mock_config.db_dir / "azevents.db"
+        conn = sqlite3.connect(db_location)
+        conn.execute(
+            """
+            CREATE TABLE maintenance_events (
+                event_id TEXT PRIMARY KEY,
+                cluster TEXT DEFAULT 'Unknown',
+                node TEXT DEFAULT 'Unknown',
+                type TEXT DEFAULT 'Unknown',
+                az_maint_not_before TEXT,
+                az_maint_scheduled TEXT,
+                az_maint_started TEXT,
+                az_maint_complete TEXT,
+                node_takeover_complete TEXT,
+                node_reboot_starts TEXT,
+                node_reboot_complete TEXT,
+                node_ready_for_giveback TEXT,
+                node_giveback_starts TEXT,
+                node_giveback_complete TEXT
+            )
+        """
+        )
+        conn.commit()
+        conn.close()
+
+        # Now open with AzEventsDB which should migrate
+        db = AzEventsDB(mock_config)
+
+        cur = db.conn.cursor()
+        cur.execute("PRAGMA table_info(maintenance_events)")
+        columns = {row[1] for row in cur.fetchall()}
+
+        # Verify SMB columns were added
+        assert "lif_failover_start" in columns
+        assert "lif_failover_complete" in columns
+        assert "cifs_transition_ms" in columns
+        assert "cifs_witness_time" in columns
+        assert "cifs_witness_clients" in columns
+        assert "aggr_giveback_start" in columns
+        assert "aggr_giveback_complete" in columns
+        db.conn.close()
+
+    def test_preserves_existing_data_on_migration(self, mock_config: MagicMock) -> None:
+        """Test that existing data is preserved during migration."""
+        import sqlite3
+
+        # Create an old-style table with data
+        db_location = mock_config.db_dir / "azevents.db"
+        conn = sqlite3.connect(db_location)
+        conn.execute(
+            """
+            CREATE TABLE maintenance_events (
+                event_id TEXT PRIMARY KEY,
+                cluster TEXT DEFAULT 'Unknown',
+                node TEXT DEFAULT 'Unknown',
+                type TEXT DEFAULT 'Unknown',
+                az_maint_not_before TEXT,
+                az_maint_scheduled TEXT,
+                az_maint_started TEXT,
+                az_maint_complete TEXT,
+                node_takeover_complete TEXT,
+                node_reboot_starts TEXT,
+                node_reboot_complete TEXT,
+                node_ready_for_giveback TEXT,
+                node_giveback_starts TEXT,
+                node_giveback_complete TEXT
+            )
+        """
+        )
+        conn.execute(
+            """
+            INSERT INTO maintenance_events (event_id, cluster, node)
+            VALUES ('test-event-123', 'test-cluster', 'test-node')
+        """
+        )
+        conn.commit()
+        conn.close()
+
+        # Now open with AzEventsDB which should migrate
+        db = AzEventsDB(mock_config)
+
+        # Verify data is preserved
+        event = db.get_event_by_id("test-event-123")
+        assert event is not None
+        assert event["cluster"] == "test-cluster"
+        assert event["node"] == "test-node"
+        db.conn.close()
+
+    def test_upsert_with_new_columns(self, mock_config: MagicMock) -> None:
+        """Test that upsert works with new SMB columns."""
+        db = AzEventsDB(mock_config)
+
+        event = {
+            "event_id": "test-event-456",
+            "cluster": "test-cluster",
+            "node": "test-node",
+            "lif_failover_start": "2024-01-15T12:01:00Z",
+            "lif_failover_complete": "2024-01-15T12:04:00Z",
+            "cifs_transition_ms": 14450,
+            "cifs_witness_clients": 5,
+        }
+        db.upsert_event(event)
+
+        result = db.get_event_by_id("test-event-456")
+        assert result is not None
+        assert result["lif_failover_start"] == "2024-01-15T12:01:00Z"
+        assert result["cifs_transition_ms"] == 14450
+        assert result["cifs_witness_clients"] == 5
+        db.conn.close()
+
+    def test_no_duplicate_columns_on_reopen(self, mock_config: MagicMock) -> None:
+        """Test that reopening database doesn't create duplicate columns."""
+        db1 = AzEventsDB(mock_config)
+        db1.conn.close()
+
+        # Reopen
+        db2 = AzEventsDB(mock_config)
+
+        cur = db2.conn.cursor()
+        cur.execute("PRAGMA table_info(maintenance_events)")
+        columns = [row[1] for row in cur.fetchall()]
+
+        # Check no duplicates
+        assert len(columns) == len(set(columns))
+        db2.conn.close()


### PR DESCRIPTION
## Description

Add automatic schema migration to AzEventsDB that adds missing columns to existing databases. This fixes the error "table maintenance_events has no column named lif_failover_complete" when running save-azure on databases created before PR #109 added the SMB client impact tracking fields.

## Related Issue

Part of #92

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Refactor `create_table` to use `SCHEMA` class variable defining all columns
- Add `_init_schema` method to handle both table creation and migration
- Add `_migrate_schema` method that uses `PRAGMA table_info` to detect missing columns and `ALTER TABLE ADD COLUMN` to add them
- Add comprehensive tests for migration behavior

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The migration is automatic and transparent - existing data is preserved and new columns are added with NULL values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)