### PR TITLE
feat: add structured log prefixes for SSH and API operations

### DIFF
--- a/src/pynetappfoundry/clients/ontap/api.py
+++ b/src/pynetappfoundry/clients/ontap/api.py
@@ -48,5 +48,6 @@ class ONTAPAPIClient(APIWrapper):
             base_api_path=ontap_settings.base_api_path,
             timeout=ontap_settings.timeout,
             verify_ssl=False,  # ONTAP clusters typically use self-signed certs
+            name=cluster.name,
             **kwargs,
         )

--- a/src/pynetappfoundry/clients/ontap/cli.py
+++ b/src/pynetappfoundry/clients/ontap/cli.py
@@ -95,12 +95,13 @@ class ONTAPCLI:
         ]
 
         self.pkey: paramiko.RSAKey | None = None
+        self.log_prefix = f"[{name}:ssh]"
 
     def connect(self) -> None:
         """Connect to the server via SSH."""
         transport = self.ssh.get_transport()
         if not transport or not transport.is_active():
-            logging.debug("Connect: creating connection")
+            logging.debug(f"{self.log_prefix} Connect: creating connection")
             if self.pkey:
                 self.ssh.connect(self.host, username=self.username, pkey=self.pkey)
             else:
@@ -158,7 +159,7 @@ class ONTAPCLI:
         output = self.run_command(cmd, arguments, respondto, response)
 
         if not output:
-            logging.info(f"{cmd} returned no output")
+            logging.info(f"{self.log_prefix} {cmd} returned no output")
             return [], {}
 
         headers = output[0].split(",")
@@ -210,7 +211,7 @@ class ONTAPCLI:
         effective_timeout = timeout if timeout is not None else self.timeout
 
         self.connect()
-        logging.info(f"host {self.name}:{self.host} - running '{cmd}'")
+        logging.info(f"{self.log_prefix} running '{cmd}'")
 
         full_command = f"{cmd} {arguments}"
 
@@ -264,7 +265,7 @@ class ONTAPCLI:
 
             for line in decoded_output.splitlines():
                 line = line.rstrip()
-                logging.info(line)
+                logging.info(f"{self.log_prefix} {line}")
                 if not line or line == "\x07":
                     continue
 
@@ -275,7 +276,7 @@ class ONTAPCLI:
                     raise CLICommandError(line)
 
                 if respondto in line:
-                    logging.info(f"found {respondto} and sending {response}")
+                    logging.info(f"{self.log_prefix} found {respondto} and sending {response}")
                     channel.send(response.encode())
                 else:
                     output.append(line)
@@ -323,21 +324,23 @@ class ONTAPCLI:
                 key = slist[0]
                 value = ":".join(slist[1:])
             except ValueError:
-                logging.error(f"bad line: {line}")
+                logging.error(f"{self.log_prefix} bad line: {line}")
                 continue
 
             key = key.strip()
             value = value.strip()
 
             if not primary_key:
-                logging.info(f"setting primary_key to {key}")
+                logging.info(f"{self.log_prefix} setting primary_key to {key}")
                 primary_key = key
             if not first_key:
-                logging.info(f"setting first_key to {key}")
+                logging.info(f"{self.log_prefix} setting first_key to {key}")
                 first_key = key
 
             if primary_key == first_key and key == primary_key:
-                logging.info(f"primary == first, setting current object to {value}")
+                logging.info(
+                    f"{self.log_prefix} primary == first, setting current object to {value}"
+                )
                 current_object = value
                 if current_object not in data:
                     data[current_object] = {}
@@ -345,18 +348,18 @@ class ONTAPCLI:
 
             if key == primary_key:
                 logging.info(
-                    f"primary_key != first_key, found primary key,"
+                    f"{self.log_prefix} primary_key != first_key, found primary key,"
                     f" setting current object to {value}"
                 )
                 current_object = value
                 if temp_data:
-                    logging.info("have temp_data")
+                    logging.info(f"{self.log_prefix} have temp_data")
                     data[current_object] = temp_data
                     temp_data = {}
 
             if key == first_key:
                 logging.info(
-                    "primary_key != first_key, found first key, "
+                    f"{self.log_prefix} primary_key != first_key, found first key, "
                     "setting current_object to None, updating temp_data"
                 )
                 current_object = None
@@ -386,7 +389,7 @@ class ONTAPCLI:
             **kwargs: Additional arguments for the CLI execute call.
         """
         logging.info(
-            f'{self.name} - running "{command}" with arguments'
+            f'{self.log_prefix} running "{command}" with arguments'
             f" {kwargs} and privilege: {privilege_level}"
         )
         with HostConnection(

--- a/src/pynetappfoundry/clients/openapi.py
+++ b/src/pynetappfoundry/clients/openapi.py
@@ -63,6 +63,7 @@ class APIWrapper:
         verify_ssl: bool = True,
         retry_config: RetryConfig | None = None,
         validation_config: ValidationConfig | None = None,
+        name: str = "",
     ) -> None:
         """Initialize the API wrapper.
 
@@ -76,7 +77,10 @@ class APIWrapper:
             verify_ssl: Whether to verify SSL certificates. Default True for security.
             retry_config: Configuration for retry behavior. Defaults to enabled.
             validation_config: Configuration for response validation. Defaults to disabled.
+            name: Name for log prefix (e.g., cluster name). Used in [name:api] format.
         """
+        self.name = name
+        self.log_prefix = f"[{name}:api]" if name else "[api]"
         self.verify_ssl = verify_ssl
         # Load the API spec
         with open(api_json_file, encoding="utf-8") as f:
@@ -88,7 +92,7 @@ class APIWrapper:
                 self.base_api_path = self.api_spec["basePath"]
 
         if not base_api_path:
-            logging.warning(f"No base api path found for base_url: {base_url}")
+            logging.warning(f"{self.log_prefix} No base api path found for base_url: {base_url}")
 
         if not auth_header:
             auth_header = {}
@@ -124,10 +128,12 @@ class APIWrapper:
         method = method.lower()
         path: dict[str, Any] = self.api_spec["paths"].get(api_path, {})
         if not path:
-            logging.error(f"_get_operation: did not find {api_path}")
+            logging.error(f"{self.log_prefix} _get_operation: did not find {api_path}")
         operation: dict[str, Any] = path.get(method, {})
         if not operation:
-            logging.error(f"_get_operation: could not find {operation} for {api_path}")
+            logging.error(
+                f"{self.log_prefix} _get_operation: could not find {operation} for {api_path}"
+            )
         return operation
 
     def _resolve_ref(self, ref: str) -> Any:
@@ -186,7 +192,9 @@ class APIWrapper:
         content = op.get("requestBody", {}).get("content", {}).get("application/json", {})
 
         if not content:
-            logging.error(f"_get_request_schema: no content for {path_template}:{method}")
+            logging.error(
+                f"{self.log_prefix} _get_request_schema: no content for {path_template}:{method}"
+            )
 
         schema = content.get("schema")
 
@@ -320,7 +328,7 @@ class APIWrapper:
             validate(instance=body, schema=schema)
             return True
         except ValidationError as e:
-            logging.error(f"Request body validation error: {e.message}")
+            logging.error(f"{self.log_prefix} Request body validation error: {e.message}")
             return False
 
     def suggest_parameters(self, path_template: str, method: str = "GET") -> dict[str, Any]:
@@ -441,7 +449,8 @@ class APIWrapper:
         schema = self._get_response_schema(path_template, method, status_code)
         if not schema:
             logging.debug(
-                f"No response schema found for {method} {path_template} status {status_code}"
+                f"{self.log_prefix} No response schema found for "
+                f"{method} {path_template} status {status_code}"
             )
             return True
 
@@ -450,7 +459,7 @@ class APIWrapper:
             return True
         except ValidationError as e:
             error_msg = (
-                f"Response validation failed for {method} {path_template} "
+                f"{self.log_prefix} Response validation failed for {method} {path_template} "
                 f"status {status_code}: {e.message}"
             )
             if config.strict:
@@ -496,12 +505,12 @@ class APIWrapper:
                     result = outcome.result() if exception is None else None
                     if exception:
                         logging.warning(
-                            f"Retry attempt {retry_state.attempt_number} "
+                            f"{self.log_prefix} Retry attempt {retry_state.attempt_number} "
                             f"after exception: {exception}"
                         )
                     elif result is not None and hasattr(result, "status_code"):
                         logging.warning(
-                            f"Retry attempt {retry_state.attempt_number} "
+                            f"{self.log_prefix} Retry attempt {retry_state.attempt_number} "
                             f"after status code: {result.status_code}"
                         )
 
@@ -619,9 +628,9 @@ class APIWrapper:
 
         # Build URL (formatting path placeholders)
         path = self._format_path(path_template, path_params)
-        logging.debug(f"API Path: {path}")
+        logging.debug(f"{self.log_prefix} API Path: {path}")
         url = f"{self.base_url}{path}"
-        logging.debug(f"API URL: {url}")
+        logging.debug(f"{self.log_prefix} API URL: {url}")
 
         # Encode query params
         if query_params:
@@ -632,7 +641,7 @@ class APIWrapper:
         if additional_headers:
             headers.update(additional_headers)
 
-        logging.debug(f"Calling {method} {url} {headers}")
+        logging.debug(f"{self.log_prefix} Calling {method} {url} {headers}")
 
         # Execute request with retry logic
         resp = self._execute_request_with_retry(
@@ -643,12 +652,12 @@ class APIWrapper:
             retry_config=retry_config,
         )
 
-        logging.debug(f"Response Status Code: {resp.status_code}")
+        logging.debug(f"{self.log_prefix} Response Status Code: {resp.status_code}")
         resp.raise_for_status()
 
         # Try JSON, else return text
         try:
-            logging.debug(f"Response Text: {resp.text}")
+            logging.debug(f"{self.log_prefix} Response Text: {resp.text}")
             response_data = resp.json()
         except ValueError:
             response_data = resp.text

--- a/tests/unit/clients/ontap/test_cli.py
+++ b/tests/unit/clients/ontap/test_cli.py
@@ -37,6 +37,43 @@ class TestCLITimeoutError:
             raise CLITimeoutError("Timeout occurred", timeout=60.0)
 
 
+class TestONTAPCLILogPrefix:
+    """Tests for ONTAPCLI log prefix functionality."""
+
+    def test_log_prefix_format(self) -> None:
+        """ONTAPCLI should have log_prefix in [name:ssh] format."""
+        with patch("paramiko.SSHClient"):
+            cli = ONTAPCLI(
+                name="cluster1",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+            assert cli.log_prefix == "[cluster1:ssh]"
+
+    def test_log_prefix_with_special_characters(self) -> None:
+        """ONTAPCLI should handle cluster names with special characters."""
+        with patch("paramiko.SSHClient"):
+            cli = ONTAPCLI(
+                name="cluster-prod-01",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+            assert cli.log_prefix == "[cluster-prod-01:ssh]"
+
+    def test_log_prefix_empty_name(self) -> None:
+        """ONTAPCLI should handle empty cluster name."""
+        with patch("paramiko.SSHClient"):
+            cli = ONTAPCLI(
+                name="",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+            assert cli.log_prefix == "[:ssh]"
+
+
 class TestONTAPCLITimeout:
     """Tests for ONTAPCLI timeout functionality."""
 

--- a/tests/unit/test_openapi.py
+++ b/tests/unit/test_openapi.py
@@ -127,6 +127,30 @@ class TestAPIWrapperInit:
         assert "paths" in api_wrapper.api_spec
         assert "/users" in api_wrapper.api_spec["paths"]
 
+    def test_log_prefix_with_name(self, spec_file: Path) -> None:
+        """Test log_prefix format when name is provided."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            name="cluster1",
+        )
+        assert wrapper.log_prefix == "[cluster1:api]"
+        assert wrapper.name == "cluster1"
+
+    def test_log_prefix_without_name(self, api_wrapper: APIWrapper) -> None:
+        """Test log_prefix format when name is not provided."""
+        assert api_wrapper.log_prefix == "[api]"
+        assert api_wrapper.name == ""
+
+    def test_log_prefix_with_special_characters(self, spec_file: Path) -> None:
+        """Test log_prefix with special characters in name."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            name="cluster-prod-01",
+        )
+        assert wrapper.log_prefix == "[cluster-prod-01:api]"
+
     def test_uses_base_path_from_spec(self, api_wrapper: APIWrapper) -> None:
         """Test that basePath is extracted from spec."""
         assert api_wrapper.base_api_path == "/api/v1"


### PR DESCRIPTION
## Description

Add structured log prefixes in `[cluster:source]` format to enable filtering interleaved SSH and API operations when debugging parallel requests.

Example output:
```
2026-02-04 17:58:02,020 - DEBUG - [cluster1:ssh] Connect: creating connection
2026-02-04 17:58:02,195 - DEBUG - [cluster1:api] API Path: /api/ontap/cluster
```

Filtering examples:
- `grep '\[.*:ssh\]'` - all SSH operations
- `grep '\[.*:api\]'` - all API operations
- `grep '\[cluster1:'` - all operations for cluster1

## Related Issue

Closes #154

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `log_prefix` property to `ONTAPCLI` initialized as `[name:ssh]`
- Add optional `name` parameter to `APIWrapper` with `[name:api]` prefix
- Update `ONTAPAPIClient` to pass cluster name to parent
- Update all logging calls in cli.py and openapi.py to include prefix

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)