### PR TITLE
fix: read cluster peer addresses from remote.ip_addresses

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -1527,15 +1527,13 @@ class MetadataCollector:
             availability = (
                 status.get("state", "") if isinstance(status, dict) else str(status or "")
             )
+            # Get peer addresses from remote.ip_addresses (not peer_applications)
+            peer_addresses = remote.get("ip_addresses", []) if isinstance(remote, dict) else []
             peer = ClusterPeer(
                 name=record.get("name", ""),
                 uuid=record.get("uuid", ""),
                 remote_cluster_name=remote_name,
-                peer_addresses=[
-                    addr.get("address", "")
-                    for addr in record.get("peer_applications", [])
-                    if isinstance(addr, dict) and addr.get("address")
-                ],
+                peer_addresses=[addr for addr in peer_addresses if addr],
                 authentication_state=auth_state,
                 availability=availability,
             )

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -780,8 +780,8 @@ class TestRelationshipsCollection:
                     {
                         "name": "peer1",
                         "uuid": "abc-123",
-                        "remote": {"name": "remote-cluster"},
-                        "peer_applications": [{"address": "10.0.1.1"}],
+                        "remote": {"name": "remote-cluster", "ip_addresses": ["10.0.1.1"]},
+                        "peer_applications": ["snapmirror"],
                         "authentication": {"state": "ok"},
                         "status": {"state": "available"},
                     }
@@ -805,6 +805,7 @@ class TestRelationshipsCollection:
         assert result.snapmirror_destinations[0].source_path == "svm1:vol1"
         assert len(result.cluster_peers) == 1
         assert result.cluster_peers[0].remote_cluster_name == "remote-cluster"
+        assert result.cluster_peers[0].peer_addresses == ["10.0.1.1"]
 
     def test_collect_relationships_no_clients(self) -> None:
         """Test relationships returns empty when no clients."""
@@ -879,6 +880,8 @@ class TestRelationshipsCollection:
         assert result.cluster_peers[0].remote_cluster_name == "remote-cluster"
         assert result.cluster_peers[0].authentication_state == "ok"
         assert result.cluster_peers[0].availability == "available"
+        # When remote is a string, peer_addresses will be empty
+        assert result.cluster_peers[0].peer_addresses == []
 
     def test_collect_relationships_with_none_path(self) -> None:
         """Test relationships handles None path values."""


### PR DESCRIPTION
## Description

The `peer_addresses` field was always empty because the code was reading from `peer_applications` (which contains app names like `["snapmirror"]`) instead of `remote.ip_addresses` (which contains the actual IP addresses per the ONTAP API schema).

## Related Issue

Closes #182

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Read `peer_addresses` from `remote.ip_addresses` instead of `peer_applications`
- Update test fixtures to match actual API schema
- Add assertions to verify `peer_addresses` is populated correctly

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)