### PR TITLE
chore: upgrade pip to fix CVE-2026-1703 vulnerability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,9 @@ jobs:
       - name: Run spell check
         run: uv run codespell src/ tests/ docs/ README.md
 
+      - name: Upgrade pip (CVE-2026-1703)
+        run: uv pip install --upgrade pip
+
       - name: Run dependency audit
         run: uv run pip-audit
 


### PR DESCRIPTION
## Description
Add step to upgrade pip before running pip-audit to resolve the security vulnerability in pip 25.3 (CVE-2026-1703).

## Related Issue
Closes #124

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Add "Upgrade pip" step in CI workflow before pip-audit

## Testing
- [x] CI should pass after this change

## Checklist
- [x] My code follows the code style of this project