### PR TITLE
refactor: migrate NodeInfo to declarative field mapping framework

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -352,7 +352,7 @@ All models use `ConfigDict(extra="allow")` for forward compatibility with new AP
 |-------|------------|-------------|
 | `CloudMetadata` | node, instance_id, provider, region, instance_type | Cloud provider metadata per node |
 | `ClusterInfo` | cluster_name, cluster_uuid, ontap_version, model, contact, location | Core cluster identity |
-| `NodeInfo` | uuid, name, serial_number, system_id, model, is_epsilon, location | Cluster node information |
+| `NodeInfo` | uuid, name, serial_number, system_id, model, location, membership, version_full, storage_configuration, system_machine_type, controller_board, controller_memory_size, controller_cpu_count, vm_provider_type, ha_enabled, ha_auto_giveback, ha_partner_uuids, system_aggregate_uuid, cluster_interface_uuids, management_interface_uuids | Cluster node information |
 
 ### Network
 

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from pynetappfoundry.cache.field_mapping import parse_api_response, parse_cli_records
 from pynetappfoundry.cache.mappings.aggregate import AGGREGATE_MAPPING
+from pynetappfoundry.cache.mappings.node import NODE_MAPPING
 from pynetappfoundry.cache.mappings.volume import VOLUME_MAPPING
 from pynetappfoundry.cache.models import (
     AggregateInfo,
@@ -898,36 +899,14 @@ class MetadataCollector:
             return []
 
         # Use cached API call to avoid duplicate requests (also used by HA collection)
-        response = self._cached_api_call("/cluster/nodes?fields=*")
+        response = self._cached_api_call(NODE_MAPPING.api_endpoint)
         if not response:
             return []
 
-        logger.debug(
-            "%s API response: %d nodes", self._log_prefix, len(response.get("records", []))
+        return cast(
+            list[NodeInfo],
+            parse_api_response(NODE_MAPPING, response, self._log_prefix, self._log_missing_fields),
         )
-        nodes = []
-        for record in response.get("records", []):
-            self._log_missing_fields(
-                record,
-                ["uuid", "name", "serial_number", "system_id", "model", "membership", "location"],
-                "Node",
-                record.get("name", record.get("uuid", "unknown")),
-            )
-            # membership may be a dict or other type depending on API version
-            membership = record.get("membership")
-            is_epsilon = membership.get("epsilon", False) if isinstance(membership, dict) else False
-            nodes.append(
-                NodeInfo(
-                    uuid=record.get("uuid", ""),
-                    name=record.get("name", ""),
-                    serial_number=record.get("serial_number", ""),
-                    system_id=str(record.get("system_id", "")),
-                    model=str(record.get("model", "")),
-                    is_epsilon=is_epsilon,
-                    location=record.get("location", ""),
-                )
-            )
-        return nodes
 
     def _collect_nodes_via_cli(self) -> list[NodeInfo]:
         """Collect nodes using CLI.
@@ -939,26 +918,11 @@ class MetadataCollector:
             logger.debug("%s No CLI client available for nodes collection", self._log_prefix)
             return []
 
-        logger.debug("%s CLI command: system node show", self._log_prefix)
-        output, _ = self.cli_client.run_a_show_command_and_parse_seperator("system node show")
-        logger.debug("%s CLI response: %d nodes", self._log_prefix, len(output))
-        nodes = []
-        for data in output:
-            self._log_missing_fields(
-                data,
-                ["node", "serial-number", "system-id", "model"],
-                "Node(CLI)",
-                data.get("node", "unknown"),
-            )
-            nodes.append(
-                NodeInfo(
-                    name=data.get("node", ""),
-                    serial_number=data.get("serial-number", ""),
-                    system_id=data.get("system-id", ""),
-                    model=data.get("model", ""),
-                )
-            )
-        return nodes
+        output, _ = self.cli_client.run_a_show_command_and_parse_seperator(NODE_MAPPING.cli_command)
+        return cast(
+            list[NodeInfo],
+            parse_cli_records(NODE_MAPPING, output, self._log_prefix, self._log_missing_fields),
+        )
 
     # -------------------------------------------------------------------------
     # Network Collection

--- a/src/pynetappfoundry/cache/diff.py
+++ b/src/pynetappfoundry/cache/diff.py
@@ -41,7 +41,7 @@ _ENTITY_CONFIGS: dict[str, tuple[str, list[str]]] = {
     "cloud": ("node", ["instance_id", "instance_type", "region", "provider"]),
     "nodes": (
         "name",
-        ["uuid", "serial_number", "model", "is_epsilon", "location"],
+        ["uuid", "serial_number", "model", "membership", "location"],
     ),
     "network.intercluster_lifs": (
         "name",

--- a/src/pynetappfoundry/cache/mappings/__init__.py
+++ b/src/pynetappfoundry/cache/mappings/__init__.py
@@ -4,6 +4,7 @@ Each sub-module defines a TypeMapping constant for one ONTAP object type.
 """
 
 from pynetappfoundry.cache.mappings.aggregate import AGGREGATE_MAPPING
+from pynetappfoundry.cache.mappings.node import NODE_MAPPING
 from pynetappfoundry.cache.mappings.volume import VOLUME_MAPPING
 
-__all__ = ["AGGREGATE_MAPPING", "VOLUME_MAPPING"]
+__all__ = ["AGGREGATE_MAPPING", "NODE_MAPPING", "VOLUME_MAPPING"]

--- a/src/pynetappfoundry/cache/mappings/node.py
+++ b/src/pynetappfoundry/cache/mappings/node.py
@@ -1,0 +1,110 @@
+"""Node type mapping definition for the declarative field mapping framework.
+
+Defines NODE_MAPPING which maps ONTAP REST API and CLI node data to
+NodeInfo cache model attributes.
+"""
+
+from __future__ import annotations
+
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.cache.models import NodeInfo
+
+NODE_MAPPING = TypeMapping(
+    name="Node",
+    model_class=NodeInfo,
+    api_endpoint="/cluster/nodes?fields=*",
+    cli_command="system node show",
+    fields=(
+        FieldMapping(
+            cache_attr="uuid",
+            api_path="uuid",
+        ),
+        FieldMapping(
+            cache_attr="name",
+            api_path="name",
+            cli_field="node",
+        ),
+        FieldMapping(
+            cache_attr="serial_number",
+            api_path="serial_number",
+            cli_field="serial-number",
+        ),
+        FieldMapping(
+            cache_attr="system_id",
+            api_path="system_id",
+            cli_field="system-id",
+        ),
+        FieldMapping(
+            cache_attr="model",
+            api_path="model",
+            cli_field="model",
+        ),
+        FieldMapping(
+            cache_attr="location",
+            api_path="location",
+        ),
+        FieldMapping(
+            cache_attr="membership",
+            api_path="membership",
+        ),
+        FieldMapping(
+            cache_attr="version_full",
+            api_path="version.full",
+        ),
+        FieldMapping(
+            cache_attr="storage_configuration",
+            api_path="storage_configuration",
+        ),
+        FieldMapping(
+            cache_attr="system_machine_type",
+            api_path="system_machine_type",
+        ),
+        FieldMapping(
+            cache_attr="controller_board",
+            api_path="controller.board",
+        ),
+        FieldMapping(
+            cache_attr="controller_memory_size",
+            api_path="controller.memory_size",
+            default=0,
+        ),
+        FieldMapping(
+            cache_attr="controller_cpu_count",
+            api_path="controller.cpu.count",
+            default=0,
+        ),
+        FieldMapping(
+            cache_attr="vm_provider_type",
+            api_path="vm.provider_type",
+        ),
+        FieldMapping(
+            cache_attr="ha_enabled",
+            api_path="ha.enabled",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="ha_auto_giveback",
+            api_path="ha.auto_giveback",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="ha_partner_uuids",
+            api_path="ha.partners[*].uuid",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="system_aggregate_uuid",
+            api_path="system_aggregate.uuid",
+        ),
+        FieldMapping(
+            cache_attr="cluster_interface_uuids",
+            api_path="cluster_interfaces[*].uuid",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="management_interface_uuids",
+            api_path="management_interfaces[*].uuid",
+            default=[],
+        ),
+    ),
+)

--- a/src/pynetappfoundry/cache/models.py
+++ b/src/pynetappfoundry/cache/models.py
@@ -133,8 +133,28 @@ class NodeInfo(BaseModel):
     serial_number: str = ""
     system_id: str = ""
     model: str = ""
-    is_epsilon: bool = False
     location: str = ""
+
+    @field_validator("system_id", "model", mode="before")
+    @classmethod
+    def coerce_to_str(cls, v: object) -> str:
+        """Coerce system_id and model to string (API sometimes returns int)."""
+        return str(v) if v is not None else ""
+
+    membership: str = ""
+    version_full: str = ""
+    storage_configuration: str = ""
+    system_machine_type: str = ""
+    controller_board: str = ""
+    controller_memory_size: int = 0
+    controller_cpu_count: int = 0
+    vm_provider_type: str = ""
+    ha_enabled: bool = False
+    ha_auto_giveback: bool = False
+    ha_partner_uuids: list[str] = Field(default_factory=list)
+    system_aggregate_uuid: str = ""
+    cluster_interface_uuids: list[str] = Field(default_factory=list)
+    management_interface_uuids: list[str] = Field(default_factory=list)
 
 
 class NetworkLIF(BaseModel):

--- a/src/pynetappfoundry/cli/commands/cache/inspect.py
+++ b/src/pynetappfoundry/cli/commands/cache/inspect.py
@@ -14,7 +14,7 @@ from rich.tree import Tree
 
 from pynetappfoundry.cache import ClusterMetadataDB
 from pynetappfoundry.cache.field_mapping import TypeMapping
-from pynetappfoundry.cache.mappings import AGGREGATE_MAPPING, VOLUME_MAPPING
+from pynetappfoundry.cache.mappings import AGGREGATE_MAPPING, NODE_MAPPING, VOLUME_MAPPING
 from pynetappfoundry.cli.utils import print_error, print_exception, print_warning
 from pynetappfoundry.clients.ontap import ONTAPCLI, ONTAPAPIClient
 from pynetappfoundry.core.config import Config
@@ -27,6 +27,7 @@ console = Console()
 # dot-path to the list of objects in CachedClusterMetadata.
 INSPECT_TYPES: dict[str, tuple[TypeMapping, str]] = {
     "aggregate": (AGGREGATE_MAPPING, "storage.aggregates"),
+    "node": (NODE_MAPPING, "nodes"),
     "volume": (VOLUME_MAPPING, "storage.volumes"),
 }
 

--- a/tests/unit/cache/mappings/test_node.py
+++ b/tests/unit/cache/mappings/test_node.py
@@ -1,0 +1,453 @@
+"""Tests for the node type mapping definition."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pynetappfoundry.cache.field_mapping import (
+    parse_api_record,
+    parse_api_response,
+    parse_cli_record,
+    parse_cli_records,
+)
+from pynetappfoundry.cache.mappings.node import NODE_MAPPING
+from pynetappfoundry.cache.models import NodeInfo
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def full_api_record() -> dict[str, Any]:
+    """Full API node record with all fields."""
+    return {
+        "uuid": "n1-uuid-1234-5678-abcd",
+        "name": "PRODCL1-01",
+        "serial_number": "123456789",
+        "system_id": "0123456789",
+        "model": "AFF-A400",
+        "location": "rack-1",
+        "membership": "available",
+        "version": {"full": "NetApp Release 9.14.1: Tue Oct 10 01:00:00 UTC 2024"},
+        "storage_configuration": "single_path_ha",
+        "system_machine_type": "040000000000",
+        "controller": {
+            "board": "System Board XXIV",
+            "memory_size": 65536000000,
+            "cpu": {"count": 16},
+        },
+        "vm": {"provider_type": "AWS"},
+        "ha": {
+            "enabled": True,
+            "auto_giveback": True,
+            "partners": [
+                {"uuid": "partner-uuid-1"},
+                {"uuid": "partner-uuid-2"},
+            ],
+        },
+        "system_aggregate": {"uuid": "sysaggr-uuid-1"},
+        "cluster_interfaces": [
+            {"uuid": "clif-uuid-1"},
+            {"uuid": "clif-uuid-2"},
+        ],
+        "management_interfaces": [
+            {"uuid": "mgmt-uuid-1"},
+        ],
+    }
+
+
+@pytest.fixture
+def full_cli_record() -> dict[str, Any]:
+    """Full CLI node record with all mapped CLI fields."""
+    return {
+        "node": "PRODCL1-01",
+        "serial-number": "123456789",
+        "system-id": "0123456789",
+        "model": "AFF-A400",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mapping definition tests
+# ---------------------------------------------------------------------------
+
+
+class TestNodeMappingDefinition:
+    """Tests for NODE_MAPPING structure."""
+
+    def test_all_cache_attrs_exist_on_model(self) -> None:
+        """Every cache_attr in the mapping is a valid NodeInfo field."""
+        model_fields = set(NodeInfo.model_fields.keys())
+        for field in NODE_MAPPING.fields:
+            assert field.cache_attr in model_fields, (
+                f"cache_attr '{field.cache_attr}' not on NodeInfo"
+            )
+
+    def test_no_duplicate_cache_attrs(self) -> None:
+        """No duplicate cache_attr values."""
+        attrs = [f.cache_attr for f in NODE_MAPPING.fields]
+        assert len(attrs) == len(set(attrs))
+
+    def test_endpoint(self) -> None:
+        """API endpoint is /cluster/nodes?fields=*."""
+        assert NODE_MAPPING.api_endpoint == "/cluster/nodes?fields=*"
+
+    def test_cli_command(self) -> None:
+        """CLI command is system node show."""
+        assert NODE_MAPPING.cli_command == "system node show"
+
+    def test_model_class(self) -> None:
+        """Model class is NodeInfo."""
+        assert NODE_MAPPING.model_class is NodeInfo
+
+    def test_api_expected_fields(self) -> None:
+        """api_expected_fields returns correct top-level keys."""
+        expected = NODE_MAPPING.api_expected_fields()
+        assert expected == [
+            "cluster_interfaces",
+            "controller",
+            "ha",
+            "location",
+            "management_interfaces",
+            "membership",
+            "model",
+            "name",
+            "serial_number",
+            "storage_configuration",
+            "system_aggregate",
+            "system_id",
+            "system_machine_type",
+            "uuid",
+            "version",
+            "vm",
+        ]
+
+    def test_field_count(self) -> None:
+        """Mapping has expected number of fields (6 original + 14 new)."""
+        assert len(NODE_MAPPING.fields) == 20
+
+
+# ---------------------------------------------------------------------------
+# API parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestNodeApiParsing:
+    """Tests for parsing API node records."""
+
+    def test_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Full API record parses to complete NodeInfo."""
+        node = parse_api_record(NODE_MAPPING, full_api_record, "[test]")
+        assert isinstance(node, NodeInfo)
+        # Original fields
+        assert node.uuid == "n1-uuid-1234-5678-abcd"
+        assert node.name == "PRODCL1-01"
+        assert node.serial_number == "123456789"
+        assert node.system_id == "0123456789"
+        assert node.model == "AFF-A400"
+        assert node.location == "rack-1"
+        # New fields
+        assert node.membership == "available"
+        assert node.version_full == "NetApp Release 9.14.1: Tue Oct 10 01:00:00 UTC 2024"
+        assert node.storage_configuration == "single_path_ha"
+        assert node.system_machine_type == "040000000000"
+        assert node.controller_board == "System Board XXIV"
+        assert node.controller_memory_size == 65536000000
+        assert node.controller_cpu_count == 16
+        assert node.vm_provider_type == "AWS"
+        assert node.ha_enabled is True
+        assert node.ha_auto_giveback is True
+        assert node.ha_partner_uuids == ["partner-uuid-1", "partner-uuid-2"]
+        assert node.system_aggregate_uuid == "sysaggr-uuid-1"
+        assert node.cluster_interface_uuids == ["clif-uuid-1", "clif-uuid-2"]
+        assert node.management_interface_uuids == ["mgmt-uuid-1"]
+
+    def test_minimal_record(self) -> None:
+        """Minimal record uses defaults for missing fields."""
+        record: dict[str, Any] = {"name": "minnode", "uuid": "abc"}
+        node = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert isinstance(node, NodeInfo)
+        assert node.name == "minnode"
+        assert node.uuid == "abc"
+        assert node.serial_number == ""
+        assert node.system_id == ""
+        assert node.model == ""
+        assert node.location == ""
+        assert node.membership == ""
+        assert node.version_full == ""
+        assert node.storage_configuration == ""
+        assert node.system_machine_type == ""
+        assert node.controller_board == ""
+        assert node.controller_memory_size == 0
+        assert node.controller_cpu_count == 0
+        assert node.vm_provider_type == ""
+        assert node.ha_enabled is False
+        assert node.ha_auto_giveback is False
+        assert node.ha_partner_uuids == []
+        assert node.system_aggregate_uuid == ""
+        assert node.cluster_interface_uuids == []
+        assert node.management_interface_uuids == []
+
+    def test_wildcard_partners_extraction(self) -> None:
+        """ha.partners[*].uuid extracts list of partner UUIDs."""
+        record: dict[str, Any] = {
+            "ha": {
+                "partners": [
+                    {"uuid": "p1"},
+                    {"uuid": "p2"},
+                    {"uuid": "p3"},
+                ],
+            },
+        }
+        node = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert node.ha_partner_uuids == ["p1", "p2", "p3"]
+
+    def test_wildcard_cluster_interfaces(self) -> None:
+        """cluster_interfaces[*].uuid extracts list of interface UUIDs."""
+        record: dict[str, Any] = {
+            "cluster_interfaces": [
+                {"uuid": "ci1"},
+                {"uuid": "ci2"},
+            ],
+        }
+        node = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert node.cluster_interface_uuids == ["ci1", "ci2"]
+
+    def test_wildcard_management_interfaces(self) -> None:
+        """management_interfaces[*].uuid extracts list of interface UUIDs."""
+        record: dict[str, Any] = {
+            "management_interfaces": [
+                {"uuid": "mi1"},
+            ],
+        }
+        node = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert node.management_interface_uuids == ["mi1"]
+
+    def test_wildcard_empty_list(self) -> None:
+        """Wildcard on empty list returns empty list."""
+        record: dict[str, Any] = {
+            "ha": {"partners": []},
+            "cluster_interfaces": [],
+            "management_interfaces": [],
+        }
+        node = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert node.ha_partner_uuids == []
+        assert node.cluster_interface_uuids == []
+        assert node.management_interface_uuids == []
+
+    def test_nested_version_extraction(self) -> None:
+        """version.full dot-path works."""
+        record: dict[str, Any] = {"version": {"full": "9.14.1"}}
+        node = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert node.version_full == "9.14.1"
+
+    def test_nested_controller_cpu_extraction(self) -> None:
+        """controller.cpu.count deep dot-path works."""
+        record: dict[str, Any] = {"controller": {"cpu": {"count": 8}}}
+        node = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert node.controller_cpu_count == 8
+
+    def test_nested_controller_memory_extraction(self) -> None:
+        """controller.memory_size dot-path works."""
+        record: dict[str, Any] = {"controller": {"memory_size": 32768000000}}
+        node = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert node.controller_memory_size == 32768000000
+
+    def test_nested_system_aggregate_extraction(self) -> None:
+        """system_aggregate.uuid dot-path works."""
+        record: dict[str, Any] = {"system_aggregate": {"uuid": "sa-uuid"}}
+        node = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert node.system_aggregate_uuid == "sa-uuid"
+
+    def test_nested_vm_extraction(self) -> None:
+        """vm.provider_type dot-path works."""
+        record: dict[str, Any] = {"vm": {"provider_type": "Azure"}}
+        node = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert node.vm_provider_type == "Azure"
+
+    def test_parse_api_response_multiple(self) -> None:
+        """parse_api_response handles multiple records."""
+        response = {
+            "records": [
+                {"name": "node1", "uuid": "a"},
+                {"name": "node2", "uuid": "b"},
+            ],
+        }
+        results = parse_api_response(NODE_MAPPING, response, "[test]", MagicMock())
+        assert len(results) == 2
+        assert results[0].name == "node1"
+        assert results[1].name == "node2"
+
+
+# ---------------------------------------------------------------------------
+# CLI parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestNodeCliParsing:
+    """Tests for parsing CLI node records."""
+
+    def test_full_record(self, full_cli_record: dict[str, Any]) -> None:
+        """Full CLI record parses to NodeInfo with CLI fields populated."""
+        node = parse_cli_record(NODE_MAPPING, full_cli_record, "[test]")
+        assert isinstance(node, NodeInfo)
+        assert node.name == "PRODCL1-01"
+        assert node.serial_number == "123456789"
+        assert node.system_id == "0123456789"
+        assert node.model == "AFF-A400"
+        # Fields without cli_field should use defaults
+        assert node.uuid == ""
+        assert node.location == ""
+        assert node.membership == ""
+        assert node.version_full == ""
+        assert node.storage_configuration == ""
+        assert node.system_machine_type == ""
+        assert node.controller_board == ""
+        assert node.controller_memory_size == 0
+        assert node.controller_cpu_count == 0
+        assert node.vm_provider_type == ""
+        assert node.ha_enabled is False
+        assert node.ha_auto_giveback is False
+        assert node.ha_partner_uuids == []
+        assert node.system_aggregate_uuid == ""
+        assert node.cluster_interface_uuids == []
+        assert node.management_interface_uuids == []
+
+    def test_dash_values_use_defaults(self) -> None:
+        """CLI dash values coerce to default."""
+        record = {
+            "node": "-",
+            "serial-number": "-",
+            "system-id": "-",
+            "model": "-",
+        }
+        node = parse_cli_record(NODE_MAPPING, record, "[test]")
+        assert node.name == ""
+        assert node.serial_number == ""
+        assert node.system_id == ""
+        assert node.model == ""
+
+    def test_parse_cli_records_multiple(self) -> None:
+        """parse_cli_records handles multiple records."""
+        records = [
+            {"node": "node1", "serial-number": "111"},
+            {"node": "node2", "serial-number": "222"},
+        ]
+        results = parse_cli_records(NODE_MAPPING, records, "[test]", MagicMock())
+        assert len(results) == 2
+        assert results[0].name == "node1"
+        assert results[1].name == "node2"
+
+
+# ---------------------------------------------------------------------------
+# Parity test: old parser vs new framework
+# ---------------------------------------------------------------------------
+
+
+class TestParityWithOldParser:
+    """Verify framework produces same output as old hand-written parser.
+
+    Note: parity tests cover the original 6 fields that existed in the old
+    parser (excluding dropped is_epsilon). New fields have no old-parser
+    equivalent.
+    """
+
+    @staticmethod
+    def _old_parse_node_api(record: dict[str, Any]) -> NodeInfo:
+        """Reproduce old inline node parsing logic for API records."""
+        return NodeInfo(
+            uuid=record.get("uuid", ""),
+            name=record.get("name", ""),
+            serial_number=record.get("serial_number", ""),
+            system_id=str(record.get("system_id", "")),
+            model=str(record.get("model", "")),
+            location=record.get("location", ""),
+        )
+
+    @staticmethod
+    def _old_parse_node_cli(data: dict[str, Any]) -> NodeInfo:
+        """Reproduce old inline node parsing logic for CLI records."""
+        return NodeInfo(
+            name=data.get("node", ""),
+            serial_number=data.get("serial-number", ""),
+            system_id=data.get("system-id", ""),
+            model=data.get("model", ""),
+        )
+
+    _ORIGINAL_FIELDS = (
+        "uuid",
+        "name",
+        "serial_number",
+        "system_id",
+        "model",
+        "location",
+    )
+
+    def test_parity_api_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Framework and old parser produce identical NodeInfo for original fields."""
+        old = self._old_parse_node_api(full_api_record)
+        new = parse_api_record(NODE_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, NodeInfo)
+        for field_name in self._ORIGINAL_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_api_minimal_record(self) -> None:
+        """Framework and old parser match on minimal API record."""
+        record: dict[str, Any] = {"name": "testnode", "uuid": "xyz"}
+        old = self._old_parse_node_api(record)
+        new = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert isinstance(new, NodeInfo)
+        for field_name in self._ORIGINAL_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_api_int_system_id_and_model(self) -> None:
+        """Framework handles int system_id/model same as old str() wrapping."""
+        record: dict[str, Any] = {
+            "name": "node1",
+            "uuid": "abc",
+            "system_id": 1234567890,
+            "model": 12345,
+        }
+        old = self._old_parse_node_api(record)
+        new = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert isinstance(new, NodeInfo)
+        # Old parser wrapped in str(), Pydantic lax mode coerces int→str
+        assert old.system_id == new.system_id
+        assert old.model == new.model
+
+    def test_parity_api_missing_nested(self) -> None:
+        """Framework and old parser match with missing fields."""
+        record: dict[str, Any] = {"name": "node1"}
+        old = self._old_parse_node_api(record)
+        new = parse_api_record(NODE_MAPPING, record, "[test]")
+        assert isinstance(new, NodeInfo)
+        for field_name in self._ORIGINAL_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_cli_full_record(self, full_cli_record: dict[str, Any]) -> None:
+        """Framework and old parser produce identical NodeInfo for CLI."""
+        old = self._old_parse_node_cli(full_cli_record)
+        new = parse_cli_record(NODE_MAPPING, full_cli_record, "[test]")
+        assert isinstance(new, NodeInfo)
+        for field_name in self._ORIGINAL_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -331,7 +331,7 @@ class TestNodesCollection:
                     "serial_number": "123456",
                     "system_id": "0123456789",
                     "model": "SIMULATED",
-                    "membership": {"epsilon": True},
+                    "membership": "available",
                     "location": "rack-1",
                 },
                 {
@@ -340,7 +340,7 @@ class TestNodesCollection:
                     "serial_number": "789012",
                     "system_id": "9876543210",
                     "model": "SIMULATED",
-                    "membership": {"epsilon": False},
+                    "membership": "available",
                     "location": "rack-2",
                 },
             ]
@@ -357,9 +357,9 @@ class TestNodesCollection:
         assert len(result) == 2
         assert result[0].name == "node1"
         assert result[0].serial_number == "123456"
-        assert result[0].is_epsilon is True
+        assert result[0].membership == "available"
         assert result[1].name == "node2"
-        assert result[1].is_epsilon is False
+        assert result[1].membership == "available"
 
     def test_collect_nodes_no_clients(self) -> None:
         """Test nodes returns empty list when no clients."""

--- a/tests/unit/cache/test_models.py
+++ b/tests/unit/cache/test_models.py
@@ -128,7 +128,7 @@ class TestNodeInfo:
         assert node.uuid == ""
         assert node.name == ""
         assert node.serial_number == ""
-        assert node.is_epsilon is False
+        assert node.membership == ""
         assert node.location == ""
 
     def test_with_values(self) -> None:
@@ -139,13 +139,13 @@ class TestNodeInfo:
             serial_number="123456789",
             system_id="0123456789",
             model="SIMULATED",
-            is_epsilon=True,
+            membership="available",
             location="rack-1",
         )
         assert node.uuid == "node-uuid-1"
         assert node.name == "node1"
         assert node.serial_number == "123456789"
-        assert node.is_epsilon is True
+        assert node.membership == "available"
         assert node.location == "rack-1"
 
 


### PR DESCRIPTION
## Description

Migrate NodeInfo from hand-written parsing to the declarative field mapping framework (ADR-0017). Replace inline extraction in `_collect_nodes_via_api` and `_collect_nodes_via_cli` with `NODE_MAPPING` definition and generic parser calls.

Drop the dead-code `is_epsilon` field (the API returns `membership` as a string, not a dict, so the `isinstance(membership, dict)` check always evaluated to `False`). Replace it with the raw `membership` string. Add 14 new API-only structural fields.

## Related Issue

Closes #210
Part of #167

## Type of Change

- [x] Code refactoring

## Changes Made

- **models.py**: Dropped `is_epsilon: bool`, added 14 new fields (membership, version_full, storage_configuration, system_machine_type, controller_board, controller_memory_size, controller_cpu_count, vm_provider_type, ha_enabled, ha_auto_giveback, ha_partner_uuids, system_aggregate_uuid, cluster_interface_uuids, management_interface_uuids). Added `field_validator` for `system_id`/`model` int→str coercion.
- **mappings/node.py** (new): `NODE_MAPPING` TypeMapping with 20 FieldMapping entries, including wildcard `[*]` syntax for list fields.
- **mappings/__init__.py**: Exported `NODE_MAPPING`.
- **collector.py**: Replaced hand-written `_collect_nodes_via_api`/`_collect_nodes_via_cli` with declarative framework calls.
- **diff.py**: Replaced `is_epsilon` with `membership` in tracked fields.
- **inspect.py**: Added `"node"` to `INSPECT_TYPES` registry.
- **test_node.py** (new): Comprehensive tests — mapping definition, API/CLI parsing, wildcard extraction, parity with old parser.
- **test_models.py / test_collector.py**: Updated existing tests for is_epsilon → membership change.
- **docs/reference/cache.md**: Updated NodeInfo field list.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (tests, lint, type-check, security, spell-check)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly

## Additional Notes

- Created issue #231 for the None sentinel framework improvement (applies to all mappings, not just nodes).
- The `system_id` and `model` fields need a `field_validator` because the ONTAP API sometimes returns integers for these fields. The old code used explicit `str()` wrapping; Pydantic v2 strict mode does not auto-coerce int→str.
- All 14 new fields are API-only (no CLI equivalent). CLI collection populates only 4 fields (node, serial-number, system-id, model).