### PR TITLE
feat: add timeout support to ONTAPCLI SSH commands

### DIFF
--- a/src/pynetappfoundry/clients/__init__.py
+++ b/src/pynetappfoundry/clients/__init__.py
@@ -2,13 +2,14 @@
 
 from pynetappfoundry.clients.dii.api import DIIAPIClient
 from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
-from pynetappfoundry.clients.ontap.cli import ONTAPCLI, CLICommandError
+from pynetappfoundry.clients.ontap.cli import ONTAPCLI, CLICommandError, CLITimeoutError
 from pynetappfoundry.clients.openapi import APIWrapper
 
 __all__ = [
     "ONTAPCLI",
     "APIWrapper",
     "CLICommandError",
+    "CLITimeoutError",
     "DIIAPIClient",
     "ONTAPAPIClient",
 ]

--- a/src/pynetappfoundry/clients/ontap/__init__.py
+++ b/src/pynetappfoundry/clients/ontap/__init__.py
@@ -1,6 +1,6 @@
 """ONTAP client modules."""
 
 from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
-from pynetappfoundry.clients.ontap.cli import ONTAPCLI, CLICommandError
+from pynetappfoundry.clients.ontap.cli import ONTAPCLI, CLICommandError, CLITimeoutError
 
-__all__ = ["ONTAPCLI", "CLICommandError", "ONTAPAPIClient"]
+__all__ = ["ONTAPCLI", "CLICommandError", "CLITimeoutError", "ONTAPAPIClient"]

--- a/src/pynetappfoundry/clients/ontap/cli.py
+++ b/src/pynetappfoundry/clients/ontap/cli.py
@@ -33,8 +33,30 @@ class CLICommandError(Exception):
         super().__init__(self.message)
 
 
+class CLITimeoutError(CLICommandError):
+    """Exception raised when a CLI command times out.
+
+    Attributes:
+        message: The error message.
+        timeout: The timeout value that was exceeded.
+    """
+
+    def __init__(self, message: str, timeout: float) -> None:
+        """Initialize the exception.
+
+        Args:
+            message: The error message.
+            timeout: The timeout value in seconds.
+        """
+        self.timeout = timeout
+        super().__init__(message)
+
+
 class ONTAPCLI:
     """Class to run commands through the ONTAP CLI."""
+
+    # Default timeout for CLI commands in seconds
+    DEFAULT_TIMEOUT: float = 10.0
 
     def __init__(
         self,
@@ -42,6 +64,7 @@ class ONTAPCLI:
         host_or_ip: str,
         username: str,
         password: str,
+        timeout: float | None = None,
     ) -> None:
         """Initialize the ONTAP CLI client.
 
@@ -50,11 +73,13 @@ class ONTAPCLI:
             host_or_ip: IP address or hostname to connect to.
             username: SSH username.
             password: SSH password.
+            timeout: Default timeout for commands in seconds. Defaults to 10s.
         """
         self.name = name
         self.host = host_or_ip
         self.username = username
         self.password = password
+        self.timeout = timeout if timeout is not None else self.DEFAULT_TIMEOUT
 
         self.ssh: paramiko.SSHClient = paramiko.SSHClient()
         self.ssh.load_system_host_keys()
@@ -162,6 +187,7 @@ class ONTAPCLI:
         arguments: str = "",
         respondto: str = " {y|n}:",
         response: str = "y\n",
+        timeout: float | None = None,
     ) -> list[str]:
         """Run a command through the CLI and return the output.
 
@@ -170,42 +196,77 @@ class ONTAPCLI:
             arguments: Arguments to the command.
             respondto: Prompt pattern to respond to.
             response: Response string to send.
+            timeout: Command timeout in seconds. Uses instance default if not specified.
 
         Returns:
             List of output lines.
 
         Raises:
             CLICommandError: If the command returns an error.
+            CLITimeoutError: If the command times out.
         """
         output: list[str] = []
+        effective_timeout = timeout if timeout is not None else self.timeout
 
         self.connect()
         logging.info(f"host {self.name}:{self.host} - running '{cmd}'")
 
-        stdin, stdout, _stderr = self.cli.exec_command(f"{cmd} {arguments}")
+        full_command = f"{cmd} {arguments}"
 
-        # Read raw bytes and decode with error handling for non-UTF-8 characters
-        raw_output = stdout.read()
-        decoded_output = raw_output.decode("utf-8", errors="replace")
+        # Get transport and open a channel with timeout
+        transport = self.ssh.get_transport()
+        if not transport:
+            raise CLICommandError("SSH transport not available")
 
-        for line in decoded_output.splitlines():
-            line = line.rstrip()
-            logging.info(line)
-            if not line or line == "\x07":
-                continue
+        channel = transport.open_session()
+        channel.settimeout(effective_timeout)
 
-            if any(line_to_skip in line for line_to_skip in self.lines_to_skip):
-                continue
+        try:
+            channel.exec_command(full_command)
 
