### PR TITLE
docs: add ADR and developer guide for declarative field mapping framework

### DIFF
--- a/docs/decisions/0017-declarative-field-mapping-framework.md
+++ b/docs/decisions/0017-declarative-field-mapping-framework.md
@@ -1,0 +1,61 @@
+# ADR-0017: Declarative field mapping framework for ONTAP collection
+
+## Status
+
+Accepted
+
+## Context
+
+The collector module contained hand-written parsing methods for each ONTAP object type (volumes, aggregates, etc.). Each method manually extracted fields from API responses and CLI output, leading to:
+
+- Significant boilerplate — every new type required custom parsing functions for both API and CLI sources
+- Inconsistent field handling — some types missed "expensive" API fields (e.g., `autosize.*`, `files.*`, `nas.path`) because they weren't explicitly requested
+- No single source of truth — API endpoints and CLI commands were scattered across collector methods, making it hard to verify coverage or reuse them in tooling like the `cache inspect` command
+- API/CLI parity gaps — differences between API and CLI parsing for the same type were hard to spot
+
+## Decision
+
+Use a declarative field mapping framework based on two frozen dataclasses — `FieldMapping` and `TypeMapping` — to map ONTAP REST API and CLI responses to cache model objects. Generic parser functions (`parse_api_response`, `parse_cli_records`, `parse_api_record`, `parse_cli_record`) replace hand-written parsing methods.
+
+Each ONTAP object type is defined as a `TypeMapping` constant in `src/pynetappfoundry/cache/mappings/<type>.py`, declaring:
+
+- The REST API endpoint (including required `?fields=` params)
+- The CLI show command
+- A tuple of `FieldMapping` entries mapping each field across API path, CLI field name, and cache model attribute
+- Optional transform functions for fields that need custom extraction logic
+
+The pilot migration (VolumeInfo) was completed in PR #189.
+
+## Rationale
+
+1. **Reduces boilerplate** — new types only need a mapping definition, not custom parsing methods.
+
+2. **Ensures API/CLI parity** — both sources produce the same model using the same field definitions, making gaps immediately visible.
+
+3. **Centralizes API endpoints and CLI commands** — `TypeMapping.api_endpoint` and `TypeMapping.cli_command` are the single source of truth, used by the collector, `cache inspect` command, and future tooling.
+
+4. **Makes field requirements explicit** — expensive API fields (e.g., `autosize.*`, `files.*`, `nas.path`) are declared in the mapping rather than hidden in endpoint query strings.
+
+5. **Leverages existing utilities** — nested API path traversal uses `get_nested_value()` from `utils/dict_path.py`, and CLI value coercion handles ONTAP conventions (`-` for missing, `%` suffix, boolean strings).
+
+### Alternatives Considered
+
+- **Keep hand-written parsers**: Simpler per-type, but doesn't scale and makes parity hard to verify.
+- **Code generation from a schema**: More automated, but ONTAP's CLI/API asymmetry makes a pure schema approach fragile.
+- **Third-party ORM/mapping library**: Adds external dependency for a domain-specific problem that's well-served by two small dataclasses.
+
+## Consequences
+
+- All new ONTAP object types should use the mapping framework instead of hand-written parsers.
+- Existing hand-written parsers can be migrated incrementally (one type at a time).
+- The `cache inspect` command automatically works with any registered mapping.
+- Adding a new type follows a documented, repeatable process.
+
+## Related Issues
+
+- Issue #188: feat: add declarative field mapping framework
+- PR #189: feat: add declarative field mapping framework (pilot: VolumeInfo)
+
+## Related Documentation
+
+- [Field Mapping Framework Developer Guide](../development/field-mapping.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -73,3 +73,4 @@ The Issue contains the full discussion; the ADR summarizes the outcome.
 | [0010](0010-use-conventional-commits-format.md) | Use conventional commits format | Accepted |
 | [0011](0011-use-pytest-for-testing.md) | Use pytest for testing | Accepted |
 | [0012](0012-use-mkdocs-with-material-theme-for-documentation.md) | Use mkdocs with Material theme for documentation | Accepted |
+| [0017](0017-declarative-field-mapping-framework.md) | Declarative field mapping framework for ONTAP collection | Accepted |

--- a/docs/development/field-mapping.md
+++ b/docs/development/field-mapping.md
@@ -1,0 +1,269 @@
+---
+title: Field Mapping Framework
+description: Declarative framework for mapping ONTAP API/CLI data to cache models
+audience:
+  - contributors
+tags:
+  - development
+  - cache
+  - mapping
+---
+
+# Field Mapping Framework
+
+The declarative field mapping framework maps ONTAP REST API and CLI responses to cache model objects using data-driven definitions instead of hand-written parsing methods.
+
+**ADR:** [ADR-0017](../decisions/0017-declarative-field-mapping-framework.md)
+
+## Architecture
+
+```
+TypeMapping (one per ONTAP object type)
+├── api_endpoint    → REST API URL with ?fields= params
+├── cli_command     → CLI show command name
+├── model_class     → Pydantic model (e.g., VolumeInfo)
+└── fields          → tuple of FieldMapping entries
+    ├── FieldMapping(cache_attr, api_path, cli_field, ...)
+    ├── FieldMapping(cache_attr, api_path, cli_field, ...)
+    └── ...
+
+Generic parsers read these definitions at runtime:
+  parse_api_response()  → list[model_class]
+  parse_cli_records()   → list[model_class]
+```
+
+## Key Components
+
+All components live in `src/pynetappfoundry/cache/field_mapping.py`.
+
+### FieldMapping
+
+Maps a single field across three domains: API response, CLI output, and cache model attribute.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `cache_attr` | `str` | Model attribute name on the target Pydantic model. |
+| `api_path` | `str \| None` | Dot-path for API extraction (e.g., `"svm.name"`, `"aggregates[0].name"`). |
+| `cli_field` | `str \| None` | Hyphenated CLI field name (e.g., `"vserver"`). |
+| `default` | `Any` | Default value when the field is missing. Default: `""`. |
+| `transform` | `Callable \| None` | Custom API extraction function receiving the full record dict. Overrides `api_path`. |
+| `cli_transform` | `Callable \| None` | Custom CLI extraction function receiving the full record dict. Overrides `cli_field`. |
+
+### TypeMapping
+
+Defines a complete ONTAP object type mapping.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Human-readable type name (e.g., `"Volume"`). |
+| `model_class` | `type[BaseModel]` | Pydantic model class for the cache object. |
+| `api_endpoint` | `str` | REST API endpoint including query params. |
+| `cli_command` | `str` | CLI show command name. |
+| `fields` | `tuple[FieldMapping, ...]` | Tuple of field mapping definitions. |
+| `id_field` | `str` | Field used for log identification. Default: `"name"`. |
+
+Helper methods:
+
+- `api_expected_fields()` — derives top-level API keys from all `api_path` values (used for missing-field logging).
+- `cli_expected_fields()` — derives CLI field names from all `cli_field` values.
+
+### Generic Parsers
+
+| Function | Input | Output |
+|----------|-------|--------|
+| `parse_api_response()` | Full API response dict (with `"records"` key) | `list[BaseModel]` |
+| `parse_cli_records()` | List of CLI record dicts | `list[BaseModel]` |
+| `parse_api_record()` | Single API record dict | `BaseModel` |
+| `parse_cli_record()` | Single CLI record dict | `BaseModel` |
+
+### CLI Value Coercion
+
+`_coerce_cli_value(value, default)` handles ONTAP CLI conventions:
+
+| CLI Value | Coercion Rule |
+|-----------|---------------|
+| `"-"` or `""` | Returns the field's default value |
+| `"85%"` | Strips `%` suffix, converts to `int` (when default is `int`) |
+| `"true"`, `"yes"`, `"on"` | Converts to `True` (when default is `bool`) |
+| `"false"`, `"no"`, `"off"` | Converts to `False` (when default is `bool`) |
+| Any other string | Returned as-is (when default is `str`) |
+
+## How to Add a Mapping for a New Type
+
+### Step 1: Create the mapping module
+
+Create `src/pynetappfoundry/cache/mappings/<type>.py`:
+
+```python
+"""<Type> type mapping definition."""
+
+from __future__ import annotations
+
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.cache.models import <TypeModel>
+
+<TYPE>_MAPPING = TypeMapping(
+    name="<Type>",
+    model_class=<TypeModel>,
+    api_endpoint="/api/endpoint?fields=*",
+    cli_command="<type> show",
+    fields=(
+        FieldMapping(
+            cache_attr="uuid",
+            api_path="uuid",
+            cli_field="instance-uuid",
+        ),
+        FieldMapping(
+            cache_attr="name",
+            api_path="name",
+            cli_field="<type>",
+        ),
+        # ... more fields
+    ),
+)
+```
+
+### Step 2: Export from the mappings package
+
+Add the import and `__all__` entry in `src/pynetappfoundry/cache/mappings/__init__.py`:
+
+```python
+from pynetappfoundry.cache.mappings.<type> import <TYPE>_MAPPING
+
+__all__ = ["VOLUME_MAPPING", "<TYPE>_MAPPING"]
+```
+
+### Step 3: Update the collector
+
+Replace hand-written parsing in the collector with the generic parsers:
+
+```python
+from pynetappfoundry.cache.field_mapping import parse_api_response, parse_cli_records
+from pynetappfoundry.cache.mappings import <TYPE>_MAPPING
+
+# API parsing
+items = parse_api_response(<TYPE>_MAPPING, response, log_prefix, log_missing_fn)
+
+# CLI parsing
+items = parse_cli_records(<TYPE>_MAPPING, records, log_prefix, log_missing_fn)
+```
+
+### Step 4: Register in the inspect command
+
+Add the type to the `INSPECT_TYPES` dict in `src/pynetappfoundry/cli/commands/cache/inspect.py`:
+
+```python
+INSPECT_TYPES: dict[str, tuple[TypeMapping, str]] = {
+    "volume": (VOLUME_MAPPING, "storage.volumes"),
+    "<type>": (<TYPE>_MAPPING, "<cache.dotted.path>"),
+}
+```
+
+### Step 5: Write tests
+
+Create `tests/unit/cache/mappings/test_<type>.py` with tests covering:
+
+- API record parsing (including nested and missing fields)
+- CLI record parsing (including coercion edge cases)
+- Transform functions (if any)
+- Expected field lists (`api_expected_fields()`, `cli_expected_fields()`)
+
+## Reference: VolumeInfo Pilot
+
+The `VOLUME_MAPPING` in `src/pynetappfoundry/cache/mappings/volume.py` is the canonical example. It demonstrates all field mapping patterns:
+
+### Simple field (direct path)
+
+```python
+FieldMapping(
+    cache_attr="name",
+    api_path="name",
+    cli_field="volume",
+)
+```
+
+Both API and CLI have a straightforward top-level field.
+
+### Nested API field (dot-path)
+
+```python
+FieldMapping(
+    cache_attr="svm",
+    api_path="svm.name",
+    cli_field="vserver",
+)
+```
+
+The API response has `{"svm": {"name": "vs1"}}`. The dot-path `"svm.name"` is resolved by `get_nested_value()` from `utils/dict_path.py`.
+
+### Array index access
+
+```python
+FieldMapping(
+    cache_attr="aggregate",
+    api_path="aggregates[0].name",
+    cli_field="aggregate",
+)
+```
+
+The API response has `{"aggregates": [{"name": "aggr1"}]}`. The bracket notation `"aggregates[0].name"` extracts the first aggregate's name.
+
+### Custom transform (API)
+
+```python
+FieldMapping(
+    cache_attr="aggregates",
+    default=[],
+    transform=_api_aggregates_list,
+    cli_transform=_cli_aggregates_list,
+)
+```
+
+When a field needs logic beyond simple path extraction, provide a `transform` function. The function receives the full record dict and returns the extracted value. Note that `api_path` and `cli_field` are omitted since the transforms handle all extraction.
+
+### Field with default and coercion
+
+```python
+FieldMapping(
+    cache_attr="autosize_grow_threshold",
+    api_path="autosize.grow_threshold",
+    cli_field="autosize-grow-threshold-percent",
+    default=0,
+)
+```
+
+The `default=0` serves two purposes: it's the fallback when the field is missing, and it tells `_coerce_cli_value()` to treat the CLI value as an integer (stripping any `%` suffix).
+
+## Transform Functions
+
+### When to use `transform` vs `api_path`
+
+Use `api_path` when the value can be extracted with a simple dot-path (including array indices). Use `transform` when you need:
+
+- Custom logic (filtering, aggregation, conditional extraction)
+- Access to multiple fields in the same record
+- Type conversions beyond what dot-path extraction provides
+
+### When to use `cli_transform` vs `cli_field`
+
+Use `cli_field` when the CLI output has a direct field name and `_coerce_cli_value()` handles the type conversion. Use `cli_transform` when:
+
+- The CLI field needs splitting (e.g., comma-separated lists)
+- Multiple CLI fields contribute to one model attribute
+- Custom parsing beyond coercion is needed
+
+### Writing a transform function
+
+Transform functions receive the full record dict and return the extracted value:
+
+```python
+def _api_aggregates_list(record: dict[str, Any]) -> list[str]:
+    """Extract all aggregate names from API response."""
+    return [
+        a.get("name", "")
+        for a in record.get("aggregates", [])
+        if isinstance(a, dict) and a.get("name")
+    ]
+```
+
+If a transform raises an exception, the framework catches it, logs a debug message, and uses the field's `default` value.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - AI Command Blocking: development/ai/command-blocking.md
       - AI Enforcement Principles: development/ai/enforcement-principles.md
       - AI Statusline: development/ai/statusline.md
+      - Field Mapping Framework: development/field-mapping.md
       - Extensions: development/extensions.md
   - Deployment:
       - Development: deployment/development.md
@@ -102,6 +103,7 @@ nav:
       - ADR-0011 pytest Testing: decisions/0011-use-pytest-for-testing.md
       - ADR-0012 MkDocs Documentation: decisions/0012-use-mkdocs-with-material-theme-for-documentation.md
       - ADR-0013 Python Version Policy: decisions/0013-python-version-support-policy.md
+      - ADR-0017 Declarative Field Mapping: decisions/0017-declarative-field-mapping-framework.md
       - ADR Template: decisions/adr-template.md
   - Template:
       - Overview: template/index.md


### PR DESCRIPTION
## Description

Add documentation and ADR for the declarative field mapping framework introduced in PR #189.

## Related Issue

Closes #222

## Type of Change

- [x] Documentation update

## Changes Made

- Created ADR-0004 (`docs/decisions/0017-declarative-field-mapping-framework.md`) documenting the decision to use `TypeMapping`/`FieldMapping` dataclasses for ONTAP data collection, including rationale and alternatives considered
- Created developer guide (`docs/development/field-mapping.md`) covering architecture, key components (`FieldMapping`, `TypeMapping`, generic parsers, CLI coercion), step-by-step instructions for adding new type mappings, and the VolumeInfo pilot as canonical reference
- Added ADR-0004 to the ADR index table in `docs/decisions/README.md`
- Added nav entries to `mkdocs.yml` under Development and Decisions sections

## Testing

- [x] All existing tests pass
- [x] `doit check` passes (format, lint, type-check, security, spell-check, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings