### PR TITLE
refactor: update CLI collectors to use separator parsing method

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -753,15 +753,13 @@ class MetadataCollector:
             return ClusterInfo()
 
         logger.debug("CLI command: cluster identity show")
-        output = self.cli_client.run_command_and_parse("cluster identity show")
+        output, _ = self.cli_client.run_a_show_command_and_parse_seperator("cluster identity show")
         logger.debug("CLI response: %d entries", len(output))
-        # Output is keyed by cluster name
         if output:
-            first_key = next(iter(output))
-            data = output[first_key]
+            data = output[0]
             return ClusterInfo(
-                cluster_name=data.get("Cluster", ""),
-                cluster_uuid=data.get("Cluster UUID", ""),
+                cluster_name=data.get("cluster", ""),
+                cluster_uuid=data.get("cluster-uuid", ""),
             )
         return ClusterInfo()
 
@@ -833,16 +831,16 @@ class MetadataCollector:
             return []
 
         logger.debug("CLI command: system node show")
-        output = self.cli_client.run_command_and_parse("system node show")
+        output, _ = self.cli_client.run_a_show_command_and_parse_seperator("system node show")
         logger.debug("CLI response: %d nodes", len(output))
         nodes = []
-        for node_name, data in output.items():
+        for data in output:
             nodes.append(
                 NodeInfo(
-                    name=node_name,
-                    serial_number=data.get("Serial Number", ""),
-                    system_id=data.get("System ID", ""),
-                    model=data.get("Model", ""),
+                    name=data.get("node", ""),
+                    serial_number=data.get("serial-number", ""),
+                    system_id=data.get("system-id", ""),
+                    model=data.get("model", ""),
                 )
             )
         return nodes
@@ -968,26 +966,26 @@ class MetadataCollector:
             return NetworkInfo()
 
         logger.debug("CLI command: network interface show")
-        output = self.cli_client.run_command_and_parse("network interface show")
+        output, _ = self.cli_client.run_a_show_command_and_parse_seperator("network interface show")
         logger.debug("CLI response: %d interfaces", len(output))
         intercluster_lifs = []
         data_lifs = []
         management_lifs = []
 
-        for lif_name, data in output.items():
+        for data in output:
             lif = NetworkLIF(
-                name=lif_name,
-                ip_address=data.get("Network Address", ""),
-                netmask=data.get("Netmask", ""),
-                home_node=data.get("Home Node", ""),
-                home_port=data.get("Home Port", ""),
-                current_node=data.get("Current Node", ""),
-                current_port=data.get("Current Port", ""),
-                operational_status=data.get("Operational Status", ""),
-                role=data.get("Role", ""),
-                svm=data.get("Vserver", ""),
+                name=data.get("lif", ""),
+                ip_address=data.get("address", ""),
+                netmask=data.get("netmask", ""),
+                home_node=data.get("home-node", ""),
+                home_port=data.get("home-port", ""),
+                current_node=data.get("curr-node", ""),
+                current_port=data.get("curr-port", ""),
+                operational_status=data.get("status-oper", ""),
+                role=data.get("role", ""),
+                svm=data.get("vserver", ""),
             )
-            role = data.get("Role", "").lower()
+            role = data.get("role", "").lower()
             if "intercluster" in role:
                 intercluster_lifs.append(lif)
             elif role in ("data", ""):
@@ -1146,29 +1144,29 @@ class MetadataCollector:
 
         # Collect aggregates
         logger.debug("CLI command: aggr show")
-        aggr_output = self.cli_client.run_command_and_parse("aggr show")
+        aggr_output, _ = self.cli_client.run_a_show_command_and_parse_seperator("aggr show")
         logger.debug("CLI response: %d aggregates", len(aggr_output))
         aggregates = []
-        for aggr_name, data in aggr_output.items():
+        for data in aggr_output:
             aggr = AggregateInfo(
-                name=aggr_name,
-                node=data.get("Node", ""),
-                state=data.get("State", ""),
-                type=data.get("Type", ""),
+                name=data.get("aggregate", ""),
+                node=data.get("node", ""),
+                state=data.get("state", ""),
+                type=data.get("type", ""),
             )
             aggregates.append(aggr)
 
         # Collect SVMs
         logger.debug("CLI command: vserver show")
-        svm_output = self.cli_client.run_command_and_parse("vserver show")
+        svm_output, _ = self.cli_client.run_a_show_command_and_parse_seperator("vserver show")
         logger.debug("CLI response: %d SVMs", len(svm_output))
         svms = []
-        for svm_name, data in svm_output.items():
+        for data in svm_output:
             svm = SVMInfo(
-                name=svm_name,
-                state=data.get("Admin State", ""),
-                subtype=data.get("Vserver Type", ""),
-                root_volume=data.get("Root Volume", ""),
+                name=data.get("vserver", ""),
+                state=data.get("admin-state", ""),
+                subtype=data.get("type", ""),
+                root_volume=data.get("root-volume", ""),
             )
             svms.append(svm)
 
@@ -1189,7 +1187,7 @@ class MetadataCollector:
 
         try:
             logger.debug("CLI command: storage aggregate object-store config show")
-            output = self.cli_client.run_command_and_parse(
+            output, _ = self.cli_client.run_a_show_command_and_parse_seperator(
                 "storage aggregate object-store config show"
             )
             logger.debug("CLI response: %d cloud targets", len(output))
@@ -1199,16 +1197,16 @@ class MetadataCollector:
             return []
 
         cloud_targets = []
-        for target_name, data in output.items():
+        for data in output:
             target = CloudTargetInfo(
-                name=target_name,
-                provider_type=data.get("Provider Type", ""),
-                server=data.get("Server", ""),
-                container=data.get("Container", "") or data.get("Bucket", ""),
-                owner=data.get("Owner", ""),
-                ssl_enabled=data.get("SSL Enabled", "").lower() == "true",
-                authentication_type=data.get("Authentication Type", ""),
-                ipspace=data.get("IPspace", ""),
+                name=data.get("object-store-name", ""),
+                provider_type=data.get("provider-type", ""),
+                server=data.get("server", ""),
+                container=data.get("container", "") or data.get("bucket", ""),
+                owner=data.get("owner", ""),
+                ssl_enabled=data.get("ssl-enabled", "").lower() == "true",
+                authentication_type=data.get("auth-type", ""),
+                ipspace=data.get("ipspace", ""),
             )
             cloud_targets.append(target)
         return cloud_targets
@@ -1286,15 +1284,15 @@ class MetadataCollector:
             return LicenseInfo()
 
         logger.debug("CLI command: license show")
-        output = self.cli_client.run_command_and_parse("license show")
+        output, _ = self.cli_client.run_a_show_command_and_parse_seperator("license show")
         logger.debug("CLI response: %d licenses", len(output))
         feature_licenses = []
 
-        for license_name, data in output.items():
+        for data in output:
             feature = LicenseFeature(
-                name=license_name,
-                state=data.get("License State", ""),
-                scope=data.get("Scope", ""),
+                name=data.get("package", ""),
+                state=data.get("state", ""),
+                scope=data.get("scope", ""),
             )
             feature_licenses.append(feature)
 
@@ -1375,18 +1373,18 @@ class MetadataCollector:
             return HAInfo()
 
         logger.debug("CLI command: storage failover show")
-        output = self.cli_client.run_command_and_parse("storage failover show")
+        output, _ = self.cli_client.run_a_show_command_and_parse_seperator("storage failover show")
         logger.debug("CLI response: %d entries", len(output))
         if not output:
             return HAInfo(is_ha=False)
 
         # Parse first node's HA info
-        first_node = next(iter(output.values()), {})
+        first_node = output[0]
         return HAInfo(
             is_ha=True,
-            partner_node=first_node.get("Partner Name", ""),
-            ha_state=first_node.get("Node State", ""),
-            takeover_state=first_node.get("Takeover State", ""),
+            partner_node=first_node.get("partner-name", ""),
+            ha_state=first_node.get("node-state", ""),
+            takeover_state=first_node.get("takeover-state", ""),
         )
 
     # -------------------------------------------------------------------------
@@ -1496,31 +1494,33 @@ class MetadataCollector:
 
         # Collect SnapMirror relationships
         logger.debug("CLI command: snapmirror show")
-        sm_output = self.cli_client.run_command_and_parse("snapmirror show")
+        sm_output, _ = self.cli_client.run_a_show_command_and_parse_seperator("snapmirror show")
         logger.debug("CLI response: %d SnapMirror relationships", len(sm_output))
         snapmirror_destinations = []
-        for dest_path, data in sm_output.items():
+        for data in sm_output:
+            # healthy field from CLI is a string "true"/"false"
+            healthy_str = data.get("healthy", "true").lower()
             sm = SnapMirrorRelationship(
-                source_path=data.get("Source Path", ""),
-                destination_path=dest_path,
-                relationship_type=data.get("Relationship Type", ""),
-                state=data.get("Mirror State", ""),
-                healthy=data.get("Relationship Status", "").lower() == "idle",
-                lag_time=data.get("Lag Time", ""),
+                source_path=data.get("source-path", ""),
+                destination_path=data.get("destination-path", ""),
+                relationship_type=data.get("type", ""),
+                state=data.get("state", ""),
+                healthy=healthy_str == "true",
+                lag_time=data.get("lag-time", ""),
             )
             snapmirror_destinations.append(sm)
 
         # Collect cluster peers
         logger.debug("CLI command: cluster peer show")
-        peer_output = self.cli_client.run_command_and_parse("cluster peer show")
+        peer_output, _ = self.cli_client.run_a_show_command_and_parse_seperator("cluster peer show")
         logger.debug("CLI response: %d cluster peers", len(peer_output))
         cluster_peers = []
-        for peer_name, data in peer_output.items():
+        for data in peer_output:
             peer = ClusterPeer(
-                name=peer_name,
-                remote_cluster_name=data.get("Remote Cluster Name", ""),
-                availability=data.get("Availability", ""),
-                authentication_state=data.get("Authentication Status", ""),
+                name=data.get("peer-cluster", ""),
+                remote_cluster_name=data.get("remote-cluster-name", ""),
+                availability=data.get("availability", ""),
+                authentication_state=data.get("auth-status-admin", ""),
             )
             cluster_peers.append(peer)
 

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -269,14 +269,12 @@ class TestClusterInfoCollection:
         }
 
     @pytest.fixture
