### PR TITLE
fix: preserve timing data across callhome.reboot.giveback reset

### DIFF
--- a/src/pynetappfoundry/cli/commands/events/azevents.py
+++ b/src/pynetappfoundry/cli/commands/events/azevents.py
@@ -132,6 +132,9 @@ class ClusterData:
         self.invalid_maintenance = False
         self.azmaints: dict[str, dict[str, Any]] = {}
         self.ems_events: list[dict[str, Any]] = []
+        # Timing data from "Unknown" events, keyed by node name
+        # Used when scheduled event aged out before callhome.reboot.giveback
+        self.pending_timing: dict[str, dict[str, Any]] = {}
 
     def _empty_azevent(self) -> dict[str, Any]:
         """Create an empty Azure event dict and reset current event tracking.
@@ -384,6 +387,19 @@ class ClusterData:
                                     # Save current event with real ID
                                     self._add_azmaint(azevent_dict)
 
+                                # Also merge any pending timing data for this node
+                                # (from callhome.reboot.giveback with Unknown event_id)
+                                if node in self.pending_timing:
+                                    print_debug(
+                                        f"{self.name}: Merging pending timing data "
+                                        f"for node {node}: {self.pending_timing[node]}"
+                                    )
+                                    for k, v in self.pending_timing[node].items():
+                                        if k not in timing_data:
+                                            timing_data[k] = v
+                                    # Clear pending data for this node
+                                    del self.pending_timing[node]
+
                                 # Check if this event already exists in azmaints
                                 if azevent_id and azevent_id in self.azmaints:
                                     # Update existing event with status and any timing data
@@ -475,7 +491,24 @@ class ClusterData:
                             azevent_dict["node_giveback_complete"] = emsevent["time"]
                             azevent_id = azevent_dict["event_id"]
                             if azevent_id == "Unknown":
-                                print_error(f"{self.name}: No Event Id for {azevent_dict}")
+                                # Scheduled event aged out - save timing data for later
+                                # when vsa.scheduledEvent.update arrives
+                                event_node = emsevent["node"]["name"]
+                                timing_data = {
+                                    k: v for k, v in azevent_dict.items() if k != "event_id"
+                                }
+                                if timing_data:
+                                    print_debug(
+                                        f"{self.name}: Saving pending timing data "
+                                        f"for node {event_node}: {timing_data}"
+                                    )
+                                    # Merge with existing pending data for this node
+                                    if event_node in self.pending_timing:
+                                        for k, v in timing_data.items():
+                                            if k not in self.pending_timing[event_node]:
+                                                self.pending_timing[event_node][k] = v
+                                    else:
+                                        self.pending_timing[event_node] = timing_data
                             else:
                                 # Add EMS event before resetting current_azevent
                                 self._add_emsevent(emsevent)


### PR DESCRIPTION
## Description

Follow-up to PRs #116 and #118. When `callhome.reboot.giveback` arrives with `event_id="Unknown"` (because the scheduled event aged out of EMS retention), timing data was being discarded. Now it's saved to a `pending_timing` dict and merged when `vsa.scheduledEvent.update` arrives later.

## Related Issue

Closes #120

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `pending_timing` dict to `ClusterData` to store timing data keyed by node name
- In `callhome.reboot.giveback` case, save timing data to `pending_timing` instead of discarding
- In `vsa.scheduledEvent.update` case, merge any pending timing data for the node

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This completes the fix for missing timing data when scheduled events age out of EMS retention. The timing data from events like `cf.fsm.takeoverOfPartnerEnabled`, `kern.shutdown`, `mgr.boot.disk_done`, etc. will now be preserved and associated with the correct maintenance event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)