### PR TITLE
feat: add filter argument (-f) to cache refresh command

### DIFF
--- a/src/pynetappfoundry/cli/commands/cache/refresh.py
+++ b/src/pynetappfoundry/cli/commands/cache/refresh.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 import time
 from pathlib import Path
@@ -106,23 +107,37 @@ class VerboseProgressDisplay:
     help="Refresh cache for all configured clusters.",
 )
 @click.option(
+    "--filter",
+    "-f",
+    "filter_str",
+    help='JSON filter for --all: \'{"env": "Prod", "bu": "Finance"}\'',
+)
+@click.option(
     "--verbose",
     "-v",
     is_flag=True,
     help="Show detailed progress for each collection phase.",
 )
 @click.pass_context
-def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool, verbose: bool) -> None:
+def refresh(
+    ctx: click.Context,
+    cluster: str | None,
+    refresh_all: bool,
+    filter_str: str | None,
+    verbose: bool,
+) -> None:
     """Refresh the metadata cache for cluster(s).
 
     If CLUSTER is specified, refresh only that cluster.
     Use --all to refresh all configured clusters.
+    Use --filter with --all to refresh only matching clusters.
 
     Examples:
 
         nf cache refresh cluster1      # Refresh single cluster
         nf cache refresh --all         # Refresh all clusters
         nf cache refresh --all -v      # Refresh all with detailed progress
+        nf cache refresh --all -f '{"env": "Prod"}'  # Refresh only Prod clusters
     """
     # Always set up file logging
     _, log_file = setup_logger("cache-refresh")
@@ -144,6 +159,19 @@ def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool, verbose:
         logger.exception("Failed to load configuration")
         ctx.exit(1)
 
+    # Parse filter if provided
+    filter_dict: dict[str, str] = {}
+    if filter_str:
+        if not refresh_all:
+            print_error("--filter can only be used with --all")
+            ctx.exit(1)
+        try:
+            filter_dict = json.loads(filter_str)
+        except json.JSONDecodeError as e:
+            print_error(f"Invalid filter JSON: {e}")
+            logger.error("Invalid filter JSON: %s", e)
+            ctx.exit(1)
+
     # Determine clusters to refresh
     if cluster:
         if cluster not in config.data.get("clusters", {}):
@@ -155,10 +183,16 @@ def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool, verbose:
             ctx.exit(1)
         clusters_to_refresh = [cluster]
     elif refresh_all:
-        clusters_to_refresh = list(config.data.get("clusters", {}).keys())
+        # Apply filter if provided, otherwise get all clusters
+        matching_clusters = config.get_clusters(filter_dict)
+        clusters_to_refresh = list(matching_clusters.keys())
         if not clusters_to_refresh:
-            print_warning("No clusters configured.")
-            logger.warning("No clusters configured")
+            if filter_dict:
+                print_warning(f"No clusters match filter: {filter_str}")
+                logger.warning("No clusters match filter: %s", filter_str)
+            else:
+                print_warning("No clusters configured.")
+                logger.warning("No clusters configured")
             ctx.exit(0)
     else:
         print_error("Specify a cluster name or use --all to refresh all clusters.")
@@ -168,8 +202,16 @@ def refresh(ctx: click.Context, cluster: str | None, refresh_all: bool, verbose:
     db = ClusterMetadataDB(config=config)
 
     console.print(f"\nRefreshing cache for {len(clusters_to_refresh)} cluster(s)...")
+    if filter_dict:
+        console.print(f"[dim]Filter: {filter_str}[/dim]")
+        logger.info(
+            "Refreshing cache for %d cluster(s) with filter: %s",
+            len(clusters_to_refresh),
+            filter_str,
+        )
+    else:
+        logger.info("Refreshing cache for %d cluster(s)", len(clusters_to_refresh))
     console.print(f"[dim]Log file: {log_file}[/dim]\n")
-    logger.info("Refreshing cache for %d cluster(s)", len(clusters_to_refresh))
 
     if verbose:
         # Verbose mode: detailed phase-by-phase progress

--- a/tests/unit/cli/commands/cache/test_refresh.py
+++ b/tests/unit/cli/commands/cache/test_refresh.py
@@ -528,3 +528,176 @@ enc = "cGFzc3dvcmQ="
         call_kwargs = mock_collector_class.call_args.kwargs
         assert "aws_sso_config" in call_kwargs
         assert call_kwargs["aws_sso_config"] is None
+
+
+class TestFilterOption:
+    """Tests for --filter option on cache refresh command."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_config_dir_with_envs(self, tmp_path: Path) -> Path:
+        """Create a mock config directory with clusters in different environments."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.toml").write_text(
+            """
+[ontapapi]
+[ontapapi.general]
+base_api_path = "/api"
+timeout = 30.0
+
+[clusters]
+searchable_keys = ["env", "bu"]
+"""
+        )
+        # Create clusters in different environments
+        (config_dir / "clusters.toml").write_text(
+            """
+[settings]
+type = "data"
+
+[clusters.prod-cluster-1]
+ip = "10.0.0.1"
+env = "Prod"
+bu = "Finance"
+
+[clusters.prod-cluster-2]
+ip = "10.0.0.2"
+env = "Prod"
+bu = "IT"
+
+[clusters.dev-cluster-1]
+ip = "10.0.0.3"
+env = "Dev"
+bu = "Finance"
+"""
+        )
+        (config_dir / "users.toml").write_text(
+            """
+[clusters]
+user = "admin"
+enc = "cGFzc3dvcmQ="
+"""
+        )
+        return config_dir
+
+    def test_filter_without_all_shows_error(
+        self, runner: CliRunner, mock_config_dir_with_envs: Path
+    ) -> None:
+        """Test that --filter without --all shows an error."""
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir_with_envs), "cache", "refresh", "-f", '{"env": "Prod"}'],
+        )
+        assert result.exit_code != 0
+        assert "--filter can only be used with --all" in result.output
+
+    def test_filter_invalid_json_shows_error(
+        self, runner: CliRunner, mock_config_dir_with_envs: Path
+    ) -> None:
+        """Test that invalid JSON filter shows an error."""
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir_with_envs), "cache", "refresh", "--all", "-f", "not json"],
+        )
+        assert result.exit_code != 0
+        assert "Invalid filter JSON" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_filter_by_env(
+        self,
+        mock_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_with_envs: Path,
+    ) -> None:
+        """Test filtering clusters by environment."""
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock()
+        mock_collector_class.return_value = mock_collector
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir_with_envs),
+                "cache",
+                "refresh",
+                "--all",
+                "-f",
+                '{"env": "Prod"}',
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Should refresh 2 Prod clusters, not all 3
+        assert "2 cluster(s)" in result.output
+        assert mock_collector.collect_all.call_count == 2
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_filter_by_multiple_fields(
+        self,
+        mock_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_with_envs: Path,
+    ) -> None:
+        """Test filtering clusters by multiple fields."""
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock()
+        mock_collector_class.return_value = mock_collector
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir_with_envs),
+                "cache",
+                "refresh",
+                "--all",
+                "-f",
+                '{"env": "Prod", "bu": "Finance"}',
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Should refresh only prod-cluster-1 (Prod + Finance)
+        assert "1 cluster(s)" in result.output
+        assert mock_collector.collect_all.call_count == 1
+
+    def test_filter_no_matches(self, runner: CliRunner, mock_config_dir_with_envs: Path) -> None:
+        """Test that filter with no matches shows warning."""
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir_with_envs),
+                "cache",
+                "refresh",
+                "--all",
+                "-f",
+                '{"env": "Staging"}',
+            ],
+        )
+        assert result.exit_code == 0
+        assert "No clusters match filter" in result.output


### PR DESCRIPTION
## Description

Add `--filter` / `-f` option to the `cache refresh` command that accepts a JSON filter string for selecting clusters when using `--all`. This allows refreshing only a subset of clusters based on metadata fields like environment, business unit, or tags.

## Related Issue

Closes #162

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `--filter` / `-f` option to cache refresh command
- Validate that `--filter` requires `--all` flag
- Parse JSON filter and use `config.get_clusters()` to filter clusters
- Display filter info in console output when used
- Add comprehensive tests for filter functionality

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Example usage:
```bash
# Refresh only production clusters
nf cache refresh --all -f '{"env": "Prod"}'

# Refresh clusters for a specific business unit
nf cache refresh --all -f '{"bu": "Finance"}'

# Refresh clusters matching multiple criteria
nf cache refresh --all -f '{"env": "Prod", "bu": "Finance"}'
```