-    def mock_cluster_cli_output(self) -> dict[str, dict[str, str]]:
+    def mock_cluster_cli_output(self) -> tuple[list[dict[str, str]], dict[str, str]]:
         """Mock CLI output for cluster identity show."""
-        return {
-            "mycluster": {
-                "Cluster": "mycluster",
-                "Cluster UUID": "abc-123-def-456",
-            }
-        }
+        return (
+            [{"cluster": "mycluster", "cluster-uuid": "abc-123-def-456"}],
+            {},
+        )
 
     def test_collect_cluster_info_via_api(self, mock_cluster_api_response: dict[str, Any]) -> None:
         """Test collecting cluster info via API."""
@@ -292,21 +290,21 @@ class TestClusterInfoCollection:
         api_client.call_endpoint.assert_called_with("/cluster?fields=*", method="GET")
 
     def test_collect_cluster_info_fallback_to_cli(
-        self, mock_cluster_cli_output: dict[str, dict[str, str]]
+        self, mock_cluster_cli_output: tuple[list[dict[str, str]], dict[str, str]]
     ) -> None:
         """Test cluster info falls back to CLI when API fails."""
         api_client = MagicMock()
         api_client.call_endpoint.side_effect = Exception("API unavailable")
 
         cli_client = MagicMock()
-        cli_client.run_command_and_parse.return_value = mock_cluster_cli_output
+        cli_client.run_a_show_command_and_parse_seperator.return_value = mock_cluster_cli_output
 
         collector = MetadataCollector(api_client=api_client, cli_client=cli_client)
         result = collector.collect_cluster_info()
 
         assert result.cluster_name == "mycluster"
         assert result.cluster_uuid == "abc-123-def-456"
-        cli_client.run_command_and_parse.assert_called()
+        cli_client.run_a_show_command_and_parse_seperator.assert_called()
 
     def test_collect_cluster_info_no_clients(self) -> None:
         """Test cluster info returns empty when no clients."""
@@ -603,23 +601,27 @@ class TestCloudTargetsCollection:
     def test_collect_cloud_targets_via_cli(self) -> None:
         """Test collecting cloud targets via CLI fallback."""
         cli_client = MagicMock()
-        cli_client.run_command_and_parse.side_effect = [
+        cli_client.run_a_show_command_and_parse_seperator.side_effect = [
             # aggr show
-            {"aggr1": {"Node": "node1", "State": "online", "Type": "ssd"}},
+            ([{"aggregate": "aggr1", "node": "node1", "state": "online", "type": "ssd"}], {}),
             # vserver show
-            {"svm1": {"Admin State": "running", "Vserver Type": "default"}},
+            ([{"vserver": "svm1", "admin-state": "running", "type": "default"}], {}),
             # storage aggregate object-store config show
-            {
-                "s3-target-1": {
-                    "Provider Type": "AWS_S3",
-                    "Server": "s3.us-east-1.amazonaws.com",
-                    "Container": "my-bucket",
-                    "Owner": "fabricpool",
-                    "SSL Enabled": "true",
-                    "Authentication Type": "key",
-                    "IPspace": "Default",
-                }
-            },
+            (
+                [
+                    {
+                        "object-store-name": "s3-target-1",
+                        "provider-type": "AWS_S3",
+                        "server": "s3.us-east-1.amazonaws.com",
+                        "container": "my-bucket",
+                        "owner": "fabricpool",
+                        "ssl-enabled": "true",
+                        "auth-type": "key",
+                        "ipspace": "Default",
+                    }
+                ],
+                {},
+            ),
         ]
 
         collector = MetadataCollector(cli_client=cli_client)
@@ -636,16 +638,16 @@ class TestCloudTargetsCollection:
         """Test that CLI fallback handles command not available."""
         cli_client = MagicMock()
 
-        def side_effect(cmd: str) -> dict[str, Any]:
+        def side_effect(cmd: str) -> tuple[list[dict[str, Any]], dict[str, str]]:
             if "object-store" in cmd:
                 raise Exception("Command not available")
             if "aggr" in cmd:
-                return {"aggr1": {"Node": "node1", "State": "online"}}
+                return ([{"aggregate": "aggr1", "node": "node1", "state": "online"}], {})
             if "vserver" in cmd:
-                return {"svm1": {"Admin State": "running"}}
-            return {}
+                return ([{"vserver": "svm1", "admin-state": "running"}], {})
+            return ([], {})
 
-        cli_client.run_command_and_parse.side_effect = side_effect
+        cli_client.run_a_show_command_and_parse_seperator.side_effect = side_effect
 
         collector = MetadataCollector(cli_client=cli_client)
         result = collector.collect_storage()


### PR DESCRIPTION
## Description

Update all CLI collection methods in the metadata collector to use `run_a_show_command_and_parse_seperator()` instead of `run_command_and_parse()`. This ensures consistent CSV-style output parsing by setting `showallfields true` and `showseparator ","` flags before running commands.

## Related Issue

Closes #172

## Type of Change

- [x] Code refactoring

## Changes Made

- Updated 8 CLI collection methods to use the separator parsing method:
  - `_collect_cluster_info_via_cli` - cluster identity show
  - `_collect_nodes_via_cli` - system node show
  - `_collect_network_via_cli` - network interface show
  - `_collect_storage_via_cli` - aggr show, vserver show
  - `_collect_cloud_targets_via_cli` - storage aggregate object-store config show
  - `_collect_licenses_via_cli` - license show
  - `_collect_ha_info_via_cli` - storage failover show
  - `_collect_relationships_via_cli` - snapmirror show, cluster peer show
- Updated field mappings from Title Case (e.g., `"Serial Number"`) to lowercase hyphenated (e.g., `"serial-number"`)
- Updated 3 unit tests to use the new method and return format

## Testing

- [x] All existing tests pass
- [x] Updated tests for changed methods

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings