### PR TITLE
fix: pass AWS SSO config to MetadataCollector during cache refresh

### DIFF
--- a/src/pynetappfoundry/cli/commands/cache/refresh.py
+++ b/src/pynetappfoundry/cli/commands/cache/refresh.py
@@ -353,11 +353,15 @@ def _process_cluster(
         logger.error("No clients available for %s", cluster_name)
         return False
 
+    # Get AWS SSO config if configured
+    aws_sso_config = config.settings.get("aws", {}).get("sso")
+
     # Collect metadata
     collector = MetadataCollector(
         api_client=api_client,
         cli_client=cli_client,
         progress_callback=progress_callback,
+        aws_sso_config=aws_sso_config,
     )
     metadata = collector.collect_all(cluster_name)
 

--- a/tests/unit/cli/commands/cache/test_refresh.py
+++ b/tests/unit/cli/commands/cache/test_refresh.py
@@ -359,3 +359,172 @@ class TestVerboseProgressDisplay:
         )
         display.on_progress(info)
         assert display.phase_times[CollectionPhase.NETWORK] == 0.5
+
+
+class TestAwsSsoConfig:
+    """Tests for AWS SSO config being passed to MetadataCollector."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_config_dir_with_aws_sso(self, tmp_path: Path) -> Path:
+        """Create a mock config directory with AWS SSO config."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        # Create a minimal settings file
+        (config_dir / "settings.toml").write_text(
+            """
+[ontapapi]
+[ontapapi.general]
+base_api_path = "/api"
+timeout = 30.0
+"""
+        )
+        # Create AWS config with SSO settings
+        (config_dir / "aws.toml").write_text(
+            """
+[sso]
+subdomain = "mycompany"
+
+[sso.account_roles]
+"123456789012" = "AdminRole"
+"987654321098" = "ReadOnlyRole"
+"""
+        )
+        # Create a data file with clusters
+        (config_dir / "clusters.toml").write_text(
+            """
+[settings]
+type = "data"
+
+[clusters.test-cluster]
+ip = "10.0.0.1"
+bu = "Test"
+env = "Dev"
+"""
+        )
+        # Create users file
+        (config_dir / "users.toml").write_text(
+            """
+[clusters]
+user = "admin"
+enc = "cGFzc3dvcmQ="
+"""
+        )
+        return config_dir
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_aws_sso_config_passed_to_collector(
+        self,
+        mock_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_with_aws_sso: Path,
+    ) -> None:
+        """Test that AWS SSO config from aws.toml is passed to MetadataCollector."""
+        # Setup mocks
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock(cluster_name="test-cluster")
+        mock_collector_class.return_value = mock_collector
+
+        mock_cli = MagicMock()
+        mock_cli_class.return_value = mock_cli
+
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir_with_aws_sso), "cache", "refresh", "test-cluster"],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify MetadataCollector was called with aws_sso_config
+        mock_collector_class.assert_called_once()
+        call_kwargs = mock_collector_class.call_args.kwargs
+        assert "aws_sso_config" in call_kwargs
+        assert call_kwargs["aws_sso_config"] is not None
+        assert call_kwargs["aws_sso_config"]["subdomain"] == "mycompany"
+        assert "123456789012" in call_kwargs["aws_sso_config"]["account_roles"]
+        assert call_kwargs["aws_sso_config"]["account_roles"]["123456789012"] == "AdminRole"
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_aws_sso_config_none_when_not_configured(
+        self,
+        mock_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Test that aws_sso_config is None when aws.toml is not configured."""
+        # Create config dir WITHOUT aws.toml
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.toml").write_text(
+            """
+[ontapapi]
+[ontapapi.general]
+base_api_path = "/api"
+timeout = 30.0
+"""
+        )
+        (config_dir / "clusters.toml").write_text(
+            """
+[settings]
+type = "data"
+
+[clusters.test-cluster]
+ip = "10.0.0.1"
+"""
+        )
+        (config_dir / "users.toml").write_text(
+            """
+[clusters]
+user = "admin"
+enc = "cGFzc3dvcmQ="
+"""
+        )
+
+        # Setup mocks
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock(cluster_name="test-cluster")
+        mock_collector_class.return_value = mock_collector
+
+        mock_cli = MagicMock()
+        mock_cli_class.return_value = mock_cli
+
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(config_dir), "cache", "refresh", "test-cluster"],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify MetadataCollector was called with aws_sso_config=None
+        mock_collector_class.assert_called_once()
+        call_kwargs = mock_collector_class.call_args.kwargs
+        assert "aws_sso_config" in call_kwargs
+        assert call_kwargs["aws_sso_config"] is None


### PR DESCRIPTION
## Description

The cache refresh command was not passing the AWS SSO configuration from `config/aws.toml` to the `MetadataCollector`, resulting in SSO shortcut links not being generated.

## Related Issue

Closes #161

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Read AWS SSO config from `config.settings.get("aws", {}).get("sso")` in `_process_cluster()`
- Pass `aws_sso_config` parameter to `MetadataCollector` constructor
- Add `TestAwsSsoConfig` test class with two tests verifying config is passed correctly

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The fix is minimal - just 4 lines of code to read and pass the config. The existing `build_cloud_instance_sso_link()` function already handles the SSO URL generation correctly.