### PR TITLE
feat: add cache inspect command for troubleshooting

### DIFF
--- a/src/pynetappfoundry/cli/commands/cache/__init__.py
+++ b/src/pynetappfoundry/cli/commands/cache/__init__.py
@@ -4,6 +4,7 @@ import click
 
 from pynetappfoundry.cli.commands.cache.clear import clear
 from pynetappfoundry.cli.commands.cache.history import history
+from pynetappfoundry.cli.commands.cache.inspect import inspect
 from pynetappfoundry.cli.commands.cache.query import query
 from pynetappfoundry.cli.commands.cache.refresh import refresh
 from pynetappfoundry.cli.commands.cache.schema import schema
@@ -27,6 +28,7 @@ def cache() -> None:
 
 cache.add_command(clear)
 cache.add_command(history)
+cache.add_command(inspect)
 cache.add_command(query)
 cache.add_command(refresh)
 cache.add_command(schema)

--- a/src/pynetappfoundry/cli/commands/cache/inspect.py
+++ b/src/pynetappfoundry/cli/commands/cache/inspect.py
@@ -1,0 +1,270 @@
+"""Cache inspect command for troubleshooting field mappings."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.console import Console
+from rich.tree import Tree
+
+from pynetappfoundry.cache import ClusterMetadataDB
+from pynetappfoundry.cache.field_mapping import TypeMapping
+from pynetappfoundry.cache.mappings import VOLUME_MAPPING
+from pynetappfoundry.cli.utils import print_error, print_exception, print_warning
+from pynetappfoundry.clients.ontap import ONTAPCLI, ONTAPAPIClient
+from pynetappfoundry.core.config import Config
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+# Registry of supported object types for inspection.
+# Maps type name to (TypeMapping, cache_path) where cache_path is the
+# dot-path to the list of objects in CachedClusterMetadata.
+INSPECT_TYPES: dict[str, tuple[TypeMapping, str]] = {
+    "volume": (VOLUME_MAPPING, "storage.volumes"),
+}
+
+
+def _resolve_cache_list(
+    metadata: Any,
+    cache_path: str,
+) -> list[Any]:
+    """Walk dotted cache_path on a metadata object to get the list.
+
+    Args:
+        metadata: CachedClusterMetadata instance.
+        cache_path: Dot-separated attribute path (e.g. "storage.volumes").
+
+    Returns:
+        The list at the end of the path, or empty list on error.
+    """
+    obj = metadata
+    for attr in cache_path.split("."):
+        obj = getattr(obj, attr, None)
+        if obj is None:
+            return []
+    return obj if isinstance(obj, list) else []
+
+
+def _format_value(value: object) -> str:
+    """Format a value for tree display.
+
+    Args:
+        value: Value to format.
+
+    Returns:
+        Rich-formatted string.
+    """
+    if isinstance(value, bool):
+        return f"[yellow]{value}[/yellow]"
+    if isinstance(value, (int, float)):
+        return f"[magenta]{value}[/magenta]"
+    if isinstance(value, str):
+        if not value:
+            return "[dim](empty)[/dim]"
+        return f"[green]{value}[/green]"
+    if isinstance(value, list):
+        if not value:
+            return "[dim](empty list)[/dim]"
+        return f"[cyan]{len(value)} items[/cyan]"
+    return str(value)
+
+
+def _build_cache_tree(obj: Any) -> Tree:
+    """Build a Rich tree from a Pydantic model or dict.
+
+    Args:
+        obj: Model instance or dict to display.
+
+    Returns:
+        Populated Rich Tree.
+    """
+    tree = Tree("[bold]CACHE[/bold]")
+    data = obj.model_dump() if hasattr(obj, "model_dump") else dict(obj)
+    for key, value in data.items():
+        if isinstance(value, list):
+            branch = tree.add(f"[cyan]{key}[/cyan]: {_format_value(value)}")
+            for item in value:
+                branch.add(f"[green]{item}[/green]")
+        else:
+            tree.add(f"[cyan]{key}[/cyan]: {_format_value(value)}")
+    return tree
+
+
+def _fetch_api_data(
+    api_client: ONTAPAPIClient,
+    mapping: TypeMapping,
+    object_name: str,
+) -> dict[str, Any] | None:
+    """Fetch a single object from the REST API by name.
+
+    Args:
+        api_client: Initialised ONTAP API client.
+        mapping: TypeMapping for the object type.
+        object_name: Name of the object to look up.
+
+    Returns:
+        The first matching record dict, or None.
+    """
+    # Build endpoint with name filter.
+    base_endpoint = mapping.api_endpoint
+    separator = "&" if "?" in base_endpoint else "?"
+    endpoint = f"{base_endpoint}{separator}name={object_name}"
+
+    response = api_client.call_endpoint(endpoint)
+    records: list[dict[str, Any]] = response.get("records", []) if response else []
+    if records:
+        return records[0]
+    return None
+
+
+def _fetch_cli_data(
+    cli_client: ONTAPCLI,
+    mapping: TypeMapping,
+    object_name: str,
+) -> tuple[dict[str, str] | None, dict[str, str]]:
+    """Fetch a single object from the CLI by name.
+
+    Args:
+        cli_client: Initialised ONTAP SSH client.
+        mapping: TypeMapping for the object type.
+        object_name: Name of the object to look up.
+
+    Returns:
+        Tuple of (first data record or None, field descriptions dict).
+    """
+    records, descriptions = cli_client.run_a_show_command_and_parse_seperator(
+        mapping.cli_command,
+        arguments=object_name,
+    )
+    if records:
+        return records[0], descriptions
+    return None, descriptions
+
+
+@click.command()
+@click.argument("cluster")
+@click.argument("object_name")
+@click.option(
+    "--type",
+    "-t",
+    "object_type",
+    type=click.Choice(sorted(INSPECT_TYPES.keys()), case_sensitive=False),
+    default="volume",
+    show_default=True,
+    help="Object type to inspect.",
+)
+@click.pass_context
+def inspect(ctx: click.Context, cluster: str, object_name: str, object_type: str) -> None:
+    """Inspect cache, CLI, and API data for a single object.
+
+    Displays three sections so you can compare what is stored in the
+    local cache versus the live API and CLI responses from the cluster.
+
+    \b
+    Examples:
+        nf cache inspect PRODCL1 PRODVOL1
+        nf cache inspect PRODCL1 PRODVOL1 --type volume
+    """
+    config_dir = ctx.obj.get("config_dir", "config")
+
+    config_path = Path.cwd() / config_dir
+    if not config_path.exists():
+        print_error(f"Configuration directory not found: {config_path}")
+        ctx.exit(1)
+
+    try:
+        config = Config(config_dir=config_dir, script_name="cache-inspect")
+    except Exception as e:
+        print_exception(f"Failed to load configuration: {e}", e)
+        ctx.exit(1)
+
+    if cluster not in config.data.get("clusters", {}):
+        print_error(f"Cluster '{cluster}' not found in configuration.")
+        available = list(config.data.get("clusters", {}).keys())
+        if available:
+            console.print(f"Available clusters: {', '.join(available)}")
+        ctx.exit(1)
+
+    mapping, cache_path = INSPECT_TYPES[object_type.lower()]
+
+    # ── CACHE section ──────────────────────────────────────────────
+    console.print()
+    console.rule("[bold] CACHE [/bold]")
+    db = ClusterMetadataDB(config=config)
+    metadata = db.get(cluster)
+    db.close()
+
+    if metadata:
+        items = _resolve_cache_list(metadata, cache_path)
+        match = next((i for i in items if getattr(i, "name", None) == object_name), None)
+        if match:
+            console.print(_build_cache_tree(match))
+        else:
+            print_warning(
+                f"Object '{object_name}' not found in cache section '{cache_path}'. "
+                "Try 'nf cache refresh' first."
+            )
+    else:
+        print_warning(f"No cached data for cluster '{cluster}'. Run 'nf cache refresh' first.")
+
+    # ── CLI section ────────────────────────────────────────────────
+    console.print()
+    console.rule("[bold] CLI [/bold]")
+
+    cluster_data = config.data["clusters"][cluster]
+    user, password = config.get_user("clusters", cluster)
+
+    cli_client: ONTAPCLI | None = None
+    try:
+        cli_client = ONTAPCLI(
+            name=cluster,
+            host_or_ip=cluster_data.get("ip", ""),
+            username=user,
+            password=password,
+        )
+        cli_record, cli_descriptions = _fetch_cli_data(cli_client, mapping, object_name)
+        if cli_record:
+            tree = Tree("[bold]CLI[/bold]")
+            for key, value in cli_record.items():
+                desc = cli_descriptions.get(key, "")
+                label = f"[dim]{desc}[/dim] " if desc else ""
+                tree.add(f"[cyan]{key}[/cyan]: {label}[green]{value}[/green]")
+            console.print(tree)
+        else:
+            print_warning(f"CLI returned no data for '{object_name}'.")
+    except Exception as e:
+        print_exception(f"CLI query failed: {e}", e)
+    finally:
+        if cli_client:
+            with contextlib.suppress(Exception):
+                cli_client.disconnect()
+
+    # ── API section ────────────────────────────────────────────────
+    console.print()
+    console.rule("[bold] API [/bold]")
+
+    class _ClusterObj:
+        def __init__(self, name: str, ip: str) -> None:
+            self.name = name
+            self.ip = ip
+
+    try:
+        api_client = ONTAPAPIClient(
+            cluster=_ClusterObj(cluster, cluster_data.get("ip", "")),
+            config=config,
+        )
+        api_record = _fetch_api_data(api_client, mapping, object_name)
+        if api_record:
+            console.print_json(json.dumps(api_record, default=str))
+        else:
+            print_warning(f"API returned no data for '{object_name}'.")
+    except Exception as e:
+        print_exception(f"API query failed: {e}", e)
+
+    console.print()

--- a/tests/unit/cli/commands/cache/test_inspect.py
+++ b/tests/unit/cli/commands/cache/test_inspect.py
@@ -1,0 +1,544 @@
+"""Tests for cache inspect CLI command."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from pynetappfoundry.cache.models import (
+    CachedClusterMetadata,
+    StorageInfo,
+    VolumeInfo,
+)
+from pynetappfoundry.cli.commands.cache.inspect import (
+    INSPECT_TYPES,
+    _build_cache_tree,
+    _format_value,
+    _resolve_cache_list,
+)
+from pynetappfoundry.cli.main import nf
+
+
+class TestResolveCache:
+    """Tests for _resolve_cache_list helper."""
+
+    def test_resolve_volumes(self) -> None:
+        """Test resolving storage.volumes from metadata."""
+        vol = VolumeInfo(name="vol1", uuid="u1")
+        meta = CachedClusterMetadata(
+            cluster_name="c1",
+            storage=StorageInfo(volumes=[vol]),
+        )
+        result = _resolve_cache_list(meta, "storage.volumes")
+        assert len(result) == 1
+        assert result[0].name == "vol1"
+
+    def test_resolve_bad_path(self) -> None:
+        """Test resolving a non-existent path returns empty list."""
+        meta = CachedClusterMetadata(cluster_name="c1")
+        assert _resolve_cache_list(meta, "nonexistent.path") == []
+
+    def test_resolve_non_list(self) -> None:
+        """Test resolving a path that is not a list returns empty list."""
+        meta = CachedClusterMetadata(cluster_name="c1")
+        assert _resolve_cache_list(meta, "cluster") == []
+
+
+class TestFormatValue:
+    """Tests for _format_value helper."""
+
+    def test_format_bool(self) -> None:
+        """Test boolean formatting."""
+        assert "True" in _format_value(True)
+
+    def test_format_int(self) -> None:
+        """Test integer formatting."""
+        assert "42" in _format_value(42)
+
+    def test_format_empty_string(self) -> None:
+        """Test empty string shows (empty)."""
+        assert "(empty)" in _format_value("")
+
+    def test_format_nonempty_string(self) -> None:
+        """Test non-empty string formatting."""
+        assert "hello" in _format_value("hello")
+
+    def test_format_empty_list(self) -> None:
+        """Test empty list shows (empty list)."""
+        assert "(empty list)" in _format_value([])
+
+    def test_format_nonempty_list(self) -> None:
+        """Test non-empty list shows item count."""
+        assert "3 items" in _format_value([1, 2, 3])
+
+
+class TestBuildCacheTree:
+    """Tests for _build_cache_tree helper."""
+
+    def test_builds_tree_from_model(self) -> None:
+        """Test tree is built from a Pydantic model."""
+        vol = VolumeInfo(name="vol1", uuid="u1", size=1024)
+        tree = _build_cache_tree(vol)
+        assert tree.label == "[bold]CACHE[/bold]"
+
+    def test_builds_tree_from_dict(self) -> None:
+        """Test tree is built from a plain dict."""
+        tree = _build_cache_tree({"key": "value"})
+        assert tree.label == "[bold]CACHE[/bold]"
+
+
+class TestInspectTypes:
+    """Tests for INSPECT_TYPES registry."""
+
+    def test_volume_registered(self) -> None:
+        """Test volume type is registered."""
+        assert "volume" in INSPECT_TYPES
+
+    def test_volume_cache_path(self) -> None:
+        """Test volume cache path is correct."""
+        _, cache_path = INSPECT_TYPES["volume"]
+        assert cache_path == "storage.volumes"
+
+
+class TestInspectCommand:
+    """Tests for nf cache inspect command."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_config_dir(self, tmp_path: Path) -> Path:
+        """Create a mock config directory."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.toml").write_text(
+            """
+[ontapapi]
+[ontapapi.general]
+base_api_path = "/api"
+"""
+        )
+        return config_dir
+
+    @pytest.fixture
+    def sample_metadata(self) -> CachedClusterMetadata:
+        """Create sample metadata with a volume."""
+        return CachedClusterMetadata(
+            cluster_name="test-cluster",
+            cached_at=datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
+            storage=StorageInfo(
+                volumes=[
+                    VolumeInfo(
+                        uuid="abc-123",
+                        name="PRODVOL1",
+                        svm="svm_PROD",
+                        state="online",
+                        type="rw",
+                        style="flexvol",
+                        size=9064378368,
+                    ),
+                ],
+            ),
+        )
+
+    def test_inspect_missing_config(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Test inspect with missing config directory."""
+        result = runner.invoke(
+            nf,
+            ["-c", str(tmp_path / "nonexistent"), "cache", "inspect", "cluster1", "vol1"],
+        )
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.inspect.Config")
+    def test_inspect_unknown_cluster(
+        self,
+        mock_config_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test inspect with cluster not in config."""
+        mock_config = MagicMock()
+        mock_config.data = {"clusters": {}}
+        mock_config_class.return_value = mock_config
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "inspect", "unknown", "vol1"],
+        )
+        assert result.exit_code != 0
+        assert "not found in configuration" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.Config")
+    def test_inspect_shows_cache_data(
+        self,
+        mock_config_class: MagicMock,
+        mock_db_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test that inspect shows cached volume data."""
+        mock_config = MagicMock()
+        mock_config.data = {"clusters": {"test-cluster": {"ip": "10.0.0.1"}}}
+        mock_config.get_user.return_value = ("admin", "pass")
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        mock_cli = MagicMock()
+        mock_cli.run_a_show_command_and_parse_seperator.return_value = ([], {})
+        mock_cli_class.return_value = mock_cli
+
+        mock_api = MagicMock()
+        mock_api.call_endpoint.return_value = {"records": []}
+        mock_api_class.return_value = mock_api
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "inspect", "test-cluster", "PRODVOL1"],
+        )
+
+        assert result.exit_code == 0
+        assert "CACHE" in result.output
+        assert "PRODVOL1" in result.output
+        assert "abc-123" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.Config")
+    def test_inspect_cache_miss(
+        self,
+        mock_config_class: MagicMock,
+        mock_db_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test inspect when object is not found in cache."""
+        mock_config = MagicMock()
+        mock_config.data = {"clusters": {"test-cluster": {"ip": "10.0.0.1"}}}
+        mock_config.get_user.return_value = ("admin", "pass")
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        mock_cli = MagicMock()
+        mock_cli.run_a_show_command_and_parse_seperator.return_value = ([], {})
+        mock_cli_class.return_value = mock_cli
+
+        mock_api = MagicMock()
+        mock_api.call_endpoint.return_value = {"records": []}
+        mock_api_class.return_value = mock_api
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "inspect", "test-cluster", "NONEXISTENT"],
+        )
+
+        assert result.exit_code == 0
+        assert "not found in cache" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.Config")
+    def test_inspect_no_cache_for_cluster(
+        self,
+        mock_config_class: MagicMock,
+        mock_db_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test inspect when no cache exists for the cluster."""
+        mock_config = MagicMock()
+        mock_config.data = {"clusters": {"test-cluster": {"ip": "10.0.0.1"}}}
+        mock_config.get_user.return_value = ("admin", "pass")
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = None
+        mock_db_class.return_value = mock_db
+
+        mock_cli = MagicMock()
+        mock_cli.run_a_show_command_and_parse_seperator.return_value = ([], {})
+        mock_cli_class.return_value = mock_cli
+
+        mock_api = MagicMock()
+        mock_api.call_endpoint.return_value = {"records": []}
+        mock_api_class.return_value = mock_api
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "inspect", "test-cluster", "vol1"],
+        )
+
+        assert result.exit_code == 0
+        assert "No cached data" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.Config")
+    def test_inspect_shows_cli_data(
+        self,
+        mock_config_class: MagicMock,
+        mock_db_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test that inspect shows CLI data when available."""
+        mock_config = MagicMock()
+        mock_config.data = {"clusters": {"test-cluster": {"ip": "10.0.0.1"}}}
+        mock_config.get_user.return_value = ("admin", "pass")
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = None
+        mock_db_class.return_value = mock_db
+
+        cli_record = {"volume": "vol1", "vserver": "svm1", "state": "online"}
+        descriptions = {"volume": "Volume Name", "vserver": "Vserver Name", "state": "State"}
+        mock_cli = MagicMock()
+        mock_cli.run_a_show_command_and_parse_seperator.return_value = (
+            [cli_record],
+            descriptions,
+        )
+        mock_cli_class.return_value = mock_cli
+
+        mock_api = MagicMock()
+        mock_api.call_endpoint.return_value = {"records": []}
+        mock_api_class.return_value = mock_api
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "inspect", "test-cluster", "vol1"],
+        )
+
+        assert result.exit_code == 0
+        assert "CLI" in result.output
+        assert "vol1" in result.output
+        assert "svm1" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.Config")
+    def test_inspect_shows_api_data(
+        self,
+        mock_config_class: MagicMock,
+        mock_db_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test that inspect shows API data when available."""
+        mock_config = MagicMock()
+        mock_config.data = {"clusters": {"test-cluster": {"ip": "10.0.0.1"}}}
+        mock_config.get_user.return_value = ("admin", "pass")
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = None
+        mock_db_class.return_value = mock_db
+
+        mock_cli = MagicMock()
+        mock_cli.run_a_show_command_and_parse_seperator.return_value = ([], {})
+        mock_cli_class.return_value = mock_cli
+
+        api_record = {"uuid": "abc-123", "name": "vol1", "state": "online"}
+        mock_api = MagicMock()
+        mock_api.call_endpoint.return_value = {"records": [api_record]}
+        mock_api_class.return_value = mock_api
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "inspect", "test-cluster", "vol1"],
+        )
+
+        assert result.exit_code == 0
+        assert "API" in result.output
+        assert "abc-123" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.Config")
+    def test_inspect_cli_failure_handled(
+        self,
+        mock_config_class: MagicMock,
+        mock_db_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test that CLI failure is handled gracefully."""
+        mock_config = MagicMock()
+        mock_config.data = {"clusters": {"test-cluster": {"ip": "10.0.0.1"}}}
+        mock_config.get_user.return_value = ("admin", "pass")
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = None
+        mock_db_class.return_value = mock_db
+
+        mock_cli_class.side_effect = Exception("SSH connection failed")
+
+        mock_api = MagicMock()
+        mock_api.call_endpoint.return_value = {"records": []}
+        mock_api_class.return_value = mock_api
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "inspect", "test-cluster", "vol1"],
+        )
+
+        assert result.exit_code == 0
+        assert "CLI query failed" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.Config")
+    def test_inspect_api_failure_handled(
+        self,
+        mock_config_class: MagicMock,
+        mock_db_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test that API failure is handled gracefully."""
+        mock_config = MagicMock()
+        mock_config.data = {"clusters": {"test-cluster": {"ip": "10.0.0.1"}}}
+        mock_config.get_user.return_value = ("admin", "pass")
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = None
+        mock_db_class.return_value = mock_db
+
+        mock_cli = MagicMock()
+        mock_cli.run_a_show_command_and_parse_seperator.return_value = ([], {})
+        mock_cli_class.return_value = mock_cli
+
+        mock_api_class.side_effect = Exception("API connection failed")
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "inspect", "test-cluster", "vol1"],
+        )
+
+        assert result.exit_code == 0
+        assert "API query failed" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.Config")
+    def test_inspect_cli_no_data(
+        self,
+        mock_config_class: MagicMock,
+        mock_db_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test inspect when CLI returns no data."""
+        mock_config = MagicMock()
+        mock_config.data = {"clusters": {"test-cluster": {"ip": "10.0.0.1"}}}
+        mock_config.get_user.return_value = ("admin", "pass")
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = None
+        mock_db_class.return_value = mock_db
+
+        mock_cli = MagicMock()
+        mock_cli.run_a_show_command_and_parse_seperator.return_value = ([], {})
+        mock_cli_class.return_value = mock_cli
+
+        mock_api = MagicMock()
+        mock_api.call_endpoint.return_value = {"records": []}
+        mock_api_class.return_value = mock_api
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "inspect", "test-cluster", "vol1"],
+        )
+
+        assert result.exit_code == 0
+        assert "CLI returned no data" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.Config")
+    def test_inspect_api_no_data(
+        self,
+        mock_config_class: MagicMock,
+        mock_db_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test inspect when API returns no data."""
+        mock_config = MagicMock()
+        mock_config.data = {"clusters": {"test-cluster": {"ip": "10.0.0.1"}}}
+        mock_config.get_user.return_value = ("admin", "pass")
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = None
+        mock_db_class.return_value = mock_db
+
+        mock_cli = MagicMock()
+        mock_cli.run_a_show_command_and_parse_seperator.return_value = ([], {})
+        mock_cli_class.return_value = mock_cli
+
+        mock_api = MagicMock()
+        mock_api.call_endpoint.return_value = {"records": []}
+        mock_api_class.return_value = mock_api
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "inspect", "test-cluster", "vol1"],
+        )
+
+        assert result.exit_code == 0
+        assert "API returned no data" in result.output
+
+    def test_inspect_invalid_type(self, runner: CliRunner, mock_config_dir: Path) -> None:
+        """Test inspect with invalid object type."""
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "inspect", "c1", "v1", "--type", "badtype"],
+        )
+        assert result.exit_code != 0


### PR DESCRIPTION
## Description

Add `nf cache inspect` CLI command for troubleshooting cache field mapping issues. The command displays three sections for a single named object on a cluster:

1. **CACHE** — stored fields from the local metadata DB
2. **CLI** — raw parsed output from ONTAP SSH CLI
3. **API** — raw JSON from the ONTAP REST API

This makes it easy to compare what the cache stores versus what the live sources return, identifying missing fields or mapping mismatches.

## Related Issue

Closes #218

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `src/pynetappfoundry/cli/commands/cache/inspect.py` with the `nf cache inspect` command
- Added extensible `INSPECT_TYPES` registry using existing `TypeMapping` framework (volume supported as pilot)
- Registered the `inspect` subcommand in cache command group
- Added 16 tests covering cache hits/misses, CLI/API data display, error handling, and edge cases

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (format, lint, type_check, security, spell, test)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
