### PR TITLE
feat: add verbose logging to cache refresh command

### DIFF
--- a/src/pynetappfoundry/cache/__init__.py
+++ b/src/pynetappfoundry/cache/__init__.py
@@ -18,7 +18,13 @@ Usage:
     cached = db.get("mycluster")
 """
 
-from pynetappfoundry.cache.collector import CollectionError, MetadataCollector
+from pynetappfoundry.cache.collector import (
+    CollectionError,
+    CollectionPhase,
+    MetadataCollector,
+    ProgressCallback,
+    ProgressInfo,
+)
 from pynetappfoundry.cache.db import ClusterMetadataDB
 from pynetappfoundry.cache.models import (
     AggregateInfo,
@@ -50,6 +56,7 @@ __all__ = [
     "ClusterMetadataDB",
     "ClusterPeer",
     "CollectionError",
+    "CollectionPhase",
     "HAInfo",
     "LicenseFeature",
     "LicenseInfo",
@@ -57,6 +64,8 @@ __all__ = [
     "NetworkInfo",
     "NetworkLIF",
     "NodeInfo",
+    "ProgressCallback",
+    "ProgressInfo",
     "RelationshipsInfo",
     "SVMInfo",
     "SnapMirrorRelationship",

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -5,11 +5,14 @@ Collects cluster metadata using REST API (primary) with CLI fallback.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from enum import Enum
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from pynetappfoundry.cache.models import (
     AggregateInfo,
@@ -38,6 +41,35 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class CollectionPhase(Enum):
+    """Phases of metadata collection."""
+
+    CLOUD = "cloud"
+    CLUSTER = "cluster"
+    NODES = "nodes"
+    NETWORK = "network"
+    STORAGE = "storage"
+    LICENSES = "licenses"
+    HA = "ha"
+    RELATIONSHIPS = "relationships"
+
+
+@dataclass
+class ProgressInfo:
+    """Progress information for a collection phase."""
+
+    phase: CollectionPhase
+    phase_name: str
+    status: str  # "starting", "completed", "failed"
+    elapsed_seconds: float = 0.0
+    error: str | None = None
+    source: str | None = None  # "api", "cli", or None
+
+
+# Type alias for progress callback
+ProgressCallback = Callable[[ProgressInfo], None]
+
+
 class CollectionError(Exception):
     """Error during metadata collection."""
 
@@ -51,19 +83,62 @@ class MetadataCollector:
     endpoints not available in REST (e.g., virtual-machine instance show).
     """
 
+    # Human-readable names for collection phases
+    PHASE_NAMES: ClassVar[dict[CollectionPhase, str]] = {
+        CollectionPhase.CLOUD: "Cloud metadata",
+        CollectionPhase.CLUSTER: "Cluster info",
+        CollectionPhase.NODES: "Nodes",
+        CollectionPhase.NETWORK: "Network",
+        CollectionPhase.STORAGE: "Storage",
+        CollectionPhase.LICENSES: "Licenses",
+        CollectionPhase.HA: "HA info",
+        CollectionPhase.RELATIONSHIPS: "Relationships",
+    }
+
     def __init__(
         self,
         api_client: ONTAPAPIClient | None = None,
         cli_client: ONTAPCLI | None = None,
+        progress_callback: ProgressCallback | None = None,
     ) -> None:
         """Initialize the metadata collector.
 
         Args:
             api_client: ONTAP REST API client.
             cli_client: ONTAP CLI (SSH) client.
+            progress_callback: Optional callback for progress updates.
         """
         self.api_client = api_client
         self.cli_client = cli_client
+        self.progress_callback = progress_callback
+
+    def _report_progress(
+        self,
+        phase: CollectionPhase,
+        status: str,
+        elapsed_seconds: float = 0.0,
+        error: str | None = None,
+        source: str | None = None,
+    ) -> None:
+        """Report progress to callback if configured.
+
+        Args:
+            phase: The collection phase.
+            status: Status string ("starting", "completed", "failed").
+            elapsed_seconds: Time taken for this phase.
+            error: Error message if failed.
+            source: Data source used ("api", "cli").
+        """
+        if self.progress_callback:
+            info = ProgressInfo(
+                phase=phase,
+                phase_name=self.PHASE_NAMES.get(phase, phase.value),
+                status=status,
+                elapsed_seconds=elapsed_seconds,
+                error=error,
+                source=source,
+            )
+            self.progress_callback(info)
 
     def collect_all(self, cluster_name: str) -> CachedClusterMetadata:
         """Collect all metadata categories for a cluster.
@@ -74,18 +149,88 @@ class MetadataCollector:
         Returns:
             Complete CachedClusterMetadata object.
         """
+        logger.info("Starting metadata collection for cluster: %s", cluster_name)
+        total_start = time.monotonic()
+
+        # Define collection phases with their methods
+        phases: list[tuple[CollectionPhase, Callable[[], Any]]] = [
+            (CollectionPhase.CLOUD, self.collect_cloud_metadata),
+            (CollectionPhase.CLUSTER, self.collect_cluster_info),
+            (CollectionPhase.NODES, self.collect_nodes),
+            (CollectionPhase.NETWORK, self.collect_network),
+            (CollectionPhase.STORAGE, self.collect_storage),
+            (CollectionPhase.LICENSES, self.collect_licenses),
+            (CollectionPhase.HA, self.collect_ha_info),
+            (CollectionPhase.RELATIONSHIPS, self.collect_relationships),
+        ]
+
+        results: dict[str, Any] = {}
+        for phase, collect_method in phases:
+            phase_start = time.monotonic()
+            self._report_progress(phase, "starting")
+            logger.debug("Collecting %s for %s", phase.value, cluster_name)
+
+            try:
+                result = collect_method()
+                elapsed = time.monotonic() - phase_start
+                # Determine source used (check if result came from API or CLI)
+                source = self._determine_source(phase)
+                self._report_progress(phase, "completed", elapsed, source=source)
+                logger.debug(
+                    "Collected %s for %s in %.2fs via %s",
+                    phase.value,
+                    cluster_name,
+                    elapsed,
+                    source or "unknown",
+                )
+                results[phase.value] = result
+            except Exception as e:
+                elapsed = time.monotonic() - phase_start
+                error_msg = str(e)
+                self._report_progress(phase, "failed", elapsed, error=error_msg)
+                logger.error(
+                    "Failed to collect %s for %s: %s",
+                    phase.value,
+                    cluster_name,
+                    error_msg,
+                    exc_info=True,
+                )
+                raise
+
+        total_elapsed = time.monotonic() - total_start
+        logger.info("Completed metadata collection for %s in %.2fs", cluster_name, total_elapsed)
+
         return CachedClusterMetadata(
             cluster_name=cluster_name,
             cached_at=datetime.now(UTC),
-            cloud=self.collect_cloud_metadata(),
-            cluster=self.collect_cluster_info(),
-            nodes=self.collect_nodes(),
-            network=self.collect_network(),
-            storage=self.collect_storage(),
-            licenses=self.collect_licenses(),
-            ha=self.collect_ha_info(),
-            relationships=self.collect_relationships(),
+            cloud=results["cloud"],
+            cluster=results["cluster"],
+            nodes=results["nodes"],
+            network=results["network"],
+            storage=results["storage"],
+            licenses=results["licenses"],
+            ha=results["ha"],
+            relationships=results["relationships"],
         )
