### PR TITLE
feat: add cloud targets to cache storage namespace

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -20,6 +20,7 @@ from pynetappfoundry.cache.models import (
     CachedClusterMetadata,
     CapacityLicense,
     CloudMetadata,
+    CloudTargetInfo,
     ClusterInfo,
     ClusterPeer,
     HAInfo,
@@ -728,7 +729,7 @@ class MetadataCollector:
         """Collect storage info using REST API.
 
         Returns:
-            StorageInfo from aggregate and SVM endpoints.
+            StorageInfo from aggregate, SVM, and cloud target endpoints.
         """
         if not self.api_client:
             logger.debug("No API client available for storage collection")
@@ -763,13 +764,55 @@ class MetadataCollector:
             )
             svms.append(svm)
 
-        return StorageInfo(aggregates=aggregates, svms=svms)
+        # Collect cloud targets
+        cloud_targets = self._collect_cloud_targets_via_api()
+
+        return StorageInfo(aggregates=aggregates, svms=svms, cloud_targets=cloud_targets)
+
+    def _collect_cloud_targets_via_api(self) -> list[CloudTargetInfo]:
+        """Collect cloud object store targets using REST API.
+
+        Returns:
+            List of CloudTargetInfo from /cloud/targets endpoint (ONTAP 9.6+).
+        """
+        if not self.api_client:
+            logger.debug("No API client available for cloud targets collection")
+            return []
+
+        try:
+            logger.debug("API call: GET /cloud/targets?fields=*")
+            response = self.api_client.call_endpoint("/cloud/targets?fields=*", method="GET")
+            logger.debug("API response: %d cloud targets", len(response.get("records", [])))
+        except Exception as e:
+            # Endpoint may not exist on older ONTAP versions or non-cloud systems
+            logger.debug("Cloud targets endpoint not available: %s", e)
+            return []
+
+        cloud_targets = []
+        for record in response.get("records", []):
+            target = CloudTargetInfo(
+                name=record.get("name", ""),
+                uuid=record.get("uuid", ""),
+                provider_type=record.get("provider_type", ""),
+                server=record.get("server", ""),
+                container=record.get("container", ""),
+                owner=record.get("owner", ""),
+                scope=record.get("scope", ""),
+                svm=record.get("svm", {}).get("name", "") if record.get("svm") else "",
+                used=record.get("used", 0),
+                ssl_enabled=record.get("ssl_enabled", True),
+                authentication_type=record.get("authentication_type", ""),
+                ipspace=record.get("ipspace", {}).get("name", "") if record.get("ipspace") else "",
+                snapmirror_use=record.get("snapmirror_use", ""),
+            )
+            cloud_targets.append(target)
+        return cloud_targets
 
     def _collect_storage_via_cli(self) -> StorageInfo:
         """Collect storage info using CLI.
 
         Returns:
-            StorageInfo from aggr show and vserver show.
+            StorageInfo from aggr show, vserver show, and object-store config show.
         """
         if not self.cli_client:
             logger.debug("No CLI client available for storage collection")
@@ -803,7 +846,46 @@ class MetadataCollector:
             )
             svms.append(svm)
 
-        return StorageInfo(aggregates=aggregates, svms=svms)
+        # Collect cloud targets
+        cloud_targets = self._collect_cloud_targets_via_cli()
+
+        return StorageInfo(aggregates=aggregates, svms=svms, cloud_targets=cloud_targets)
+
+    def _collect_cloud_targets_via_cli(self) -> list[CloudTargetInfo]:
+        """Collect cloud object store targets using CLI.
+
+        Returns:
+            List of CloudTargetInfo from storage aggregate object-store config show.
+        """
+        if not self.cli_client:
+            logger.debug("No CLI client available for cloud targets collection")
+            return []
+
+        try:
+            logger.debug("CLI command: storage aggregate object-store config show")
+            output = self.cli_client.run_command_and_parse(
+                "storage aggregate object-store config show"
+            )
+            logger.debug("CLI response: %d cloud targets", len(output))
+        except Exception as e:
+            # Command may not be available on systems without FabricPool
+            logger.debug("Cloud targets CLI command not available: %s", e)
+            return []
+
+        cloud_targets = []
+        for target_name, data in output.items():
+            target = CloudTargetInfo(
+                name=target_name,
+                provider_type=data.get("Provider Type", ""),
+                server=data.get("Server", ""),
+                container=data.get("Container", "") or data.get("Bucket", ""),
+                owner=data.get("Owner", ""),
+                ssl_enabled=data.get("SSL Enabled", "").lower() == "true",
+                authentication_type=data.get("Authentication Type", ""),
+                ipspace=data.get("IPspace", ""),
+            )
+            cloud_targets.append(target)
+        return cloud_targets
 
     # -------------------------------------------------------------------------
     # License Collection

--- a/src/pynetappfoundry/cache/models.py
+++ b/src/pynetappfoundry/cache/models.py
@@ -149,16 +149,41 @@ class SVMInfo(BaseModel):
     root_volume_aggregate: str = ""
 
 
+class CloudTargetInfo(BaseModel):
+    """Cloud object store target configuration.
+
+    Represents a cloud target used for FabricPool tiering or SnapMirror-to-cloud.
+    Available via /cloud/targets REST API (ONTAP 9.6+).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = ""
+    uuid: str = ""
+    provider_type: str = ""  # AWS_S3, Azure_Cloud, SGWS, etc.
+    server: str = ""
+    container: str = ""  # Bucket/container name
+    owner: str = ""  # fabricpool, snapmirror
+    scope: str = ""  # cluster, svm (9.12+)
+    svm: str = ""
+    used: int = 0  # Space used in bytes
+    ssl_enabled: bool = True
+    authentication_type: str = ""  # key, cap, etc.
+    ipspace: str = ""
+    snapmirror_use: str = ""
+
+
 class StorageInfo(BaseModel):
     """Storage topology information.
 
-    Contains aggregates and SVMs.
+    Contains aggregates, SVMs, and cloud targets.
     """
 
     model_config = ConfigDict(extra="allow")
 
     aggregates: list[AggregateInfo] = Field(default_factory=list)
     svms: list[SVMInfo] = Field(default_factory=list)
+    cloud_targets: list[CloudTargetInfo] = Field(default_factory=list)
 
 
 class LicenseFeature(BaseModel):

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -456,6 +456,7 @@ class TestStorageCollection:
             "/svm/svms?fields=*": {
                 "records": [{"name": "svm1", "state": "running", "subtype": "default"}]
             },
+            "/cloud/targets?fields=*": {"records": []},
         }
 
     def test_collect_storage_via_api(
@@ -483,6 +484,187 @@ class TestStorageCollection:
 
         assert isinstance(result, StorageInfo)
         assert result.aggregates == []
+
+
+class TestCloudTargetsCollection:
+    """Tests for cloud targets collection."""
+
+    @pytest.fixture
+    def mock_cloud_targets_api_response(self) -> dict[str, Any]:
+        """Mock API response for /cloud/targets endpoint."""
+        return {
+            "records": [
+                {
+                    "name": "s3-target-1",
+                    "uuid": "abc-123-def-456",
+                    "provider_type": "AWS_S3",
+                    "server": "s3.us-east-1.amazonaws.com",
+                    "container": "my-bucket",
+                    "owner": "fabricpool",
+                    "scope": "cluster",
+                    "used": 1099511627776,
+                    "ssl_enabled": True,
+                    "authentication_type": "key",
+                    "ipspace": {"name": "Default"},
+                },
+                {
+                    "name": "azure-target-1",
+                    "uuid": "xyz-789",
+                    "provider_type": "Azure_Cloud",
+                    "server": "mystorageaccount.blob.core.windows.net",
+                    "container": "mycontainer",
+                    "owner": "snapmirror",
+                    "scope": "svm",
+                    "svm": {"name": "svm1"},
+                    "used": 549755813888,
+                    "ssl_enabled": True,
+                    "authentication_type": "cap",
+                    "snapmirror_use": "data_protection",
+                },
+            ]
+        }
+
+    @pytest.fixture
+    def mock_storage_with_cloud_targets_api_responses(
+        self, mock_cloud_targets_api_response: dict[str, Any]
+    ) -> dict[str, dict[str, Any]]:
+        """Mock API responses for storage endpoints including cloud targets."""
+        return {
+            "/storage/aggregates?fields=*": {
+                "records": [
+                    {
+                        "name": "aggr1",
+                        "node": {"name": "node1"},
+                        "state": "online",
+                        "block_storage": {"primary": {"disk_type": "ssd"}},
+                        "space": {"block_storage": {"size": 1099511627776, "used": 549755813888}},
+                    }
+                ]
+            },
+            "/svm/svms?fields=*": {
+                "records": [{"name": "svm1", "state": "running", "subtype": "default"}]
+            },
+            "/cloud/targets?fields=*": mock_cloud_targets_api_response,
+        }
+
+    def test_collect_cloud_targets_via_api(
+        self, mock_storage_with_cloud_targets_api_responses: dict[str, dict[str, Any]]
+    ) -> None:
+        """Test collecting cloud targets via API."""
+        api_client = MagicMock()
+        api_client.call_endpoint.side_effect = (
+            lambda endpoint, **_: mock_storage_with_cloud_targets_api_responses.get(endpoint, {})
+        )
+
+        collector = MetadataCollector(api_client=api_client)
+        result = collector.collect_storage()
+
+        assert len(result.cloud_targets) == 2
+        # Check AWS S3 target
+        s3_target = result.cloud_targets[0]
+        assert s3_target.name == "s3-target-1"
+        assert s3_target.provider_type == "AWS_S3"
+        assert s3_target.container == "my-bucket"
+        assert s3_target.owner == "fabricpool"
+        assert s3_target.used == 1099511627776
+        assert s3_target.ipspace == "Default"
+        # Check Azure target
+        azure_target = result.cloud_targets[1]
+        assert azure_target.name == "azure-target-1"
+        assert azure_target.provider_type == "Azure_Cloud"
+        assert azure_target.svm == "svm1"
+        assert azure_target.snapmirror_use == "data_protection"
+
+    def test_collect_cloud_targets_api_not_available(self) -> None:
+        """Test that cloud targets collection handles API errors gracefully."""
+        api_client = MagicMock()
+
+        def side_effect(endpoint: str, **_: Any) -> dict[str, Any]:
+            if endpoint == "/cloud/targets?fields=*":
+                raise Exception("Endpoint not available")
+            if endpoint == "/storage/aggregates?fields=*":
+                return {
+                    "records": [{"name": "aggr1", "node": {"name": "node1"}, "state": "online"}]
+                }
+            if endpoint == "/svm/svms?fields=*":
+                return {"records": [{"name": "svm1", "state": "running"}]}
+            return {}
+
+        api_client.call_endpoint.side_effect = side_effect
+
+        collector = MetadataCollector(api_client=api_client)
+        result = collector.collect_storage()
+
+        # Should still return storage info, just with empty cloud_targets
+        assert len(result.aggregates) == 1
+        assert result.cloud_targets == []
+
+    def test_collect_cloud_targets_via_cli(self) -> None:
+        """Test collecting cloud targets via CLI fallback."""
+        cli_client = MagicMock()
+        cli_client.run_command_and_parse.side_effect = [
+            # aggr show
+            {"aggr1": {"Node": "node1", "State": "online", "Type": "ssd"}},
+            # vserver show
+            {"svm1": {"Admin State": "running", "Vserver Type": "default"}},
+            # storage aggregate object-store config show
+            {
+                "s3-target-1": {
+                    "Provider Type": "AWS_S3",
+                    "Server": "s3.us-east-1.amazonaws.com",
+                    "Container": "my-bucket",
+                    "Owner": "fabricpool",
+                    "SSL Enabled": "true",
+                    "Authentication Type": "key",
+                    "IPspace": "Default",
+                }
+            },
+        ]
+
+        collector = MetadataCollector(cli_client=cli_client)
+        result = collector.collect_storage()
+
+        assert len(result.cloud_targets) == 1
+        target = result.cloud_targets[0]
+        assert target.name == "s3-target-1"
+        assert target.provider_type == "AWS_S3"
+        assert target.container == "my-bucket"
+        assert target.ssl_enabled is True
+
+    def test_collect_cloud_targets_cli_not_available(self) -> None:
+        """Test that CLI fallback handles command not available."""
+        cli_client = MagicMock()
+
+        def side_effect(cmd: str) -> dict[str, Any]:
+            if "object-store" in cmd:
+                raise Exception("Command not available")
+            if "aggr" in cmd:
+                return {"aggr1": {"Node": "node1", "State": "online"}}
+            if "vserver" in cmd:
+                return {"svm1": {"Admin State": "running"}}
+            return {}
+
+        cli_client.run_command_and_parse.side_effect = side_effect
+
+        collector = MetadataCollector(cli_client=cli_client)
+        result = collector.collect_storage()
+
+        assert len(result.aggregates) == 1
+        assert result.cloud_targets == []
+
+    def test_collect_cloud_targets_empty(self) -> None:
+        """Test collecting when no cloud targets exist."""
+        api_client = MagicMock()
+        api_client.call_endpoint.side_effect = lambda endpoint, **_: {
+            "/storage/aggregates?fields=*": {"records": []},
+            "/svm/svms?fields=*": {"records": []},
+            "/cloud/targets?fields=*": {"records": []},
+        }.get(endpoint, {})
+
+        collector = MetadataCollector(api_client=api_client)
+        result = collector.collect_storage()
+
+        assert result.cloud_targets == []
 
 
 class TestLicenseCollection:

--- a/tests/unit/cache/test_models.py
+++ b/tests/unit/cache/test_models.py
@@ -10,6 +10,7 @@ from pynetappfoundry.cache.models import (
     CachedClusterMetadata,
     CapacityLicense,
     CloudMetadata,
+    CloudTargetInfo,
     ClusterInfo,
     ClusterPeer,
     HAInfo,
@@ -239,6 +240,65 @@ class TestSVMInfo:
         assert svm.state == "running"
 
 
+class TestCloudTargetInfo:
+    """Tests for CloudTargetInfo model."""
+
+    def test_default_values(self) -> None:
+        """Test default values."""
+        target = CloudTargetInfo()
+        assert target.name == ""
+        assert target.uuid == ""
+        assert target.provider_type == ""
+        assert target.ssl_enabled is True
+        assert target.used == 0
+
+    def test_with_aws_values(self) -> None:
+        """Test with AWS S3 cloud target data."""
+        target = CloudTargetInfo(
+            name="s3-target-1",
+            uuid="abc-123-def-456",
+            provider_type="AWS_S3",
+            server="s3.us-east-1.amazonaws.com",
+            container="my-bucket",
+            owner="fabricpool",
+            scope="cluster",
+            used=1099511627776,  # 1TB
+            ssl_enabled=True,
+            authentication_type="key",
+            ipspace="Default",
+        )
+        assert target.name == "s3-target-1"
+        assert target.provider_type == "AWS_S3"
+        assert target.container == "my-bucket"
+        assert target.owner == "fabricpool"
+        assert target.used == 1099511627776
+
+    def test_with_azure_values(self) -> None:
+        """Test with Azure cloud target data."""
+        target = CloudTargetInfo(
+            name="azure-target-1",
+            provider_type="Azure_Cloud",
+            server="mystorageaccount.blob.core.windows.net",
+            container="mycontainer",
+            owner="snapmirror",
+            scope="svm",
+            svm="svm1",
+            snapmirror_use="data_protection",
+        )
+        assert target.provider_type == "Azure_Cloud"
+        assert target.owner == "snapmirror"
+        assert target.svm == "svm1"
+        assert target.snapmirror_use == "data_protection"
+
+    def test_extra_fields_allowed(self) -> None:
+        """Test that extra fields are allowed."""
+        target = CloudTargetInfo(
+            name="test-target",
+            custom_field="custom_value",
+        )
+        assert target.custom_field == "custom_value"  # type: ignore[attr-defined]
+
+
 class TestStorageInfo:
     """Tests for StorageInfo model."""
 
@@ -247,6 +307,7 @@ class TestStorageInfo:
         storage = StorageInfo()
         assert storage.aggregates == []
         assert storage.svms == []
+        assert storage.cloud_targets == []
 
     def test_with_data(self) -> None:
         """Test with storage data."""
@@ -255,6 +316,13 @@ class TestStorageInfo:
         storage = StorageInfo(aggregates=[aggr], svms=[svm])
         assert len(storage.aggregates) == 1
         assert len(storage.svms) == 1
+
+    def test_with_cloud_targets(self) -> None:
+        """Test with cloud targets."""
+        target = CloudTargetInfo(name="s3-target", provider_type="AWS_S3")
+        storage = StorageInfo(cloud_targets=[target])
+        assert len(storage.cloud_targets) == 1
+        assert storage.cloud_targets[0].name == "s3-target"
 
 
 class TestLicenseFeature:


### PR DESCRIPTION
## Description

Add cloud object-storage targets to the cache storage namespace for FabricPool and SnapMirror-to-cloud configurations.

## Related Issue

Closes #145

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `CloudTargetInfo` model with fields: name, uuid, provider_type, server, container, owner, scope, svm, used, ssl_enabled, authentication_type, ipspace, snapmirror_use
- Add `cloud_targets: list[CloudTargetInfo]` field to `StorageInfo` model
- Implement `_collect_cloud_targets_via_api()` using `/cloud/targets?fields=*` endpoint (ONTAP 9.6+)
- Implement `_collect_cloud_targets_via_cli()` using `storage aggregate object-store config show`
- Add comprehensive unit tests for models and collector

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)