### PR TITLE
fix: prevent Unknown event_id in Azure maintenance tracking

### DIFF
--- a/src/pynetappfoundry/cli/commands/events/azevents.py
+++ b/src/pynetappfoundry/cli/commands/events/azevents.py
@@ -363,7 +363,7 @@ class ClusterData:
 
                         case "vsa.scheduledEvent.update":
                             print_debug(f"Found vsa.scheduledEvent.update: {emsevent.to_dict()}")
-                            # Handle out-of-order events
+                            # Handle out-of-order events (update before scheduled)
                             if azevent_id != azevent_dict["event_id"]:
                                 print_warning(
                                     f"{self.name}: Out of order az event - "
@@ -372,21 +372,32 @@ class ClusterData:
                                 )
                                 print_debug(f"Current Event details: {azevent_dict}")
                                 print_debug(f"Full current EMS details: {emsevent.to_dict()}")
-                                self._add_azmaint(azevent_dict)
-                                self._empty_azevent()
-                                # Check if this event already exists (e.g., callhome.reboot.giveback
-                                # came before vsa.scheduledEvent.update complete)
+
+                                # Only save current event if it has a real event_id
+                                if azevent_dict["event_id"] != "Unknown":
+                                    self._add_azmaint(azevent_dict)
+
+                                # Check if this event already exists in azmaints
                                 if azevent_id and azevent_id in self.azmaints:
                                     # Update existing event with status
                                     status_field = f"az_maint_{status}"
                                     self.azmaints[azevent_id][status_field] = emsevent["time"]
                                     print_debug(f"Updated event {azevent_id} with {status_field}")
-                                elif azevent_dict["event_id"] == "Unknown":
-                                    azevent_dict["event_id"] = azevent_id
-                                    azevent_dict["node"] = node
-                                    azevent_dict["type"] = event_type
+                                    # Reset to empty - this event is already tracked
+                                    azevent_dict = self._empty_azevent()
+                                else:
+                                    # Create new event dict with proper ID
+                                    # (scheduled event was missing from EMS)
+                                    azevent_dict = {
+                                        "event_id": azevent_id,
+                                        "node": node,
+                                        "type": event_type,
+                                        "cluster": self.name,
+                                        f"az_maint_{status}": emsevent["time"],
+                                    }
+                                    self.current_azevent = azevent_id or ""
                             else:
-                                # Record started/complete status
+                                # Normal case - IDs match
                                 azevent_dict[f"az_maint_{status}"] = emsevent["time"]
 
                             # For non-HA CVO, complete on az_maint_complete


### PR DESCRIPTION
## Description

Fix out-of-order Azure event handling to prevent "Unknown" event_id entries in azmaints when `vsa.scheduledEvent.scheduled` ages out of EMS retention before processing.

## Related Issue

Closes #115

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Only save events with real event_ids to azmaints (skip entries with "Unknown")
- Create proper event dict with correct ID when recovering from missing scheduled event
- Reset azevent_dict when updating existing events that are already tracked in azmaints

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Test with debug database `ZUSNCLTELFST012_Unknown_02-02-2026-14-20-47.db` to verify the fix handles missing scheduled events correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)