+
+    def _determine_source(self, phase: CollectionPhase) -> str | None:
+        """Determine which data source is available for a phase.
+
+        Args:
+            phase: The collection phase.
+
+        Returns:
+            "api", "cli", or None if unknown.
+        """
+        # Cloud metadata is CLI-only
+        if phase == CollectionPhase.CLOUD:
+            return "cli" if self.cli_client else None
+        # All others prefer API
+        if self.api_client:
+            return "api"
+        if self.cli_client:
+            return "cli"
+        return None
 
     # -------------------------------------------------------------------------
     # Cloud Metadata Collection
@@ -113,9 +258,12 @@ class MetadataCollector:
             CloudMetadata from virtual-machine instance show.
         """
         if not self.cli_client:
+            logger.debug("No CLI client available for cloud metadata collection")
             return CloudMetadata()
 
+        logger.debug("CLI command: virtual-machine instance show")
         output = self.cli_client.run_command("virtual-machine instance show")
+        logger.debug("CLI response: %d lines", len(output))
         return self._parse_vm_instance_output(output)
 
     def _parse_vm_instance_output(self, output: list[str]) -> CloudMetadata:
@@ -209,9 +357,12 @@ class MetadataCollector:
             ClusterInfo from /cluster endpoint.
         """
         if not self.api_client:
+            logger.debug("No API client available for cluster info collection")
             return ClusterInfo()
 
+        logger.debug("API call: GET /cluster?fields=*")
         response = self.api_client.call_endpoint("/cluster?fields=*", method="GET")
+        logger.debug("API response: cluster=%s", response.get("name", "unknown"))
         return ClusterInfo(
             cluster_name=response.get("name", ""),
             cluster_uuid=response.get("uuid", ""),
@@ -226,9 +377,12 @@ class MetadataCollector:
             ClusterInfo from cluster identity show.
         """
         if not self.cli_client:
+            logger.debug("No CLI client available for cluster info collection")
             return ClusterInfo()
 
+        logger.debug("CLI command: cluster identity show")
         output = self.cli_client.run_command_and_parse("cluster identity show")
+        logger.debug("CLI response: %d entries", len(output))
         # Output is keyed by cluster name
         if output:
             first_key = next(iter(output))
@@ -270,9 +424,12 @@ class MetadataCollector:
             List of NodeInfo from /cluster/nodes endpoint.
         """
         if not self.api_client:
+            logger.debug("No API client available for nodes collection")
             return []
 
+        logger.debug("API call: GET /cluster/nodes?fields=*")
         response = self.api_client.call_endpoint("/cluster/nodes?fields=*", method="GET")
+        logger.debug("API response: %d nodes", len(response.get("records", [])))
         nodes = []
         for record in response.get("records", []):
             # membership may be a dict or other type depending on API version
@@ -297,9 +454,12 @@ class MetadataCollector:
             List of NodeInfo from system node show.
         """
         if not self.cli_client:
+            logger.debug("No CLI client available for nodes collection")
             return []
 
+        logger.debug("CLI command: system node show")
         output = self.cli_client.run_command_and_parse("system node show")
+        logger.debug("CLI response: %d nodes", len(output))
         nodes = []
         for node_name, data in output.items():
             nodes.append(
@@ -343,12 +503,15 @@ class MetadataCollector:
             NetworkInfo from various network endpoints.
         """
         if not self.api_client:
+            logger.debug("No API client available for network collection")
             return NetworkInfo()
 
         # Collect LIFs
+        logger.debug("API call: GET /network/ip/interfaces?fields=*")
         lifs_response = self.api_client.call_endpoint(
             "/network/ip/interfaces?fields=*", method="GET"
         )
+        logger.debug("API response: %d LIFs", len(lifs_response.get("records", [])))
         intercluster_lifs = []
         data_lifs = []
         management_lifs = []
@@ -378,9 +541,11 @@ class MetadataCollector:
                 management_lifs.append(lif)
 
         # Collect broadcast domains
+        logger.debug("API call: GET /network/ethernet/broadcast-domains?fields=*")
         bd_response = self.api_client.call_endpoint(
             "/network/ethernet/broadcast-domains?fields=*", method="GET"
         )
+        logger.debug("API response: %d broadcast domains", len(bd_response.get("records", [])))
         broadcast_domains = []
         for record in bd_response.get("records", []):
             bd = BroadcastDomain(
@@ -392,7 +557,9 @@ class MetadataCollector:
             broadcast_domains.append(bd)
 
         # Collect IPspaces
+        logger.debug("API call: GET /network/ipspaces?fields=*")
         ipspace_response = self.api_client.call_endpoint("/network/ipspaces?fields=*", method="GET")
+        logger.debug("API response: %d IPspaces", len(ipspace_response.get("records", [])))
         ipspaces = [r.get("name", "") for r in ipspace_response.get("records", [])]
 
         return NetworkInfo(
@@ -410,9 +577,12 @@ class MetadataCollector:
             NetworkInfo from network interface show.
         """
         if not self.cli_client:
+            logger.debug("No CLI client available for network collection")
             return NetworkInfo()
 
+        logger.debug("CLI command: network interface show")
         output = self.cli_client.run_command_and_parse("network interface show")
+        logger.debug("CLI response: %d interfaces", len(output))
         intercluster_lifs = []
         data_lifs = []
         management_lifs = []
@@ -477,10 +647,13 @@ class MetadataCollector:
             StorageInfo from aggregate and SVM endpoints.
         """
         if not self.api_client:
+            logger.debug("No API client available for storage collection")
             return StorageInfo()
 
         # Collect aggregates
+        logger.debug("API call: GET /storage/aggregates?fields=*")
         aggr_response = self.api_client.call_endpoint("/storage/aggregates?fields=*", method="GET")
+        logger.debug("API response: %d aggregates", len(aggr_response.get("records", [])))
         aggregates = []
         for record in aggr_response.get("records", []):
             aggr = AggregateInfo(
@@ -494,7 +667,9 @@ class MetadataCollector:
             aggregates.append(aggr)
 
         # Collect SVMs
+        logger.debug("API call: GET /svm/svms?fields=*")
         svm_response = self.api_client.call_endpoint("/svm/svms?fields=*", method="GET")
+        logger.debug("API response: %d SVMs", len(svm_response.get("records", [])))
         svms = []
         for record in svm_response.get("records", []):
             svm = SVMInfo(
@@ -513,10 +688,13 @@ class MetadataCollector:
             StorageInfo from aggr show and vserver show.
         """
         if not self.cli_client:
+            logger.debug("No CLI client available for storage collection")
             return StorageInfo()
 
         # Collect aggregates
+        logger.debug("CLI command: aggr show")
         aggr_output = self.cli_client.run_command_and_parse("aggr show")
+        logger.debug("CLI response: %d aggregates", len(aggr_output))
         aggregates = []
         for aggr_name, data in aggr_output.items():
             aggr = AggregateInfo(
@@ -528,7 +706,9 @@ class MetadataCollector:
             aggregates.append(aggr)
 
         # Collect SVMs
+        logger.debug("CLI command: vserver show")
         svm_output = self.cli_client.run_command_and_parse("vserver show")
+        logger.debug("CLI response: %d SVMs", len(svm_output))
         svms = []
         for svm_name, data in svm_output.items():
             svm = SVMInfo(
@@ -572,11 +752,14 @@ class MetadataCollector:
             LicenseInfo from /cluster/licensing/licenses endpoint.
         """
         if not self.api_client:
+            logger.debug("No API client available for license collection")
             return LicenseInfo()
 
+        logger.debug("API call: GET /cluster/licensing/licenses?fields=*")
         response = self.api_client.call_endpoint(
             "/cluster/licensing/licenses?fields=*", method="GET"
         )
+        logger.debug("API response: %d licenses", len(response.get("records", [])))
         feature_licenses = []
         capacity_licenses = []
 
@@ -607,9 +790,12 @@ class MetadataCollector:
             LicenseInfo from license show.
         """
         if not self.cli_client:
+            logger.debug("No CLI client available for license collection")
             return LicenseInfo()
 
+        logger.debug("CLI command: license show")
         output = self.cli_client.run_command_and_parse("license show")
+        logger.debug("CLI response: %d licenses", len(output))
         feature_licenses = []
 
         for license_name, data in output.items():
@@ -653,9 +839,12 @@ class MetadataCollector:
             HAInfo from /cluster endpoint.
         """
         if not self.api_client:
+            logger.debug("No API client available for HA info collection")
             return HAInfo()
 
+        logger.debug("API call: GET /cluster/nodes?fields=*")
         nodes_response = self.api_client.call_endpoint("/cluster/nodes?fields=*", method="GET")
+        logger.debug("API response: %d nodes", len(nodes_response.get("records", [])))
 
         # Check if HA is configured
         ha_configured = len(nodes_response.get("records", [])) > 1
@@ -664,14 +853,18 @@ class MetadataCollector:
         mediator_address = ""
         mediator_status = ""
         # Mediator endpoint may not exist on all clusters
-        with contextlib.suppress(Exception):
+        logger.debug("API call: GET /cluster/mediators?fields=*")
+        try:
             mediator_response = self.api_client.call_endpoint(
                 "/cluster/mediators?fields=*", method="GET"
             )
             mediators = mediator_response.get("records", [])
+            logger.debug("API response: %d mediators", len(mediators))
             if mediators:
                 mediator_address = mediators[0].get("ip_address", "")
                 mediator_status = mediators[0].get("reachable", "")
+        except Exception as e:
+            logger.debug("Mediator endpoint not available: %s", e)
 
         return HAInfo(
             is_ha=ha_configured,
@@ -686,9 +879,12 @@ class MetadataCollector:
             HAInfo from storage failover show.
         """
         if not self.cli_client:
+            logger.debug("No CLI client available for HA info collection")
             return HAInfo()
 
+        logger.debug("CLI command: storage failover show")
         output = self.cli_client.run_command_and_parse("storage failover show")
+        logger.debug("CLI response: %d entries", len(output))
         if not output:
             return HAInfo(is_ha=False)
 
@@ -732,11 +928,17 @@ class MetadataCollector:
             RelationshipsInfo from snapmirror and cluster peer endpoints.
         """
         if not self.api_client:
+            logger.debug("No API client available for relationships collection")
             return RelationshipsInfo()
 
         # Collect SnapMirror relationships
+        logger.debug("API call: GET /snapmirror/relationships?fields=*")
         sm_response = self.api_client.call_endpoint(
             "/snapmirror/relationships?fields=*", method="GET"
+        )
+        logger.debug(
+            "API response: %d SnapMirror relationships",
+            len(sm_response.get("records", [])),
         )
         snapmirror_destinations = []
         for record in sm_response.get("records", []):
@@ -751,7 +953,9 @@ class MetadataCollector:
             snapmirror_destinations.append(sm)
 
         # Collect cluster peers
+        logger.debug("API call: GET /cluster/peers?fields=*")
         peer_response = self.api_client.call_endpoint("/cluster/peers?fields=*", method="GET")
+        logger.debug("API response: %d cluster peers", len(peer_response.get("records", [])))
         cluster_peers = []
         for record in peer_response.get("records", []):
             peer = ClusterPeer(
@@ -780,10 +984,13 @@ class MetadataCollector:
             RelationshipsInfo from snapmirror show and cluster peer show.
         """
         if not self.cli_client:
+            logger.debug("No CLI client available for relationships collection")
             return RelationshipsInfo()
 
         # Collect SnapMirror relationships
+        logger.debug("CLI command: snapmirror show")
         sm_output = self.cli_client.run_command_and_parse("snapmirror show")
+        logger.debug("CLI response: %d SnapMirror relationships", len(sm_output))
         snapmirror_destinations = []
         for dest_path, data in sm_output.items():
             sm = SnapMirrorRelationship(
@@ -797,7 +1004,9 @@ class MetadataCollector:
             snapmirror_destinations.append(sm)
 
         # Collect cluster peers
+        logger.debug("CLI command: cluster peer show")
         peer_output = self.cli_client.run_command_and_parse("cluster peer show")
+        logger.debug("CLI response: %d cluster peers", len(peer_output))
         cluster_peers = []
         for peer_name, data in peer_output.items():
             peer = ClusterPeer(

--- a/src/pynetappfoundry/cli/commands/cache/refresh.py
+++ b/src/pynetappfoundry/cli/commands/cache/refresh.py
@@ -3,18 +3,156 @@
 from __future__ import annotations
 
 import contextlib
+import logging
+import time
+from datetime import UTC, datetime
 from pathlib import Path
 
 import click
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
-from pynetappfoundry.cache import ClusterMetadataDB, MetadataCollector
-from pynetappfoundry.cli.utils import print_error, print_exception, print_success, print_warning
+from pynetappfoundry.cache import (
+    ClusterMetadataDB,
+    CollectionPhase,
+    MetadataCollector,
+    ProgressCallback,
+    ProgressInfo,
+)
+from pynetappfoundry.cli.utils import (
+    print_error,
+    print_exception,
+    print_success,
+    print_warning,
+)
 from pynetappfoundry.clients.ontap import ONTAPCLI, ONTAPAPIClient
 from pynetappfoundry.core.config import Config
 
 console = Console()
+
+# Module logger
+logger = logging.getLogger(__name__)
+
+# Log directory for cache refresh operations
+LOG_DIR = Path.home() / ".cache" / "pynetappfoundry" / "logs"
+MAX_LOG_FILES = 10  # Keep last N log files
+
+
+def setup_file_logging() -> Path:
+    """Configure file logging for the cache refresh operation.
+
+    Returns:
+        Path to the log file.
+    """
+    # Ensure log directory exists
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Create timestamped log file
+    timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    log_file = LOG_DIR / f"cache-refresh-{timestamp}.log"
+
+    # Configure file handler for the cache module
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    file_handler.setFormatter(formatter)
+
+    # Add handler to cache module loggers
+    cache_logger = logging.getLogger("pynetappfoundry.cache")
+    cache_logger.setLevel(logging.DEBUG)
+    cache_logger.addHandler(file_handler)
+
+    # Also add to this module's logger
+    refresh_logger = logging.getLogger(__name__)
+    refresh_logger.setLevel(logging.DEBUG)
+    refresh_logger.addHandler(file_handler)
+
+    # Clean up old log files
+    cleanup_old_logs()
+
+    return log_file
+
+
+def cleanup_old_logs() -> None:
+    """Remove old log files, keeping only the most recent ones."""
+    if not LOG_DIR.exists():
+        return
+
+    log_files = sorted(
+        LOG_DIR.glob("cache-refresh-*.log"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+
+    # Remove files beyond MAX_LOG_FILES
+    for old_file in log_files[MAX_LOG_FILES:]:
+        try:
+            old_file.unlink()
+            logger.debug("Removed old log file: %s", old_file)
+        except OSError as e:
+            logger.warning("Failed to remove old log file %s: %s", old_file, e)
+
+
+class VerboseProgressDisplay:
+    """Displays detailed progress information in verbose mode."""
+
+    def __init__(
+        self, console: Console, cluster_name: str, cluster_index: int, total_clusters: int
+    ) -> None:
+        """Initialize the verbose progress display.
+
+        Args:
+            console: Rich console for output.
+            cluster_name: Name of the cluster being processed.
+            cluster_index: 1-based index of the current cluster.
+            total_clusters: Total number of clusters to process.
+        """
+        self.console = console
+        self.cluster_name = cluster_name
+        self.cluster_index = cluster_index
+        self.total_clusters = total_clusters
+        self.phase_times: dict[CollectionPhase, float] = {}
+        self.start_time = time.monotonic()
+        self.current_phase: CollectionPhase | None = None
+
+    def on_progress(self, info: ProgressInfo) -> None:
+        """Handle progress callback from MetadataCollector.
+
+        Args:
+            info: Progress information for the current phase.
+        """
+        if info.status == "starting":
+            self.current_phase = info.phase
+            # Print phase starting (will be overwritten or followed by completion)
+            self.console.print(f"  [dim]|-[/dim] {info.phase_name}...", end="\r")
+        elif info.status == "completed":
+            self.phase_times[info.phase] = info.elapsed_seconds
+            source_str = f" [dim]({info.source})[/dim]" if info.source else ""
+            line = f"  [green]|-[/green] {info.phase_name:<20} "
+            line += f"{info.elapsed_seconds:>5.1f}s{source_str}"
+            self.console.print(line)
+        elif info.status == "failed":
+            self.phase_times[info.phase] = info.elapsed_seconds
+            error_str = f" - {info.error}" if info.error else ""
+            line = f"  [red]|-[/red] {info.phase_name:<20} "
+            line += f"{info.elapsed_seconds:>5.1f}s [red]FAILED{error_str}[/red]"
+            self.console.print(line)
+
+    def print_header(self) -> None:
+        """Print the cluster header."""
+        self.console.print(
+            f"\n[bold][{self.cluster_index}/{self.total_clusters}] {self.cluster_name}[/bold]"
+        )
+
+    def print_summary(self, success: bool) -> None:
+        """Print the cluster summary.
+
+        Args:
+            success: Whether the collection was successful.
+        """
+        total_time = time.monotonic() - self.start_time
+        status = "[green]OK[/green]" if success else "[red]FAILED[/red]"
+        self.console.print(f"  [dim]`-[/dim] Total: {total_time:.1f}s {status}")
 
 
 @click.command()
@@ -26,8 +164,14 @@ console = Console()
     is_flag=True,
     help="Refresh cache for all configured clusters.",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Show detailed progress for each collection phase.",
+)
 @click.pass_context
-def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool) -> None:
+def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool, verbose: bool) -> None:
     """Refresh the metadata cache for cluster(s).
 
     If CLUSTER is specified, refresh only that cluster.
@@ -37,19 +181,26 @@ def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool) -> None:
 
         nf cache refresh cluster1      # Refresh single cluster
         nf cache refresh --all         # Refresh all clusters
+        nf cache refresh --all -v      # Refresh all with detailed progress
     """
+    # Always set up file logging
+    log_file = setup_file_logging()
+    logger.info("Starting cache refresh operation")
+
     config_dir = ctx.obj.get("config_dir", "config")
 
     # Check if config directory exists
     config_path = Path.cwd() / config_dir
     if not config_path.exists():
         print_error(f"Configuration directory not found: {config_path}")
+        logger.error("Configuration directory not found: %s", config_path)
         ctx.exit(1)
 
     try:
         config = Config(config_dir=config_dir, script_name="cache-refresh")
     except Exception as e:
         print_exception(f"Failed to load configuration: {e}", e)
+        logger.exception("Failed to load configuration")
         ctx.exit(1)
 
     # Determine clusters to refresh
@@ -59,12 +210,14 @@ def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool) -> None:
             available = list(config.data.get("clusters", {}).keys())
             if available:
                 console.print(f"Available clusters: {', '.join(available)}")
+            logger.error("Cluster '%s' not found in configuration", cluster)
             ctx.exit(1)
         clusters_to_refresh = [cluster]
     elif refresh_all:
         clusters_to_refresh = list(config.data.get("clusters", {}).keys())
         if not clusters_to_refresh:
             print_warning("No clusters configured.")
+            logger.warning("No clusters configured")
             ctx.exit(0)
     else:
         print_error("Specify a cluster name or use --all to refresh all clusters.")
@@ -73,8 +226,34 @@ def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool) -> None:
     # Initialize cache database
     db = ClusterMetadataDB(config=config)
 
-    console.print(f"\nRefreshing cache for {len(clusters_to_refresh)} cluster(s)...\n")
+    console.print(f"\nRefreshing cache for {len(clusters_to_refresh)} cluster(s)...")
+    console.print(f"[dim]Log file: {log_file}[/dim]\n")
+    logger.info("Refreshing cache for %d cluster(s)", len(clusters_to_refresh))
 
+    if verbose:
+        # Verbose mode: detailed phase-by-phase progress
+        _refresh_verbose(ctx, config, db, clusters_to_refresh)
+    else:
+        # Normal mode: spinner per cluster
+        _refresh_normal(ctx, config, db, clusters_to_refresh)
+
+    db.close()
+
+
+def _refresh_normal(
+    ctx: click.Context,
+    config: Config,
+    db: ClusterMetadataDB,
+    clusters_to_refresh: list[str],
+) -> None:
+    """Refresh clusters with spinner progress (normal mode).
+
+    Args:
+        ctx: Click context.
+        config: Configuration object.
+        db: Cache database.
+        clusters_to_refresh: List of cluster names.
+    """
     success_count = 0
     error_count = 0
 
@@ -85,68 +264,22 @@ def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool) -> None:
     ) as progress:
         for cluster_name in clusters_to_refresh:
             task = progress.add_task(f"Collecting metadata for {cluster_name}...", total=1)
+            logger.info("Processing cluster: %s", cluster_name)
 
             try:
-                cluster_data = config.data["clusters"][cluster_name]
-
-                # Get credentials
-                user, password = config.get_user("clusters", cluster_name)
-
-                # Create cluster object for API client
-                class ClusterObj:
-                    def __init__(self, name: str, ip: str) -> None:
-                        self.name = name
-                        self.ip = ip
-
-                cluster_obj = ClusterObj(cluster_name, cluster_data.get("ip", ""))
-
-                # Initialize clients
-                api_client: ONTAPAPIClient | None = None
-                cli_client: ONTAPCLI | None = None
-
-                try:
-                    api_client = ONTAPAPIClient(cluster=cluster_obj, config=config)
-                except Exception as e:
-                    print_warning(f"  API client unavailable: {e}")
-
-                try:
-                    cli_client = ONTAPCLI(
-                        name=cluster_name,
-                        host_or_ip=cluster_data.get("ip", ""),
-                        username=user,
-                        password=password,
-                    )
-                except Exception as e:
-                    print_warning(f"  CLI client unavailable: {e}")
-
-                if not api_client and not cli_client:
-                    print_error(f"  No clients available for {cluster_name}")
+                success = _process_cluster(config, db, cluster_name, verbose=False)
+                if success:
+                    print_success(f"  {cluster_name}: Cache refreshed")
+                    success_count += 1
+                else:
                     error_count += 1
-                    progress.update(task, completed=1)
-                    continue
-
-                # Collect metadata
-                collector = MetadataCollector(api_client=api_client, cli_client=cli_client)
-                metadata = collector.collect_all(cluster_name)
-
-                # Store in cache
-                db.set(cluster_name, metadata)
-
-                # Clean up CLI client
-                if cli_client:
-                    with contextlib.suppress(Exception):
-                        cli_client.disconnect()
-
-                print_success(f"  {cluster_name}: Cache refreshed")
-                success_count += 1
 
             except Exception as e:
                 print_exception(f"  {cluster_name}: Failed - {e}", e)
+                logger.exception("Failed to process cluster %s", cluster_name)
                 error_count += 1
 
             progress.update(task, completed=1)
-
-    db.close()
 
     # Summary
     console.print()
@@ -154,4 +287,147 @@ def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool) -> None:
         print_success(f"Successfully refreshed {success_count} cluster(s)")
     if error_count > 0:
         print_error(f"Failed to refresh {error_count} cluster(s)")
+        logger.error("Failed to refresh %d cluster(s)", error_count)
         ctx.exit(1)
+
+    logger.info("Cache refresh completed: %d success, %d failed", success_count, error_count)
+
+
+def _refresh_verbose(
+    ctx: click.Context,
+    config: Config,
+    db: ClusterMetadataDB,
+    clusters_to_refresh: list[str],
+) -> None:
+    """Refresh clusters with detailed progress (verbose mode).
+
+    Args:
+        ctx: Click context.
+        config: Configuration object.
+        db: Cache database.
+        clusters_to_refresh: List of cluster names.
+    """
+    success_count = 0
+    error_count = 0
+    total_clusters = len(clusters_to_refresh)
+
+    for idx, cluster_name in enumerate(clusters_to_refresh, 1):
+        logger.info("Processing cluster: %s (%d/%d)", cluster_name, idx, total_clusters)
+
+        display = VerboseProgressDisplay(
+            console=console,
+            cluster_name=cluster_name,
+            cluster_index=idx,
+            total_clusters=total_clusters,
+        )
+        display.print_header()
+
+        try:
+            success = _process_cluster(
+                config, db, cluster_name, verbose=True, progress_callback=display.on_progress
+            )
+            display.print_summary(success)
+            if success:
+                success_count += 1
+            else:
+                error_count += 1
+
+        except Exception as e:
+            display.print_summary(success=False)
+            print_exception(f"  Error: {e}", e)
+            logger.exception("Failed to process cluster %s", cluster_name)
+            error_count += 1
+
+    # Summary
+    console.print()
+    if success_count > 0:
+        print_success(f"Successfully refreshed {success_count} cluster(s)")
+    if error_count > 0:
+        print_error(f"Failed to refresh {error_count} cluster(s)")
+        logger.error("Failed to refresh %d cluster(s)", error_count)
+        ctx.exit(1)
+
+    logger.info("Cache refresh completed: %d success, %d failed", success_count, error_count)
+
+
+def _process_cluster(
+    config: Config,
+    db: ClusterMetadataDB,
+    cluster_name: str,
+    verbose: bool = False,
+    progress_callback: ProgressCallback | None = None,
+) -> bool:
+    """Process a single cluster for cache refresh.
+
+    Args:
+        config: Configuration object.
+        db: Cache database.
+        cluster_name: Name of the cluster.
+        verbose: Whether verbose mode is enabled.
+        progress_callback: Optional callback for progress updates.
+
+    Returns:
+        True if successful, False otherwise.
+    """
+    cluster_data = config.data["clusters"][cluster_name]
+
+    # Get credentials
+    user, password = config.get_user("clusters", cluster_name)
+
+    # Create cluster object for API client
+    class ClusterObj:
+        def __init__(self, name: str, ip: str) -> None:
+            self.name = name
+            self.ip = ip
+
+    cluster_obj = ClusterObj(cluster_name, cluster_data.get("ip", ""))
+
+    # Initialize clients
+    api_client: ONTAPAPIClient | None = None
+    cli_client: ONTAPCLI | None = None
+
+    try:
+        api_client = ONTAPAPIClient(cluster=cluster_obj, config=config)
+        logger.debug("API client initialized for %s", cluster_name)
+    except Exception as e:
+        if verbose:
+            print_warning(f"  [dim]API client unavailable: {e}[/dim]")
+        logger.warning("API client unavailable for %s: %s", cluster_name, e)
+
+    try:
+        cli_client = ONTAPCLI(
+            name=cluster_name,
+            host_or_ip=cluster_data.get("ip", ""),
+            username=user,
+            password=password,
+        )
+        logger.debug("CLI client initialized for %s", cluster_name)
+    except Exception as e:
+        if verbose:
+            print_warning(f"  [dim]CLI client unavailable: {e}[/dim]")
+        logger.warning("CLI client unavailable for %s: %s", cluster_name, e)
+
+    if not api_client and not cli_client:
+        print_error(f"  No clients available for {cluster_name}")
+        logger.error("No clients available for %s", cluster_name)
+        return False
+
+    # Collect metadata
+    collector = MetadataCollector(
+        api_client=api_client,
+        cli_client=cli_client,
+        progress_callback=progress_callback,
+    )
+    metadata = collector.collect_all(cluster_name)
+
+    # Store in cache
+    db.set(cluster_name, metadata)
+    logger.info("Cache updated for %s", cluster_name)
+
+    # Clean up CLI client
+    if cli_client:
+        with contextlib.suppress(Exception):
+            cli_client.disconnect()
+            logger.debug("CLI client disconnected for %s", cluster_name)
+
+    return True

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from pynetappfoundry.cache.collector import MetadataCollector
+from pynetappfoundry.cache.collector import (
+    CollectionPhase,
+    MetadataCollector,
+    ProgressInfo,
+)
 from pynetappfoundry.cache.models import (
     CloudMetadata,
     HAInfo,
@@ -530,3 +534,165 @@ class TestNormalizeCliKey:
     def test_normalize_special_chars(self) -> None:
         """Test normalizing keys with special characters."""
         assert MetadataCollector._normalize_cli_key("Region (AWS)") == "region_aws"
+
+
+class TestProgressCallback:
+    """Tests for progress callback functionality."""
+
+    def test_init_with_progress_callback(self) -> None:
+        """Test initialization with progress callback."""
+        callback = MagicMock()
+        collector = MetadataCollector(progress_callback=callback)
+        assert collector.progress_callback is callback
+
+    def test_progress_callback_called_for_each_phase(self) -> None:
+        """Test that progress callback is called for each collection phase."""
+        api_client = MagicMock()
+        api_client.call_endpoint.return_value = {"records": []}
+
+        cli_client = MagicMock()
+        cli_client.run_command.return_value = []
+        cli_client.run_command_and_parse.return_value = {}
+
+        callback = MagicMock()
+        collector = MetadataCollector(
+            api_client=api_client, cli_client=cli_client, progress_callback=callback
+        )
+        collector.collect_all("test-cluster")
+
+        # Should have 8 phases * 2 calls (starting + completed) = 16 calls
+        assert callback.call_count == 16
+
+        # Verify callback was called with ProgressInfo objects
+        for call in callback.call_args_list:
+            info = call[0][0]
+            assert isinstance(info, ProgressInfo)
+            assert isinstance(info.phase, CollectionPhase)
+            assert info.status in ("starting", "completed", "failed")
+
+    def test_progress_callback_receives_correct_phases(self) -> None:
+        """Test that progress callback receives all expected phases."""
+        api_client = MagicMock()
+        api_client.call_endpoint.return_value = {"records": []}
+
+        cli_client = MagicMock()
+        cli_client.run_command.return_value = []
+        cli_client.run_command_and_parse.return_value = {}
+
+        received_phases: list[CollectionPhase] = []
+
+        def track_phases(info: ProgressInfo) -> None:
+            if info.status == "starting":
+                received_phases.append(info.phase)
+
+        collector = MetadataCollector(
+            api_client=api_client, cli_client=cli_client, progress_callback=track_phases
+        )
+        collector.collect_all("test-cluster")
+
+        expected_phases = [
+            CollectionPhase.CLOUD,
+            CollectionPhase.CLUSTER,
+            CollectionPhase.NODES,
+            CollectionPhase.NETWORK,
+            CollectionPhase.STORAGE,
+            CollectionPhase.LICENSES,
+            CollectionPhase.HA,
+            CollectionPhase.RELATIONSHIPS,
+        ]
+        assert received_phases == expected_phases
+
+    def test_progress_callback_elapsed_time(self) -> None:
+        """Test that progress callback receives elapsed time on completion."""
+        api_client = MagicMock()
+        api_client.call_endpoint.return_value = {"records": []}
+
+        cli_client = MagicMock()
+        cli_client.run_command.return_value = []
+        cli_client.run_command_and_parse.return_value = {}
+
+        elapsed_times: list[float] = []
+
+        def track_elapsed(info: ProgressInfo) -> None:
+            if info.status == "completed":
+                elapsed_times.append(info.elapsed_seconds)
+
+        collector = MetadataCollector(
+            api_client=api_client, cli_client=cli_client, progress_callback=track_elapsed
+        )
+        collector.collect_all("test-cluster")
+
+        # Should have 8 elapsed times (one per completed phase)
+        assert len(elapsed_times) == 8
+        # All should be non-negative
+        for elapsed in elapsed_times:
+            assert elapsed >= 0
+
+    def test_progress_callback_source_tracking(self) -> None:
+        """Test that progress callback receives correct source information."""
+        api_client = MagicMock()
+        api_client.call_endpoint.return_value = {"records": []}
+
+        cli_client = MagicMock()
+        cli_client.run_command.return_value = []
+        cli_client.run_command_and_parse.return_value = {}
+
+        sources: dict[CollectionPhase, str | None] = {}
+
+        def track_sources(info: ProgressInfo) -> None:
+            if info.status == "completed":
+                sources[info.phase] = info.source
+
+        collector = MetadataCollector(
+            api_client=api_client, cli_client=cli_client, progress_callback=track_sources
+        )
+        collector.collect_all("test-cluster")
+
+        # Cloud metadata should be from CLI
+        assert sources[CollectionPhase.CLOUD] == "cli"
+        # Other phases should be from API (since API client is provided)
+        assert sources[CollectionPhase.CLUSTER] == "api"
+        assert sources[CollectionPhase.NODES] == "api"
+
+    def test_progress_callback_none_no_error(self) -> None:
+        """Test that no callback (None) doesn't cause errors."""
+        api_client = MagicMock()
+        api_client.call_endpoint.return_value = {"records": []}
+
+        cli_client = MagicMock()
+        cli_client.run_command.return_value = []
+        cli_client.run_command_and_parse.return_value = {}
+
+        collector = MetadataCollector(
+            api_client=api_client, cli_client=cli_client, progress_callback=None
+        )
+        # Should not raise any errors
+        result = collector.collect_all("test-cluster")
+        assert result.cluster_name == "test-cluster"
+
+    def test_report_progress_with_no_callback(self) -> None:
+        """Test _report_progress does nothing when callback is None."""
+        collector = MetadataCollector()
+        # Should not raise any errors
+        collector._report_progress(CollectionPhase.CLOUD, "starting")
+
+
+class TestCollectionPhase:
+    """Tests for CollectionPhase enum."""
+
+    def test_all_phases_have_names(self) -> None:
+        """Test that all phases have human-readable names."""
+        for phase in CollectionPhase:
+            assert phase in MetadataCollector.PHASE_NAMES
+            assert len(MetadataCollector.PHASE_NAMES[phase]) > 0
+
+    def test_phase_values(self) -> None:
+        """Test CollectionPhase enum values."""
+        assert CollectionPhase.CLOUD.value == "cloud"
+        assert CollectionPhase.CLUSTER.value == "cluster"
+        assert CollectionPhase.NODES.value == "nodes"
+        assert CollectionPhase.NETWORK.value == "network"
+        assert CollectionPhase.STORAGE.value == "storage"
+        assert CollectionPhase.LICENSES.value == "licenses"
+        assert CollectionPhase.HA.value == "ha"
+        assert CollectionPhase.RELATIONSHIPS.value == "relationships"

--- a/tests/unit/cli/commands/cache/test_refresh.py
+++ b/tests/unit/cli/commands/cache/test_refresh.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
+from pynetappfoundry.cli.commands.cache.refresh import (
+    VerboseProgressDisplay,
+    cleanup_old_logs,
+    setup_file_logging,
+)
 from pynetappfoundry.cli.main import nf
 
 
@@ -152,3 +158,302 @@ enc = "cGFzc3dvcmQ="
         )
         assert result.exit_code != 0
         assert "not found" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.setup_file_logging")
+    def test_refresh_verbose_flag(
+        self,
+        mock_setup_logging: MagicMock,
+        mock_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test refreshing with verbose flag."""
+        # Setup mocks
+        mock_setup_logging.return_value = Path("/tmp/test.log")
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock(cluster_name="test-cluster")
+        mock_collector_class.return_value = mock_collector
+
+        mock_cli = MagicMock()
+        mock_cli_class.return_value = mock_cli
+
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "refresh", "--all", "-v"],
+        )
+
+        assert result.exit_code == 0
+        # Verbose mode should show progress details
+        mock_collector.collect_all.assert_called()
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.setup_file_logging")
+    def test_refresh_always_logs_to_file(
+        self,
+        mock_setup_logging: MagicMock,
+        mock_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test that file logging is always configured (with or without -v)."""
+        mock_setup_logging.return_value = Path("/tmp/test.log")
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock()
+        mock_collector_class.return_value = mock_collector
+
+        mock_cli = MagicMock()
+        mock_cli_class.return_value = mock_cli
+
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+
+        # Without verbose flag
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "refresh", "test-cluster"],
+        )
+
+        assert result.exit_code == 0
+        # setup_file_logging should always be called
+        mock_setup_logging.assert_called_once()
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.setup_file_logging")
+    def test_refresh_displays_log_path(
+        self,
+        mock_setup_logging: MagicMock,
+        mock_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test that log file path is displayed to user."""
+        mock_setup_logging.return_value = Path("/tmp/cache-refresh-test.log")
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock()
+        mock_collector_class.return_value = mock_collector
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "refresh", "--all"],
+        )
+
+        # Log file path should be shown in output
+        assert "Log file:" in result.output or "cache-refresh" in result.output
+
+
+class TestSetupFileLogging:
+    """Tests for file logging setup."""
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.LOG_DIR", None)
+    def test_setup_file_logging_creates_directory(self, tmp_path: Path) -> None:
+        """Test that setup creates log directory if it doesn't exist."""
+        with (
+            patch("pynetappfoundry.cli.commands.cache.refresh.LOG_DIR", tmp_path / "logs"),
+            patch("pynetappfoundry.cli.commands.cache.refresh.cleanup_old_logs"),
+        ):
+            log_file = setup_file_logging()
+            assert log_file.parent.exists()
+            assert "cache-refresh" in log_file.name
+
+    def test_setup_file_logging_creates_timestamped_file(self, tmp_path: Path) -> None:
+        """Test that log files have timestamps in names."""
+        with (
+            patch("pynetappfoundry.cli.commands.cache.refresh.LOG_DIR", tmp_path / "logs"),
+            patch("pynetappfoundry.cli.commands.cache.refresh.cleanup_old_logs"),
+        ):
+            log_file = setup_file_logging()
+            # Should match pattern: cache-refresh-YYYYMMDD-HHMMSS.log
+            assert log_file.name.startswith("cache-refresh-")
+            assert log_file.suffix == ".log"
+
+    def test_setup_file_logging_configures_handlers(self, tmp_path: Path) -> None:
+        """Test that logging handlers are configured."""
+        with (
+            patch("pynetappfoundry.cli.commands.cache.refresh.LOG_DIR", tmp_path / "logs"),
+            patch("pynetappfoundry.cli.commands.cache.refresh.cleanup_old_logs"),
+        ):
+            log_file = setup_file_logging()
+            assert log_file.exists()
+
+            # Cache logger should have a file handler
+            cache_logger = logging.getLogger("pynetappfoundry.cache")
+            file_handlers = [h for h in cache_logger.handlers if isinstance(h, logging.FileHandler)]
+            assert len(file_handlers) > 0
+
+            # Clean up handlers
+            for handler in file_handlers:
+                cache_logger.removeHandler(handler)
+                handler.close()
+
+
+class TestCleanupOldLogs:
+    """Tests for log file cleanup."""
+
+    def test_cleanup_old_logs_keeps_recent_files(self, tmp_path: Path) -> None:
+        """Test that recent log files are kept."""
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        # Create some log files
+        for i in range(5):
+            (log_dir / f"cache-refresh-2024010{i}-120000.log").write_text("test")
+
+        with (
+            patch("pynetappfoundry.cli.commands.cache.refresh.LOG_DIR", log_dir),
+            patch("pynetappfoundry.cli.commands.cache.refresh.MAX_LOG_FILES", 10),
+        ):
+            cleanup_old_logs()
+
+        # All 5 files should still exist (under MAX_LOG_FILES)
+        remaining = list(log_dir.glob("cache-refresh-*.log"))
+        assert len(remaining) == 5
+
+    def test_cleanup_old_logs_removes_old_files(self, tmp_path: Path) -> None:
+        """Test that old log files are removed."""
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        # Create 15 log files
+        for i in range(15):
+            (log_dir / f"cache-refresh-2024010{i:02d}-120000.log").write_text("test")
+
+        with (
+            patch("pynetappfoundry.cli.commands.cache.refresh.LOG_DIR", log_dir),
+            patch("pynetappfoundry.cli.commands.cache.refresh.MAX_LOG_FILES", 10),
+        ):
+            cleanup_old_logs()
+
+        # Only MAX_LOG_FILES should remain
+        remaining = list(log_dir.glob("cache-refresh-*.log"))
+        assert len(remaining) == 10
+
+    def test_cleanup_old_logs_nonexistent_directory(self, tmp_path: Path) -> None:
+        """Test cleanup handles nonexistent directory gracefully."""
+        with patch(
+            "pynetappfoundry.cli.commands.cache.refresh.LOG_DIR",
+            tmp_path / "nonexistent",
+        ):
+            # Should not raise any errors
+            cleanup_old_logs()
+
+
+class TestVerboseProgressDisplay:
+    """Tests for VerboseProgressDisplay class."""
+
+    def test_init(self) -> None:
+        """Test VerboseProgressDisplay initialization."""
+        from rich.console import Console
+
+        console = Console()
+        display = VerboseProgressDisplay(
+            console=console,
+            cluster_name="test-cluster",
+            cluster_index=1,
+            total_clusters=3,
+        )
+        assert display.cluster_name == "test-cluster"
+        assert display.cluster_index == 1
+        assert display.total_clusters == 3
+        assert display.phase_times == {}
+
+    def test_on_progress_starting(self) -> None:
+        """Test on_progress handles 'starting' status."""
+        from rich.console import Console
+
+        from pynetappfoundry.cache.collector import CollectionPhase, ProgressInfo
+
+        console = Console(force_terminal=True, width=80)
+        display = VerboseProgressDisplay(
+            console=console,
+            cluster_name="test-cluster",
+            cluster_index=1,
+            total_clusters=1,
+        )
+
+        info = ProgressInfo(
+            phase=CollectionPhase.CLOUD,
+            phase_name="Cloud metadata",
+            status="starting",
+        )
+        # Should not raise any errors
+        display.on_progress(info)
+        assert display.current_phase == CollectionPhase.CLOUD
+
+    def test_on_progress_completed(self) -> None:
+        """Test on_progress handles 'completed' status."""
+        from rich.console import Console
+
+        from pynetappfoundry.cache.collector import CollectionPhase, ProgressInfo
+
+        console = Console(force_terminal=True, width=80)
+        display = VerboseProgressDisplay(
+            console=console,
+            cluster_name="test-cluster",
+            cluster_index=1,
+            total_clusters=1,
+        )
+
+        info = ProgressInfo(
+            phase=CollectionPhase.CLOUD,
+            phase_name="Cloud metadata",
+            status="completed",
+            elapsed_seconds=1.5,
+            source="cli",
+        )
+        display.on_progress(info)
+        assert display.phase_times[CollectionPhase.CLOUD] == 1.5
+
+    def test_on_progress_failed(self) -> None:
+        """Test on_progress handles 'failed' status."""
+        from rich.console import Console
+
+        from pynetappfoundry.cache.collector import CollectionPhase, ProgressInfo
+
+        console = Console(force_terminal=True, width=80)
+        display = VerboseProgressDisplay(
+            console=console,
+            cluster_name="test-cluster",
+            cluster_index=1,
+            total_clusters=1,
+        )
+
+        info = ProgressInfo(
+            phase=CollectionPhase.NETWORK,
+            phase_name="Network",
+            status="failed",
+            elapsed_seconds=0.5,
+            error="Connection timeout",
+        )
+        display.on_progress(info)
+        assert display.phase_times[CollectionPhase.NETWORK] == 0.5


### PR DESCRIPTION
## Description

Add verbose logging to cache refresh command for better troubleshooting and visibility into long-running operations. File logging always happens; verbose console output is opt-in with `-v` flag.

## Related Issue

Closes #126

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Always log detailed debug info to `~/.cache/pynetappfoundry/logs/cache-refresh-*.log`
- Add `--verbose/-v` flag for detailed console progress during cache refresh
- Show phase-by-phase timing for all 8 collection phases (cloud, cluster, nodes, network, storage, licenses, HA, relationships)
- Track data source used (API vs CLI) for each phase
- Auto-cleanup old log files (keeps last 10)
- Add progress callback infrastructure to MetadataCollector

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Example verbose output:
```
Refreshing cache for 2 cluster(s)...
Log file: ~/.cache/pynetappfoundry/logs/cache-refresh-20240115-102345.log

[1/2] cluster1
  |- Cloud metadata        0.8s (cli)
  |- Cluster info          0.3s (api)
  |- Nodes                 0.5s (api)
  |- Network               1.2s (api)
  |- Storage               0.9s (api)
  |- Licenses              0.4s (api)
  |- HA info               0.3s (api)
  `- Relationships         0.6s (api)
  `- Total: 5.0s OK
```
