### PR TITLE
fix: preserve timing data when recovering from missing scheduled event

### DIFF
--- a/src/pynetappfoundry/cli/commands/events/azevents.py
+++ b/src/pynetappfoundry/cli/commands/events/azevents.py
@@ -373,15 +373,26 @@ class ClusterData:
                                 print_debug(f"Current Event details: {azevent_dict}")
                                 print_debug(f"Full current EMS details: {emsevent.to_dict()}")
 
-                                # Only save current event if it has a real event_id
-                                if azevent_dict["event_id"] != "Unknown":
+                                # Preserve timing data from "Unknown" event before resetting
+                                timing_data: dict[str, Any] = {}
+                                if azevent_dict["event_id"] == "Unknown":
+                                    # Copy all timing fields (exclude event_id)
+                                    timing_data = {
+                                        k: v for k, v in azevent_dict.items() if k != "event_id"
+                                    }
+                                else:
+                                    # Save current event with real ID
                                     self._add_azmaint(azevent_dict)
 
                                 # Check if this event already exists in azmaints
                                 if azevent_id and azevent_id in self.azmaints:
-                                    # Update existing event with status
+                                    # Update existing event with status and any timing data
                                     status_field = f"az_maint_{status}"
                                     self.azmaints[azevent_id][status_field] = emsevent["time"]
+                                    # Merge preserved timing data (don't overwrite existing)
+                                    for k, v in timing_data.items():
+                                        if k not in self.azmaints[azevent_id]:
+                                            self.azmaints[azevent_id][k] = v
                                     print_debug(f"Updated event {azevent_id} with {status_field}")
                                     # Reset to empty - this event is already tracked
                                     azevent_dict = self._empty_azevent()
@@ -395,6 +406,8 @@ class ClusterData:
                                         "cluster": self.name,
                                         f"az_maint_{status}": emsevent["time"],
                                     }
+                                    # Merge preserved timing data
+                                    azevent_dict.update(timing_data)
                                     self.current_azevent = azevent_id or ""
                             else:
                                 # Normal case - IDs match


### PR DESCRIPTION
## Description

Follow-up to PR #116. Preserves timing data collected while tracking an "Unknown" event, merging it into the event once its real ID is discovered from a `vsa.scheduledEvent.update`.

## Related Issue

Closes #117

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Extract timing fields from "Unknown" event dict before resetting
- Merge preserved timing data into new event dict when scheduled event is missing
- Merge preserved timing data into existing azmaints entry (without overwriting existing values)

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This ensures timing data like `lif_failover_complete`, `node_giveback_starts`, and `cifs_transition_ms` are preserved when the scheduled event aged out of EMS retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)