### PR TITLE
fix: use cluster-based naming for Azure VM portal links

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -224,10 +224,18 @@ class MetadataCollector:
         total_elapsed = time.monotonic() - total_start
         logger.info("Completed metadata collection for %s in %.2fs", cluster_name, total_elapsed)
 
+        # Post-process Azure cloud metadata to fix instance links
+        ha_info: HAInfo = results["ha"]
+        cloud_metadata = self._update_azure_cloud_links(
+            results["cloud"],
+            cluster_name,
+            ha_info.is_ha,
+        )
+
         return CachedClusterMetadata(
             cluster_name=cluster_name,
             cached_at=datetime.now(UTC),
-            cloud=results["cloud"],
+            cloud=cloud_metadata,
             cluster=results["cluster"],
             nodes=results["nodes"],
             network=results["network"],
@@ -596,6 +604,79 @@ class MetadataCollector:
             instance_sso_link=instance_sso_link,
             resource_group_link=resource_group_link,
         )
+
+    def _update_azure_cloud_links(
+        self,
+        cloud_metadata: list[CloudMetadata],
+        cluster_name: str,
+        is_ha: bool,
+    ) -> list[CloudMetadata]:
+        """Update Azure cloud metadata with correct instance links.
+
+        Azure VM portal links require the VM name derived from cluster name
+        and node information, not the instance_id from cloud metadata.
+
+        Args:
+            cloud_metadata: List of CloudMetadata objects to update.
+            cluster_name: The cluster name.
+            is_ha: Whether the cluster is HA.
+
+        Returns:
+            Updated list of CloudMetadata with correct Azure instance links.
+        """
+        updated = []
+        for meta in cloud_metadata:
+            if meta.provider.lower() != "azure":
+                updated.append(meta)
+                continue
+
+            # Rebuild the instance link with cluster/node info
+            instance_link = build_cloud_instance_link(
+                provider=meta.provider,
+                instance_id=meta.instance_id,
+                account_id=meta.account_id,
+                resource_group=meta.resource_group_name,
+                cluster_name=cluster_name,
+                node_name=meta.node,
+                is_ha=is_ha,
+            )
+
+            # Rebuild SSO link (not applicable for Azure, but keep for consistency)
+            instance_sso_link = build_cloud_instance_sso_link(
+                provider=meta.provider,
+                instance_link=instance_link,
+                account_id=meta.account_id,
+                sso_config=self.aws_sso_config,
+            )
+
+            # Create updated CloudMetadata with new links
+            updated.append(
+                CloudMetadata(
+                    node=meta.node,
+                    instance_id=meta.instance_id,
+                    account_id=meta.account_id,
+                    image_id=meta.image_id,
+                    instance_type=meta.instance_type,
+                    cpu_platform=meta.cpu_platform,
+                    region=meta.region,
+                    provider=meta.provider,
+                    consumer=meta.consumer,
+                    primary_ip=meta.primary_ip,
+                    metadata_version=meta.metadata_version,
+                    availability_zone=meta.availability_zone,
+                    availability_zone_id=meta.availability_zone_id,
+                    fault_domain=meta.fault_domain,
+                    update_domain=meta.update_domain,
+                    resource_group_name=meta.resource_group_name,
+                    offer=meta.offer,
+                    sku=meta.sku,
+                    sku_version=meta.sku_version,
+                    instance_link=instance_link,
+                    instance_sso_link=instance_sso_link,
+                    resource_group_link=meta.resource_group_link,
+                )
+            )
+        return updated
 
     @staticmethod
     def _normalize_cli_key(key: str) -> str:

--- a/src/pynetappfoundry/utils/cloud.py
+++ b/src/pynetappfoundry/utils/cloud.py
@@ -79,6 +79,64 @@ def get_cloud_types() -> list[str]:
     return CLOUD_TYPES.copy()
 
 
+def get_node_number(node_name: str) -> int | None:
+    """Extract the node number from a node name.
+
+    ONTAP node names typically end with a numeric suffix like -01, -02.
+    This function extracts that number.
+
+    Args:
+        node_name: The node name (e.g., 'mycluster-01', 'cluster-02').
+
+    Returns:
+        The node number as an integer, or None if not found.
+    """
+    if not node_name:
+        return None
+
+    # Match trailing digits, optionally preceded by a dash or underscore
+    import re
+
+    match = re.search(r"[-_]?(\d+)$", node_name)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def build_azure_vm_name(
+    cluster_name: str,
+    node_name: str = "",
+    is_ha: bool = True,
+) -> str:
+    """Build the Azure VM name for an ONTAP instance.
+
+    Azure VMs for ONTAP follow a naming convention based on cluster name:
+    - HA clusters: <cluster>-vm1 for node 01, <cluster>-vm2 for node 02
+    - Single node: <cluster>
+
+    Args:
+        cluster_name: The ONTAP cluster name.
+        node_name: The node name (used to determine node number for HA).
+        is_ha: Whether the cluster is HA (default True).
+
+    Returns:
+        The Azure VM name, or empty string if cluster_name is missing.
+    """
+    if not cluster_name:
+        return ""
+
+    if not is_ha:
+        return cluster_name
+
+    # For HA, derive VM name from node number
+    node_num = get_node_number(node_name)
+    if node_num is not None:
+        return f"{cluster_name}-vm{node_num}"
+
+    # Fallback: if we can't determine node number, return cluster name
+    return cluster_name
+
+
 def build_aws_instance_link(region: str, instance_id: str) -> str:
     """Build an AWS EC2 console URL for an instance.
 
@@ -103,6 +161,9 @@ def build_cloud_instance_link(
     region: str = "",
     account_id: str = "",
     resource_group: str = "",
+    cluster_name: str = "",
+    node_name: str = "",
+    is_ha: bool = True,
 ) -> str:
     """Build a cloud console URL for an instance based on provider.
 
@@ -112,6 +173,9 @@ def build_cloud_instance_link(
         region: Region (required for AWS).
         account_id: Account/subscription ID (required for Azure).
         resource_group: Resource group name (required for Azure).
+        cluster_name: Cluster name (used for Azure VM name derivation).
+        node_name: Node name (used for Azure VM name derivation in HA).
+        is_ha: Whether cluster is HA (default True, used for Azure).
 
     Returns:
         Cloud console URL for the instance, or empty string if not supported.
@@ -120,9 +184,16 @@ def build_cloud_instance_link(
     if provider_lower == "aws":
         return build_aws_instance_link(region, instance_id)
     elif provider_lower == "azure":
-        if not account_id or not resource_group or not instance_id:
+        if not account_id or not resource_group:
             return ""
-        resource_id = build_azure_id(account_id, resource_group, "vm", instance_id)
+        # For Azure, derive VM name from cluster/node info if available
+        if cluster_name:
+            vm_name = build_azure_vm_name(cluster_name, node_name, is_ha)
+        else:
+            vm_name = instance_id
+        if not vm_name:
+            return ""
+        resource_id = build_azure_id(account_id, resource_group, "vm", vm_name)
         return build_azure_portal_link(resource_id)
     return ""
 

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -13,6 +13,7 @@ from pynetappfoundry.cache.collector import (
     ProgressInfo,
 )
 from pynetappfoundry.cache.models import (
+    CloudMetadata,
     HAInfo,
     LicenseInfo,
     NetworkInfo,
@@ -1006,3 +1007,129 @@ class TestCollectionPhase:
         assert CollectionPhase.LICENSES.value == "licenses"
         assert CollectionPhase.HA.value == "ha"
         assert CollectionPhase.RELATIONSHIPS.value == "relationships"
+
+
+class TestUpdateAzureCloudLinks:
+    """Tests for Azure cloud link post-processing."""
+
+    def test_updates_azure_ha_cluster_links(self) -> None:
+        """Test Azure instance links are updated with cluster-based VM names for HA."""
+        collector = MetadataCollector()
+        cloud_metadata = [
+            CloudMetadata(
+                node="mycluster-01",
+                instance_id="old-instance-id",
+                account_id="sub-123",
+                resource_group_name="my-rg",
+                provider="Azure",
+                instance_link="https://old-link.com",
+            ),
+            CloudMetadata(
+                node="mycluster-02",
+                instance_id="old-instance-id-2",
+                account_id="sub-123",
+                resource_group_name="my-rg",
+                provider="Azure",
+                instance_link="https://old-link-2.com",
+            ),
+        ]
+
+        result = collector._update_azure_cloud_links(
+            cloud_metadata,
+            cluster_name="mycluster",
+            is_ha=True,
+        )
+
+        assert len(result) == 2
+        # Node 01 should get -vm1
+        assert "mycluster-vm1" in result[0].instance_link
+        assert "old-instance-id" not in result[0].instance_link
+        # Node 02 should get -vm2
+        assert "mycluster-vm2" in result[1].instance_link
+        assert "old-instance-id-2" not in result[1].instance_link
+
+    def test_updates_azure_single_node_links(self) -> None:
+        """Test Azure instance links are updated for single node cluster."""
+        collector = MetadataCollector()
+        cloud_metadata = [
+            CloudMetadata(
+                node="mycluster-01",
+                instance_id="old-instance-id",
+                account_id="sub-123",
+                resource_group_name="my-rg",
+                provider="Azure",
+                instance_link="https://old-link.com",
+            ),
+        ]
+
+        result = collector._update_azure_cloud_links(
+            cloud_metadata,
+            cluster_name="mycluster",
+            is_ha=False,
+        )
+
+        assert len(result) == 1
+        # Single node should just use cluster name
+        assert "mycluster" in result[0].instance_link
+        assert "mycluster-vm1" not in result[0].instance_link
+
+    def test_preserves_aws_cloud_metadata(self) -> None:
+        """Test AWS cloud metadata is preserved without modification."""
+        collector = MetadataCollector()
+        cloud_metadata = [
+            CloudMetadata(
+                node="aws-node",
+                instance_id="i-0abc123",
+                account_id="123456789012",
+                provider="AWS",
+                region="us-east-1",
+                instance_link="https://aws-link.com",
+            ),
+        ]
+
+        result = collector._update_azure_cloud_links(
+            cloud_metadata,
+            cluster_name="mycluster",
+            is_ha=True,
+        )
+
+        assert len(result) == 1
+        # AWS should be unchanged
+        assert result[0] is cloud_metadata[0]
+        assert result[0].instance_link == "https://aws-link.com"
+
+    def test_preserves_other_azure_fields(self) -> None:
+        """Test that other Azure cloud metadata fields are preserved."""
+        collector = MetadataCollector()
+        cloud_metadata = [
+            CloudMetadata(
+                node="mycluster-01",
+                instance_id="old-instance-id",
+                account_id="sub-123",
+                image_id="image-123",
+                instance_type="Standard_D4s_v3",
+                region="eastus",
+                provider="Azure",
+                fault_domain="0",
+                update_domain="1",
+                resource_group_name="my-rg",
+                offer="netapp-ontap-cloud",
+                sku="ontap_cloud",
+                resource_group_link="https://rg-link.com",
+            ),
+        ]
+
+        result = collector._update_azure_cloud_links(
+            cloud_metadata,
+            cluster_name="mycluster",
+            is_ha=True,
+        )
+
+        assert len(result) == 1
+        assert result[0].image_id == "image-123"
+        assert result[0].instance_type == "Standard_D4s_v3"
+        assert result[0].region == "eastus"
+        assert result[0].fault_domain == "0"
+        assert result[0].update_domain == "1"
+        assert result[0].offer == "netapp-ontap-cloud"
+        assert result[0].resource_group_link == "https://rg-link.com"

--- a/tests/unit/utils/test_cloud.py
+++ b/tests/unit/utils/test_cloud.py
@@ -10,12 +10,83 @@ from pynetappfoundry.utils.cloud import (
     build_aws_sso_link,
     build_azure_id,
     build_azure_portal_link,
+    build_azure_vm_name,
     build_cloud_instance_link,
     build_cloud_instance_sso_link,
     build_cloud_resource_group_link,
     get_cloud_account_name,
     get_cloud_types,
+    get_node_number,
 )
+
+
+class TestGetNodeNumber:
+    """Tests for get_node_number."""
+
+    def test_extracts_number_with_dash(self) -> None:
+        """Test extracts node number from name with dash separator."""
+        assert get_node_number("mycluster-01") == 1
+        assert get_node_number("mycluster-02") == 2
+        assert get_node_number("cluster-1") == 1
+        assert get_node_number("cluster-12") == 12
+
+    def test_extracts_number_with_underscore(self) -> None:
+        """Test extracts node number from name with underscore separator."""
+        assert get_node_number("mycluster_01") == 1
+        assert get_node_number("mycluster_02") == 2
+
+    def test_extracts_number_without_separator(self) -> None:
+        """Test extracts trailing number without separator."""
+        assert get_node_number("cluster01") == 1
+        assert get_node_number("cluster02") == 2
+
+    def test_returns_none_for_no_number(self) -> None:
+        """Test returns None when no trailing number found."""
+        assert get_node_number("mycluster") is None
+        assert get_node_number("cluster-abc") is None
+
+    def test_returns_none_for_empty_string(self) -> None:
+        """Test returns None for empty string."""
+        assert get_node_number("") is None
+
+
+class TestBuildAzureVmName:
+    """Tests for build_azure_vm_name."""
+
+    def test_ha_cluster_node_01(self) -> None:
+        """Test HA cluster VM name for node 01."""
+        result = build_azure_vm_name("mycluster", "mycluster-01", is_ha=True)
+        assert result == "mycluster-vm1"
+
+    def test_ha_cluster_node_02(self) -> None:
+        """Test HA cluster VM name for node 02."""
+        result = build_azure_vm_name("mycluster", "mycluster-02", is_ha=True)
+        assert result == "mycluster-vm2"
+
+    def test_single_node_cluster(self) -> None:
+        """Test single node cluster VM name."""
+        result = build_azure_vm_name("mycluster", "mycluster-01", is_ha=False)
+        assert result == "mycluster"
+
+    def test_single_node_empty_node_name(self) -> None:
+        """Test single node cluster with empty node name."""
+        result = build_azure_vm_name("mycluster", "", is_ha=False)
+        assert result == "mycluster"
+
+    def test_ha_cluster_no_node_number(self) -> None:
+        """Test HA cluster fallback when node number can't be determined."""
+        result = build_azure_vm_name("mycluster", "mycluster", is_ha=True)
+        assert result == "mycluster"
+
+    def test_returns_empty_for_empty_cluster_name(self) -> None:
+        """Test returns empty string when cluster name is empty."""
+        result = build_azure_vm_name("", "node-01", is_ha=True)
+        assert result == ""
+
+    def test_default_is_ha(self) -> None:
+        """Test default is_ha is True."""
+        result = build_azure_vm_name("mycluster", "mycluster-01")
+        assert result == "mycluster-vm1"
 
 
 class TestBuildAzureId:
@@ -121,6 +192,47 @@ class TestBuildCloudInstanceLink:
             # missing account_id and resource_group
         )
         assert result == ""
+
+    def test_azure_derives_vm_name_from_cluster_ha(self) -> None:
+        """Test Azure VM name is derived from cluster/node info for HA."""
+        result = build_cloud_instance_link(
+            provider="Azure",
+            instance_id="some-instance-id",  # This should be ignored
+            account_id="sub-123",
+            resource_group="my-rg",
+            cluster_name="mycluster",
+            node_name="mycluster-01",
+            is_ha=True,
+        )
+        assert AZURE_BASE_URL in result
+        assert "mycluster-vm1" in result
+        assert "some-instance-id" not in result
+
+    def test_azure_derives_vm_name_from_cluster_single_node(self) -> None:
+        """Test Azure VM name is derived from cluster for single node."""
+        result = build_cloud_instance_link(
+            provider="Azure",
+            instance_id="some-instance-id",  # This should be ignored
+            account_id="sub-123",
+            resource_group="my-rg",
+            cluster_name="mycluster",
+            node_name="mycluster-01",
+            is_ha=False,
+        )
+        assert AZURE_BASE_URL in result
+        assert "mycluster" in result
+        # For single node, it should just be cluster name, not cluster-vm1
+        assert "mycluster-vm1" not in result
+
+    def test_azure_uses_instance_id_when_no_cluster_name(self) -> None:
+        """Test Azure uses instance_id when cluster_name is not provided."""
+        result = build_cloud_instance_link(
+            provider="Azure",
+            instance_id="my-vm-instance",
+            account_id="sub-123",
+            resource_group="my-rg",
+        )
+        assert "my-vm-instance" in result
 
 
 class TestBuildCloudResourceGroupLink:


### PR DESCRIPTION
## Description

Azure VM portal links were incorrectly using `instance_id` from cloud metadata. Azure VMs follow a naming convention based on cluster name:
- HA clusters: `<cluster>-vm1` for node 01, `<cluster>-vm2` for node 02
- Single node: `<cluster>`

This PR adds helper functions to derive the correct Azure VM name and post-processes cloud metadata after collection when cluster name and HA status are available.

## Related Issue

Closes #152

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `get_node_number()` helper to extract node number from node names (e.g., `mycluster-01` → `1`)
- Added `build_azure_vm_name()` to derive Azure VM names from cluster/node/HA info
- Updated `build_cloud_instance_link()` with optional `cluster_name`, `node_name`, `is_ha` parameters
- Added `_update_azure_cloud_links()` post-processing method in collector
- Updated `collect_all()` to call post-processing before returning metadata

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

New tests added:
- `TestGetNodeNumber` - 5 tests for node number extraction
- `TestBuildAzureVmName` - 7 tests for Azure VM name building
- 3 tests in `TestBuildCloudInstanceLink` for Azure VM name derivation
- `TestUpdateAzureCloudLinks` - 4 tests for collector post-processing

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings