### PR TITLE
fix: handle invalid cluster name gracefully in cache show

### DIFF
--- a/src/pynetappfoundry/cli/commands/cache/show.py
+++ b/src/pynetappfoundry/cli/commands/cache/show.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import click
@@ -13,6 +14,7 @@ from pynetappfoundry.cache import ClusterMetadataDB
 from pynetappfoundry.cli.utils import print_error, print_exception, print_warning
 from pynetappfoundry.core.config import Config
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 
@@ -136,7 +138,17 @@ def show(ctx: click.Context, cluster: str | None, section: str | None, output_js
         return
 
     # Show specific cluster
-    metadata = db.get(cluster)
+    try:
+        metadata = db.get(cluster)
+    except ValueError as e:
+        logger.debug("Invalid cluster name: %s", e)
+        db.close()
+        print_error(f"Invalid cluster name: '{cluster}'")
+        # Check if it looks like a query path
+        if "." in cluster or "[" in cluster:
+            console.print("Did you mean to use [cyan]nf cache query[/cyan] instead?")
+            console.print(f"  Example: nf cache query --all {cluster}")
+        ctx.exit(1)
     db.close()
 
     if not metadata:

--- a/tests/unit/cli/commands/cache/test_show.py
+++ b/tests/unit/cli/commands/cache/test_show.py
@@ -177,3 +177,47 @@ base_api_path = "/api"
         )
         assert result.exit_code != 0
         assert "not found" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.show.ClusterMetadataDB")
+    def test_show_invalid_cluster_name(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test showing invalid cluster name gives user-friendly error."""
+        mock_db = MagicMock()
+        mock_db.get.side_effect = ValueError("Invalid cluster name")
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "show", "cloud[*].account_id"],
+        )
+
+        assert result.exit_code != 0
+        assert "Invalid cluster name" in result.output
+        # Should suggest using cache query instead
+        assert "nf cache query" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.show.ClusterMetadataDB")
+    def test_show_invalid_cluster_name_no_query_suggestion(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test invalid cluster name without dots doesn't suggest query."""
+        mock_db = MagicMock()
+        mock_db.get.side_effect = ValueError("Invalid cluster name")
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "show", "invalid@name!"],
+        )
+
+        assert result.exit_code != 0
+        assert "Invalid cluster name" in result.output
+        # Should NOT suggest cache query for names without dots/brackets
+        assert "nf cache query" not in result.output


### PR DESCRIPTION
## Description

Fixes the traceback displayed when an invalid cluster name is passed to `nf cache show`. Now displays a user-friendly error message and suggests using `nf cache query` if the input looks like a query path.

## Related Issue

Closes #142

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added try/except around `db.get()` to catch ValueError
- Logs exception at debug level
- Displays user-friendly error message
- Suggests `nf cache query` when input contains dots or brackets

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Example

Before:
```
$ nf cache show cloud[*].account_id
Traceback (most recent call last):
  ...
ValueError: Invalid cluster name: 'cloud[*].account_id'...
```

After:
```
$ nf cache show cloud[*].account_id
Error: Invalid cluster name: 'cloud[*].account_id'
Did you mean to use nf cache query instead?
  Example: nf cache query --all cloud[*].account_id
```