### PR TITLE
feat: add --csv output option to nf cache query

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -238,6 +238,12 @@ nf cache query cluster1 nodes[*].name
 # Wildcard with raw output (one value per line, for scripting)
 nf cache query cluster1 nodes[*].name --raw
 
+# CSV output
+nf cache query --all cloud.provider cloud.region --csv
+
+# CSV with wildcards (expands to multiple rows)
+nf cache query cluster1 nodes[*].name nodes[*].serial_number --csv
+
 # View cache schema as tree
 nf cache schema
 

--- a/src/pynetappfoundry/cli/commands/cache/query.py
+++ b/src/pynetappfoundry/cli/commands/cache/query.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import csv
+import io
 import json
 from pathlib import Path
 from typing import Any
@@ -51,6 +53,78 @@ def _format_value(value: Any) -> str:
     return str(value)
 
 
+def _format_csv_value(value: Any) -> str:
+    """Format a value for CSV output.
+
+    Args:
+        value: Value to format.
+
+    Returns:
+        String representation suitable for CSV.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, dict):
+        return json.dumps(value)
+    return str(value)
+
+
+def _output_csv(
+    results: dict[str, dict[str, Any]],
+    fields: tuple[str, ...],
+) -> str:
+    """Format results as CSV.
+
+    For wildcard results (lists), expands to multiple rows.
+    All list values in a cluster result are assumed to have the same length.
+
+    Args:
+        results: Query results keyed by cluster name.
+        fields: Field names in order.
+
+    Returns:
+        CSV formatted string.
+    """
+    output = io.StringIO()
+    writer = csv.writer(output)
+
+    # Write header
+    writer.writerow(["cluster", *fields])
+
+    # Write data rows
+    for cluster_name, cluster_result in results.items():
+        # Check if any field has a list value (wildcard result)
+        list_length = 0
+        for field in fields:
+            value = cluster_result.get(field)
+            if isinstance(value, list) and list_length == 0:
+                list_length = len(value)
+                # If lists have different lengths, use the first one found
+
+        if list_length > 0:
+            # Expand wildcard results to multiple rows
+            for i in range(list_length):
+                row = [cluster_name]
+                for field in fields:
+                    value = cluster_result.get(field)
+                    if isinstance(value, list):
+                        row.append(_format_csv_value(value[i] if i < len(value) else None))
+                    else:
+                        row.append(_format_csv_value(value))
+                writer.writerow(row)
+        else:
+            # Single row for this cluster
+            row = [cluster_name]
+            for field in fields:
+                value = cluster_result.get(field)
+                row.append(_format_csv_value(value))
+            writer.writerow(row)
+
+    return output.getvalue().rstrip("\r\n")
+
+
 @click.command()
 @click.argument("cluster", required=False)
 @click.argument("fields", nargs=-1)
@@ -77,6 +151,12 @@ def _format_value(value: Any) -> str:
     is_flag=True,
     help="Output values only, no field names (single cluster only).",
 )
+@click.option(
+    "--csv",
+    "output_csv",
+    is_flag=True,
+    help="Output as CSV with header row.",
+)
 @click.pass_context
 def query(
     ctx: click.Context,
@@ -86,6 +166,7 @@ def query(
     query_all: bool,
     output_json: bool,
     raw: bool,
+    output_csv: bool,
 ) -> None:
     """Query specific fields from cached cluster metadata.
 
@@ -121,6 +202,12 @@ def query(
 
         # Wildcard with --raw (one value per line, for scripting)
         nf cache query cluster1 nodes[*].name --raw
+
+        # CSV output
+        nf cache query --all cloud.provider cloud.region --csv
+
+        # CSV with wildcards (expands to multiple rows)
+        nf cache query cluster1 nodes[*].name nodes[*].serial_number --csv
     """
     config_dir = ctx.obj.get("config_dir", "config")
 
@@ -233,6 +320,8 @@ def query(
     # Output results
     if output_json:
         console.print(json.dumps(results, default=str))
+    elif output_csv:
+        console.print(_output_csv(results, effective_fields))
     elif raw:
         # Raw output: only values, one per line
         # Only valid for single cluster (already validated above)

--- a/tests/unit/cli/commands/cache/test_query.py
+++ b/tests/unit/cli/commands/cache/test_query.py
@@ -728,3 +728,182 @@ base_api_path = "/api"
         assert result.exit_code == 0
         lines = result.output.strip().split("\n")
         assert lines == ["SN001", "SN002"]
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_csv_output_single_cluster(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test CSV output format with single cluster."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "test-cluster",
+                "cloud.provider",
+                "cloud.region",
+                "--csv",
+            ],
+        )
+
+        assert result.exit_code == 0
+        lines = result.output.strip().split("\n")
+        assert lines[0] == "cluster,cloud.provider,cloud.region"
+        assert lines[1] == "test-cluster,AWS,us-east-1"
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_csv_output_multiple_clusters(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test CSV output format with multiple clusters."""
+        mock_db = MagicMock()
+        mock_db.list_clusters.return_value = [
+            {"cluster_name": "cluster1"},
+            {"cluster_name": "cluster2"},
+        ]
+
+        metadata1 = CachedClusterMetadata(
+            cluster_name="cluster1",
+            cached_at=datetime(2024, 1, 15, tzinfo=UTC),
+            cloud=CloudMetadata(provider="AWS", region="us-east-1"),
+        )
+        metadata2 = CachedClusterMetadata(
+            cluster_name="cluster2",
+            cached_at=datetime(2024, 1, 15, tzinfo=UTC),
+            cloud=CloudMetadata(provider="Azure", region="eastus"),
+        )
+        mock_db.get.side_effect = lambda name: metadata1 if name == "cluster1" else metadata2
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "--all",
+                "cloud.provider",
+                "cloud.region",
+                "--csv",
+            ],
+        )
+
+        assert result.exit_code == 0
+        lines = result.output.strip().split("\n")
+        assert lines[0] == "cluster,cloud.provider,cloud.region"
+        assert "cluster1,AWS,us-east-1" in lines
+        assert "cluster2,Azure,eastus" in lines
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_csv_output_with_wildcard(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test CSV output with wildcard expands to multiple rows."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "test-cluster",
+                "nodes[*].name",
+                "nodes[*].serial_number",
+                "--csv",
+            ],
+        )
+
+        assert result.exit_code == 0
+        lines = result.output.strip().split("\n")
+        assert lines[0] == "cluster,nodes[*].name,nodes[*].serial_number"
+        assert lines[1] == "test-cluster,node-01,SN001"
+        assert lines[2] == "test-cluster,node-02,SN002"
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_csv_output_with_boolean(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test CSV output formats boolean values correctly."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "test-cluster",
+                "ha.is_ha",
+                "--csv",
+            ],
+        )
+
+        assert result.exit_code == 0
+        lines = result.output.strip().split("\n")
+        assert lines[0] == "cluster,ha.is_ha"
+        assert lines[1] == "test-cluster,false"
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_csv_output_with_empty_value(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test CSV output handles empty string values correctly."""
+        mock_db = MagicMock()
+        metadata = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            cached_at=datetime(2024, 1, 15, tzinfo=UTC),
+            cloud=CloudMetadata(provider="AWS", region=""),
+        )
+        mock_db.get.return_value = metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "test-cluster",
+                "cloud.provider",
+                "cloud.region",
+                "--csv",
+            ],
+        )
+
+        assert result.exit_code == 0
+        lines = result.output.strip().split("\n")
+        assert lines[0] == "cluster,cloud.provider,cloud.region"
+        assert lines[1] == "test-cluster,AWS,"


### PR DESCRIPTION
## Description

Add `--csv` flag to output cache query results in CSV format. Useful for importing data into spreadsheets or other tools.

## Related Issue

Closes #136

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `--csv` flag to `nf cache query` command
- CSV output includes header row with "cluster" + field names
- Wildcard results expand to multiple rows (one per array item)
- Added helper functions for CSV formatting

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Example usage:
```bash
# CSV output for multiple clusters
nf cache query --all cloud.provider cloud.region --csv
# Output:
# cluster,cloud.provider,cloud.region
# cluster1,AWS,us-east-1
# cluster2,Azure,eastus

# CSV with wildcards (expands to multiple rows)
nf cache query cluster1 nodes[*].name nodes[*].serial_number --csv
# Output:
# cluster,nodes[*].name,nodes[*].serial_number
# cluster1,node-01,SN001
# cluster1,node-02,SN002
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)