### PR TITLE
refactor: add volume_count field to AggregateInfo

### DIFF
--- a/src/pynetappfoundry/cache/mappings/aggregate.py
+++ b/src/pynetappfoundry/cache/mappings/aggregate.py
@@ -137,6 +137,12 @@ AGGREGATE_MAPPING = TypeMapping(
             api_path="inactive_data_reporting.enabled",
             default=False,
         ),
+        FieldMapping(
+            cache_attr="volume_count",
+            api_path="volume_count",
+            cli_field="volcount",
+            default=0,
+        ),
         # expensive field (needs explicit API request)
         FieldMapping(
             cache_attr="is_spare_low",

--- a/src/pynetappfoundry/cache/models.py
+++ b/src/pynetappfoundry/cache/models.py
@@ -228,6 +228,7 @@ class AggregateInfo(BaseModel):
     encryption_drive: bool = False  # SED enabled
     sidl_enabled: bool = False  # single-instance data logging
     inactive_data_reporting_enabled: bool = False  # inactive data reporting
+    volume_count: int = 0  # number of volumes on the aggregate
     # expensive field (needs explicit API request)
     is_spare_low: bool = False  # disk pool health flag
 

--- a/tests/unit/cache/mappings/test_aggregate.py
+++ b/tests/unit/cache/mappings/test_aggregate.py
@@ -69,6 +69,7 @@ def full_api_record() -> dict[str, Any]:
             "enabled": True,
         },
         "is_spare_low": False,
+        "volume_count": 40,
     }
 
 
@@ -80,6 +81,7 @@ def full_cli_record() -> dict[str, Any]:
         "node": "PRODCL1-01",
         "state": "online",
         "type": "ssd",
+        "volcount": "40",
     }
 
 
@@ -138,11 +140,12 @@ class TestAggregateMappingDefinition:
             "space",
             "state",
             "uuid",
+            "volume_count",
         ]
 
     def test_field_count(self) -> None:
-        """Mapping has expected number of fields (9 original + 18 new)."""
-        assert len(AGGREGATE_MAPPING.fields) == 27
+        """Mapping has expected number of fields (9 original + 19 new)."""
+        assert len(AGGREGATE_MAPPING.fields) == 28
 
 
 # ---------------------------------------------------------------------------
@@ -187,6 +190,7 @@ class TestAggregateApiParsing:
         assert aggr.encryption_drive is False
         assert aggr.sidl_enabled is True
         assert aggr.inactive_data_reporting_enabled is True
+        assert aggr.volume_count == 40
         # Expensive field
         assert aggr.is_spare_low is False
 
@@ -222,6 +226,7 @@ class TestAggregateApiParsing:
         assert aggr.encryption_drive is False
         assert aggr.sidl_enabled is False
         assert aggr.inactive_data_reporting_enabled is False
+        assert aggr.volume_count == 0
         assert aggr.is_spare_low is False
 
     def test_nested_node_extraction(self) -> None:
@@ -351,6 +356,7 @@ class TestAggregateCliParsing:
         assert aggr.node == "PRODCL1-01"
         assert aggr.state == "online"
         assert aggr.type == "ssd"
+        assert aggr.volume_count == 40
         # Fields without cli_field should use defaults
         assert aggr.uuid == ""
         assert aggr.total_size == 0


### PR DESCRIPTION
## Description

Add `volume_count` field to AggregateInfo model and AGGREGATE_MAPPING to track the number of volumes on each aggregate. Mapped from API `volume_count` and CLI `volcount`.

## Related Issue

Part of #191

## Type of Change

- [x] Code refactoring

## Changes Made

- Add `volume_count: int = 0` to AggregateInfo model
- Add FieldMapping with `api_path="volume_count"` and `cli_field="volcount"`
- Update test fixtures and assertions for both API and CLI parsing
- Update field count test (28 total) and api_expected_fields test

## Testing

- [x] All existing tests pass
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings