### PR TITLE
feat: add nf cache query command

### DIFF
--- a/src/pynetappfoundry/cli/commands/cache/__init__.py
+++ b/src/pynetappfoundry/cli/commands/cache/__init__.py
@@ -3,6 +3,7 @@
 import click
 
 from pynetappfoundry.cli.commands.cache.clear import clear
+from pynetappfoundry.cli.commands.cache.query import query
 from pynetappfoundry.cli.commands.cache.refresh import refresh
 from pynetappfoundry.cli.commands.cache.show import show
 from pynetappfoundry.cli.commands.cache.status import status
@@ -22,6 +23,7 @@ def cache() -> None:
 
 
 cache.add_command(clear)
+cache.add_command(query)
 cache.add_command(refresh)
 cache.add_command(show)
 cache.add_command(status)

--- a/src/pynetappfoundry/cli/commands/cache/query.py
+++ b/src/pynetappfoundry/cli/commands/cache/query.py
@@ -1,0 +1,242 @@
+"""Cache query command for querying specific fields from cached metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.console import Console
+
+from pynetappfoundry.cache import ClusterMetadataDB
+from pynetappfoundry.cli.utils import print_error, print_exception, print_warning
+from pynetappfoundry.core.config import Config
+from pynetappfoundry.utils.dict_path import PathNotFoundError, get_nested_value
+
+console = Console()
+
+
+def _get_field_value(data: dict[str, Any], field: str) -> tuple[Any, str | None]:
+    """Get a field value from data, returning value and error message if any.
+
+    Args:
+        data: Dictionary to query.
+        field: Dot-notation path to the field.
+
+    Returns:
+        Tuple of (value, error_message). If successful, error_message is None.
+    """
+    try:
+        return get_nested_value(data, field), None
+    except PathNotFoundError as e:
+        return None, str(e)
+
+
+def _format_value(value: Any) -> str:
+    """Format a value for display.
+
+    Args:
+        value: Value to format.
+
+    Returns:
+        String representation of the value.
+    """
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    return str(value)
+
+
+@click.command()
+@click.argument("cluster", required=False)
+@click.argument("fields", nargs=-1)
+@click.option(
+    "--filter",
+    "-f",
+    "filter_str",
+    help='JSON filter for cluster selection: \'{"bu":"Business", "env":"Prod"}\'',
+)
+@click.option(
+    "--all",
+    "query_all",
+    is_flag=True,
+    help="Query all cached clusters.",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output as JSON.",
+)
+@click.option(
+    "--raw",
+    is_flag=True,
+    help="Output values only, no field names (single cluster only).",
+)
+@click.pass_context
+def query(
+    ctx: click.Context,
+    cluster: str | None,
+    fields: tuple[str, ...],
+    filter_str: str | None,
+    query_all: bool,
+    output_json: bool,
+    raw: bool,
+) -> None:
+    """Query specific fields from cached cluster metadata.
+
+    Use dot notation to access nested fields (e.g., cloud.instance_type).
+    Use bracket notation for array access (e.g., nodes[0].name).
+
+    \b
+    Examples:
+        # Single cluster, single field
+        nf cache query cluster1 cloud.instance_type
+
+        # Single cluster, multiple fields
+        nf cache query cluster1 cloud.instance_type cluster.ontap_version
+
+        # All cached clusters
+        nf cache query --all cloud.instance_type
+
+        # Filtered clusters
+        nf cache query -f '{"bu":"Business"}' cloud.provider cloud.region
+
+        # JSON output
+        nf cache query cluster1 cloud.instance_type --json
+
+        # Raw output (single cluster only, for scripting)
+        nf cache query cluster1 cluster.ontap_version --raw
+
+        # Array access
+        nf cache query cluster1 nodes[0].name
+    """
+    config_dir = ctx.obj.get("config_dir", "config")
+
+    # Check if config directory exists
+    config_path = Path.cwd() / config_dir
+    if not config_path.exists():
+        print_error(f"Configuration directory not found: {config_path}")
+        ctx.exit(1)
+
+    # When --all or --filter is used, Click still parses the first positional arg as 'cluster'.
+    # We need to treat it as a field in that case and combine with any additional fields.
+    effective_fields: tuple[str, ...]
+    effective_cluster: str | None
+
+    if query_all or filter_str:
+        # Treat cluster as first field if provided
+        effective_fields = (cluster, *fields) if cluster else fields
+        effective_cluster = None
+    else:
+        effective_fields = fields
+        effective_cluster = cluster
+
+    # Validate arguments
+    if not effective_cluster and not query_all and not filter_str:
+        print_error("Must specify CLUSTER, --all, or --filter/-f")
+        ctx.exit(1)
+
+    if not effective_fields:
+        print_error("Must specify at least one FIELD to query")
+        ctx.exit(1)
+
+    # Raw output only valid with single cluster
+    if raw and (query_all or filter_str):
+        print_error("--raw is only valid when querying a single cluster")
+        ctx.exit(1)
+
+    try:
+        config = Config(config_dir=config_dir, script_name="cache-query")
+    except Exception as e:
+        print_exception(f"Failed to load configuration: {e}", e)
+        ctx.exit(1)
+
+    db = ClusterMetadataDB(config=config)
+
+    # Determine which clusters to query
+    cluster_names: list[str] = []
+    if effective_cluster:
+        cluster_names = [effective_cluster]
+    elif query_all:
+        cached = db.list_clusters()
+        cluster_names = [c["cluster_name"] for c in cached]
+        if not cluster_names:
+            print_warning("No cached clusters found. Use 'nf cache refresh' to populate.")
+            db.close()
+            ctx.exit(0)
+    elif filter_str:
+        try:
+            filter_dict = json.loads(filter_str)
+        except json.JSONDecodeError as e:
+            print_error(f"Invalid filter JSON: {e}")
+            db.close()
+            ctx.exit(1)
+
+        filtered = config.get_clusters(filter_dict)
+        if not filtered:
+            print_warning("No clusters match the filter criteria.")
+            db.close()
+            ctx.exit(0)
+        cluster_names = list(filtered.keys())
+
+    # Query each cluster
+    results: dict[str, dict[str, Any]] = {}
+    errors: list[str] = []
+
+    for name in cluster_names:
+        metadata = db.get(name)
+        if not metadata:
+            print_warning(f"No cached data for cluster '{name}', skipping.")
+            continue
+
+        data = metadata.model_dump()
+        cluster_results: dict[str, Any] = {}
+
+        for field in effective_fields:
+            value, error = _get_field_value(data, field)
+            if error:
+                errors.append(f"{name}: {error}")
+            else:
+                cluster_results[field] = value
+
+        if cluster_results:
+            results[name] = cluster_results
+
+    db.close()
+
+    # Handle errors
+    if errors and not results:
+        for err in errors:
+            print_error(err)
+        ctx.exit(1)
+
+    if not results:
+        print_error("No results found.")
+        ctx.exit(1)
+
+    # Print warnings for any errors that occurred but we still have some results
+    for err in errors:
+        print_warning(err)
+
+    # Output results
+    if output_json:
+        console.print(json.dumps(results, default=str))
+    elif raw:
+        # Raw output: only values, one per line
+        # Only valid for single cluster (already validated above)
+        cluster_result = next(iter(results.values()))
+        for field in effective_fields:
+            if field in cluster_result:
+                console.print(_format_value(cluster_result[field]))
+    else:
+        # Default output: grouped by cluster
+        for name, cluster_result in results.items():
+            console.print(f"[bold]{name}:[/bold]")
+            for field in effective_fields:
+                if field in cluster_result:
+                    console.print(f"  {field}: {_format_value(cluster_result[field])}")

--- a/src/pynetappfoundry/utils/__init__.py
+++ b/src/pynetappfoundry/utils/__init__.py
@@ -6,6 +6,7 @@ from pynetappfoundry.utils.cloud import (
     get_cloud_account_name,
     get_cloud_types,
 )
+from pynetappfoundry.utils.dict_path import PathNotFoundError, get_nested_value
 from pynetappfoundry.utils.email import send_email
 from pynetappfoundry.utils.size import (
     SUFFIXES,
@@ -17,6 +18,7 @@ from pynetappfoundry.utils.time import to_epoch_ms
 
 __all__ = [
     "SUFFIXES",
+    "PathNotFoundError",
     "approximate_size",
     "approximate_size_specific",
     "build_azure_id",
@@ -24,6 +26,7 @@ __all__ = [
     "convert_size",
     "get_cloud_account_name",
     "get_cloud_types",
+    "get_nested_value",
     "send_email",
     "to_epoch_ms",
 ]

--- a/src/pynetappfoundry/utils/dict_path.py
+++ b/src/pynetappfoundry/utils/dict_path.py
@@ -1,0 +1,140 @@
+"""Utility for accessing nested dictionary values via dot notation paths.
+
+This module provides functions for traversing nested dictionaries and lists
+using dot notation paths like "cloud.instance_type" or "nodes[0].name".
+
+Example:
+    >>> data = {"cloud": {"instance_type": "m5.xlarge"}, "nodes": [{"name": "node-01"}]}
+    >>> get_nested_value(data, "cloud.instance_type")
+    'm5.xlarge'
+    >>> get_nested_value(data, "nodes[0].name")
+    'node-01'
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Pattern to match array index access like "nodes[0]"
+_ARRAY_INDEX_PATTERN = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\[(\d+)\]$")
+
+
+class PathNotFoundError(Exception):
+    """Raised when a path cannot be resolved in a nested structure.
+
+    Attributes:
+        path: The full path that was being resolved.
+        position: The part of the path where the error occurred.
+        reason: Why the path resolution failed.
+    """
+
+    def __init__(self, path: str, position: str, reason: str) -> None:
+        """Initialize PathNotFoundError.
+
+        Args:
+            path: The full path that was being resolved.
+            position: The part of the path where the error occurred.
+            reason: Why the path resolution failed.
+        """
+        self.path = path
+        self.position = position
+        self.reason = reason
+        super().__init__(f"Path '{path}' not found at '{position}': {reason}")
+
+
+def get_nested_value(data: dict[str, Any], path: str) -> Any:
+    """Retrieve a value from a nested dictionary using dot notation.
+
+    Supports accessing nested dictionaries and lists. Array indices can be
+    specified using bracket notation (e.g., "nodes[0].name").
+
+    Args:
+        data: The dictionary to traverse.
+        path: Dot-notation path (e.g., "cloud.instance_type", "nodes[0].name").
+
+    Returns:
+        The value at the specified path.
+
+    Raises:
+        PathNotFoundError: If the path cannot be resolved.
+
+    Examples:
+        >>> data = {"cloud": {"provider": "AWS", "region": "us-east-1"}}
+        >>> get_nested_value(data, "cloud.provider")
+        'AWS'
+
+        >>> data = {"nodes": [{"name": "node-01"}, {"name": "node-02"}]}
+        >>> get_nested_value(data, "nodes[0].name")
+        'node-01'
+    """
+    if not path:
+        raise PathNotFoundError(path, "", "empty path")
+
+    parts = path.split(".")
+    current: Any = data
+    traversed: list[str] = []
+
+    for part in parts:
+        if not part:
+            raise PathNotFoundError(path, ".".join(traversed) or "(root)", "empty path segment")
+
+        # Check for array index pattern like "nodes[0]"
+        match = _ARRAY_INDEX_PATTERN.match(part)
+        if match:
+            key, index_str = match.groups()
+            index = int(index_str)
+
+            # First access the key
+            if not isinstance(current, dict):
+                raise PathNotFoundError(
+                    path,
+                    ".".join(traversed) or "(root)",
+                    f"expected dict, got {type(current).__name__}",
+                )
+            if key not in current:
+                raise PathNotFoundError(
+                    path,
+                    ".".join([*traversed, key]) if traversed else key,
+                    "key not found",
+                )
+
+            current = current[key]
+            traversed.append(key)
+
+            # Then access the index
+            if not isinstance(current, list):
+                raise PathNotFoundError(
+                    path,
+                    ".".join(traversed),
+                    f"expected list for index access, got {type(current).__name__}",
+                )
+            if index < 0 or index >= len(current):
+                raise PathNotFoundError(
+                    path,
+                    f"{'.'.join(traversed)}[{index}]",
+                    f"index {index} out of range (list has {len(current)} items)",
+                )
+
+            current = current[index]
+            # Update traversed to include the index for future error messages
+            traversed[-1] = f"{key}[{index}]"
+        else:
+            # Regular key access
+            if not isinstance(current, dict):
+                raise PathNotFoundError(
+                    path,
+                    ".".join(traversed) or "(root)",
+                    f"expected dict, got {type(current).__name__}",
+                )
+            if part not in current:
+                raise PathNotFoundError(
+                    path,
+                    ".".join([*traversed, part]) if traversed else part,
+                    "key not found",
+                )
+
+            current = current[part]
+            traversed.append(part)
+
+    return current

--- a/tests/unit/cli/commands/cache/test_query.py
+++ b/tests/unit/cli/commands/cache/test_query.py
@@ -1,0 +1,618 @@
+"""Tests for cache query CLI command."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from pynetappfoundry.cache.models import (
+    CachedClusterMetadata,
+    CloudMetadata,
+    ClusterInfo,
+    NodeInfo,
+)
+from pynetappfoundry.cli.main import nf
+
+
+class TestCacheQueryCommand:
+    """Tests for nf cache query command."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_config_dir(self, tmp_path: Path) -> Path:
+        """Create a mock config directory."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.toml").write_text(
+            """
+[ontapapi]
+[ontapapi.general]
+base_api_path = "/api"
+"""
+        )
+        return config_dir
+
+    @pytest.fixture
+    def sample_metadata(self) -> CachedClusterMetadata:
+        """Create sample metadata for testing."""
+        return CachedClusterMetadata(
+            cluster_name="test-cluster",
+            cached_at=datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
+            cloud=CloudMetadata(
+                provider="AWS",
+                region="us-east-1",
+                instance_type="m5.xlarge",
+            ),
+            cluster=ClusterInfo(
+                cluster_name="test-cluster",
+                cluster_uuid="abc-123",
+                ontap_version="9.14.1",
+            ),
+            nodes=[
+                NodeInfo(name="node-01", serial_number="SN001"),
+                NodeInfo(name="node-02", serial_number="SN002"),
+            ],
+        )
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_single_cluster_single_field(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test querying a single field from a single cluster."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "query", "test-cluster", "cloud.provider"],
+        )
+
+        assert result.exit_code == 0
+        assert "test-cluster:" in result.output
+        assert "cloud.provider: AWS" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_single_cluster_multiple_fields(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test querying multiple fields from a single cluster."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "test-cluster",
+                "cloud.provider",
+                "cluster.ontap_version",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "cloud.provider: AWS" in result.output
+        assert "cluster.ontap_version: 9.14.1" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_query_all_clusters(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test querying all cached clusters."""
+        mock_db = MagicMock()
+        mock_db.list_clusters.return_value = [
+            {"cluster_name": "cluster1"},
+            {"cluster_name": "cluster2"},
+        ]
+
+        metadata1 = CachedClusterMetadata(
+            cluster_name="cluster1",
+            cached_at=datetime(2024, 1, 15, tzinfo=UTC),
+            cloud=CloudMetadata(provider="AWS", instance_type="m5.xlarge"),
+        )
+        metadata2 = CachedClusterMetadata(
+            cluster_name="cluster2",
+            cached_at=datetime(2024, 1, 15, tzinfo=UTC),
+            cloud=CloudMetadata(provider="Azure", instance_type="Standard_D4s_v3"),
+        )
+        mock_db.get.side_effect = lambda name: metadata1 if name == "cluster1" else metadata2
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "query", "--all", "cloud.instance_type"],
+        )
+
+        assert result.exit_code == 0
+        assert "cluster1:" in result.output
+        assert "cloud.instance_type: m5.xlarge" in result.output
+        assert "cluster2:" in result.output
+        assert "cloud.instance_type: Standard_D4s_v3" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.Config")
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_query_with_filter(
+        self,
+        mock_db_class: MagicMock,
+        mock_config_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test querying clusters with JSON filter."""
+        mock_config = MagicMock()
+        mock_config.get_clusters.return_value = {"prod-cluster": {"name": "prod-cluster"}}
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        metadata = CachedClusterMetadata(
+            cluster_name="prod-cluster",
+            cached_at=datetime(2024, 1, 15, tzinfo=UTC),
+            cloud=CloudMetadata(provider="AWS", region="us-east-1"),
+        )
+        mock_db.get.return_value = metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "-f",
+                '{"env":"prod"}',
+                "cloud.provider",
+                "cloud.region",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "prod-cluster:" in result.output
+        assert "cloud.provider: AWS" in result.output
+        assert "cloud.region: us-east-1" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_json_output(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test JSON output format."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "test-cluster",
+                "cloud.instance_type",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output == {"test-cluster": {"cloud.instance_type": "m5.xlarge"}}
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_raw_output(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test raw output format."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "test-cluster",
+                "cluster.ontap_version",
+                "--raw",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert result.output.strip() == "9.14.1"
+
+    def test_raw_with_multiple_clusters_error(
+        self,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test that --raw errors when used with --all."""
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "--all",
+                "cloud.provider",
+                "--raw",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "--raw is only valid when querying a single cluster" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_array_index_access(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test querying array elements by index."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "query", "test-cluster", "nodes[0].name"],
+        )
+
+        assert result.exit_code == 0
+        assert "nodes[0].name: node-01" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_invalid_field_path_error(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test error when field path doesn't exist."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "query", "test-cluster", "invalid.path"],
+        )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_missing_cluster_error(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test error when cluster doesn't exist in cache."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = None
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "query", "nonexistent", "cloud.provider"],
+        )
+
+        assert result.exit_code != 0
+        assert "No cached data" in result.output or "No results found" in result.output
+
+    def test_no_cluster_or_all_or_filter_error(
+        self,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test error when no cluster selection method specified."""
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "query", "cloud.provider"],
+        )
+
+        # Click will parse "cloud.provider" as the CLUSTER argument but no fields
+        # So we expect an error about missing fields
+        assert result.exit_code != 0
+
+    def test_no_fields_error(
+        self,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test error when no fields specified."""
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "query", "--all"],
+        )
+
+        assert result.exit_code != 0
+        assert "FIELD" in result.output or "field" in result.output.lower()
+
+    def test_config_not_found_error(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Test error when config directory doesn't exist."""
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(tmp_path / "nonexistent"),
+                "cache",
+                "query",
+                "cluster1",
+                "cloud.provider",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_positional_args_with_all_treated_as_fields(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test that positional args with --all are treated as fields, not cluster."""
+        mock_db = MagicMock()
+        mock_db.list_clusters.return_value = [{"cluster_name": "cluster1"}]
+        metadata = CachedClusterMetadata(
+            cluster_name="cluster1",
+            cached_at=datetime(2024, 1, 15, tzinfo=UTC),
+            cloud=CloudMetadata(provider="AWS", region="us-east-1"),
+        )
+        mock_db.get.return_value = metadata
+        mock_db_class.return_value = mock_db
+
+        # With --all, both positional args should be treated as fields
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "--all",
+                "cloud.provider",
+                "cloud.region",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "cloud.provider: AWS" in result.output
+        assert "cloud.region: us-east-1" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_empty_cache_with_all(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test --all with empty cache."""
+        mock_db = MagicMock()
+        mock_db.list_clusters.return_value = []
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "query", "--all", "cloud.provider"],
+        )
+
+        assert result.exit_code == 0
+        assert "No cached clusters" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.Config")
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_filter_no_matches(
+        self,
+        mock_db_class: MagicMock,
+        mock_config_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test filter with no matching clusters."""
+        mock_config = MagicMock()
+        mock_config.get_clusters.return_value = {}
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "-f",
+                '{"env":"nonexistent"}',
+                "cloud.provider",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "No clusters match the filter" in result.output
+
+    def test_invalid_filter_json(
+        self,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test error with invalid filter JSON."""
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "-f",
+                "not valid json",
+                "cloud.provider",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "Invalid filter JSON" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_multiple_fields_json_output(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test JSON output with multiple fields."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "test-cluster",
+                "cloud.provider",
+                "cloud.region",
+                "cluster.ontap_version",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output == {
+            "test-cluster": {
+                "cloud.provider": "AWS",
+                "cloud.region": "us-east-1",
+                "cluster.ontap_version": "9.14.1",
+            }
+        }
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_raw_output_multiple_fields(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test raw output with multiple fields (one value per line)."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "test-cluster",
+                "cloud.provider",
+                "cluster.ontap_version",
+                "--raw",
+            ],
+        )
+
+        assert result.exit_code == 0
+        lines = result.output.strip().split("\n")
+        assert lines == ["AWS", "9.14.1"]
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_query_boolean_value(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test querying a boolean value."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "query", "test-cluster", "ha.is_ha", "--raw"],
+        )
+
+        assert result.exit_code == 0
+        assert result.output.strip() == "false"
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_query_nested_array(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test querying nested array with multiple indices."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "test-cluster",
+                "nodes[1].serial_number",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "SN002" in result.output

--- a/tests/unit/utils/test_dict_path.py
+++ b/tests/unit/utils/test_dict_path.py
@@ -1,0 +1,218 @@
+"""Tests for dict_path utility module."""
+
+from __future__ import annotations
+
+import pytest
+
+from pynetappfoundry.utils.dict_path import PathNotFoundError, get_nested_value
+
+
+class TestGetNestedValue:
+    """Tests for get_nested_value function."""
+
+    def test_simple_field_access(self) -> None:
+        """Test accessing a simple top-level field."""
+        data = {"name": "test-cluster"}
+        assert get_nested_value(data, "name") == "test-cluster"
+
+    def test_nested_field_access(self) -> None:
+        """Test accessing nested fields with dot notation."""
+        data = {"cloud": {"instance_type": "m5.xlarge"}}
+        assert get_nested_value(data, "cloud.instance_type") == "m5.xlarge"
+
+    def test_deeply_nested_access(self) -> None:
+        """Test accessing deeply nested fields."""
+        data = {"a": {"b": {"c": {"d": "value"}}}}
+        assert get_nested_value(data, "a.b.c.d") == "value"
+
+    def test_array_index_access(self) -> None:
+        """Test accessing array elements by index."""
+        data = {"nodes": [{"name": "node-01"}, {"name": "node-02"}]}
+        assert get_nested_value(data, "nodes[0].name") == "node-01"
+        assert get_nested_value(data, "nodes[1].name") == "node-02"
+
+    def test_array_index_only(self) -> None:
+        """Test accessing array element directly."""
+        data = {"items": ["first", "second", "third"]}
+        assert get_nested_value(data, "items[0]") == "first"
+        assert get_nested_value(data, "items[2]") == "third"
+
+    def test_array_of_dicts(self) -> None:
+        """Test accessing complex nested array structures."""
+        data = {
+            "cluster": {
+                "nodes": [
+                    {"name": "node-01", "status": "healthy"},
+                    {"name": "node-02", "status": "warning"},
+                ]
+            }
+        }
+        assert get_nested_value(data, "cluster.nodes[0].name") == "node-01"
+        assert get_nested_value(data, "cluster.nodes[1].status") == "warning"
+
+    def test_returns_various_types(self) -> None:
+        """Test returning various value types."""
+        data = {
+            "string": "text",
+            "number": 42,
+            "float": 3.14,
+            "boolean": True,
+            "null": None,
+            "list": [1, 2, 3],
+            "dict": {"nested": "value"},
+        }
+        assert get_nested_value(data, "string") == "text"
+        assert get_nested_value(data, "number") == 42
+        assert get_nested_value(data, "float") == 3.14
+        assert get_nested_value(data, "boolean") is True
+        assert get_nested_value(data, "null") is None
+        assert get_nested_value(data, "list") == [1, 2, 3]
+        assert get_nested_value(data, "dict") == {"nested": "value"}
+
+
+class TestPathNotFoundError:
+    """Tests for PathNotFoundError exception."""
+
+    def test_missing_field_error(self) -> None:
+        """Test error when field doesn't exist."""
+        data = {"name": "test"}
+        with pytest.raises(PathNotFoundError) as exc_info:
+            get_nested_value(data, "missing")
+        assert exc_info.value.path == "missing"
+        assert exc_info.value.position == "missing"
+        assert "key not found" in exc_info.value.reason
+
+    def test_missing_nested_field_error(self) -> None:
+        """Test error when nested field doesn't exist."""
+        data = {"cloud": {"provider": "AWS"}}
+        with pytest.raises(PathNotFoundError) as exc_info:
+            get_nested_value(data, "cloud.missing")
+        assert exc_info.value.path == "cloud.missing"
+        assert exc_info.value.position == "cloud.missing"
+        assert "key not found" in exc_info.value.reason
+
+    def test_index_out_of_range_error(self) -> None:
+        """Test error when array index is out of range."""
+        data = {"nodes": [{"name": "node-01"}]}
+        with pytest.raises(PathNotFoundError) as exc_info:
+            get_nested_value(data, "nodes[5]")
+        assert exc_info.value.path == "nodes[5]"
+        assert "index 5 out of range" in exc_info.value.reason
+        assert "list has 1 items" in exc_info.value.reason
+
+    def test_non_dict_access_error(self) -> None:
+        """Test error when trying to access field on non-dict."""
+        data = {"name": "test"}
+        with pytest.raises(PathNotFoundError) as exc_info:
+            get_nested_value(data, "name.sub")
+        assert exc_info.value.path == "name.sub"
+        assert "expected dict" in exc_info.value.reason
+        assert "got str" in exc_info.value.reason
+
+    def test_non_list_index_access_error(self) -> None:
+        """Test error when trying array access on non-list."""
+        data = {"cloud": {"provider": "AWS"}}
+        with pytest.raises(PathNotFoundError) as exc_info:
+            get_nested_value(data, "cloud.provider[0]")
+        assert exc_info.value.path == "cloud.provider[0]"
+        assert "expected list for index access" in exc_info.value.reason
+
+    def test_empty_path_error(self) -> None:
+        """Test error when path is empty."""
+        data = {"name": "test"}
+        with pytest.raises(PathNotFoundError) as exc_info:
+            get_nested_value(data, "")
+        assert "empty path" in exc_info.value.reason
+
+    def test_empty_segment_error(self) -> None:
+        """Test error when path has empty segment."""
+        data = {"a": {"b": "value"}}
+        with pytest.raises(PathNotFoundError) as exc_info:
+            get_nested_value(data, "a..b")
+        assert "empty path segment" in exc_info.value.reason
+
+    def test_error_message_format(self) -> None:
+        """Test that error message contains useful information."""
+        data = {"cloud": {"provider": "AWS"}}
+        with pytest.raises(PathNotFoundError) as exc_info:
+            get_nested_value(data, "cloud.missing_field")
+        error = exc_info.value
+        error_str = str(error)
+        assert "cloud.missing_field" in error_str
+        assert "not found" in error_str
+
+    def test_exception_attributes(self) -> None:
+        """Test PathNotFoundError has correct attributes."""
+        error = PathNotFoundError(
+            path="a.b.c",
+            position="a.b",
+            reason="key not found",
+        )
+        assert error.path == "a.b.c"
+        assert error.position == "a.b"
+        assert error.reason == "key not found"
+
+
+class TestEdgeCases:
+    """Tests for edge cases."""
+
+    def test_key_with_underscores(self) -> None:
+        """Test keys containing underscores."""
+        data = {"instance_type": "m5.xlarge", "is_ha": True}
+        assert get_nested_value(data, "instance_type") == "m5.xlarge"
+        assert get_nested_value(data, "is_ha") is True
+
+    def test_key_with_numbers(self) -> None:
+        """Test keys containing numbers."""
+        data = {"node1": {"name": "first"}, "node2": {"name": "second"}}
+        assert get_nested_value(data, "node1.name") == "first"
+        assert get_nested_value(data, "node2.name") == "second"
+
+    def test_empty_list(self) -> None:
+        """Test accessing index on empty list."""
+        data = {"items": []}
+        with pytest.raises(PathNotFoundError) as exc_info:
+            get_nested_value(data, "items[0]")
+        assert "index 0 out of range" in exc_info.value.reason
+        assert "list has 0 items" in exc_info.value.reason
+
+    def test_empty_dict(self) -> None:
+        """Test accessing key on empty dict."""
+        data: dict[str, object] = {"nested": {}}
+        with pytest.raises(PathNotFoundError):
+            get_nested_value(data, "nested.key")
+
+    def test_zero_index(self) -> None:
+        """Test accessing index 0."""
+        data = {"items": ["zero", "one", "two"]}
+        assert get_nested_value(data, "items[0]") == "zero"
+
+    def test_nested_list_in_list(self) -> None:
+        """Test nested arrays (arrays within arrays)."""
+        data = {"matrix": [[1, 2], [3, 4]]}
+        # First access gets [1, 2], but we can't do [0][1] in dot notation
+        result = get_nested_value(data, "matrix[0]")
+        assert result == [1, 2]
+
+    def test_mixed_access_patterns(self) -> None:
+        """Test combining dict and array access in complex paths."""
+        data = {
+            "clusters": [
+                {
+                    "name": "cluster-1",
+                    "nodes": [
+                        {"name": "node-a", "cpus": 4},
+                        {"name": "node-b", "cpus": 8},
+                    ],
+                },
+                {
+                    "name": "cluster-2",
+                    "nodes": [
+                        {"name": "node-c", "cpus": 16},
+                    ],
+                },
+            ]
+        }
+        assert get_nested_value(data, "clusters[0].name") == "cluster-1"
+        assert get_nested_value(data, "clusters[0].nodes[1].cpus") == 8
+        assert get_nested_value(data, "clusters[1].nodes[0].name") == "node-c"


### PR DESCRIPTION
## Description

Adds a new `nf cache query` command to query specific fields from cached cluster metadata using dot notation paths. This allows users to extract specific values for scripting or quick lookups without displaying the entire cache.

## Related Issue

Closes #130

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `dict_path` utility module for traversing nested dicts/lists with dot notation and array index support
- Add `nf cache query` command with support for:
  - Single cluster queries: `nf cache query cluster1 cloud.instance_type`
  - All cached clusters: `nf cache query --all cloud.instance_type`
  - Filtered clusters: `nf cache query -f '{"bu":"Business"}' cloud.provider`
  - Array index access: `nf cache query cluster1 nodes[0].name`
  - JSON output: `--json` flag
  - Raw output: `--raw` flag (single cluster only)
- Add comprehensive unit tests for both modules

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)