### PR TITLE
feat: add nf cache schema command

### DIFF
--- a/docs/decisions/0014-use-sqlite-for-cluster-metadata-caching.md
+++ b/docs/decisions/0014-use-sqlite-for-cluster-metadata-caching.md
@@ -30,8 +30,11 @@ Use **SQLite** as the storage backend for caching ONTAP cluster metadata that do
 
 - Issue #32: feat: add cluster metadata cache for ONTAP clusters
 - Issue #38: refactor: move cluster metadata cache to config directory
+- Issue #130: feat: add nf cache query command
 
 ## Related Documentation
 
 - Cache module: `src/pynetappfoundry/cache/`
-- CLI commands: `nf cache refresh`, `nf cache show`, `nf cache status`, `nf cache clear`
+- CLI commands: `nf cache refresh`, `nf cache show`, `nf cache query`, `nf cache schema`, `nf cache status`, `nf cache clear`
+- CLI Reference: [docs/reference/cli.md](../reference/cli.md#cache)
+- Usage Guide: [docs/usage/basics.md](../usage/basics.md#cluster-metadata-caching)

--- a/docs/plans/cache-query-command.md
+++ b/docs/plans/cache-query-command.md
@@ -1,0 +1,163 @@
+# Plan: Add `nf cache query` Command
+
+## Summary
+
+Create a new `nf cache query` command to query specific fields from cached cluster metadata using dot notation. Supports querying single clusters, all clusters, or a filtered subset.
+
+## CLI Interface
+
+```bash
+# Single cluster, single field
+nf cache query cluster1 cloud.instance_type
+# Output:
+# cluster1:
+#   cloud.instance_type: m5.xlarge
+
+# Single cluster, multiple fields
+nf cache query cluster1 cloud.instance_type cluster.ontap_version
+# Output:
+# cluster1:
+#   cloud.instance_type: m5.xlarge
+#   cluster.ontap_version: 9.14.1
+
+# All cached clusters
+nf cache query --all cloud.instance_type
+# Output:
+# cluster1:
+#   cloud.instance_type: m5.xlarge
+# cluster2:
+#   cloud.instance_type: r5.xlarge
+
+# Filtered clusters (using existing -f pattern)
+nf cache query -f '{"bu":"Business"}' cloud.provider cloud.region
+# Output:
+# prod-cluster:
+#   cloud.provider: AWS
+#   cloud.region: us-east-1
+
+# JSON output
+nf cache query cluster1 cloud.instance_type --json
+# Output: {"cluster1": {"cloud.instance_type": "m5.xlarge"}}
+
+# Raw output (single cluster only, for scripting)
+nf cache query cluster1 cluster.ontap_version --raw
+# Output: 9.14.1
+
+# Array access
+nf cache query cluster1 nodes[0].name
+# Output:
+# cluster1:
+#   nodes[0].name: node-01
+```
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `src/pynetappfoundry/utils/dict_path.py` | Create |
+| `src/pynetappfoundry/cli/commands/cache/query.py` | Create |
+| `src/pynetappfoundry/cli/commands/cache/__init__.py` | Modify |
+| `tests/unit/utils/test_dict_path.py` | Create |
+| `tests/unit/cli/commands/cache/test_query.py` | Create |
+
+## Implementation Details
+
+### 1. `utils/dict_path.py`
+
+Utility for nested dict/list access via dot notation:
+
+- `PathNotFoundError` - custom exception with path, position, and reason
+- `get_nested_value(data, path)` - traverse dict with dot notation, supports `nodes[0].name` syntax
+- Regex pattern: `^([a-zA-Z_][a-zA-Z0-9_]*)\[(\d+)\]$` for array indices
+
+### 2. `cli/commands/cache/query.py`
+
+New Click command following existing patterns:
+
+```python
+@click.command()
+@click.argument("cluster", required=False)
+@click.argument("fields", nargs=-1, required=True)
+@click.option("--filter", "-f", "filter", help='JSON filter: \'{"bu":"Business", "env":"Prod"}\'')
+@click.option("--all", "query_all", is_flag=True, help="Query all cached clusters.")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON.")
+@click.option("--raw", is_flag=True, help="Output values only, no field names (single cluster only).")
+@click.pass_context
+def query(ctx, cluster, fields, filter, query_all, output_json, raw):
+```
+
+**Cluster selection logic:**
+1. If `cluster` specified: query that single cluster
+2. If `--all`: query all cached clusters
+3. If `--filter/-f`: parse JSON, get filtered clusters from config, query cached data for those
+4. Error if none of the above (must specify cluster, --all, or --filter)
+
+**Behavior:**
+- `--raw` only valid with single cluster (error otherwise)
+- `--json` outputs nested JSON: `{"cluster_name": {"field": value, ...}, ...}`
+- Default outputs grouped by cluster with indented fields
+- Skips clusters that have no cached data (with warning)
+- Error if field path not found (shows which cluster/field failed)
+
+### 3. `cache/__init__.py`
+
+Add import and register command:
+```python
+from pynetappfoundry.cli.commands.cache.query import query
+cache.add_command(query)
+```
+
+## Testing
+
+### `test_dict_path.py`
+- Simple field access: `cloud.instance_type`
+- Array index access: `nodes[0].name`
+- Deeply nested: `a.b.c.d`
+- Missing field raises `PathNotFoundError`
+- Index out of range raises `PathNotFoundError`
+- Non-dict access raises `PathNotFoundError`
+
+### `test_query.py`
+- Single cluster, single field query
+- Single cluster, multiple field query
+- `--all` queries all cached clusters
+- `--filter` with JSON filter
+- `--json` output format
+- `--raw` output format (single cluster)
+- `--raw` with multiple clusters errors
+- Invalid field path error
+- Missing cluster error
+- No cluster/--all/--filter specified error
+- No config directory error
+
+## Verification
+
+1. Run `doit check` to verify all tests pass
+2. Manual testing:
+   ```bash
+   # Single cluster
+   nf cache query <cluster> cloud.provider
+   nf cache query <cluster> cloud.provider cluster.ontap_version
+   nf cache query <cluster> cloud.instance_type --raw
+   nf cache query <cluster> nodes[0].name --json
+
+   # Multiple clusters
+   nf cache query --all cloud.provider cloud.region
+   nf cache query -f '{"env":"prod"}' cloud.instance_type
+   nf cache query --all cloud.provider --json
+
+   # Error cases
+   nf cache query <cluster> invalid.path  # should error
+   nf cache query --all cloud.provider --raw  # should error (raw with multi)
+   nf cache query cloud.provider  # should error (no cluster specified)
+   ```
+
+## Status
+
+**Implemented**: PR #131 merged, closes #130
+
+## Related Documentation
+
+- [CLI Reference - Cache Commands](../reference/cli.md#cache)
+- [Usage Guide - Cluster Metadata Caching](../usage/basics.md#cluster-metadata-caching)
+- [ADR-0014: Use SQLite for cluster metadata caching](../decisions/0014-use-sqlite-for-cluster-metadata-caching.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -92,6 +92,25 @@ nf metrics [OPTIONS] COMMAND [ARGS]...
 | `query` | Query stored metrics |
 | `export` | Export metrics to file |
 
+### cache
+
+Cluster metadata cache management. The cache stores discoverable ONTAP cluster information that doesn't change frequently.
+
+```bash
+nf cache [OPTIONS] COMMAND [ARGS]...
+```
+
+**Subcommands:**
+
+| Command | Description |
+|---------|-------------|
+| `refresh` | Refresh the metadata cache for cluster(s) |
+| `show` | Display cached metadata for a cluster |
+| `query` | Query specific fields from cached metadata |
+| `schema` | Display the cache metadata schema |
+| `status` | Show cache status for all clusters |
+| `clear` | Clear the metadata cache |
+
 ### utils
 
 Utility commands.
@@ -166,6 +185,76 @@ nf metrics query --metric volume_used --cluster cluster1
 
 # Export metrics
 nf metrics export --format json -o metrics.json
+```
+
+### Cache Management
+
+```bash
+# Refresh cache for a single cluster
+nf cache refresh cluster1
+
+# Refresh cache for all configured clusters
+nf cache refresh --all
+
+# Refresh with verbose progress output
+nf cache refresh --all -v
+
+# List all cached clusters
+nf cache show
+
+# Show all cached data for a cluster
+nf cache show cluster1
+
+# Show only a specific section
+nf cache show cluster1 -s nodes
+
+# Output cached data as JSON
+nf cache show cluster1 --json
+
+# Query specific fields using dot notation
+nf cache query cluster1 cloud.instance_type
+
+# Query multiple fields
+nf cache query cluster1 cloud.provider cluster.ontap_version
+
+# Query all cached clusters
+nf cache query --all cloud.instance_type
+
+# Query with cluster filter
+nf cache query -f '{"env":"Prod"}' cloud.provider cloud.region
+
+# Query with JSON output (for scripting)
+nf cache query cluster1 cloud.instance_type --json
+
+# Query with raw output (values only, single cluster)
+nf cache query cluster1 cluster.ontap_version --raw
+
+# Query array elements
+nf cache query cluster1 nodes[0].name
+
+# View cache schema as tree
+nf cache schema
+
+# View schema as flat list of queryable paths
+nf cache schema --flat
+
+# Output JSON schema
+nf cache schema --json
+
+# Check cache status
+nf cache status
+
+# Check with custom staleness threshold
+nf cache status --ttl 7
+
+# Clear cache for a cluster
+nf cache clear cluster1
+
+# Clear all cached data
+nf cache clear --all
+
+# Clear without confirmation
+nf cache clear --all -f
 ```
 
 ## Environment Variables

--- a/docs/usage/basics.md
+++ b/docs/usage/basics.md
@@ -102,6 +102,7 @@ nf --debug                   # Enable debug logging
 ### Available Commands
 
 ```bash
+nf cache                     # Cluster metadata cache management
 nf licenses                  # License management
 nf reports                   # Report generation
 nf events                    # Event management
@@ -219,6 +220,34 @@ db.upsert_data("cluster_metrics", {
 ```
 
 ## Common Workflows
+
+### Cluster Metadata Caching
+
+The cache stores ONTAP cluster metadata that doesn't change frequently (instance IDs, node serials, ONTAP versions, etc.). This reduces API calls and enables quick lookups.
+
+```bash
+# Populate the cache for all clusters
+nf cache refresh --all
+
+# Check cache status
+nf cache status
+
+# View cached data for a cluster
+nf cache show cluster1
+
+# View the cache schema to see available fields
+nf cache schema --flat
+
+# Query specific fields (useful for scripting)
+nf cache query cluster1 cloud.provider cloud.region
+nf cache query cluster1 cluster.ontap_version --raw
+
+# Query all clusters at once
+nf cache query --all cloud.instance_type
+
+# Query with filtering
+nf cache query -f '{"env":"Prod"}' cluster.ontap_version
+```
 
 ### License Reporting
 

--- a/src/pynetappfoundry/cli/commands/cache/__init__.py
+++ b/src/pynetappfoundry/cli/commands/cache/__init__.py
@@ -5,6 +5,7 @@ import click
 from pynetappfoundry.cli.commands.cache.clear import clear
 from pynetappfoundry.cli.commands.cache.query import query
 from pynetappfoundry.cli.commands.cache.refresh import refresh
+from pynetappfoundry.cli.commands.cache.schema import schema
 from pynetappfoundry.cli.commands.cache.show import show
 from pynetappfoundry.cli.commands.cache.status import status
 
@@ -25,5 +26,6 @@ def cache() -> None:
 cache.add_command(clear)
 cache.add_command(query)
 cache.add_command(refresh)
+cache.add_command(schema)
 cache.add_command(show)
 cache.add_command(status)

--- a/src/pynetappfoundry/cli/commands/cache/schema.py
+++ b/src/pynetappfoundry/cli/commands/cache/schema.py
@@ -1,0 +1,218 @@
+"""Cache schema command for displaying the cache metadata structure."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, TypeGuard, get_args, get_origin
+
+import click
+from pydantic import BaseModel
+from rich.console import Console
+from rich.tree import Tree
+
+from pynetappfoundry.cache.models import CachedClusterMetadata
+
+console = Console()
+
+
+def _get_type_name(annotation: Any) -> str:
+    """Get a human-readable type name from a type annotation.
+
+    Args:
+        annotation: Type annotation to convert.
+
+    Returns:
+        Human-readable type name.
+    """
+    origin = get_origin(annotation)
+    if origin is list:
+        args = get_args(annotation)
+        if args:
+            inner = _get_type_name(args[0])
+            return f"list[{inner}]"
+        return "list"
+    if origin is dict:
+        args = get_args(annotation)
+        if len(args) == 2:
+            return f"dict[{_get_type_name(args[0])}, {_get_type_name(args[1])}]"
+        return "dict"
+
+    # Handle Pydantic models
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation.__name__
+
+    # Handle basic types
+    if hasattr(annotation, "__name__"):
+        return str(annotation.__name__)
+
+    return str(annotation)
+
+
+def _is_pydantic_model(annotation: Any) -> TypeGuard[type[BaseModel]]:
+    """Check if an annotation is a Pydantic model class.
+
+    Args:
+        annotation: Type annotation to check.
+
+    Returns:
+        True if it's a Pydantic model.
+    """
+    return isinstance(annotation, type) and issubclass(annotation, BaseModel)
+
+
+def _get_list_item_type(annotation: Any) -> Any | None:
+    """Get the item type from a list annotation.
+
+    Args:
+        annotation: List type annotation.
+
+    Returns:
+        The item type, or None if not a list.
+    """
+    origin = get_origin(annotation)
+    if origin is list:
+        args = get_args(annotation)
+        if args:
+            return args[0]
+    return None
+
+
+def _build_schema_tree(
+    tree: Tree,
+    model: type[BaseModel],
+    prefix: str = "",
+    visited: set[str] | None = None,
+) -> None:
+    """Build a Rich tree showing the schema structure.
+
+    Args:
+        tree: Rich Tree to populate.
+        model: Pydantic model class to introspect.
+        prefix: Dot-notation prefix for field paths.
+        visited: Set of visited model names to prevent infinite recursion.
+    """
+    if visited is None:
+        visited = set()
+
+    model_name = model.__name__
+    if model_name in visited:
+        tree.add("[dim](recursive reference)[/dim]")
+        return
+    visited = visited | {model_name}
+
+    for field_name, field_info in model.model_fields.items():
+        annotation = field_info.annotation
+        type_name = _get_type_name(annotation)
+        full_path = f"{prefix}{field_name}" if prefix else field_name
+
+        # Check if this is a nested Pydantic model
+        if _is_pydantic_model(annotation):
+            branch = tree.add(f"[cyan]{field_name}[/cyan]: [yellow]{type_name}[/yellow]")
+            _build_schema_tree(branch, annotation, f"{full_path}.", visited)
+        # Check if this is a list of Pydantic models
+        elif get_origin(annotation) is list:
+            item_type = _get_list_item_type(annotation)
+            if item_type is not None and _is_pydantic_model(item_type):
+                branch = tree.add(
+                    f"[cyan]{field_name}[/cyan]: [yellow]{type_name}[/yellow] "
+                    f"[dim](use {field_name}[N].field)[/dim]"
+                )
+                _build_schema_tree(branch, item_type, f"{full_path}[N].", visited)
+            else:
+                tree.add(f"[cyan]{field_name}[/cyan]: [green]{type_name}[/green]")
+        else:
+            tree.add(f"[cyan]{field_name}[/cyan]: [green]{type_name}[/green]")
+
+
+def _build_flat_schema(
+    model: type[BaseModel],
+    prefix: str = "",
+    visited: set[str] | None = None,
+) -> list[tuple[str, str]]:
+    """Build a flat list of field paths and types.
+
+    Args:
+        model: Pydantic model class to introspect.
+        prefix: Dot-notation prefix for field paths.
+        visited: Set of visited model names to prevent infinite recursion.
+
+    Returns:
+        List of (path, type_name) tuples.
+    """
+    if visited is None:
+        visited = set()
+
+    model_name = model.__name__
+    if model_name in visited:
+        return []
+    visited = visited | {model_name}
+
+    result: list[tuple[str, str]] = []
+
+    for field_name, field_info in model.model_fields.items():
+        annotation = field_info.annotation
+        type_name = _get_type_name(annotation)
+        full_path = f"{prefix}{field_name}" if prefix else field_name
+
+        if _is_pydantic_model(annotation):
+            result.extend(_build_flat_schema(annotation, f"{full_path}.", visited))
+        elif get_origin(annotation) is list:
+            item_type = _get_list_item_type(annotation)
+            if item_type is not None and _is_pydantic_model(item_type):
+                result.extend(_build_flat_schema(item_type, f"{full_path}[N].", visited))
+            else:
+                result.append((full_path, type_name))
+        else:
+            result.append((full_path, type_name))
+
+    return result
+
+
+@click.command()
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output as JSON schema.",
+)
+@click.option(
+    "--flat",
+    "output_flat",
+    is_flag=True,
+    help="Output as flat list of queryable paths.",
+)
+def schema(output_json: bool, output_flat: bool) -> None:
+    """Display the cache metadata schema.
+
+    Shows the structure of cached cluster metadata, including all fields
+    and their types. Use this to discover available fields for querying
+    with 'nf cache query'.
+
+    \b
+    Examples:
+        nf cache schema              # Show schema as tree
+        nf cache schema --flat       # Show flat list of paths
+        nf cache schema --json       # Output JSON schema
+    """
+    if output_json:
+        # Output the full JSON schema from Pydantic
+        # Use click.echo instead of console.print to avoid Rich formatting
+        json_schema = CachedClusterMetadata.model_json_schema()
+        click.echo(json.dumps(json_schema, indent=2))
+    elif output_flat:
+        # Output flat list of queryable paths
+        paths = _build_flat_schema(CachedClusterMetadata)
+        console.print("\n[bold]Queryable Field Paths:[/bold]\n")
+        for path, type_name in paths:
+            console.print(f"  [cyan]{path}[/cyan]: [green]{type_name}[/green]")
+        console.print()
+        console.print("[dim]Use with: nf cache query <cluster> <path>[/dim]")
+        console.print("[dim]For arrays, replace [N] with index (e.g., nodes[0].name)[/dim]")
+    else:
+        # Output as tree
+        tree = Tree("[bold blue]CachedClusterMetadata[/bold blue]")
+        _build_schema_tree(tree, CachedClusterMetadata)
+        console.print()
+        console.print(tree)
+        console.print()
+        console.print("[dim]Use 'nf cache schema --flat' to see queryable paths[/dim]")

--- a/tests/unit/cli/commands/cache/test_schema.py
+++ b/tests/unit/cli/commands/cache/test_schema.py
@@ -1,0 +1,99 @@
+"""Tests for cache schema CLI command."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from pynetappfoundry.cli.main import nf
+
+
+class TestCacheSchemaCommand:
+    """Tests for nf cache schema command."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    def test_schema_tree_output(self, runner: CliRunner) -> None:
+        """Test default tree output."""
+        result = runner.invoke(nf, ["cache", "schema"])
+
+        assert result.exit_code == 0
+        assert "CachedClusterMetadata" in result.output
+        assert "cluster_name" in result.output
+        assert "cloud" in result.output
+        assert "cluster" in result.output
+        assert "nodes" in result.output
+
+    def test_schema_flat_output(self, runner: CliRunner) -> None:
+        """Test flat output with --flat flag."""
+        result = runner.invoke(nf, ["cache", "schema", "--flat"])
+
+        assert result.exit_code == 0
+        assert "Queryable Field Paths" in result.output
+        # Check for dotted paths
+        assert "cloud.provider" in result.output
+        assert "cloud.instance_type" in result.output
+        assert "cluster.ontap_version" in result.output
+        # Check for array notation
+        assert "nodes[N]" in result.output
+        assert "nodes[N].name" in result.output
+
+    def test_schema_json_output(self, runner: CliRunner) -> None:
+        """Test JSON schema output with --json flag."""
+        result = runner.invoke(nf, ["cache", "schema", "--json"])
+
+        assert result.exit_code == 0
+        # Should be valid JSON
+        schema = json.loads(result.output)
+        assert "properties" in schema
+        assert "cluster_name" in schema["properties"]
+        assert "cloud" in schema["properties"]
+
+    def test_schema_contains_all_top_level_fields(self, runner: CliRunner) -> None:
+        """Test that schema includes all top-level fields."""
+        result = runner.invoke(nf, ["cache", "schema", "--flat"])
+
+        assert result.exit_code == 0
+        # All top-level sections should be present
+        assert "cloud." in result.output
+        assert "cluster." in result.output
+        assert "nodes[N]." in result.output
+        assert "network." in result.output
+        assert "storage." in result.output
+        assert "licenses." in result.output
+        assert "ha." in result.output
+        assert "relationships." in result.output
+
+    def test_schema_contains_nested_fields(self, runner: CliRunner) -> None:
+        """Test that schema includes nested fields."""
+        result = runner.invoke(nf, ["cache", "schema", "--flat"])
+
+        assert result.exit_code == 0
+        # Check deeply nested paths
+        assert "network.intercluster_lifs[N].ip_address" in result.output
+        assert "storage.aggregates[N].name" in result.output
+        assert "licenses.feature_licenses[N].name" in result.output
+
+    def test_schema_shows_types(self, runner: CliRunner) -> None:
+        """Test that schema shows field types."""
+        result = runner.invoke(nf, ["cache", "schema", "--flat"])
+
+        assert result.exit_code == 0
+        # Types should be displayed
+        assert "str" in result.output
+        assert "int" in result.output
+        assert "bool" in result.output
+
+    def test_schema_help(self, runner: CliRunner) -> None:
+        """Test schema command help."""
+        result = runner.invoke(nf, ["cache", "schema", "--help"])
+
+        assert result.exit_code == 0
+        assert "Display the cache metadata schema" in result.output
+        assert "--json" in result.output
+        assert "--flat" in result.output


### PR DESCRIPTION
## Description

Adds a new `nf cache schema` command that displays the structure of cached cluster metadata. This helps users discover available fields for use with `nf cache query`.

## Related Issue

Closes #133

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `nf cache schema` command with three output formats:
  - Tree view (default): hierarchical display of fields
  - Flat list (`--flat`): queryable paths with types
  - JSON schema (`--json`): Pydantic JSON schema output
- Update CLI reference documentation with schema command
- Update usage guide with schema example
- Add plan document for cache query command

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)