### PR TITLE
fix: include endpoint path in API response log messages

### DIFF
--- a/src/pynetappfoundry/clients/openapi.py
+++ b/src/pynetappfoundry/clients/openapi.py
@@ -660,12 +660,12 @@ class APIWrapper:
             retry_config=retry_config,
         )
 
-        logging.debug(f"{self.log_prefix} Response Status Code: {resp.status_code}")
+        logging.debug(f"{self.log_prefix} {path} Response Status Code: {resp.status_code}")
         resp.raise_for_status()
 
         # Try JSON, else return text
         try:
-            logging.debug(f"{self.log_prefix} Response Text: {resp.text}")
+            logging.debug(f"{self.log_prefix} {path} Response Text: {resp.text}")
             response_data = resp.json()
         except ValueError:
             response_data = resp.text


### PR DESCRIPTION
## Description

Add the API path to Response Status Code and Response Text debug messages to make it easier to identify which endpoint a response relates to when debugging.

**Before:**
```
[CLUSTER:api] Response Status Code: 200
[CLUSTER:api] Response Text: {
```

**After:**
```
[CLUSTER:api] /cluster?fields=* Response Status Code: 200
[CLUSTER:api] /cluster?fields=* Response Text: {
```

## Related Issue

Closes #176

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `{path}` to Response Status Code log message
- Added `{path}` to Response Text log message

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings