### PR TITLE
docs: update ADR-0004 and field mapping guide for NodeInfo migration

### DIFF
--- a/docs/decisions/0017-declarative-field-mapping-framework.md
+++ b/docs/decisions/0017-declarative-field-mapping-framework.md
@@ -56,6 +56,8 @@ The pilot migration (VolumeInfo) was completed in PR #189.
 - Issue #188: feat: add declarative field mapping framework
 - PR #189: feat: add declarative field mapping framework (pilot: VolumeInfo)
 - Issue #191: refactor: migrate AggregateInfo to field mapping framework
+- Issue #210: refactor: migrate NodeInfo to field mapping framework
+- PR #232: refactor: migrate NodeInfo to declarative field mapping framework
 
 ## Related Documentation
 

--- a/docs/development/field-mapping.md
+++ b/docs/development/field-mapping.md
@@ -168,7 +168,15 @@ Create `tests/unit/cache/mappings/test_<type>.py` with tests covering:
 - Transform functions (if any)
 - Expected field lists (`api_expected_fields()`, `cli_expected_fields()`)
 
-## Reference: VolumeInfo Pilot
+## Migrated Types
+
+| Type | Mapping | Model | Fields | Notes |
+|------|---------|-------|--------|-------|
+| Volume | `VOLUME_MAPPING` | `VolumeInfo` | 21 | Pilot migration. Uses transforms for aggregate list extraction. |
+| Aggregate | `AGGREGATE_MAPPING` | `AggregateInfo` | 28 | Deeply nested API paths (`block_storage.primary.*`). Explicit `?fields=*,is_spare_low,sidl_enabled`. |
+| Node | `NODE_MAPPING` | `NodeInfo` | 20 | Wildcard `[*]` syntax for list fields. `field_validator` for int→str coercion. 14 API-only fields. |
+
+## Reference: Field Mapping Patterns
 
 The `VOLUME_MAPPING` in `src/pynetappfoundry/cache/mappings/volume.py` is the canonical example. It demonstrates all field mapping patterns:
 
@@ -207,6 +215,18 @@ FieldMapping(
 ```
 
 The API response has `{"aggregates": [{"name": "aggr1"}]}`. The bracket notation `"aggregates[0].name"` extracts the first aggregate's name.
+
+### Wildcard array access
+
+```python
+FieldMapping(
+    cache_attr="ha_partner_uuids",
+    api_path="ha.partners[*].uuid",
+    default=[],
+)
+```
+
+The API response has `{"ha": {"partners": [{"uuid": "a"}, {"uuid": "b"}]}}`. The wildcard `[*]` syntax extracts a value from every item in the array, returning a list. This is handled by `get_nested_value()` from `utils/dict_path.py`. Use `default=[]` for wildcard fields since the result is always a list.
 
 ### Custom transform (API)
 


### PR DESCRIPTION
## Description

Update ADR-0004 and the field mapping developer guide to reflect the NodeInfo migration completed in PR #232.

## Related Issue

Part of #210

## Type of Change

- [x] Documentation update

## Changes Made

- **ADR-0004**: Added Issue #210 and PR #232 to Related Issues section
- **field-mapping.md**: Added wildcard array access (`[*]`) pattern documentation (new pattern introduced by NodeInfo mapping)
- **field-mapping.md**: Added "Migrated Types" summary table listing all three migrated types (Volume, Aggregate, Node) with field counts and notes
- **field-mapping.md**: Renamed "Reference: VolumeInfo Pilot" to "Reference: Field Mapping Patterns" since multiple types are now migrated

## Testing

- [x] All existing tests pass
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly