### PR TITLE
fix: explicitly request sidl_enabled in aggregate API endpoint

### DIFF
--- a/src/pynetappfoundry/cache/mappings/aggregate.py
+++ b/src/pynetappfoundry/cache/mappings/aggregate.py
@@ -12,7 +12,7 @@ from pynetappfoundry.cache.models import AggregateInfo
 AGGREGATE_MAPPING = TypeMapping(
     name="Aggregate",
     model_class=AggregateInfo,
-    api_endpoint="/storage/aggregates?fields=*,is_spare_low",
+    api_endpoint="/storage/aggregates?fields=*,is_spare_low,sidl_enabled",
     cli_command="aggr show",
     fields=(
         FieldMapping(

--- a/tests/unit/cache/mappings/test_aggregate.py
+++ b/tests/unit/cache/mappings/test_aggregate.py
@@ -105,8 +105,11 @@ class TestAggregateMappingDefinition:
         assert len(attrs) == len(set(attrs))
 
     def test_endpoint(self) -> None:
-        """API endpoint is storage aggregates with all fields plus is_spare_low."""
-        assert AGGREGATE_MAPPING.api_endpoint == "/storage/aggregates?fields=*,is_spare_low"
+        """API endpoint includes explicit fields not returned by fields=*."""
+        assert (
+            AGGREGATE_MAPPING.api_endpoint
+            == "/storage/aggregates?fields=*,is_spare_low,sidl_enabled"
+        )
 
     def test_cli_command(self) -> None:
         """CLI command is aggr show."""

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -475,7 +475,7 @@ class TestStorageCollection:
     def mock_storage_api_responses(self) -> dict[str, dict[str, Any]]:
         """Mock API responses for storage endpoints."""
         return {
-            "/storage/aggregates?fields=*,is_spare_low": {
+            "/storage/aggregates?fields=*,is_spare_low,sidl_enabled": {
                 "records": [
                     {
                         "name": "aggr1",
@@ -731,7 +731,7 @@ class TestCloudTargetsCollection:
     ) -> dict[str, dict[str, Any]]:
         """Mock API responses for storage endpoints including cloud targets."""
         return {
-            "/storage/aggregates?fields=*,is_spare_low": {
+            "/storage/aggregates?fields=*,is_spare_low,sidl_enabled": {
                 "records": [
                     {
                         "name": "aggr1",
@@ -790,7 +790,7 @@ class TestCloudTargetsCollection:
         def side_effect(endpoint: str, **_: Any) -> dict[str, Any]:
             if endpoint == "/cloud/targets?fields=*":
                 raise Exception("Endpoint not available")
-            if endpoint == "/storage/aggregates?fields=*,is_spare_low":
+            if endpoint == "/storage/aggregates?fields=*,is_spare_low,sidl_enabled":
                 return {
                     "records": [{"name": "aggr1", "node": {"name": "node1"}, "state": "online"}]
                 }
@@ -870,7 +870,7 @@ class TestCloudTargetsCollection:
         """Test collecting when no cloud targets exist."""
         api_client = MagicMock()
         api_client.call_endpoint.side_effect = lambda endpoint, **_: {
-            "/storage/aggregates?fields=*,is_spare_low": {"records": []},
+            "/storage/aggregates?fields=*,is_spare_low,sidl_enabled": {"records": []},
             "/svm/svms?fields=*": {"records": []},
             "/cloud/targets?fields=*": {"records": []},
         }.get(endpoint, {})


### PR DESCRIPTION
## Description

`sidl_enabled` is not included in the ONTAP REST API response when using `fields=*`. This causes the cached value to default to `False` even when SIDL is enabled on the aggregate (CLI shows `single-instance-data-logging: on`). Add `sidl_enabled` to the explicit field list in the API endpoint alongside `is_spare_low`.

## Related Issue

Closes #191

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Update API endpoint from `?fields=*,is_spare_low` to `?fields=*,is_spare_low,sidl_enabled`
- Update endpoint assertion in mapping tests
- Update endpoint references in collector tests

## Testing

- [x] All existing tests pass
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings