### PR TITLE
fix: add dual API calls to cache inspect for comparison

### DIFF
--- a/src/pynetappfoundry/cli/commands/cache/inspect.py
+++ b/src/pynetappfoundry/cli/commands/cache/inspect.py
@@ -127,15 +127,15 @@ def _build_cli_command(mapping: TypeMapping, object_name: str) -> str:
     return f"{mapping.cli_command} {object_name}"
 
 
-def _fetch_api_data(
+def _fetch_api_filtered(
     api_client: ONTAPAPIClient,
     endpoint: str,
 ) -> dict[str, Any] | None:
-    """Fetch a single object from the REST API.
+    """Fetch a single object from the REST API using a name filter.
 
     Args:
         api_client: Initialised ONTAP API client.
-        endpoint: Full API endpoint to call.
+        endpoint: Full API endpoint with name= filter.
 
     Returns:
         The first matching record dict, or None.
@@ -144,6 +144,29 @@ def _fetch_api_data(
     records: list[dict[str, Any]] = response.get("records", []) if response else []
     if records:
         return records[0]
+    return None
+
+
+def _fetch_api_all(
+    api_client: ONTAPAPIClient,
+    endpoint: str,
+    object_name: str,
+) -> dict[str, Any] | None:
+    """Fetch all objects then search client-side (same as cache refresh).
+
+    Args:
+        api_client: Initialised ONTAP API client.
+        endpoint: Base API endpoint without name filter.
+        object_name: Name of the object to find in results.
+
+    Returns:
+        The matching record dict, or None.
+    """
+    response = api_client.call_endpoint(endpoint)
+    records: list[dict[str, Any]] = response.get("records", []) if response else []
+    for record in records:
+        if record.get("name") == object_name:
+            return record
     return None
 
 
@@ -274,9 +297,9 @@ def inspect(ctx: click.Context, cluster: str, object_name: str, object_type: str
             with contextlib.suppress(Exception):
                 cli_client.disconnect()
 
-    # ── API section ────────────────────────────────────────────────
+    # ── API (filtered) section ────────────────────────────────────
     console.print()
-    console.rule("[bold] API [/bold]")
+    console.rule("[bold] API (filtered) [/bold]")
     console.print(f"[dim]Endpoint: {api_endpoint}[/dim]")
 
     class _ClusterObj:
@@ -284,14 +307,35 @@ def inspect(ctx: click.Context, cluster: str, object_name: str, object_type: str
             self.name = name
             self.ip = ip
 
+    api_client: ONTAPAPIClient | None = None
     try:
         api_client = ONTAPAPIClient(
             cluster=_ClusterObj(cluster, cluster_data.get("ip", "")),
             config=config,
         )
-        api_record = _fetch_api_data(api_client, api_endpoint)
+        api_record = _fetch_api_filtered(api_client, api_endpoint)
         if api_record:
             console.print_json(json.dumps(api_record, default=str))
+        else:
+            print_warning(f"API returned no data for '{object_name}'.")
+    except Exception as e:
+        print_exception(f"API query failed: {e}", e)
+
+    # ── API (all) section ──────────────────────────────────────
+    base_endpoint = mapping.api_endpoint
+    console.print()
+    console.rule("[bold] API (all) [/bold]")
+    console.print(f"[dim]Endpoint: {base_endpoint}[/dim]")
+
+    try:
+        if not api_client:
+            api_client = ONTAPAPIClient(
+                cluster=_ClusterObj(cluster, cluster_data.get("ip", "")),
+                config=config,
+            )
+        api_record_all = _fetch_api_all(api_client, base_endpoint, object_name)
+        if api_record_all:
+            console.print_json(json.dumps(api_record_all, default=str))
         else:
             print_warning(f"API returned no data for '{object_name}'.")
     except Exception as e:

--- a/tests/unit/cli/commands/cache/test_inspect.py
+++ b/tests/unit/cli/commands/cache/test_inspect.py
@@ -619,13 +619,58 @@ base_api_path = "/api"
         )
 
         assert result.exit_code == 0
-        # Should show the API endpoint used
-        assert "Endpoint:" in result.output
-        assert "/storage/volumes" in result.output
+        # Should show both API sections
+        assert "API (filtered)" in result.output
+        assert "API (all)" in result.output
         assert "name=vol1" in result.output
         # Should show the CLI command used
         assert "Command:" in result.output
         assert "volume show vol1" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.ClusterMetadataDB")
+    @patch("pynetappfoundry.cli.commands.cache.inspect.Config")
+    def test_inspect_api_all_finds_by_name(
+        self,
+        mock_config_class: MagicMock,
+        mock_db_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test that API (all) fetches all records and finds the match."""
+        mock_config = MagicMock()
+        mock_config.data = {"clusters": {"test-cluster": {"ip": "10.0.0.1"}}}
+        mock_config.get_user.return_value = ("admin", "pass")
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = None
+        mock_db_class.return_value = mock_db
+
+        mock_cli = MagicMock()
+        mock_cli.run_a_show_command_and_parse_seperator.return_value = ([], {})
+        mock_cli_class.return_value = mock_cli
+
+        # API returns multiple records; the "all" section searches client-side
+        records = [
+            {"name": "other_vol", "uuid": "other-uuid"},
+            {"name": "vol1", "uuid": "target-uuid", "extra_field": "present"},
+        ]
+        mock_api = MagicMock()
+        mock_api.call_endpoint.return_value = {"records": records}
+        mock_api_class.return_value = mock_api
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "inspect", "test-cluster", "vol1"],
+        )
+
+        assert result.exit_code == 0
+        assert "target-uuid" in result.output
+        assert "extra_field" in result.output
 
     def test_inspect_invalid_type(self, runner: CliRunner, mock_config_dir: Path) -> None:
         """Test inspect with invalid object type."""


### PR DESCRIPTION
## Description

Split the API section in `nf cache inspect` into two separate calls for comparison:

1. **API (filtered)** — Queries with `&name=VOLNAME` (single object)
2. **API (all)** — Queries without name filter then searches client-side (same as `nf cache refresh`)

This reveals ONTAP API behavioral differences between filtered and bulk queries (e.g., `nas.security_style` is returned in bulk but not in filtered requests).

## Related Issue

Part of #218

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Split `_fetch_api_data` into `_fetch_api_filtered` (name filter) and `_fetch_api_all` (bulk + client search)
- Output now shows two API sections with their respective endpoints
- Added test for API (all) client-side name matching
- Updated endpoint display test for both sections

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
