### PR TITLE
fix: increase HTTP connection pool size for parallel API calls

### DIFF
--- a/src/pynetappfoundry/clients/openapi.py
+++ b/src/pynetappfoundry/clients/openapi.py
@@ -10,6 +10,7 @@ from urllib.parse import urlencode
 
 import requests
 from jsonschema import ValidationError, validate
+from requests.adapters import HTTPAdapter
 from tenacity import (
     RetryCallState,
     retry,
@@ -101,6 +102,13 @@ class APIWrapper:
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self.session = session or requests.Session()
+
+        # Configure connection pool to handle parallel API calls
+        # Default pool size (10) is insufficient when using ThreadPoolExecutor
+        adapter = HTTPAdapter(pool_connections=20, pool_maxsize=20)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
+
         # Default headers (can be extended per request)
         default_headers = {
             "Content-Type": "application/json",

--- a/tests/unit/test_openapi.py
+++ b/tests/unit/test_openapi.py
@@ -177,6 +177,14 @@ class TestAPIWrapperInit:
         )
         assert wrapper.session.headers["Authorization"] == "Bearer token123"
 
+    def test_connection_pool_configured(self, api_wrapper: APIWrapper) -> None:
+        """Test that connection pool is configured for parallel requests."""
+        # Get the adapter mounted for https://
+        adapter = api_wrapper.session.get_adapter("https://example.com")
+        # Verify pool is configured with increased size (stored as private attrs)
+        assert adapter._pool_connections == 20  # type: ignore[union-attr]
+        assert adapter._pool_maxsize == 20  # type: ignore[union-attr]
+
 
 class TestReferenceResolution:
     """Tests for $ref resolution."""


### PR DESCRIPTION
## Description

Configure `requests.Session` with `HTTPAdapter` using increased pool size (`pool_connections=20`, `pool_maxsize=20`) to prevent connection pool overflow during parallel API calls.

**Problem:** When `MetadataCollector` runs parallel API calls with `ThreadPoolExecutor` (up to 8 workers), the default urllib3 pool size (10) was insufficient, causing warnings:
```
Connection pool is full, discarding connection: <ip>. Connection pool size: 10
```

**Solution:** Mount `HTTPAdapter` with larger pool size on the session in `APIWrapper.__init__()`.

## Related Issue

Closes #174

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `HTTPAdapter` import to `openapi.py`
- Configured session with adapter using `pool_connections=20` and `pool_maxsize=20`
- Added test to verify connection pool configuration

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings