### PR TITLE
feat: add azure_account and access_key to CloudTargetInfo

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -1047,6 +1047,8 @@ class MetadataCollector:
                 authentication_type=record.get("authentication_type", ""),
                 ipspace=record.get("ipspace", {}).get("name", "") if record.get("ipspace") else "",
                 snapmirror_use=record.get("snapmirror_use", ""),
+                access_key=record.get("access_key", ""),
+                azure_account=record.get("azure_account", ""),
             )
             cloud_targets.append(target)
         return cloud_targets

--- a/src/pynetappfoundry/cache/models.py
+++ b/src/pynetappfoundry/cache/models.py
@@ -171,6 +171,8 @@ class CloudTargetInfo(BaseModel):
     authentication_type: str = ""  # key, cap, etc.
     ipspace: str = ""
     snapmirror_use: str = ""
+    access_key: str = ""  # AWS/S3 access key ID
+    azure_account: str = ""  # Azure account name
 
 
 class StorageInfo(BaseModel):


### PR DESCRIPTION
## Description

Add missing fields from /cloud/targets API response to CloudTargetInfo model.

## Related Issue

Closes #158

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `access_key` field to CloudTargetInfo (AWS/S3 access key ID)
- Add `azure_account` field to CloudTargetInfo (Azure account name)
- Update `_parse_cloud_targets_response` to extract these fields

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)