### PR TITLE
fix: use csv.reader in separator parser to handle quoted values

### DIFF
--- a/src/pynetappfoundry/clients/ontap/cli.py
+++ b/src/pynetappfoundry/clients/ontap/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import json
 import logging
 import threading
@@ -16,6 +17,49 @@ CMD_KEYS: dict[str, str] = {
     "volume show": "Volume Name",
     "vol show": "Volume Name",
 }
+
+
+def _parse_separator_output(
+    lines: list[str],
+) -> tuple[list[dict[str, str]], dict[str, str]]:
+    """Parse comma-separated CLI output using CSV reader.
+
+    Uses ``csv.reader`` to correctly handle quoted values that contain
+    commas or span multiple lines (RFC 4180).
+
+    Args:
+        lines: Raw output lines from ``run_command``.
+
+    Returns:
+        Tuple of (data rows as list of dicts, descriptions dict).
+    """
+    if not lines:
+        return [], {}
+
+    reader = csv.reader(iter(lines))
+
+    try:
+        raw_headers = next(reader)
+    except StopIteration:
+        return [], {}
+
+    headers = [h for h in raw_headers if h]
+
+    try:
+        raw_descriptions = next(reader)
+    except StopIteration:
+        return [], {}
+
+    descriptions = [d for d in raw_descriptions if d]
+    descriptions_dict = dict(zip(headers, descriptions, strict=False))
+
+    data: list[dict[str, str]] = []
+    for row in reader:
+        datadict = dict(zip(headers, row, strict=False))
+        datadict.pop("", None)
+        data.append(datadict)
+
+    return data, descriptions_dict
 
 
 class CLICommandError(Exception):
@@ -179,26 +223,7 @@ class ONTAPCLI:
             logging.info(f"{self.log_prefix} {cmd} returned no output")
             return [], {}
 
-        headers = output[0].split(",")
-        if "" in headers:
-            headers.remove("")
-        del output[0]
-
-        descriptions = output[0].split(",")
-        if "" in descriptions:
-            descriptions.remove("")
-        descriptions_dict = dict(zip(headers, descriptions, strict=False))
-        del output[0]
-
-        data: list[dict[str, str]] = []
-        for line in output:
-            tdata = line.split(",")
-            datadict = dict(zip(headers, tdata, strict=False))
-            datadict.pop("", None)
-
-            data.append(datadict)
-
-        return data, descriptions_dict
+        return _parse_separator_output(output)
 
     def run_command(
         self,

--- a/tests/unit/clients/ontap/test_cli.py
+++ b/tests/unit/clients/ontap/test_cli.py
@@ -11,6 +11,7 @@ from pynetappfoundry.clients.ontap.cli import (
     ONTAPCLI,
     CLICommandError,
     CLITimeoutError,
+    _parse_separator_output,
 )
 
 if TYPE_CHECKING:
@@ -430,3 +431,214 @@ class TestONTAPCLIRunCommand:
 
             assert "Last login time" not in " ".join(result)
             assert "Node: node1" in result
+
+
+class TestParseSeparatorOutput:
+    """Tests for the _parse_separator_output helper function."""
+
+    def test_empty_input(self) -> None:
+        """Empty list returns empty data and descriptions."""
+        data, descriptions = _parse_separator_output([])
+        assert data == []
+        assert descriptions == {}
+
+    def test_headers_only(self) -> None:
+        """Single header line with no description/data returns empty."""
+        data, descriptions = _parse_separator_output(["node,aggr,status"])
+        assert data == []
+        assert descriptions == {}
+
+    def test_headers_and_descriptions_only(self) -> None:
+        """Headers + descriptions but no data returns empty data with descriptions."""
+        lines = [
+            "node,aggr,status",
+            "Node Name,Aggregate,Status",
+        ]
+        data, descriptions = _parse_separator_output(lines)
+        assert data == []
+        assert descriptions == {
+            "node": "Node Name",
+            "aggr": "Aggregate",
+            "status": "Status",
+        }
+
+    def test_simple_data(self) -> None:
+        """Standard unquoted rows parse correctly."""
+        lines = [
+            "node,aggr,status",
+            "Node Name,Aggregate,Status",
+            "node1,aggr0,online",
+            "node2,aggr1,offline",
+        ]
+        data, descriptions = _parse_separator_output(lines)
+        assert len(data) == 2
+        assert data[0] == {"node": "node1", "aggr": "aggr0", "status": "online"}
+        assert data[1] == {"node": "node2", "aggr": "aggr1", "status": "offline"}
+        assert descriptions == {
+            "node": "Node Name",
+            "aggr": "Aggregate",
+            "status": "Status",
+        }
+
+    def test_quoted_value_with_comma(self) -> None:
+        """Quoted value containing a comma is kept intact."""
+        lines = [
+            "node,raidstatus,state",
+            "Node Name,RAID Status,State",
+            'node1,"raid0, normal",online',
+        ]
+        data, _ = _parse_separator_output(lines)
+        assert len(data) == 1
+        assert data[0]["raidstatus"] == "raid0, normal"
+        assert data[0]["node"] == "node1"
+        assert data[0]["state"] == "online"
+
+    def test_multiline_quoted_value(self) -> None:
+        """Value spanning multiple input lines is reassembled by csv.reader.
+
+        When run_command splits SSH output by lines, a quoted value like
+        ``"raid0\\nnormal"`` arrives as two separate strings. csv.reader
+        reassembles them into a single field (joining without newline).
+        """
+        lines = [
+            "node,raidstatus,state",
+            "Node Name,RAID Status,State",
+            'node1,"raid0',
+            'normal",online',
+        ]
+        data, _ = _parse_separator_output(lines)
+        assert len(data) == 1
+        assert data[0]["raidstatus"] == "raid0normal"
+        assert data[0]["state"] == "online"
+
+    def test_trailing_comma_in_headers(self) -> None:
+        """Trailing comma produces empty header that is filtered out."""
+        lines = [
+            "node,aggr,",
+            "Node Name,Aggregate,",
+            "node1,aggr0,",
+        ]
+        data, _ = _parse_separator_output(lines)
+        assert "" not in data[0]
+        assert data[0] == {"node": "node1", "aggr": "aggr0"}
+
+    def test_empty_field_values(self) -> None:
+        """Empty fields between commas are preserved as empty strings."""
+        lines = [
+            "node,aggr,status",
+            "Node Name,Aggregate,Status",
+            "node1,,online",
+        ]
+        data, _ = _parse_separator_output(lines)
+        assert data[0]["aggr"] == ""
+
+    def test_backward_compat_unquoted(self) -> None:
+        """Unquoted values produce identical results to old str.split behavior."""
+        lines = [
+            "node,aggr,status",
+            "Node Name,Aggregate,Status",
+            "node1,aggr0,online",
+        ]
+        data, descriptions = _parse_separator_output(lines)
+
+        # Simulate old str.split behavior
+        headers = lines[0].split(",")
+        old_desc = dict(zip(headers, lines[1].split(","), strict=False))
+        old_data = dict(zip(headers, lines[2].split(","), strict=False))
+
+        assert data[0] == old_data
+        assert descriptions == old_desc
+
+
+class TestSeparatorParserMethod:
+    """Tests for ONTAPCLI.run_a_show_command_and_parse_seperator."""
+
+    def test_delegates_to_helper(self) -> None:
+        """Method returns correct data and command includes set -showseparator."""
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            mock_transport = MagicMock()
+            mock_channel = MagicMock()
+            mock_ssh.get_transport.return_value = mock_transport
+            mock_transport.open_session.return_value = mock_channel
+            mock_transport.is_active.return_value = True
+            mock_channel.recv_ready.side_effect = [True, True]
+            mock_channel.recv.side_effect = [
+                b"node,aggr,status\nNode Name,Aggregate,Status\nnode1,aggr0,online\n",
+                b"",
+            ]
+
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+
+            data, _ = cli.run_a_show_command_and_parse_seperator("aggr show")
+
+            assert len(data) == 1
+            assert data[0]["node"] == "node1"
+
+            # Verify command includes separator config
+            executed_cmd = mock_channel.exec_command.call_args[0][0]
+            assert 'set -showseparator ","' in executed_cmd
+            assert "aggr show" in executed_cmd
+
+    def test_empty_output_returns_empty(self) -> None:
+        """Empty output from run_command returns empty data and descriptions."""
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            mock_transport = MagicMock()
+            mock_channel = MagicMock()
+            mock_ssh.get_transport.return_value = mock_transport
+            mock_transport.open_session.return_value = mock_channel
+            mock_transport.is_active.return_value = True
+            # Command produces no output lines
+            mock_channel.recv_ready.side_effect = [True, True]
+            mock_channel.recv.side_effect = [b"\n", b""]
+
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+
+            data, desc = cli.run_a_show_command_and_parse_seperator("aggr show")
+
+            assert data == []
+            assert desc == {}
+
+    def test_quoted_commas_end_to_end(self) -> None:
+        """Quoted values with commas are parsed without corruption end-to-end."""
+        with patch("paramiko.SSHClient") as mock_ssh_class:
+            mock_ssh = MagicMock()
+            mock_ssh_class.return_value = mock_ssh
+            mock_transport = MagicMock()
+            mock_channel = MagicMock()
+            mock_ssh.get_transport.return_value = mock_transport
+            mock_transport.open_session.return_value = mock_channel
+            mock_transport.is_active.return_value = True
+            mock_channel.recv_ready.side_effect = [True, True]
+            mock_channel.recv.side_effect = [
+                b"node,raidstatus,state\n"
+                b"Node Name,RAID Status,State\n"
+                b'node1,"raid0, normal",online\n',
+                b"",
+            ]
+
+            cli = ONTAPCLI(
+                name="test",
+                host_or_ip="192.168.1.1",
+                username="admin",
+                password="password",
+            )
+
+            data, _ = cli.run_a_show_command_and_parse_seperator("aggr show")
+
+            assert len(data) == 1
+            assert data[0]["raidstatus"] == "raid0, normal"
+            assert data[0]["state"] == "online"


### PR DESCRIPTION
## Description

Replace naive `str.split(",")` with `csv.reader` in the CLI separator parser so that quoted fields containing commas (e.g. `raidstatus="raid0, normal"`) are no longer split incorrectly, which was silently corrupting cached data.

Closes #225

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `import csv` to stdlib imports in `cli.py`
- Extracted `_parse_separator_output(lines)` helper function that uses `csv.reader` to correctly parse comma-separated CLI output per RFC 4180
- Simplified `run_a_show_command_and_parse_seperator` to delegate parsing to the new helper
- Added `TestParseSeparatorOutput` class with 9 unit tests covering: empty input, headers-only, headers+descriptions, simple data, quoted commas, multiline quoted values, trailing commas, empty fields, backward compatibility
- Added `TestSeparatorParserMethod` class with 3 integration tests covering: delegation, empty output, quoted commas end-to-end

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (tests, lint, type-check, security)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings