### PR TITLE
fix: handle string values in SnapMirror and cluster peer API parsing

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -1493,7 +1493,8 @@ class MetadataCollector:
         # Process SnapMirror relationships
         sm_response = responses.get(endpoints[0]) or {}
         logger.debug(
-            "API response: %d SnapMirror relationships",
+            "%s API response: %d SnapMirror relationships",
+            self._log_prefix,
             len(sm_response.get("records", [])),
         )
         snapmirror_destinations = []
@@ -1517,17 +1518,26 @@ class MetadataCollector:
         )
         cluster_peers = []
         for record in peer_response.get("records", []):
+            # Handle fields that may be dicts or strings depending on API version
+            remote = record.get("remote")
+            remote_name = remote.get("name", "") if isinstance(remote, dict) else str(remote or "")
+            auth = record.get("authentication")
+            auth_state = auth.get("state", "") if isinstance(auth, dict) else str(auth or "")
+            status = record.get("status")
+            availability = (
+                status.get("state", "") if isinstance(status, dict) else str(status or "")
+            )
             peer = ClusterPeer(
                 name=record.get("name", ""),
                 uuid=record.get("uuid", ""),
-                remote_cluster_name=record.get("remote", {}).get("name", ""),
+                remote_cluster_name=remote_name,
                 peer_addresses=[
                     addr.get("address", "")
                     for addr in record.get("peer_applications", [])
-                    if addr.get("address")
+                    if isinstance(addr, dict) and addr.get("address")
                 ],
-                authentication_state=record.get("authentication", {}).get("state", ""),
-                availability=record.get("status", {}).get("state", ""),
+                authentication_state=auth_state,
+                availability=availability,
             )
             cluster_peers.append(peer)
 
@@ -1588,15 +1598,21 @@ class MetadataCollector:
         )
 
     @staticmethod
-    def _format_path(path_info: dict[str, Any]) -> str:
+    def _format_path(path_info: dict[str, Any] | str | None) -> str:
         """Format SVM:volume path from API response.
 
         Args:
-            path_info: Path info dict with svm and path keys.
+            path_info: Path info dict with svm and path keys, or a string path,
+                or None.
 
         Returns:
             Formatted path string.
         """
+        # Handle string paths (API may return path directly as string)
+        if isinstance(path_info, str):
+            return path_info
+        if not path_info:
+            return ""
         svm_dict = path_info.get("svm")
         svm: str = svm_dict.get("name", "") if isinstance(svm_dict, dict) else ""
         path_val = path_info.get("path")

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -814,6 +814,102 @@ class TestRelationshipsCollection:
         assert isinstance(result, RelationshipsInfo)
         assert result.snapmirror_destinations == []
 
+    def test_collect_relationships_with_string_paths(self) -> None:
+        """Test relationships handles string paths from API (instead of dicts)."""
+        sm_endpoint = (
+            "/snapmirror/relationships?fields=source,destination,policy.type,state,healthy,lag_time"
+        )
+        api_responses = {
+            sm_endpoint: {
+                "records": [
+                    {
+                        # API returns path as string directly instead of dict
+                        "source": "svm1:vol1",
+                        "destination": "svm2:vol1_dp",
+                        "policy": {"type": "async"},
+                        "state": "snapmirrored",
+                        "healthy": True,
+                        "lag_time": "PT5M",
+                    }
+                ]
+            },
+            "/cluster/peers?fields=*": {"records": []},
+        }
+
+        api_client = MagicMock()
+        api_client.call_endpoint.side_effect = lambda endpoint, **_: api_responses.get(endpoint, {})
+
+        collector = MetadataCollector(api_client=api_client)
+        result = collector.collect_relationships()
+
+        assert len(result.snapmirror_destinations) == 1
+        assert result.snapmirror_destinations[0].source_path == "svm1:vol1"
+        assert result.snapmirror_destinations[0].destination_path == "svm2:vol1_dp"
+
+    def test_collect_relationships_with_string_peer_fields(self) -> None:
+        """Test relationships handles string fields in cluster peers (instead of dicts)."""
+        sm_endpoint = (
+            "/snapmirror/relationships?fields=source,destination,policy.type,state,healthy,lag_time"
+        )
+        api_responses = {
+            sm_endpoint: {"records": []},
+            "/cluster/peers?fields=*": {
+                "records": [
+                    {
+                        "name": "peer1",
+                        "uuid": "abc-123",
+                        # API returns these as strings instead of dicts
+                        "remote": "remote-cluster",
+                        "peer_applications": [],
+                        "authentication": "ok",
+                        "status": "available",
+                    }
+                ]
+            },
+        }
+
+        api_client = MagicMock()
+        api_client.call_endpoint.side_effect = lambda endpoint, **_: api_responses.get(endpoint, {})
+
+        collector = MetadataCollector(api_client=api_client)
+        result = collector.collect_relationships()
+
+        assert len(result.cluster_peers) == 1
+        assert result.cluster_peers[0].name == "peer1"
+        assert result.cluster_peers[0].remote_cluster_name == "remote-cluster"
+        assert result.cluster_peers[0].authentication_state == "ok"
+        assert result.cluster_peers[0].availability == "available"
+
+    def test_collect_relationships_with_none_path(self) -> None:
+        """Test relationships handles None path values."""
+        sm_endpoint = (
+            "/snapmirror/relationships?fields=source,destination,policy.type,state,healthy,lag_time"
+        )
+        api_responses = {
+            sm_endpoint: {
+                "records": [
+                    {
+                        "source": None,
+                        "destination": None,
+                        "policy": {"type": "async"},
+                        "state": "snapmirrored",
+                        "healthy": True,
+                    }
+                ]
+            },
+            "/cluster/peers?fields=*": {"records": []},
+        }
+
+        api_client = MagicMock()
+        api_client.call_endpoint.side_effect = lambda endpoint, **_: api_responses.get(endpoint, {})
+
+        collector = MetadataCollector(api_client=api_client)
+        result = collector.collect_relationships()
+
+        assert len(result.snapmirror_destinations) == 1
+        assert result.snapmirror_destinations[0].source_path == ""
+        assert result.snapmirror_destinations[0].destination_path == ""
+
 
 class TestCollectAll:
     """Tests for collect_all method."""
@@ -833,6 +929,43 @@ class TestCollectAll:
         assert result.cluster_name == "test-cluster"
         assert result.cached_at is not None
         assert result.cache_version == "1.1"
+
+
+class TestFormatPath:
+    """Tests for _format_path static method."""
+
+    def test_format_path_with_dict(self) -> None:
+        """Test formatting path from dict with svm and path keys."""
+        path_info = {"svm": {"name": "svm1"}, "path": "vol1"}
+        assert MetadataCollector._format_path(path_info) == "svm1:vol1"
+
+    def test_format_path_with_string(self) -> None:
+        """Test formatting path when API returns string directly."""
+        assert MetadataCollector._format_path("svm1:vol1") == "svm1:vol1"
+
+    def test_format_path_with_none(self) -> None:
+        """Test formatting path with None input."""
+        assert MetadataCollector._format_path(None) == ""
+
+    def test_format_path_with_empty_dict(self) -> None:
+        """Test formatting path with empty dict."""
+        assert MetadataCollector._format_path({}) == ""
+
+    def test_format_path_with_path_only(self) -> None:
+        """Test formatting path when only path is present (no svm)."""
+        path_info: dict[str, Any] = {"path": "vol1"}
+        assert MetadataCollector._format_path(path_info) == "vol1"
+
+    def test_format_path_with_svm_only(self) -> None:
+        """Test formatting path when only svm is present (no path)."""
+        path_info = {"svm": {"name": "svm1"}}
+        assert MetadataCollector._format_path(path_info) == "svm1"
+
+    def test_format_path_with_svm_as_string(self) -> None:
+        """Test formatting path when svm is string instead of dict."""
+        path_info: dict[str, Any] = {"svm": "svm1", "path": "vol1"}
+        # When svm is string (not dict), we can't extract name, so only path is used
+        assert MetadataCollector._format_path(path_info) == "vol1"
 
 
 class TestNormalizeCliKey:


### PR DESCRIPTION
## Description

The ONTAP API may return string values instead of dicts for certain fields depending on API version or cluster configuration. This caused `'str' object has no attribute 'get'` errors during metadata collection, forcing unnecessary fallback to CLI.

## Related Issue

Closes #178

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Fix `_format_path` to handle string paths and None values instead of only dicts
- Fix cluster peer parsing to handle `remote`, `authentication`, and `status` fields that may be strings
- Add missing `self._log_prefix` to SnapMirror relationships log message
- Add comprehensive tests for string and None value edge cases

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)