-            if "Error:" in line:
-                raise CLICommandError(line)
+            # Read output with timeout
+            raw_output = b""
+            while True:
+                try:
+                    chunk = channel.recv(4096)
+                    if not chunk:
+                        break
+                    raw_output += chunk
+                except TimeoutError:
+                    channel.close()
+                    raise CLITimeoutError(
+                        f"Command '{cmd}' timed out after {effective_timeout} seconds",
+                        timeout=effective_timeout,
+                    ) from None
 
-            if respondto in line:
-                logging.info(f"found {respondto} and sending {response}")
-                stdin.write(response)
-                stdin.flush()
-            else:
-                output.append(line)
+            decoded_output = raw_output.decode("utf-8", errors="replace")
+
+            for line in decoded_output.splitlines():
+                line = line.rstrip()
+                logging.info(line)
+                if not line or line == "\x07":
+                    continue
+
+                if any(line_to_skip in line for line_to_skip in self.lines_to_skip):
+                    continue
+
+                if "Error:" in line:
+                    raise CLICommandError(line)
+
+                if respondto in line:
+                    logging.info(f"found {respondto} and sending {response}")
+                    channel.send(response.encode())
+                else:
+                    output.append(line)
+
+        except TimeoutError:
+            channel.close()
+            raise CLITimeoutError(
+                f"Command '{cmd}' timed out after {effective_timeout} seconds",
+                timeout=effective_timeout,
+            ) from None
+        finally:
+            channel.close()
 
         return output
 

--- a/tests/unit/clients/__init__.py
+++ b/tests/unit/clients/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for client modules."""

--- a/tests/unit/clients/ontap/__init__.py
+++ b/tests/unit/clients/ontap/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for ONTAP client modules."""

--- a/tests/unit/clients/ontap/test_cli.py
+++ b/tests/unit/clients/ontap/test_cli.py
@@ -1,0 +1,301 @@
+"""Unit tests for ONTAP CLI client."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pynetappfoundry.clients.ontap.cli import (
+    ONTAPCLI,
+    CLICommandError,
+    CLITimeoutError,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+class TestCLITimeoutError:
+    """Tests for CLITimeoutError exception."""
+
+    def test_inherits_from_cli_command_error(self) -> None:
+        """CLITimeoutError should inherit from CLICommandError."""
+        error = CLITimeoutError("Test timeout", timeout=30.0)
+        assert isinstance(error, CLICommandError)
+
+    def test_stores_timeout_value(self) -> None:
+        """CLITimeoutError should store the timeout value."""
+        error = CLITimeoutError("Test timeout", timeout=45.5)
+        assert error.timeout == 45.5
+        assert error.message == "Test timeout"
+
+    def test_can_be_caught_as_cli_command_error(self) -> None:
+        """CLITimeoutError can be caught as CLICommandError."""
+        with pytest.raises(CLICommandError):
+            raise CLITimeoutError("Timeout occurred", timeout=60.0)
+
+
+class TestONTAPCLITimeout:
+    """Tests for ONTAPCLI timeout functionality."""
+
+    def test_default_timeout(self) -> None:
+        """ONTAPCLI should have a default timeout of 10 seconds."""
+        with patch("paramiko.SSHClient"):
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+            assert cli.timeout == 10.0
+
+    def test_custom_timeout_in_init(self) -> None:
+        """ONTAPCLI should accept custom timeout in __init__."""
+        with patch("paramiko.SSHClient"):
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+                timeout=120.0,
+            )
+            assert cli.timeout == 120.0
+
+    def test_zero_timeout_is_valid(self) -> None:
+        """Zero timeout should be accepted (though not practical)."""
+        with patch("paramiko.SSHClient"):
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+                timeout=0,
+            )
+            assert cli.timeout == 0
+
+    def test_run_command_uses_instance_timeout(self) -> None:
+        """run_command should use the instance timeout by default."""
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            mock_transport = MagicMock()
+            mock_channel = MagicMock()
+            mock_ssh.get_transport.return_value = mock_transport
+            mock_transport.open_session.return_value = mock_channel
+            mock_transport.is_active.return_value = True
+            mock_channel.recv.return_value = b""
+
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+                timeout=90.0,
+            )
+
+            cli.run_command("test command")
+
+            mock_channel.settimeout.assert_called_once_with(90.0)
+
+    def test_run_command_timeout_override(self) -> None:
+        """run_command should allow timeout override per-call."""
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            mock_transport = MagicMock()
+            mock_channel = MagicMock()
+            mock_ssh.get_transport.return_value = mock_transport
+            mock_transport.open_session.return_value = mock_channel
+            mock_transport.is_active.return_value = True
+            mock_channel.recv.return_value = b""
+
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+                timeout=60.0,
+            )
+
+            cli.run_command("test command", timeout=30.0)
+
+            mock_channel.settimeout.assert_called_once_with(30.0)
+
+    def test_timeout_raises_cli_timeout_error(self) -> None:
+        """run_command should raise CLITimeoutError on socket.timeout."""
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            mock_transport = MagicMock()
+            mock_channel = MagicMock()
+            mock_ssh.get_transport.return_value = mock_transport
+            mock_transport.open_session.return_value = mock_channel
+            mock_transport.is_active.return_value = True
+            mock_channel.recv.side_effect = TimeoutError("timed out")
+
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+                timeout=5.0,
+            )
+
+            with pytest.raises(CLITimeoutError) as exc_info:
+                cli.run_command("slow command")
+
+            assert exc_info.value.timeout == 5.0
+            assert "slow command" in str(exc_info.value)
+            assert "5.0 seconds" in str(exc_info.value)
+            mock_channel.close.assert_called()
+
+    def test_timeout_error_includes_command_name(self) -> None:
+        """CLITimeoutError message should include the command name."""
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            mock_transport = MagicMock()
+            mock_channel = MagicMock()
+            mock_ssh.get_transport.return_value = mock_transport
+            mock_transport.open_session.return_value = mock_channel
+            mock_transport.is_active.return_value = True
+            mock_channel.recv.side_effect = TimeoutError("timed out")
+
+            cli = ONTAPCLI(
+                name="test-cluster",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+                timeout=10.0,
+            )
+
+            with pytest.raises(CLITimeoutError) as exc_info:
+                cli.run_command("virtual-machine instance show")
+
+            assert "virtual-machine instance show" in str(exc_info.value)
+
+    def test_channel_closed_on_timeout(self) -> None:
+        """Channel should be closed when timeout occurs."""
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            mock_transport = MagicMock()
+            mock_channel = MagicMock()
+            mock_ssh.get_transport.return_value = mock_transport
+            mock_transport.open_session.return_value = mock_channel
+            mock_transport.is_active.return_value = True
+            mock_channel.recv.side_effect = TimeoutError("timed out")
+
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+
+            with pytest.raises(CLITimeoutError):
+                cli.run_command("test")
+
+            # Channel should be closed (called in except block and finally)
+            assert mock_channel.close.call_count >= 1
+
+
+class TestONTAPCLIRunCommand:
+    """Tests for ONTAPCLI.run_command method."""
+
+    def test_successful_command_returns_output(self) -> None:
+        """run_command should return parsed output lines."""
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            mock_transport = MagicMock()
+            mock_channel = MagicMock()
+            mock_ssh.get_transport.return_value = mock_transport
+            mock_transport.open_session.return_value = mock_channel
+            mock_transport.is_active.return_value = True
+            # Return output then empty to signal end
+            mock_channel.recv.side_effect = [b"Node: node1\nStatus: up\n", b""]
+
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+
+            result = cli.run_command("system node show")
+
+            assert "Node: node1" in result
+            assert "Status: up" in result
+
+    def test_error_in_output_raises_cli_command_error(self) -> None:
+        """run_command should raise CLICommandError if output contains Error:."""
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            mock_transport = MagicMock()
+            mock_channel = MagicMock()
+            mock_ssh.get_transport.return_value = mock_transport
+            mock_transport.open_session.return_value = mock_channel
+            mock_transport.is_active.return_value = True
+            mock_channel.recv.side_effect = [b"Error: command not found\n", b""]
+
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+
+            with pytest.raises(CLICommandError) as exc_info:
+                cli.run_command("invalid command")
+
+            assert "Error:" in str(exc_info.value)
+
+    def test_no_transport_raises_error(self) -> None:
+        """run_command should raise CLICommandError if transport is unavailable."""
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            mock_ssh.get_transport.return_value = None
+
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+
+            with pytest.raises(CLICommandError) as exc_info:
+                cli.run_command("test")
+
+            assert "transport not available" in str(exc_info.value)
+
+    def test_skips_login_messages(self) -> None:
+        """run_command should skip login-related messages."""
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            mock_transport = MagicMock()
+            mock_channel = MagicMock()
+            mock_ssh.get_transport.return_value = mock_transport
+            mock_transport.open_session.return_value = mock_channel
+            mock_transport.is_active.return_value = True
+            mock_channel.recv.side_effect = [
+                b"Last login time: 2024-01-01\nNode: node1\nStatus: up\n",
+                b"",
+            ]
+
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+
+            result = cli.run_command("system node show")
+
+            assert "Last login time" not in " ".join(result)
+            assert "Node: node1" in result


### PR DESCRIPTION
## Description

Add configurable timeout for CLI command execution to prevent indefinite blocking when clusters become unresponsive during SSH command execution.

## Related Issue

Closes #144

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `CLITimeoutError` exception (inherits from `CLICommandError`)
- Add `timeout` parameter to `ONTAPCLI.__init__()` with 10-second default
- Add optional `timeout` override to `run_command()` method
- Refactor `run_command()` to use channel-based execution with `settimeout()`
- Export `CLITimeoutError` from clients module

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
