### PR TITLE
docs: add missing aggregate PRs to ADR-0004 related issues

### DIFF
--- a/docs/decisions/0017-declarative-field-mapping-framework.md
+++ b/docs/decisions/0017-declarative-field-mapping-framework.md
@@ -56,8 +56,13 @@ The pilot migration (VolumeInfo) was completed in PR #189.
 - Issue #188: feat: add declarative field mapping framework
 - PR #189: feat: add declarative field mapping framework (pilot: VolumeInfo)
 - Issue #191: refactor: migrate AggregateInfo to field mapping framework
+- PR #224: refactor: migrate AggregateInfo to declarative field mapping framework
+- PR #227: refactor: add new structural fields to AggregateInfo
+- PR #229: fix: explicitly request sidl_enabled in aggregate API endpoint
+- PR #230: refactor: add volume_count field to AggregateInfo
 - Issue #210: refactor: migrate NodeInfo to field mapping framework
 - PR #232: refactor: migrate NodeInfo to declarative field mapping framework
+- PR #233: docs: update ADR-0017 and field mapping guide for NodeInfo migration
 
 ## Related Documentation
 


### PR DESCRIPTION
## Description

Add the missing AggregateInfo migration PRs (#224, #227, #229, #230) and NodeInfo docs PR (#233) to ADR-0004's Related Issues section.

## Related Issue

Part of #188, part of #191

## Type of Change

- [x] Documentation update

## Changes Made

- **ADR-0004**: Added PRs #224, #227, #229, #230 (AggregateInfo migration) and PR #233 (NodeInfo docs) to Related Issues

## Testing

- [x] All existing tests pass
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly