### PR TITLE
fix: pass timeout to SSH connection establishment

### DIFF
--- a/src/pynetappfoundry/clients/ontap/cli.py
+++ b/src/pynetappfoundry/clients/ontap/cli.py
@@ -110,9 +110,19 @@ class ONTAPCLI:
             if not transport or not transport.is_active():
                 logging.debug(f"{self.log_prefix} Connect: creating connection")
                 if self.pkey:
-                    self.ssh.connect(self.host, username=self.username, pkey=self.pkey)
+                    self.ssh.connect(
+                        self.host,
+                        username=self.username,
+                        pkey=self.pkey,
+                        timeout=self.timeout,
+                    )
                 else:
-                    self.ssh.connect(self.host, username=self.username, password=self.password)
+                    self.ssh.connect(
+                        self.host,
+                        username=self.username,
+                        password=self.password,
+                        timeout=self.timeout,
+                    )
                 transport = self.ssh.get_transport()
                 if transport:
                     transport.set_keepalive(5)


### PR DESCRIPTION
## Description

Pass `self.timeout` to `ssh.connect()` to prevent the program from hanging when SSH connections fail. Previously, connection establishment used the system default socket timeout (~2 minutes on Linux). Now it uses the configured timeout value (default 10 seconds).

## Related Issue

Closes #170

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `timeout=self.timeout` parameter to both `ssh.connect()` calls in the `connect()` method

## Testing

- [x] All existing tests pass
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings