### PR TITLE
fix: store cloud metadata as list to capture all HA nodes

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -236,58 +236,103 @@ class MetadataCollector:
     # Cloud Metadata Collection
     # -------------------------------------------------------------------------
 
-    def collect_cloud_metadata(self) -> CloudMetadata:
+    def collect_cloud_metadata(self) -> list[CloudMetadata]:
         """Collect cloud provider metadata.
 
         Cloud metadata is only available via CLI (virtual-machine instance show).
+        Returns one CloudMetadata per node in the cluster.
 
         Returns:
-            CloudMetadata object.
+            List of CloudMetadata objects, one per node.
         """
         if self.cli_client:
             try:
                 return self._collect_cloud_metadata_via_cli()
             except Exception as e:
                 logger.warning(f"Failed to collect cloud metadata via CLI: {e}")
-        return CloudMetadata()
+        return []
 
-    def _collect_cloud_metadata_via_cli(self) -> CloudMetadata:
+    def _collect_cloud_metadata_via_cli(self) -> list[CloudMetadata]:
         """Collect cloud metadata using CLI.
 
         Returns:
-            CloudMetadata from virtual-machine instance show.
+            List of CloudMetadata from virtual-machine instance show.
         """
         if not self.cli_client:
             logger.debug("No CLI client available for cloud metadata collection")
-            return CloudMetadata()
+            return []
 
         logger.debug("CLI command: virtual-machine instance show")
         output = self.cli_client.run_command("virtual-machine instance show")
         logger.debug("CLI response: %d lines", len(output))
         return self._parse_vm_instance_output(output)
 
-    def _parse_vm_instance_output(self, output: list[str]) -> CloudMetadata:
+    def _parse_vm_instance_output(self, output: list[str]) -> list[CloudMetadata]:
         """Parse virtual-machine instance show output.
+
+        The CLI output contains entries for each node, separated by blank lines
+        or new "Node:" entries. Each node has its own cloud metadata.
 
         Args:
             output: Lines of CLI output.
 
         Returns:
-            CloudMetadata object.
+            List of CloudMetadata objects, one per node.
         """
-        data: dict[str, str] = {}
+        results: list[CloudMetadata] = []
+        current_data: dict[str, str] = {}
+        current_node: str = ""
+
         for line in output:
+            line = line.strip()
+            if not line:
+                # Empty line may indicate end of a node's data
+                continue
+
             if ":" not in line:
                 continue
-            parts = line.split(":", 1)
-            if len(parts) == 2:
-                key = parts[0].strip()
-                value = parts[1].strip()
-                # Normalize key names
-                key_normalized = self._normalize_cli_key(key)
-                data[key_normalized] = value
 
+            parts = line.split(":", 1)
+            if len(parts) != 2:
+                continue
+
+            key = parts[0].strip()
+            value = parts[1].strip()
+            key_normalized = self._normalize_cli_key(key)
+
+            # Check if this is a new node entry
+            if key_normalized == "node":
+                # Save previous node's data if we have any
+                if current_node and current_data:
+                    results.append(self._create_cloud_metadata(current_node, current_data))
+                # Start new node
+                current_node = value
+                current_data = {}
+            else:
+                current_data[key_normalized] = value
+
+        # Don't forget the last node
+        if current_node and current_data:
+            results.append(self._create_cloud_metadata(current_node, current_data))
+
+        # If no node field was found but we have data, create single entry
+        if not results and current_data:
+            results.append(self._create_cloud_metadata("", current_data))
+
+        return results
+
+    def _create_cloud_metadata(self, node: str, data: dict[str, str]) -> CloudMetadata:
+        """Create a CloudMetadata object from parsed data.
+
+        Args:
+            node: Node name.
+            data: Parsed key-value data.
+
+        Returns:
+            CloudMetadata object.
+        """
         return CloudMetadata(
+            node=node,
             instance_id=data.get("instance_id", ""),
             account_id=data.get("account_id", ""),
             image_id=data.get("image_id", ""),

--- a/src/pynetappfoundry/cache/models.py
+++ b/src/pynetappfoundry/cache/models.py
@@ -16,10 +16,12 @@ class CloudMetadata(BaseModel):
     """Cloud provider metadata from virtual-machine instance show.
 
     Contains instance-level information from the cloud provider.
+    Each node in a cluster has its own cloud metadata.
     """
 
     model_config = ConfigDict(extra="allow")
 
+    node: str = ""  # Node name this metadata belongs to
     instance_id: str = ""
     account_id: str = ""
     image_id: str = ""
@@ -252,10 +254,10 @@ class CachedClusterMetadata(BaseModel):
     # Cache metadata
     cluster_name: str
     cached_at: datetime = Field(default_factory=_utcnow)
-    cache_version: str = "1.0"
+    cache_version: str = "1.1"  # Bumped for cloud list change
 
     # Data categories
-    cloud: CloudMetadata = Field(default_factory=CloudMetadata)
+    cloud: list[CloudMetadata] = Field(default_factory=list)
     cluster: ClusterInfo = Field(default_factory=ClusterInfo)
     nodes: list[NodeInfo] = Field(default_factory=list)
     network: NetworkInfo = Field(default_factory=NetworkInfo)
@@ -279,16 +281,20 @@ class CachedClusterMetadata(BaseModel):
     def to_flat_dict(self) -> dict[str, str | int | bool | None]:
         """Convert to flat dictionary for merging with cluster config.
 
+        For cloud metadata, uses the first node's data if available.
+
         Returns:
             Flat dictionary with selected commonly-used fields.
         """
+        # Use first node's cloud data if available
+        first_cloud = self.cloud[0] if self.cloud else CloudMetadata()
         return {
-            # Cloud metadata
-            "instance_id": self.cloud.instance_id,
-            "provider": self.cloud.provider,
-            "region": self.cloud.region or self.cloud.availability_zone,
-            "instance_type": self.cloud.instance_type,
-            "availability_zone": self.cloud.availability_zone,
+            # Cloud metadata (from first node)
+            "instance_id": first_cloud.instance_id,
+            "provider": first_cloud.provider,
+            "region": first_cloud.region or first_cloud.availability_zone,
+            "instance_type": first_cloud.instance_type,
+            "availability_zone": first_cloud.availability_zone,
             # Cluster info
             "cluster_uuid": self.cluster.cluster_uuid,
             "ontap_version": self.cluster.ontap_version,

--- a/src/pynetappfoundry/core/config.py
+++ b/src/pynetappfoundry/core/config.py
@@ -339,9 +339,11 @@ class Config:
             if cache_db:
                 try:
                     cached = cache_db.get(cluster_name)
+                    # cloud is now a list of CloudMetadata, use first node's data
                     if cached and cached.cloud:
+                        first_cloud = cached.cloud[0]
                         for field in cloud_fields:
-                            cache_value = getattr(cached.cloud, field, "")
+                            cache_value = getattr(first_cloud, field, "")
                             if cache_value:  # Only override if cache has a value
                                 cluster_data[f"cloud_{field}"] = cache_value
                         logging.debug(f"{_file_name} : enriched {cluster_name} with cache data")

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -13,7 +13,6 @@ from pynetappfoundry.cache.collector import (
     ProgressInfo,
 )
 from pynetappfoundry.cache.models import (
-    CloudMetadata,
     HAInfo,
     LicenseInfo,
     NetworkInfo,
@@ -86,11 +85,13 @@ class TestCloudMetadataCollection:
         collector = MetadataCollector(cli_client=cli_client)
         result = collector.collect_cloud_metadata()
 
-        assert result.provider == "AWS"
-        assert result.instance_id == "i-0abc123def456"
-        assert result.region == "us-east-1"
-        assert result.availability_zone == "us-east-1a"
-        assert result.instance_type == "m5.2xlarge"
+        assert len(result) == 1
+        assert result[0].node == "cvo-node1"
+        assert result[0].provider == "AWS"
+        assert result[0].instance_id == "i-0abc123def456"
+        assert result[0].region == "us-east-1"
+        assert result[0].availability_zone == "us-east-1a"
+        assert result[0].instance_type == "m5.2xlarge"
 
     def test_collect_cloud_metadata_azure(self, mock_vm_instance_output_azure: list[str]) -> None:
         """Test collecting Azure cloud metadata."""
@@ -100,17 +101,47 @@ class TestCloudMetadataCollection:
         collector = MetadataCollector(cli_client=cli_client)
         result = collector.collect_cloud_metadata()
 
-        assert result.provider == "Azure"
-        assert result.fault_domain == "0"
-        assert result.resource_group_name == "rg-storage"
+        assert len(result) == 1
+        assert result[0].node == "cvo-node1"
+        assert result[0].provider == "Azure"
+        assert result[0].fault_domain == "0"
+        assert result[0].resource_group_name == "rg-storage"
+
+    def test_collect_cloud_metadata_ha_cluster(self) -> None:
+        """Test collecting cloud metadata from HA cluster with two nodes."""
+        cli_client = MagicMock()
+        cli_client.run_command.return_value = [
+            "Node: cvo-node1",
+            "    Instance ID: i-0abc123",
+            "    Provider: AWS",
+            "    Primary IP: 10.0.0.1",
+            "    Availability Zone: us-east-1a",
+            "Node: cvo-node2",
+            "    Instance ID: i-0def456",
+            "    Provider: AWS",
+            "    Primary IP: 10.0.0.2",
+            "    Availability Zone: us-east-1b",
+        ]
+
+        collector = MetadataCollector(cli_client=cli_client)
+        result = collector.collect_cloud_metadata()
+
+        assert len(result) == 2
+        assert result[0].node == "cvo-node1"
+        assert result[0].instance_id == "i-0abc123"
+        assert result[0].primary_ip == "10.0.0.1"
+        assert result[0].availability_zone == "us-east-1a"
+        assert result[1].node == "cvo-node2"
+        assert result[1].instance_id == "i-0def456"
+        assert result[1].primary_ip == "10.0.0.2"
+        assert result[1].availability_zone == "us-east-1b"
 
     def test_collect_cloud_metadata_no_cli(self) -> None:
-        """Test cloud metadata returns empty when no CLI client."""
+        """Test cloud metadata returns empty list when no CLI client."""
         collector = MetadataCollector()
         result = collector.collect_cloud_metadata()
 
-        assert result.provider == ""
-        assert result.instance_id == ""
+        assert result == []
 
     def test_collect_cloud_metadata_cli_error(self) -> None:
         """Test cloud metadata handles CLI errors gracefully."""
@@ -120,8 +151,8 @@ class TestCloudMetadataCollection:
         collector = MetadataCollector(cli_client=cli_client)
         result = collector.collect_cloud_metadata()
 
-        assert isinstance(result, CloudMetadata)
-        assert result.provider == ""
+        assert isinstance(result, list)
+        assert result == []
 
 
 class TestClusterInfoCollection:
@@ -516,7 +547,7 @@ class TestCollectAll:
 
         assert result.cluster_name == "test-cluster"
         assert result.cached_at is not None
-        assert result.cache_version == "1.0"
+        assert result.cache_version == "1.1"
 
 
 class TestNormalizeCliKey:

--- a/tests/unit/cache/test_db.py
+++ b/tests/unit/cache/test_db.py
@@ -62,7 +62,7 @@ class TestClusterMetadataDB:
         """Create sample metadata for testing."""
         return CachedClusterMetadata(
             cluster_name="test-cluster",
-            cloud=CloudMetadata(provider="AWS", region="us-east-1"),
+            cloud=[CloudMetadata(provider="AWS", region="us-east-1")],
             cluster=ClusterInfo(
                 cluster_name="test-cluster",
                 ontap_version="9.14.1",
@@ -89,7 +89,7 @@ class TestClusterMetadataDB:
 
         assert retrieved is not None
         assert retrieved.cluster_name == "test-cluster"
-        assert retrieved.cloud.provider == "AWS"
+        assert retrieved.cloud[0].provider == "AWS"
         assert retrieved.cluster.ontap_version == "9.14.1"
         assert len(retrieved.nodes) == 2
 
@@ -107,14 +107,14 @@ class TestClusterMetadataDB:
         # Update with new metadata
         updated_metadata = CachedClusterMetadata(
             cluster_name="test-cluster",
-            cloud=CloudMetadata(provider="Azure", region="eastus"),
+            cloud=[CloudMetadata(provider="Azure", region="eastus")],
         )
         db.set("test-cluster", updated_metadata)
 
         retrieved = db.get("test-cluster")
         assert retrieved is not None
-        assert retrieved.cloud.provider == "Azure"
-        assert retrieved.cloud.region == "eastus"
+        assert retrieved.cloud[0].provider == "Azure"
+        assert retrieved.cloud[0].region == "eastus"
 
     def test_clear_specific_cluster(
         self, db: ClusterMetadataDB, sample_metadata: CachedClusterMetadata

--- a/tests/unit/cache/test_models.py
+++ b/tests/unit/cache/test_models.py
@@ -393,7 +393,7 @@ class TestCachedClusterMetadata:
         """Test creating with minimal required fields."""
         metadata = CachedClusterMetadata(cluster_name="test-cluster")
         assert metadata.cluster_name == "test-cluster"
-        assert metadata.cache_version == "1.0"
+        assert metadata.cache_version == "1.1"
         assert metadata.cached_at is not None
 
     def test_cached_at_default(self) -> None:
@@ -407,7 +407,7 @@ class TestCachedClusterMetadata:
         """Test with full metadata."""
         metadata = CachedClusterMetadata(
             cluster_name="production-cluster",
-            cloud=CloudMetadata(provider="AWS", region="us-east-1"),
+            cloud=[CloudMetadata(provider="AWS", region="us-east-1")],
             cluster=ClusterInfo(
                 cluster_name="production-cluster",
                 ontap_version="9.14.1",
@@ -417,7 +417,7 @@ class TestCachedClusterMetadata:
                 NodeInfo(name="node2", serial_number="456"),
             ],
         )
-        assert metadata.cloud.provider == "AWS"
+        assert metadata.cloud[0].provider == "AWS"
         assert len(metadata.nodes) == 2
         assert metadata.cluster.ontap_version == "9.14.1"
 
@@ -457,12 +457,14 @@ class TestCachedClusterMetadata:
         """Test converting to flat dictionary."""
         metadata = CachedClusterMetadata(
             cluster_name="test-cluster",
-            cloud=CloudMetadata(
-                instance_id="i-123",
-                provider="AWS",
-                region="us-east-1",
-                instance_type="m5.xlarge",
-            ),
+            cloud=[
+                CloudMetadata(
+                    instance_id="i-123",
+                    provider="AWS",
+                    region="us-east-1",
+                    instance_type="m5.xlarge",
+                )
+            ],
             cluster=ClusterInfo(
                 cluster_uuid="abc-123",
                 ontap_version="9.14.1",
@@ -485,7 +487,7 @@ class TestCachedClusterMetadata:
         """Test JSON serialization."""
         metadata = CachedClusterMetadata(
             cluster_name="test",
-            cloud=CloudMetadata(provider="AWS"),
+            cloud=[CloudMetadata(provider="AWS")],
         )
         json_str = metadata.model_dump_json()
         assert "test" in json_str
@@ -496,8 +498,8 @@ class TestCachedClusterMetadata:
         data = {
             "cluster_name": "test",
             "cached_at": "2024-01-15T10:30:00+00:00",
-            "cache_version": "1.0",
-            "cloud": {"provider": "Azure", "region": "eastus"},
+            "cache_version": "1.1",
+            "cloud": [{"provider": "Azure", "region": "eastus"}],
             "cluster": {"ontap_version": "9.13.1"},
             "nodes": [],
             "network": {},
@@ -508,5 +510,5 @@ class TestCachedClusterMetadata:
         }
         metadata = CachedClusterMetadata.model_validate(data)
         assert metadata.cluster_name == "test"
-        assert metadata.cloud.provider == "Azure"
+        assert metadata.cloud[0].provider == "Azure"
         assert metadata.cluster.ontap_version == "9.13.1"

--- a/tests/unit/cli/commands/cache/test_query.py
+++ b/tests/unit/cli/commands/cache/test_query.py
@@ -47,11 +47,13 @@ base_api_path = "/api"
         return CachedClusterMetadata(
             cluster_name="test-cluster",
             cached_at=datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
-            cloud=CloudMetadata(
-                provider="AWS",
-                region="us-east-1",
-                instance_type="m5.xlarge",
-            ),
+            cloud=[
+                CloudMetadata(
+                    provider="AWS",
+                    region="us-east-1",
+                    instance_type="m5.xlarge",
+                )
+            ],
             cluster=ClusterInfo(
                 cluster_name="test-cluster",
                 cluster_uuid="abc-123",
@@ -78,12 +80,12 @@ base_api_path = "/api"
 
         result = runner.invoke(
             nf,
-            ["-c", str(mock_config_dir), "cache", "query", "test-cluster", "cloud.provider"],
+            ["-c", str(mock_config_dir), "cache", "query", "test-cluster", "cloud[0].provider"],
         )
 
         assert result.exit_code == 0
         assert "test-cluster:" in result.output
-        assert "cloud.provider: AWS" in result.output
+        assert "cloud[0].provider: AWS" in result.output
 
     @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
     def test_single_cluster_multiple_fields(
@@ -106,13 +108,13 @@ base_api_path = "/api"
                 "cache",
                 "query",
                 "test-cluster",
-                "cloud.provider",
+                "cloud[0].provider",
                 "cluster.ontap_version",
             ],
         )
 
         assert result.exit_code == 0
-        assert "cloud.provider: AWS" in result.output
+        assert "cloud[0].provider: AWS" in result.output
         assert "cluster.ontap_version: 9.14.1" in result.output
 
     @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
@@ -132,26 +134,26 @@ base_api_path = "/api"
         metadata1 = CachedClusterMetadata(
             cluster_name="cluster1",
             cached_at=datetime(2024, 1, 15, tzinfo=UTC),
-            cloud=CloudMetadata(provider="AWS", instance_type="m5.xlarge"),
+            cloud=[CloudMetadata(provider="AWS", instance_type="m5.xlarge")],
         )
         metadata2 = CachedClusterMetadata(
             cluster_name="cluster2",
             cached_at=datetime(2024, 1, 15, tzinfo=UTC),
-            cloud=CloudMetadata(provider="Azure", instance_type="Standard_D4s_v3"),
+            cloud=[CloudMetadata(provider="Azure", instance_type="Standard_D4s_v3")],
         )
         mock_db.get.side_effect = lambda name: metadata1 if name == "cluster1" else metadata2
         mock_db_class.return_value = mock_db
 
         result = runner.invoke(
             nf,
-            ["-c", str(mock_config_dir), "cache", "query", "--all", "cloud.instance_type"],
+            ["-c", str(mock_config_dir), "cache", "query", "--all", "cloud[0].instance_type"],
         )
 
         assert result.exit_code == 0
         assert "cluster1:" in result.output
-        assert "cloud.instance_type: m5.xlarge" in result.output
+        assert "cloud[0].instance_type: m5.xlarge" in result.output
         assert "cluster2:" in result.output
-        assert "cloud.instance_type: Standard_D4s_v3" in result.output
+        assert "cloud[0].instance_type: Standard_D4s_v3" in result.output
 
     @patch("pynetappfoundry.cli.commands.cache.query.Config")
     @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
@@ -171,7 +173,7 @@ base_api_path = "/api"
         metadata = CachedClusterMetadata(
             cluster_name="prod-cluster",
             cached_at=datetime(2024, 1, 15, tzinfo=UTC),
-            cloud=CloudMetadata(provider="AWS", region="us-east-1"),
+            cloud=[CloudMetadata(provider="AWS", region="us-east-1")],
         )
         mock_db.get.return_value = metadata
         mock_db_class.return_value = mock_db
@@ -185,15 +187,15 @@ base_api_path = "/api"
                 "query",
                 "-f",
                 '{"env":"prod"}',
-                "cloud.provider",
-                "cloud.region",
+                "cloud[0].provider",
+                "cloud[0].region",
             ],
         )
 
         assert result.exit_code == 0
         assert "prod-cluster:" in result.output
-        assert "cloud.provider: AWS" in result.output
-        assert "cloud.region: us-east-1" in result.output
+        assert "cloud[0].provider: AWS" in result.output
+        assert "cloud[0].region: us-east-1" in result.output
 
     @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
     def test_json_output(
@@ -216,14 +218,14 @@ base_api_path = "/api"
                 "cache",
                 "query",
                 "test-cluster",
-                "cloud.instance_type",
+                "cloud[0].instance_type",
                 "--json",
             ],
         )
 
         assert result.exit_code == 0
         output = json.loads(result.output)
-        assert output == {"test-cluster": {"cloud.instance_type": "m5.xlarge"}}
+        assert output == {"test-cluster": {"cloud[0].instance_type": "m5.xlarge"}}
 
     @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
     def test_raw_output(
@@ -268,7 +270,7 @@ base_api_path = "/api"
                 "cache",
                 "query",
                 "--all",
-                "cloud.provider",
+                "cloud[0].provider",
                 "--raw",
             ],
         )
@@ -332,7 +334,7 @@ base_api_path = "/api"
 
         result = runner.invoke(
             nf,
-            ["-c", str(mock_config_dir), "cache", "query", "nonexistent", "cloud.provider"],
+            ["-c", str(mock_config_dir), "cache", "query", "nonexistent", "cloud[0].provider"],
         )
 
         assert result.exit_code != 0
@@ -346,10 +348,10 @@ base_api_path = "/api"
         """Test error when no cluster selection method specified."""
         result = runner.invoke(
             nf,
-            ["-c", str(mock_config_dir), "cache", "query", "cloud.provider"],
+            ["-c", str(mock_config_dir), "cache", "query", "cloud[0].provider"],
         )
 
-        # Click will parse "cloud.provider" as the CLUSTER argument but no fields
+        # Click will parse "cloud[0].provider" as the CLUSTER argument but no fields
         # So we expect an error about missing fields
         assert result.exit_code != 0
 
@@ -381,7 +383,7 @@ base_api_path = "/api"
                 "cache",
                 "query",
                 "cluster1",
-                "cloud.provider",
+                "cloud[0].provider",
             ],
         )
 
@@ -401,7 +403,7 @@ base_api_path = "/api"
         metadata = CachedClusterMetadata(
             cluster_name="cluster1",
             cached_at=datetime(2024, 1, 15, tzinfo=UTC),
-            cloud=CloudMetadata(provider="AWS", region="us-east-1"),
+            cloud=[CloudMetadata(provider="AWS", region="us-east-1")],
         )
         mock_db.get.return_value = metadata
         mock_db_class.return_value = mock_db
@@ -415,14 +417,14 @@ base_api_path = "/api"
                 "cache",
                 "query",
                 "--all",
-                "cloud.provider",
-                "cloud.region",
+                "cloud[0].provider",
+                "cloud[0].region",
             ],
         )
 
         assert result.exit_code == 0
-        assert "cloud.provider: AWS" in result.output
-        assert "cloud.region: us-east-1" in result.output
+        assert "cloud[0].provider: AWS" in result.output
+        assert "cloud[0].region: us-east-1" in result.output
 
     @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
     def test_empty_cache_with_all(
@@ -438,7 +440,7 @@ base_api_path = "/api"
 
         result = runner.invoke(
             nf,
-            ["-c", str(mock_config_dir), "cache", "query", "--all", "cloud.provider"],
+            ["-c", str(mock_config_dir), "cache", "query", "--all", "cloud[0].provider"],
         )
 
         assert result.exit_code == 0
@@ -470,7 +472,7 @@ base_api_path = "/api"
                 "query",
                 "-f",
                 '{"env":"nonexistent"}',
-                "cloud.provider",
+                "cloud[0].provider",
             ],
         )
 
@@ -492,7 +494,7 @@ base_api_path = "/api"
                 "query",
                 "-f",
                 "not valid json",
-                "cloud.provider",
+                "cloud[0].provider",
             ],
         )
 
@@ -520,8 +522,8 @@ base_api_path = "/api"
                 "cache",
                 "query",
                 "test-cluster",
-                "cloud.provider",
-                "cloud.region",
+                "cloud[0].provider",
+                "cloud[0].region",
                 "cluster.ontap_version",
                 "--json",
             ],
@@ -531,8 +533,8 @@ base_api_path = "/api"
         output = json.loads(result.output)
         assert output == {
             "test-cluster": {
-                "cloud.provider": "AWS",
-                "cloud.region": "us-east-1",
+                "cloud[0].provider": "AWS",
+                "cloud[0].region": "us-east-1",
                 "cluster.ontap_version": "9.14.1",
             }
         }
@@ -558,7 +560,7 @@ base_api_path = "/api"
                 "cache",
                 "query",
                 "test-cluster",
-                "cloud.provider",
+                "cloud[0].provider",
                 "cluster.ontap_version",
                 "--raw",
             ],
@@ -750,15 +752,15 @@ base_api_path = "/api"
                 "cache",
                 "query",
                 "test-cluster",
-                "cloud.provider",
-                "cloud.region",
+                "cloud[0].provider",
+                "cloud[0].region",
                 "--csv",
             ],
         )
 
         assert result.exit_code == 0
         lines = result.output.strip().split("\n")
-        assert lines[0] == "cluster,cloud.provider,cloud.region"
+        assert lines[0] == "cluster,cloud[0].provider,cloud[0].region"
         assert lines[1] == "test-cluster,AWS,us-east-1"
 
     @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
@@ -778,12 +780,12 @@ base_api_path = "/api"
         metadata1 = CachedClusterMetadata(
             cluster_name="cluster1",
             cached_at=datetime(2024, 1, 15, tzinfo=UTC),
-            cloud=CloudMetadata(provider="AWS", region="us-east-1"),
+            cloud=[CloudMetadata(provider="AWS", region="us-east-1")],
         )
         metadata2 = CachedClusterMetadata(
             cluster_name="cluster2",
             cached_at=datetime(2024, 1, 15, tzinfo=UTC),
-            cloud=CloudMetadata(provider="Azure", region="eastus"),
+            cloud=[CloudMetadata(provider="Azure", region="eastus")],
         )
         mock_db.get.side_effect = lambda name: metadata1 if name == "cluster1" else metadata2
         mock_db_class.return_value = mock_db
@@ -796,15 +798,15 @@ base_api_path = "/api"
                 "cache",
                 "query",
                 "--all",
-                "cloud.provider",
-                "cloud.region",
+                "cloud[0].provider",
+                "cloud[0].region",
                 "--csv",
             ],
         )
 
         assert result.exit_code == 0
         lines = result.output.strip().split("\n")
-        assert lines[0] == "cluster,cloud.provider,cloud.region"
+        assert lines[0] == "cluster,cloud[0].provider,cloud[0].region"
         assert "cluster1,AWS,us-east-1" in lines
         assert "cluster2,Azure,eastus" in lines
 
@@ -884,7 +886,7 @@ base_api_path = "/api"
         metadata = CachedClusterMetadata(
             cluster_name="test-cluster",
             cached_at=datetime(2024, 1, 15, tzinfo=UTC),
-            cloud=CloudMetadata(provider="AWS", region=""),
+            cloud=[CloudMetadata(provider="AWS", region="")],
         )
         mock_db.get.return_value = metadata
         mock_db_class.return_value = mock_db
@@ -897,13 +899,13 @@ base_api_path = "/api"
                 "cache",
                 "query",
                 "test-cluster",
-                "cloud.provider",
-                "cloud.region",
+                "cloud[0].provider",
+                "cloud[0].region",
                 "--csv",
             ],
         )
 
         assert result.exit_code == 0
         lines = result.output.strip().split("\n")
-        assert lines[0] == "cluster,cloud.provider,cloud.region"
+        assert lines[0] == "cluster,cloud[0].provider,cloud[0].region"
         assert lines[1] == "test-cluster,AWS,"

--- a/tests/unit/cli/commands/cache/test_schema.py
+++ b/tests/unit/cli/commands/cache/test_schema.py
@@ -35,9 +35,9 @@ class TestCacheSchemaCommand:
 
         assert result.exit_code == 0
         assert "Queryable Field Paths" in result.output
-        # Check for dotted paths
-        assert "cloud.provider" in result.output
-        assert "cloud.instance_type" in result.output
+        # Check for dotted paths - cloud is now a list
+        assert "cloud[N].provider" in result.output
+        assert "cloud[N].instance_type" in result.output
         assert "cluster.ontap_version" in result.output
         # Check for array notation
         assert "nodes[N]" in result.output
@@ -60,7 +60,7 @@ class TestCacheSchemaCommand:
 
         assert result.exit_code == 0
         # All top-level sections should be present
-        assert "cloud." in result.output
+        assert "cloud[N]." in result.output  # cloud is now a list
         assert "cluster." in result.output
         assert "nodes[N]." in result.output
         assert "network." in result.output

--- a/tests/unit/cli/commands/cache/test_show.py
+++ b/tests/unit/cli/commands/cache/test_show.py
@@ -41,7 +41,7 @@ base_api_path = "/api"
         return CachedClusterMetadata(
             cluster_name="test-cluster",
             cached_at=datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
-            cloud=CloudMetadata(provider="AWS", region="us-east-1"),
+            cloud=[CloudMetadata(provider="AWS", region="us-east-1")],
         )
 
     @patch("pynetappfoundry.cli.commands.cache.show.ClusterMetadataDB")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -893,13 +893,15 @@ class TestCacheEnrichment:
             db = ClusterMetadataDB(config=config1)
             cached_metadata = CachedClusterMetadata(
                 cluster_name="test-cluster-1",
-                cloud=CloudMetadata(
-                    provider="Azure",
-                    region="eastus",
-                    account_id="sub-12345",
-                    resource_group_name="rg-test",
-                    instance_type="Standard_E20ds_v5",
-                ),
+                cloud=[
+                    CloudMetadata(
+                        provider="Azure",
+                        region="eastus",
+                        account_id="sub-12345",
+                        resource_group_name="rg-test",
+                        instance_type="Standard_E20ds_v5",
+                    )
+                ],
             )
             db.set("test-cluster-1", cached_metadata)
             db.close()
@@ -952,7 +954,7 @@ class TestCacheEnrichment:
                 "test-cluster-1",
                 CachedClusterMetadata(
                     cluster_name="test-cluster-1",
-                    cloud=CloudMetadata(provider="Azure", region="eastus"),
+                    cloud=[CloudMetadata(provider="Azure", region="eastus")],
                 ),
             )
             # Add AWS cluster
@@ -960,7 +962,7 @@ class TestCacheEnrichment:
                 "test-cluster-2",
                 CachedClusterMetadata(
                     cluster_name="test-cluster-2",
-                    cloud=CloudMetadata(provider="AWS", region="us-east-1"),
+                    cloud=[CloudMetadata(provider="AWS", region="us-east-1")],
                 ),
             )
             db.close()


### PR DESCRIPTION
## Description

Fixes cloud metadata cache to store all node data in HA clusters instead of only one node.

## Related Issue

Closes #138

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Changed `cloud` field from `CloudMetadata` to `list[CloudMetadata]`
- Added `node` field to `CloudMetadata` to identify which node the data belongs to
- Updated collector to parse all node entries from CLI output
- Bumped cache version to indicate schema change
- Updated all affected tests for new structure

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This is a breaking change for existing cache data. Users will need to run `nf cache refresh` after upgrading to rebuild the cache with the new schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)