### PR TITLE
chore: remove PR references from ADR related issues sections

### DIFF
--- a/docs/decisions/0015-track-smb-client-impact-azure-maintenance.md
+++ b/docs/decisions/0015-track-smb-client-impact-azure-maintenance.md
@@ -41,7 +41,6 @@ These events are consistently available across clusters when CIFS is in use.
 ## Related Issues
 
 - Issue #92: Azure maintenance event tracking improvements
-- PR #106: Fix az_maint_complete when callhome.reboot.giveback comes first
 
 ## Related Documentation
 

--- a/docs/decisions/0017-declarative-field-mapping-framework.md
+++ b/docs/decisions/0017-declarative-field-mapping-framework.md
@@ -54,15 +54,8 @@ The pilot migration (VolumeInfo) was completed in PR #189.
 ## Related Issues
 
 - Issue #188: feat: add declarative field mapping framework
-- PR #189: feat: add declarative field mapping framework (pilot: VolumeInfo)
 - Issue #191: refactor: migrate AggregateInfo to field mapping framework
-- PR #224: refactor: migrate AggregateInfo to declarative field mapping framework
-- PR #227: refactor: add new structural fields to AggregateInfo
-- PR #229: fix: explicitly request sidl_enabled in aggregate API endpoint
-- PR #230: refactor: add volume_count field to AggregateInfo
 - Issue #210: refactor: migrate NodeInfo to field mapping framework
-- PR #232: refactor: migrate NodeInfo to declarative field mapping framework
-- PR #233: docs: update ADR-0017 and field mapping guide for NodeInfo migration
 
 ## Related Documentation
 

--- a/docs/decisions/adr-template.md
+++ b/docs/decisions/adr-template.md
@@ -17,6 +17,7 @@ Why this decision was made.
 
 ## Related Issues
 
+<!-- List issues only, not PRs. PRs are discoverable from issue timelines. -->
 - Issue #XX: Description
 
 ## Related Documentation


### PR DESCRIPTION
## Description

ADRs should reference issues only — PRs are discoverable from issue timelines. Remove PR lines from ADR-0002 and ADR-0004, and add a clarifying comment to the ADR template.

## Related Issue

Closes #235

## Type of Change

- [x] Documentation update

## Changes Made

- **ADR-0002**: Removed `PR #106` line (issue #92 already listed)
- **ADR-0004**: Removed 7 PR lines, kept 3 issue lines (#188, #191, #210)
- **ADR template**: Added comment clarifying issues-only convention

## Testing

- [x] All existing tests pass
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly