### PR TITLE
fix: add thread-safe locking to ONTAPCLI.connect()

### DIFF
--- a/src/pynetappfoundry/clients/ontap/cli.py
+++ b/src/pynetappfoundry/clients/ontap/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 import time
 from typing import Any
 
@@ -96,19 +97,25 @@ class ONTAPCLI:
 
         self.pkey: paramiko.RSAKey | None = None
         self.log_prefix = f"[{name}:ssh]"
+        self._connect_lock = threading.Lock()
 
     def connect(self) -> None:
-        """Connect to the server via SSH."""
-        transport = self.ssh.get_transport()
-        if not transport or not transport.is_active():
-            logging.debug(f"{self.log_prefix} Connect: creating connection")
-            if self.pkey:
-                self.ssh.connect(self.host, username=self.username, pkey=self.pkey)
-            else:
-                self.ssh.connect(self.host, username=self.username, password=self.password)
+        """Connect to the server via SSH.
+
+        Thread-safe: uses a lock to prevent race conditions when multiple
+        threads attempt to connect simultaneously.
+        """
+        with self._connect_lock:
             transport = self.ssh.get_transport()
-            if transport:
-                transport.set_keepalive(5)
+            if not transport or not transport.is_active():
+                logging.debug(f"{self.log_prefix} Connect: creating connection")
+                if self.pkey:
+                    self.ssh.connect(self.host, username=self.username, pkey=self.pkey)
+                else:
+                    self.ssh.connect(self.host, username=self.username, password=self.password)
+                transport = self.ssh.get_transport()
+                if transport:
+                    transport.set_keepalive(5)
 
     def run_command_and_parse(
         self,

--- a/tests/unit/clients/ontap/test_cli.py
+++ b/tests/unit/clients/ontap/test_cli.py
@@ -74,6 +74,74 @@ class TestONTAPCLILogPrefix:
             assert cli.log_prefix == "[:ssh]"
 
 
+class TestONTAPCLIConnect:
+    """Tests for ONTAPCLI connect functionality."""
+
+    def test_connect_lock_exists(self) -> None:
+        """ONTAPCLI should have a connect lock for thread safety."""
+        with patch("paramiko.SSHClient"):
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+            assert hasattr(cli, "_connect_lock")
+            import threading
+
+            assert isinstance(cli._connect_lock, type(threading.Lock()))
+
+    def test_connect_is_thread_safe(self) -> None:
+        """Multiple threads calling connect should only create one connection."""
+        import threading
+        import time
+        from typing import Any
+
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            # First call: no transport, second+ calls: active transport
+            mock_transport = MagicMock()
+            mock_transport.is_active.return_value = True
+            # Start with no transport, then return the mock after connect
+            transport_state: dict[str, Any] = {"transport": None}
+
+            def get_transport_side_effect() -> MagicMock | None:
+                if transport_state["transport"] is None:
+                    # Simulate connection delay
+                    time.sleep(0.05)
+                    transport_state["transport"] = mock_transport
+                    return None
+                return transport_state["transport"]
+
+            mock_ssh.get_transport.side_effect = get_transport_side_effect
+
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+
+            # Reset to track actual connect calls
+            mock_ssh.connect.reset_mock()
+            transport_state["transport"] = None
+
+            # Launch multiple threads that all try to connect
+            threads = []
+            for _ in range(5):
+                t = threading.Thread(target=cli.connect)
+                threads.append(t)
+
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            # Only one connect call should have been made due to locking
+            assert mock_ssh.connect.call_count == 1
+
+
 class TestONTAPCLITimeout:
     """Tests for ONTAPCLI timeout functionality."""
 


### PR DESCRIPTION
## Description

Add a threading lock to `ONTAPCLI.connect()` to prevent race conditions when multiple threads attempt to connect simultaneously on the same instance.

When the background SSH pre-connection thread and the main thread both call `connect()` at nearly the same time, both see the transport as inactive and both attempt to connect. This corrupts paramiko's internal state and causes subsequent SSH commands to hang indefinitely.

Log evidence of the race:
```
18:34:35,475 - [ZUSCUPDAXCST110:ssh] Connect: creating connection
18:34:35,477 - [ZUSCUPDAXCST110:ssh] Connect: creating connection  (2ms later!)
```

## Related Issue

Closes #156

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `threading.Lock` (`_connect_lock`) to `ONTAPCLI.__init__()`
- Wrap connect logic in `with self._connect_lock:` context manager
- Add tests for thread-safe connect behavior

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)