### PR TITLE
refactor: implement all-or-nothing collection with no CLI fallback

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -1,7 +1,9 @@
 """Metadata collector for ONTAP clusters.
 
-Collects cluster metadata using REST API (primary) with CLI fallback.
-Optimized for performance with parallel API calls and response caching.
+Collects cluster metadata using REST API with all-or-nothing semantics.
+Collection either succeeds completely or fails entirely — no partial
+cache updates. Cloud metadata (CLI-only) is optional; all other phases
+are API-only and must succeed.
 """
 
 from __future__ import annotations
@@ -17,7 +19,7 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from pynetappfoundry.cache.field_mapping import parse_api_response, parse_cli_records
+from pynetappfoundry.cache.field_mapping import parse_api_response
 from pynetappfoundry.cache.mappings.aggregate import AGGREGATE_MAPPING
 from pynetappfoundry.cache.mappings.node import NODE_MAPPING
 from pynetappfoundry.cache.mappings.volume import VOLUME_MAPPING
@@ -112,8 +114,8 @@ class CollectionError(Exception):
 class MetadataCollector:
     """Collects cluster metadata from ONTAP via API and CLI.
 
-    Uses REST API as primary data source with CLI fallback for
-    endpoints not available in REST (e.g., virtual-machine instance show).
+    Uses REST API for all collection phases (all-or-nothing). Cloud
+    metadata is CLI-only and optional — failure warns but doesn't abort.
     """
 
     # Human-readable names for collection phases
@@ -328,11 +330,11 @@ class MetadataCollector:
                 error_msg = str(e)
                 self._report_progress(phase, "failed", elapsed, error=error_msg)
                 logger.error(
-                    "%s Failed to collect %s: %s",
+                    "%s COLLECTION_ABORTED: Failed phase: %s - %s: %s",
                     self._log_prefix,
                     phase.value,
+                    type(e).__name__,
                     error_msg,
-                    exc_info=True,
                 )
                 raise
 
@@ -438,6 +440,13 @@ class MetadataCollector:
         # If any phase failed, raise the first error
         if errors:
             first_phase, first_error = errors[0]
+            logger.error(
+                "%s COLLECTION_ABORTED: Failed phase: %s - %s: %s",
+                self._log_prefix,
+                first_phase.value,
+                type(first_error).__name__,
+                first_error,
+            )
             raise CollectionError(
                 f"Collection failed for phase {first_phase.value}: {first_error}"
             ) from first_error
@@ -490,12 +499,8 @@ class MetadataCollector:
         # Cloud metadata is CLI-only
         if phase == CollectionPhase.CLOUD:
             return "cli" if self.cli_client else None
-        # All others prefer API
-        if self.api_client:
-            return "api"
-        if self.cli_client:
-            return "cli"
-        return None
+        # All other phases are API-only
+        return "api" if self.api_client else None
 
     def _log_missing_fields(
         self,
@@ -504,7 +509,7 @@ class MetadataCollector:
         record_type: str,
         record_id: str,
     ) -> None:
-        """Log debug messages for expected API fields missing from a record.
+        """Log error messages for expected API fields missing from a record.
 
         Only logs when a key is absent from the dict — not when present
         with a null, empty, or zero value.
@@ -517,7 +522,7 @@ class MetadataCollector:
         """
         for field in expected_fields:
             if field not in record:
-                logger.debug(
+                logger.error(
                     "%s MISSING_FIELD: %s '%s' - '%s' not in API response",
                     self._log_prefix,
                     record_type,
@@ -533,7 +538,8 @@ class MetadataCollector:
         """Collect cloud provider metadata.
 
         Cloud metadata is only available via CLI (virtual-machine instance show).
-        Returns one CloudMetadata per node in the cluster.
+        Returns one CloudMetadata per node in the cluster. This is the only
+        CLI-only phase — failure warns but does not abort collection.
 
         Returns:
             List of CloudMetadata objects, one per node.
@@ -542,7 +548,12 @@ class MetadataCollector:
             try:
                 return self._collect_cloud_metadata_via_cli()
             except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect cloud metadata via CLI: {e}")
+                logger.error(
+                    "%s CLI_FAILURE: Cloud metadata - %s: %s",
+                    self._log_prefix,
+                    type(e).__name__,
+                    e,
+                )
         return []
 
     def _collect_cloud_metadata_via_cli(self) -> list[CloudMetadata]:
@@ -784,26 +795,29 @@ class MetadataCollector:
     # -------------------------------------------------------------------------
 
     def collect_cluster_info(self) -> ClusterInfo:
-        """Collect cluster identity information.
+        """Collect cluster identity information (API-only).
 
         Returns:
             ClusterInfo object.
+
+        Raises:
+            CollectionError: If no API client is available.
+            Exception: If the API call fails.
         """
-        # Try API first
-        if self.api_client:
-            try:
-                return self._collect_cluster_info_via_api()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect cluster info via API: {e}")
-
-        # Fall back to CLI
-        if self.cli_client:
-            try:
-                return self._collect_cluster_info_via_cli()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect cluster info via CLI: {e}")
-
-        return ClusterInfo()
+        if not self.api_client:
+            raise CollectionError(
+                f"{self._log_prefix} API_FAILURE: Cluster info - no API client available"
+            )
+        try:
+            return self._collect_cluster_info_via_api()
+        except Exception as e:
+            logger.error(
+                "%s API_FAILURE: Cluster info - %s: %s",
+                self._log_prefix,
+                type(e).__name__,
+                e,
+            )
+            raise
 
     def _collect_cluster_info_via_api(self) -> ClusterInfo:
         """Collect cluster info using REST API.
@@ -837,56 +851,34 @@ class MetadataCollector:
             location=response.get("location", ""),
         )
 
-    def _collect_cluster_info_via_cli(self) -> ClusterInfo:
-        """Collect cluster info using CLI.
-
-        Returns:
-            ClusterInfo from cluster identity show.
-        """
-        if not self.cli_client:
-            logger.debug("%s No CLI client available for cluster info collection", self._log_prefix)
-            return ClusterInfo()
-
-        logger.debug("%s CLI command: cluster identity show", self._log_prefix)
-        output, _ = self.cli_client.run_a_show_command_and_parse_seperator("cluster identity show")
-        logger.debug("%s CLI response: %d entries", self._log_prefix, len(output))
-        if output:
-            data = output[0]
-            self._log_missing_fields(
-                data,
-                ["cluster", "cluster-uuid"],
-                "Cluster(CLI)",
-                data.get("cluster", "unknown"),
-            )
-            return ClusterInfo(
-                cluster_name=data.get("cluster", ""),
-                cluster_uuid=data.get("cluster-uuid", ""),
-            )
-        return ClusterInfo()
-
     # -------------------------------------------------------------------------
     # Node Collection
     # -------------------------------------------------------------------------
 
     def collect_nodes(self) -> list[NodeInfo]:
-        """Collect node information.
+        """Collect node information (API-only).
 
         Returns:
             List of NodeInfo objects.
+
+        Raises:
+            CollectionError: If no API client is available.
+            Exception: If the API call fails.
         """
-        if self.api_client:
-            try:
-                return self._collect_nodes_via_api()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect nodes via API: {e}")
-
-        if self.cli_client:
-            try:
-                return self._collect_nodes_via_cli()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect nodes via CLI: {e}")
-
-        return []
+        if not self.api_client:
+            raise CollectionError(
+                f"{self._log_prefix} API_FAILURE: Nodes - no API client available"
+            )
+        try:
+            return self._collect_nodes_via_api()
+        except Exception as e:
+            logger.error(
+                "%s API_FAILURE: Nodes - %s: %s",
+                self._log_prefix,
+                type(e).__name__,
+                e,
+            )
+            raise
 
     def _collect_nodes_via_api(self) -> list[NodeInfo]:
         """Collect nodes using REST API.
@@ -908,45 +900,34 @@ class MetadataCollector:
             parse_api_response(NODE_MAPPING, response, self._log_prefix, self._log_missing_fields),
         )
 
-    def _collect_nodes_via_cli(self) -> list[NodeInfo]:
-        """Collect nodes using CLI.
-
-        Returns:
-            List of NodeInfo from system node show.
-        """
-        if not self.cli_client:
-            logger.debug("%s No CLI client available for nodes collection", self._log_prefix)
-            return []
-
-        output, _ = self.cli_client.run_a_show_command_and_parse_seperator(NODE_MAPPING.cli_command)
-        return cast(
-            list[NodeInfo],
-            parse_cli_records(NODE_MAPPING, output, self._log_prefix, self._log_missing_fields),
-        )
-
     # -------------------------------------------------------------------------
     # Network Collection
     # -------------------------------------------------------------------------
 
     def collect_network(self) -> NetworkInfo:
-        """Collect network configuration.
+        """Collect network configuration (API-only).
 
         Returns:
             NetworkInfo object.
+
+        Raises:
+            CollectionError: If no API client is available.
+            Exception: If the API call fails.
         """
-        if self.api_client:
-            try:
-                return self._collect_network_via_api()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect network via API: {e}")
-
-        if self.cli_client:
-            try:
-                return self._collect_network_via_cli()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect network via CLI: {e}")
-
-        return NetworkInfo()
+        if not self.api_client:
+            raise CollectionError(
+                f"{self._log_prefix} API_FAILURE: Network - no API client available"
+            )
+        try:
+            return self._collect_network_via_api()
+        except Exception as e:
+            logger.error(
+                "%s API_FAILURE: Network - %s: %s",
+                self._log_prefix,
+                type(e).__name__,
+                e,
+            )
+            raise
 
     def _collect_network_via_api(self) -> NetworkInfo:
         """Collect network info using REST API.
@@ -1064,78 +1045,34 @@ class MetadataCollector:
             subnets=subnets,
         )
 
-    def _collect_network_via_cli(self) -> NetworkInfo:
-        """Collect network info using CLI.
-
-        Returns:
-            NetworkInfo from network interface show.
-        """
-        if not self.cli_client:
-            logger.debug("%s No CLI client available for network collection", self._log_prefix)
-            return NetworkInfo()
-
-        logger.debug("%s CLI command: network interface show", self._log_prefix)
-        output, _ = self.cli_client.run_a_show_command_and_parse_seperator("network interface show")
-        logger.debug("%s CLI response: %d interfaces", self._log_prefix, len(output))
-        intercluster_lifs = []
-        data_lifs = []
-        management_lifs = []
-
-        for data in output:
-            self._log_missing_fields(
-                data,
-                ["lif", "address", "netmask", "home-node", "home-port", "role", "vserver"],
-                "LIF(CLI)",
-                data.get("lif", "unknown"),
-            )
-            lif = NetworkLIF(
-                name=data.get("lif", ""),
-                ip_address=data.get("address", ""),
-                netmask=data.get("netmask", ""),
-                home_node=data.get("home-node", ""),
-                home_port=data.get("home-port", ""),
-                role=data.get("role", ""),
-                svm=data.get("vserver", ""),
-            )
-            role = data.get("role", "").lower()
-            if "intercluster" in role:
-                intercluster_lifs.append(lif)
-            elif role in ("data", ""):
-                data_lifs.append(lif)
-            elif "mgmt" in role or "management" in role:
-                management_lifs.append(lif)
-            else:
-                data_lifs.append(lif)
-
-        return NetworkInfo(
-            intercluster_lifs=intercluster_lifs,
-            data_lifs=data_lifs,
-            management_lifs=management_lifs,
-        )
-
     # -------------------------------------------------------------------------
     # Storage Collection
     # -------------------------------------------------------------------------
 
     def collect_storage(self) -> StorageInfo:
-        """Collect storage topology information.
+        """Collect storage topology information (API-only).
 
         Returns:
             StorageInfo object.
+
+        Raises:
+            CollectionError: If no API client is available.
+            Exception: If the API call fails.
         """
-        if self.api_client:
-            try:
-                return self._collect_storage_via_api()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect storage via API: {e}")
-
-        if self.cli_client:
-            try:
-                return self._collect_storage_via_cli()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect storage via CLI: {e}")
-
-        return StorageInfo()
+        if not self.api_client:
+            raise CollectionError(
+                f"{self._log_prefix} API_FAILURE: Storage - no API client available"
+            )
+        try:
+            return self._collect_storage_via_api()
+        except Exception as e:
+            logger.error(
+                "%s API_FAILURE: Storage - %s: %s",
+                self._log_prefix,
+                type(e).__name__,
+                e,
+            )
+            raise
 
     def _collect_storage_via_api(self) -> StorageInfo:
         """Collect storage info using REST API.
@@ -1315,143 +1252,34 @@ class MetadataCollector:
             cloud_targets.append(target)
         return cloud_targets
 
-    def _collect_storage_via_cli(self) -> StorageInfo:
-        """Collect storage info using CLI.
-
-        Returns:
-            StorageInfo from aggr show, vserver show, and object-store config show.
-        """
-        if not self.cli_client:
-            logger.debug("%s No CLI client available for storage collection", self._log_prefix)
-            return StorageInfo()
-
-        # Collect aggregates
-        aggr_output, _ = self.cli_client.run_a_show_command_and_parse_seperator("aggr show")
-        aggregates = cast(
-            list[AggregateInfo],
-            parse_cli_records(
-                AGGREGATE_MAPPING, aggr_output, self._log_prefix, self._log_missing_fields
-            ),
-        )
-
-        # Collect SVMs
-        logger.debug("%s CLI command: vserver show", self._log_prefix)
-        svm_output, _ = self.cli_client.run_a_show_command_and_parse_seperator("vserver show")
-        logger.debug("%s CLI response: %d SVMs", self._log_prefix, len(svm_output))
-        svms = []
-        for data in svm_output:
-            self._log_missing_fields(
-                data,
-                ["vserver", "admin-state", "type", "root-volume"],
-                "SVM(CLI)",
-                data.get("vserver", "unknown"),
-            )
-            svm = SVMInfo(
-                name=data.get("vserver", ""),
-                state=data.get("admin-state", ""),
-                subtype=data.get("type", ""),
-                root_volume=data.get("root-volume", ""),
-            )
-            svms.append(svm)
-
-        # Collect cloud targets
-        cloud_targets = self._collect_cloud_targets_via_cli()
-
-        # Collect volumes
-        logger.debug("%s CLI command: volume show", self._log_prefix)
-        vol_output, _ = self.cli_client.run_a_show_command_and_parse_seperator("volume show")
-        volumes = cast(
-            list[VolumeInfo],
-            parse_cli_records(
-                VOLUME_MAPPING, vol_output, self._log_prefix, self._log_missing_fields
-            ),
-        )
-
-        return StorageInfo(
-            aggregates=aggregates,
-            svms=svms,
-            cloud_targets=cloud_targets,
-            volumes=volumes,
-        )
-
-    def _collect_cloud_targets_via_cli(self) -> list[CloudTargetInfo]:
-        """Collect cloud object store targets using CLI.
-
-        Returns:
-            List of CloudTargetInfo from storage aggregate object-store config show.
-        """
-        if not self.cli_client:
-            logger.debug(
-                "%s No CLI client available for cloud targets collection", self._log_prefix
-            )
-            return []
-
-        try:
-            logger.debug(
-                "%s CLI command: storage aggregate object-store config show", self._log_prefix
-            )
-            output, _ = self.cli_client.run_a_show_command_and_parse_seperator(
-                "storage aggregate object-store config show"
-            )
-            logger.debug("%s CLI response: %d cloud targets", self._log_prefix, len(output))
-        except Exception as e:
-            # Command may not be available on systems without FabricPool
-            logger.debug("%s Cloud targets CLI command not available: %s", self._log_prefix, e)
-            return []
-
-        cloud_targets = []
-        for data in output:
-            self._log_missing_fields(
-                data,
-                [
-                    "object-store-name",
-                    "provider-type",
-                    "server",
-                    "container",
-                    "owner",
-                    "ssl-enabled",
-                    "auth-type",
-                    "ipspace",
-                ],
-                "CloudTarget(CLI)",
-                data.get("object-store-name", "unknown"),
-            )
-            target = CloudTargetInfo(
-                name=data.get("object-store-name", ""),
-                provider_type=data.get("provider-type", ""),
-                server=data.get("server", ""),
-                container=data.get("container", "") or data.get("bucket", ""),
-                owner=data.get("owner", ""),
-                ssl_enabled=data.get("ssl-enabled", "").lower() == "true",
-                authentication_type=data.get("auth-type", ""),
-                ipspace=data.get("ipspace", ""),
-            )
-            cloud_targets.append(target)
-        return cloud_targets
-
     # -------------------------------------------------------------------------
     # License Collection
     # -------------------------------------------------------------------------
 
     def collect_licenses(self) -> LicenseInfo:
-        """Collect licensing information.
+        """Collect licensing information (API-only).
 
         Returns:
             LicenseInfo object.
+
+        Raises:
+            CollectionError: If no API client is available.
+            Exception: If the API call fails.
         """
-        if self.api_client:
-            try:
-                return self._collect_licenses_via_api()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect licenses via API: {e}")
-
-        if self.cli_client:
-            try:
-                return self._collect_licenses_via_cli()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect licenses via CLI: {e}")
-
-        return LicenseInfo()
+        if not self.api_client:
+            raise CollectionError(
+                f"{self._log_prefix} API_FAILURE: Licenses - no API client available"
+            )
+        try:
+            return self._collect_licenses_via_api()
+        except Exception as e:
+            logger.error(
+                "%s API_FAILURE: Licenses - %s: %s",
+                self._log_prefix,
+                type(e).__name__,
+                e,
+            )
+            raise
 
     def _collect_licenses_via_api(self) -> LicenseInfo:
         """Collect licenses using REST API.
@@ -1499,60 +1327,34 @@ class MetadataCollector:
 
         return LicenseInfo(feature_licenses=feature_licenses, capacity_licenses=capacity_licenses)
 
-    def _collect_licenses_via_cli(self) -> LicenseInfo:
-        """Collect licenses using CLI.
-
-        Returns:
-            LicenseInfo from license show.
-        """
-        if not self.cli_client:
-            logger.debug("%s No CLI client available for license collection", self._log_prefix)
-            return LicenseInfo()
-
-        logger.debug("%s CLI command: license show", self._log_prefix)
-        output, _ = self.cli_client.run_a_show_command_and_parse_seperator("license show")
-        logger.debug("%s CLI response: %d licenses", self._log_prefix, len(output))
-        feature_licenses = []
-
-        for data in output:
-            self._log_missing_fields(
-                data,
-                ["package", "state", "scope"],
-                "License(CLI)",
-                data.get("package", "unknown"),
-            )
-            feature = LicenseFeature(
-                name=data.get("package", ""),
-                state=data.get("state", ""),
-                scope=data.get("scope", ""),
-            )
-            feature_licenses.append(feature)
-
-        return LicenseInfo(feature_licenses=feature_licenses)
-
     # -------------------------------------------------------------------------
     # HA Info Collection
     # -------------------------------------------------------------------------
 
     def collect_ha_info(self) -> HAInfo:
-        """Collect HA configuration information.
+        """Collect HA configuration information (API-only).
 
         Returns:
             HAInfo object.
+
+        Raises:
+            CollectionError: If no API client is available.
+            Exception: If the API call fails.
         """
-        if self.api_client:
-            try:
-                return self._collect_ha_info_via_api()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect HA info via API: {e}")
-
-        if self.cli_client:
-            try:
-                return self._collect_ha_info_via_cli()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect HA info via CLI: {e}")
-
-        return HAInfo()
+        if not self.api_client:
+            raise CollectionError(
+                f"{self._log_prefix} API_FAILURE: HA info - no API client available"
+            )
+        try:
+            return self._collect_ha_info_via_api()
+        except Exception as e:
+            logger.error(
+                "%s API_FAILURE: HA info - %s: %s",
+                self._log_prefix,
+                type(e).__name__,
+                e,
+            )
+            raise
 
     def _collect_ha_info_via_api(self) -> HAInfo:
         """Collect HA info using REST API.
@@ -1613,59 +1415,34 @@ class MetadataCollector:
             mediator_address=mediator_address,
         )
 
-    def _collect_ha_info_via_cli(self) -> HAInfo:
-        """Collect HA info using CLI.
-
-        Returns:
-            HAInfo from storage failover show.
-        """
-        if not self.cli_client:
-            logger.debug("%s No CLI client available for HA info collection", self._log_prefix)
-            return HAInfo()
-
-        logger.debug("%s CLI command: storage failover show", self._log_prefix)
-        output, _ = self.cli_client.run_a_show_command_and_parse_seperator("storage failover show")
-        logger.debug("%s CLI response: %d entries", self._log_prefix, len(output))
-        if not output:
-            return HAInfo(is_ha=False)
-
-        # Parse first node's HA info
-        first_node = output[0]
-        self._log_missing_fields(
-            first_node,
-            ["partner-name", "node-state"],
-            "HA(CLI)",
-            first_node.get("node", "unknown"),
-        )
-        return HAInfo(
-            is_ha=True,
-            partner_node=first_node.get("partner-name", ""),
-            ha_state=first_node.get("node-state", ""),
-        )
-
     # -------------------------------------------------------------------------
     # Relationships Collection
     # -------------------------------------------------------------------------
 
     def collect_relationships(self) -> RelationshipsInfo:
-        """Collect cluster relationships information.
+        """Collect cluster relationships information (API-only).
 
         Returns:
             RelationshipsInfo object.
+
+        Raises:
+            CollectionError: If no API client is available.
+            Exception: If the API call fails.
         """
-        if self.api_client:
-            try:
-                return self._collect_relationships_via_api()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect relationships via API: {e}")
-
-        if self.cli_client:
-            try:
-                return self._collect_relationships_via_cli()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect relationships via CLI: {e}")
-
-        return RelationshipsInfo()
+        if not self.api_client:
+            raise CollectionError(
+                f"{self._log_prefix} API_FAILURE: Relationships - no API client available"
+            )
+        try:
+            return self._collect_relationships_via_api()
+        except Exception as e:
+            logger.error(
+                "%s API_FAILURE: Relationships - %s: %s",
+                self._log_prefix,
+                type(e).__name__,
+                e,
+            )
+            raise
 
     def _collect_relationships_via_api(self) -> RelationshipsInfo:
         """Collect relationships using REST API.
@@ -1761,64 +1538,6 @@ class MetadataCollector:
             snapmirror_destinations=snapmirror_destinations,
             cluster_peers=cluster_peers,
             svm_peers=svm_peers,
-        )
-
-    def _collect_relationships_via_cli(self) -> RelationshipsInfo:
-        """Collect relationships using CLI.
-
-        Returns:
-            RelationshipsInfo from snapmirror show and cluster peer show.
-        """
-        if not self.cli_client:
-            logger.debug(
-                "%s No CLI client available for relationships collection", self._log_prefix
-            )
-            return RelationshipsInfo()
-
-        # Collect SnapMirror relationships
-        logger.debug("%s CLI command: snapmirror show", self._log_prefix)
-        sm_output, _ = self.cli_client.run_a_show_command_and_parse_seperator("snapmirror show")
-        logger.debug(
-            "%s CLI response: %d SnapMirror relationships", self._log_prefix, len(sm_output)
-        )
-        snapmirror_destinations = []
-        for data in sm_output:
-            self._log_missing_fields(
-                data,
-                ["source-path", "destination-path", "type", "state"],
-                "SnapMirror(CLI)",
-                data.get("source-path", "unknown"),
-            )
-            sm = SnapMirrorRelationship(
-                source_path=data.get("source-path", ""),
-                destination_path=data.get("destination-path", ""),
-                relationship_type=data.get("type", ""),
-                state=data.get("state", ""),
-            )
-            snapmirror_destinations.append(sm)
-
-        # Collect cluster peers
-        logger.debug("%s CLI command: cluster peer show", self._log_prefix)
-        peer_output, _ = self.cli_client.run_a_show_command_and_parse_seperator("cluster peer show")
-        logger.debug("%s CLI response: %d cluster peers", self._log_prefix, len(peer_output))
-        cluster_peers = []
-        for data in peer_output:
-            self._log_missing_fields(
-                data,
-                ["peer-cluster", "remote-cluster-name", "auth-status-admin"],
-                "ClusterPeer(CLI)",
-                data.get("peer-cluster", "unknown"),
-            )
-            peer = ClusterPeer(
-                name=data.get("peer-cluster", ""),
-                remote_cluster_name=data.get("remote-cluster-name", ""),
-                authentication_state=data.get("auth-status-admin", ""),
-            )
-            cluster_peers.append(peer)
-
-        return RelationshipsInfo(
-            snapmirror_destinations=snapmirror_destinations,
-            cluster_peers=cluster_peers,
         )
 
     # -------------------------------------------------------------------------
@@ -2115,18 +1834,29 @@ class MetadataCollector:
     # -------------------------------------------------------------------------
 
     def collect_protocols(self) -> ProtocolsInfo:
-        """Collect protocol configuration information.
+        """Collect protocol configuration information (API-only).
 
         Returns:
             ProtocolsInfo object.
-        """
-        if self.api_client:
-            try:
-                return self._collect_protocols_via_api()
-            except Exception as e:
-                logger.warning(f"{self._log_prefix} Failed to collect protocols via API: {e}")
 
-        return ProtocolsInfo()
+        Raises:
+            CollectionError: If no API client is available.
+            Exception: If the API call fails.
+        """
+        if not self.api_client:
+            raise CollectionError(
+                f"{self._log_prefix} API_FAILURE: Protocols - no API client available"
+            )
+        try:
+            return self._collect_protocols_via_api()
+        except Exception as e:
+            logger.error(
+                "%s API_FAILURE: Protocols - %s: %s",
+                self._log_prefix,
+                type(e).__name__,
+                e,
+            )
+            raise
 
     def _collect_protocols_via_api(self) -> ProtocolsInfo:
         """Collect protocol info using REST API.

--- a/src/pynetappfoundry/cache/field_mapping.py
+++ b/src/pynetappfoundry/cache/field_mapping.py
@@ -134,7 +134,8 @@ def parse_api_record(
 
     For each field: uses ``transform(record)`` if set, otherwise extracts
     via ``get_nested_value(record, api_path)``. Falls back to default on
-    ``PathNotFoundError`` or transform exception.
+    ``PathNotFoundError``. Transform exceptions propagate (logged as
+    ``TRANSFORM_FAILURE``).
 
     Args:
         mapping: Type mapping definition.
@@ -150,13 +151,14 @@ def parse_api_record(
             try:
                 kwargs[field.cache_attr] = field.transform(record)
             except Exception:
-                logger.debug(
-                    "%s transform error for %s.%s, using default",
+                logger.error(
+                    "%s TRANSFORM_FAILURE: %s '%s' - transform error for field '%s'",
                     log_prefix,
                     mapping.name,
+                    record.get(mapping.id_field, record.get("uuid", "unknown")),
                     field.cache_attr,
                 )
-                kwargs[field.cache_attr] = field.default
+                raise
         elif field.api_path is not None:
             try:
                 kwargs[field.cache_attr] = get_nested_value(record, field.api_path)
@@ -191,13 +193,13 @@ def parse_cli_record(
             try:
                 kwargs[field.cache_attr] = field.cli_transform(record)
             except Exception:
-                logger.debug(
-                    "%s cli_transform error for %s.%s, using default",
+                logger.error(
+                    "%s TRANSFORM_FAILURE: %s - cli_transform error for field '%s'",
                     log_prefix,
                     mapping.name,
                     field.cache_attr,
                 )
-                kwargs[field.cache_attr] = field.default
+                raise
         elif field.cli_field is not None:
             raw = record.get(field.cli_field)
             if raw is None:

--- a/src/pynetappfoundry/cache/mappings/aggregate.py
+++ b/src/pynetappfoundry/cache/mappings/aggregate.py
@@ -22,22 +22,18 @@ AGGREGATE_MAPPING = TypeMapping(
         FieldMapping(
             cache_attr="name",
             api_path="name",
-            cli_field="aggregate",
         ),
         FieldMapping(
             cache_attr="node",
             api_path="node.name",
-            cli_field="node",
         ),
         FieldMapping(
             cache_attr="state",
             api_path="state",
-            cli_field="state",
         ),
         FieldMapping(
             cache_attr="type",
             api_path="block_storage.primary.disk_type",
-            cli_field="type",
         ),
         FieldMapping(
             cache_attr="total_size",
@@ -140,7 +136,6 @@ AGGREGATE_MAPPING = TypeMapping(
         FieldMapping(
             cache_attr="volume_count",
             api_path="volume_count",
-            cli_field="volcount",
             default=0,
         ),
         # expensive field (needs explicit API request)

--- a/src/pynetappfoundry/cache/mappings/node.py
+++ b/src/pynetappfoundry/cache/mappings/node.py
@@ -22,22 +22,18 @@ NODE_MAPPING = TypeMapping(
         FieldMapping(
             cache_attr="name",
             api_path="name",
-            cli_field="node",
         ),
         FieldMapping(
             cache_attr="serial_number",
             api_path="serial_number",
-            cli_field="serial-number",
         ),
         FieldMapping(
             cache_attr="system_id",
             api_path="system_id",
-            cli_field="system-id",
         ),
         FieldMapping(
             cache_attr="model",
             api_path="model",
-            cli_field="model",
         ),
         FieldMapping(
             cache_attr="location",

--- a/src/pynetappfoundry/cache/mappings/volume.py
+++ b/src/pynetappfoundry/cache/mappings/volume.py
@@ -1,6 +1,6 @@
 """Volume type mapping definition for the declarative field mapping framework.
 
-Defines VOLUME_MAPPING which maps ONTAP REST API and CLI volume data to
+Defines VOLUME_MAPPING which maps ONTAP REST API volume data to
 VolumeInfo cache model attributes.
 """
 
@@ -28,23 +28,6 @@ def _api_aggregates_list(record: dict[str, Any]) -> list[str]:
     ]
 
 
-def _cli_aggregates_list(record: dict[str, Any]) -> list[str]:
-    """Parse aggregate list from CLI output.
-
-    CLI returns comma or space-separated aggregate names in ``aggr-list``.
-
-    Args:
-        record: Full CLI volume record.
-
-    Returns:
-        List of non-empty aggregate names.
-    """
-    raw = record.get("aggr-list", "")
-    if not raw or raw == "-":
-        return []
-    return [n.strip() for n in raw.replace(",", " ").split() if n.strip()]
-
-
 VOLUME_MAPPING = TypeMapping(
     name="Volume",
     model_class=VolumeInfo,
@@ -54,115 +37,94 @@ VOLUME_MAPPING = TypeMapping(
         FieldMapping(
             cache_attr="uuid",
             api_path="uuid",
-            cli_field="instance-uuid",
         ),
         FieldMapping(
             cache_attr="name",
             api_path="name",
-            cli_field="volume",
         ),
         FieldMapping(
             cache_attr="svm",
             api_path="svm.name",
-            cli_field="vserver",
         ),
         FieldMapping(
             cache_attr="state",
             api_path="state",
-            cli_field="state",
         ),
         FieldMapping(
             cache_attr="type",
             api_path="type",
-            cli_field="type",
         ),
         FieldMapping(
             cache_attr="style",
             api_path="style",
-            cli_field="volume-style-extended",
         ),
         FieldMapping(
             cache_attr="size",
             api_path="size",
-            cli_field="size",
             default=0,
         ),
         FieldMapping(
             cache_attr="autosize_mode",
             api_path="autosize.mode",
-            cli_field="autosize-mode",
         ),
         FieldMapping(
             cache_attr="autosize_grow_threshold",
             api_path="autosize.grow_threshold",
-            cli_field="autosize-grow-threshold-percent",
             default=0,
         ),
         FieldMapping(
             cache_attr="autosize_shrink_threshold",
             api_path="autosize.shrink_threshold",
-            cli_field="autosize-shrink-threshold-percent",
             default=0,
         ),
         FieldMapping(
             cache_attr="autosize_maximum",
             api_path="autosize.maximum",
-            cli_field="max-autosize",
             default=0,
         ),
         FieldMapping(
             cache_attr="autosize_minimum",
             api_path="autosize.minimum",
-            cli_field="min-autosize",
             default=0,
         ),
         FieldMapping(
             cache_attr="files_maximum",
             api_path="files.maximum",
-            cli_field="files",
             default=0,
         ),
         FieldMapping(
             cache_attr="tiering_policy",
             api_path="tiering.policy",
-            cli_field="tiering-policy",
         ),
         FieldMapping(
             cache_attr="tiering_minimum_cooling_days",
             api_path="tiering.min_cooling_days",
-            cli_field="tiering-minimum-cooling-days",
             default=0,
         ),
         FieldMapping(
             cache_attr="aggregate",
             api_path="aggregates[0].name",
-            cli_field="aggregate",
         ),
         FieldMapping(
             cache_attr="aggregates",
             default=[],
             transform=_api_aggregates_list,
-            cli_transform=_cli_aggregates_list,
         ),
         FieldMapping(
             cache_attr="snapshot_policy",
             api_path="snapshot_policy.name",
-            cli_field="snapshot-policy",
         ),
         FieldMapping(
             cache_attr="export_policy",
             api_path="nas.export_policy.name",
-            cli_field="policy",
         ),
         FieldMapping(
             cache_attr="junction_path",
             api_path="nas.path",
-            cli_field="junction-path",
         ),
         FieldMapping(
             cache_attr="nas_security_style",
             api_path="nas.security_style",
-            cli_field="security-style",
         ),
     ),
 )

--- a/src/pynetappfoundry/cli/commands/cache/refresh.py
+++ b/src/pynetappfoundry/cli/commands/cache/refresh.py
@@ -229,6 +229,47 @@ def refresh(
     history_db.close()
 
 
+def _categorize_failure(error: Exception) -> tuple[str, str]:
+    """Categorize a collection failure for the failure summary.
+
+    Args:
+        error: The exception that caused the failure.
+
+    Returns:
+        Tuple of (category, detail) for display.
+    """
+    error_str = str(error)
+    error_type = type(error).__name__
+
+    if "CLI_FAILURE" in error_str:
+        return "CLI", error_str.split("CLI_FAILURE: ", 1)[
+            -1
+        ] if "CLI_FAILURE: " in error_str else f"{error_type}: {error}"
+    if "API_FAILURE" in error_str or "Collection failed for phase" in error_str:
+        return "API", error_str.split("API_FAILURE: ", 1)[
+            -1
+        ] if "API_FAILURE: " in error_str else f"{error_type}: {error}"
+    return "API", f"{error_type}: {error}"
+
+
+def _print_failure_summary(
+    failures: dict[str, list[str]],
+) -> None:
+    """Print a per-cluster failure summary.
+
+    Args:
+        failures: Dict mapping cluster name to list of failure descriptions.
+    """
+    if not failures:
+        return
+
+    console.print("\n[bold red]Failure Summary:[/bold red]")
+    for cluster_name, messages in failures.items():
+        console.print(f"  {cluster_name}:")
+        for msg in messages:
+            console.print(f"    {msg}")
+
+
 def _refresh_normal(
     ctx: click.Context,
     config: Config,
@@ -247,6 +288,7 @@ def _refresh_normal(
     """
     success_count = 0
     error_count = 0
+    failures: dict[str, list[str]] = {}
 
     with Progress(
         SpinnerColumn(),
@@ -264,11 +306,14 @@ def _refresh_normal(
                     success_count += 1
                 else:
                     error_count += 1
+                    failures.setdefault(cluster_name, []).append("No clients available")
 
             except Exception as e:
                 print_exception(f"  {cluster_name}: Failed - {e}", e)
                 logger.exception("Failed to process cluster %s", cluster_name)
                 error_count += 1
+                category, detail = _categorize_failure(e)
+                failures.setdefault(cluster_name, []).append(f"{category}: {detail}")
 
             progress.update(task, completed=1)
 
@@ -278,6 +323,7 @@ def _refresh_normal(
         print_success(f"Successfully refreshed {success_count} cluster(s)")
     if error_count > 0:
         print_error(f"Failed to refresh {error_count} cluster(s)")
+        _print_failure_summary(failures)
         logger.error("Failed to refresh %d cluster(s)", error_count)
         ctx.exit(1)
 
@@ -303,6 +349,7 @@ def _refresh_verbose(
     success_count = 0
     error_count = 0
     total_clusters = len(clusters_to_refresh)
+    failures: dict[str, list[str]] = {}
 
     for idx, cluster_name in enumerate(clusters_to_refresh, 1):
         logger.info("Processing cluster: %s (%d/%d)", cluster_name, idx, total_clusters)
@@ -329,12 +376,15 @@ def _refresh_verbose(
                 success_count += 1
             else:
                 error_count += 1
+                failures.setdefault(cluster_name, []).append("No clients available")
 
         except Exception as e:
             display.print_summary(success=False)
             print_exception(f"  Error: {e}", e)
             logger.exception("Failed to process cluster %s", cluster_name)
             error_count += 1
+            category, detail = _categorize_failure(e)
+            failures.setdefault(cluster_name, []).append(f"{category}: {detail}")
 
     # Summary
     console.print()
@@ -342,6 +392,7 @@ def _refresh_verbose(
         print_success(f"Successfully refreshed {success_count} cluster(s)")
     if error_count > 0:
         print_error(f"Failed to refresh {error_count} cluster(s)")
+        _print_failure_summary(failures)
         logger.error("Failed to refresh %d cluster(s)", error_count)
         ctx.exit(1)
 

--- a/tests/unit/cache/mappings/test_aggregate.py
+++ b/tests/unit/cache/mappings/test_aggregate.py
@@ -10,8 +10,6 @@ import pytest
 from pynetappfoundry.cache.field_mapping import (
     parse_api_record,
     parse_api_response,
-    parse_cli_record,
-    parse_cli_records,
 )
 from pynetappfoundry.cache.mappings.aggregate import AGGREGATE_MAPPING
 from pynetappfoundry.cache.models import AggregateInfo
@@ -70,18 +68,6 @@ def full_api_record() -> dict[str, Any]:
         },
         "is_spare_low": False,
         "volume_count": 40,
-    }
-
-
-@pytest.fixture
-def full_cli_record() -> dict[str, Any]:
-    """Full CLI aggregate record with all fields."""
-    return {
-        "aggregate": "PRODAGGR1",
-        "node": "PRODCL1-01",
-        "state": "online",
-        "type": "ssd",
-        "volcount": "40",
     }
 
 
@@ -341,75 +327,6 @@ class TestAggregateApiParsing:
 
 
 # ---------------------------------------------------------------------------
-# CLI parsing tests
-# ---------------------------------------------------------------------------
-
-
-class TestAggregateCliParsing:
-    """Tests for parsing CLI aggregate records."""
-
-    def test_full_record(self, full_cli_record: dict[str, Any]) -> None:
-        """Full CLI record parses to complete AggregateInfo."""
-        aggr = parse_cli_record(AGGREGATE_MAPPING, full_cli_record, "[test]")
-        assert isinstance(aggr, AggregateInfo)
-        assert aggr.name == "PRODAGGR1"
-        assert aggr.node == "PRODCL1-01"
-        assert aggr.state == "online"
-        assert aggr.type == "ssd"
-        assert aggr.volume_count == 40
-        # Fields without cli_field should use defaults
-        assert aggr.uuid == ""
-        assert aggr.total_size == 0
-        assert aggr.disk_count == 0
-        assert aggr.disk_type == ""
-        assert aggr.raid_type == ""
-        # New fields without cli_field should use defaults
-        assert aggr.storage_type == ""
-        assert aggr.disk_class == ""
-        assert aggr.raid_size == 0
-        assert aggr.checksum_style == ""
-        assert aggr.uses_partitions is False
-        assert aggr.mirror_enabled is False
-        assert aggr.mirror_state == ""
-        assert aggr.hybrid_cache_enabled is False
-        assert aggr.snaplock_type == ""
-        assert aggr.home_node == ""
-        assert aggr.dr_home_node == ""
-        assert aggr.create_time == ""
-        assert aggr.cloud_attach_eligible is False
-        assert aggr.encryption_software is False
-        assert aggr.encryption_drive is False
-        assert aggr.sidl_enabled is False
-        assert aggr.inactive_data_reporting_enabled is False
-        assert aggr.is_spare_low is False
-
-    def test_dash_values_use_defaults(self) -> None:
-        """CLI dash values coerce to default."""
-        record = {
-            "aggregate": "-",
-            "node": "-",
-            "state": "-",
-            "type": "-",
-        }
-        aggr = parse_cli_record(AGGREGATE_MAPPING, record, "[test]")
-        assert aggr.name == ""
-        assert aggr.node == ""
-        assert aggr.state == ""
-        assert aggr.type == ""
-
-    def test_parse_cli_records_multiple(self) -> None:
-        """parse_cli_records handles multiple records."""
-        records = [
-            {"aggregate": "aggr1", "node": "node1"},
-            {"aggregate": "aggr2", "node": "node2"},
-        ]
-        results = parse_cli_records(AGGREGATE_MAPPING, records, "[test]", MagicMock())
-        assert len(results) == 2
-        assert results[0].name == "aggr1"
-        assert results[1].name == "aggr2"
-
-
-# ---------------------------------------------------------------------------
 # Parity test: old parser vs new framework
 # ---------------------------------------------------------------------------
 
@@ -436,16 +353,6 @@ class TestParityWithOldParser:
             disk_count=primary.get("disk_count", 0),
             disk_type=primary.get("disk_type", ""),
             raid_type=primary.get("raid_type", ""),
-        )
-
-    @staticmethod
-    def _old_parse_aggregate_cli(data: dict[str, Any]) -> AggregateInfo:
-        """Reproduce old inline aggregate parsing logic for CLI records."""
-        return AggregateInfo(
-            name=data.get("aggregate", ""),
-            node=data.get("node", ""),
-            state=data.get("state", ""),
-            type=data.get("type", ""),
         )
 
     _ORIGINAL_FIELDS = (
@@ -495,18 +402,6 @@ class TestParityWithOldParser:
         }
         old = self._old_parse_aggregate_api(record)
         new = parse_api_record(AGGREGATE_MAPPING, record, "[test]")
-        assert isinstance(new, AggregateInfo)
-        for field_name in self._ORIGINAL_FIELDS:
-            old_val = getattr(old, field_name)
-            new_val = getattr(new, field_name)
-            assert old_val == new_val, (
-                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
-            )
-
-    def test_parity_cli_full_record(self, full_cli_record: dict[str, Any]) -> None:
-        """Framework and old parser produce identical AggregateInfo for CLI."""
-        old = self._old_parse_aggregate_cli(full_cli_record)
-        new = parse_cli_record(AGGREGATE_MAPPING, full_cli_record, "[test]")
         assert isinstance(new, AggregateInfo)
         for field_name in self._ORIGINAL_FIELDS:
             old_val = getattr(old, field_name)

--- a/tests/unit/cache/mappings/test_node.py
+++ b/tests/unit/cache/mappings/test_node.py
@@ -10,8 +10,6 @@ import pytest
 from pynetappfoundry.cache.field_mapping import (
     parse_api_record,
     parse_api_response,
-    parse_cli_record,
-    parse_cli_records,
 )
 from pynetappfoundry.cache.mappings.node import NODE_MAPPING
 from pynetappfoundry.cache.models import NodeInfo
@@ -57,17 +55,6 @@ def full_api_record() -> dict[str, Any]:
         "management_interfaces": [
             {"uuid": "mgmt-uuid-1"},
         ],
-    }
-
-
-@pytest.fixture
-def full_cli_record() -> dict[str, Any]:
-    """Full CLI node record with all mapped CLI fields."""
-    return {
-        "node": "PRODCL1-01",
-        "serial-number": "123456789",
-        "system-id": "0123456789",
-        "model": "AFF-A400",
     }
 
 
@@ -284,66 +271,6 @@ class TestNodeApiParsing:
 
 
 # ---------------------------------------------------------------------------
-# CLI parsing tests
-# ---------------------------------------------------------------------------
-
-
-class TestNodeCliParsing:
-    """Tests for parsing CLI node records."""
-
-    def test_full_record(self, full_cli_record: dict[str, Any]) -> None:
-        """Full CLI record parses to NodeInfo with CLI fields populated."""
-        node = parse_cli_record(NODE_MAPPING, full_cli_record, "[test]")
-        assert isinstance(node, NodeInfo)
-        assert node.name == "PRODCL1-01"
-        assert node.serial_number == "123456789"
-        assert node.system_id == "0123456789"
-        assert node.model == "AFF-A400"
-        # Fields without cli_field should use defaults
-        assert node.uuid == ""
-        assert node.location == ""
-        assert node.membership == ""
-        assert node.version_full == ""
-        assert node.storage_configuration == ""
-        assert node.system_machine_type == ""
-        assert node.controller_board == ""
-        assert node.controller_memory_size == 0
-        assert node.controller_cpu_count == 0
-        assert node.vm_provider_type == ""
-        assert node.ha_enabled is False
-        assert node.ha_auto_giveback is False
-        assert node.ha_partner_uuids == []
-        assert node.system_aggregate_uuid == ""
-        assert node.cluster_interface_uuids == []
-        assert node.management_interface_uuids == []
-
-    def test_dash_values_use_defaults(self) -> None:
-        """CLI dash values coerce to default."""
-        record = {
-            "node": "-",
-            "serial-number": "-",
-            "system-id": "-",
-            "model": "-",
-        }
-        node = parse_cli_record(NODE_MAPPING, record, "[test]")
-        assert node.name == ""
-        assert node.serial_number == ""
-        assert node.system_id == ""
-        assert node.model == ""
-
-    def test_parse_cli_records_multiple(self) -> None:
-        """parse_cli_records handles multiple records."""
-        records = [
-            {"node": "node1", "serial-number": "111"},
-            {"node": "node2", "serial-number": "222"},
-        ]
-        results = parse_cli_records(NODE_MAPPING, records, "[test]", MagicMock())
-        assert len(results) == 2
-        assert results[0].name == "node1"
-        assert results[1].name == "node2"
-
-
-# ---------------------------------------------------------------------------
 # Parity test: old parser vs new framework
 # ---------------------------------------------------------------------------
 
@@ -366,16 +293,6 @@ class TestParityWithOldParser:
             system_id=str(record.get("system_id", "")),
             model=str(record.get("model", "")),
             location=record.get("location", ""),
-        )
-
-    @staticmethod
-    def _old_parse_node_cli(data: dict[str, Any]) -> NodeInfo:
-        """Reproduce old inline node parsing logic for CLI records."""
-        return NodeInfo(
-            name=data.get("node", ""),
-            serial_number=data.get("serial-number", ""),
-            system_id=data.get("system-id", ""),
-            model=data.get("model", ""),
         )
 
     _ORIGINAL_FIELDS = (
@@ -432,18 +349,6 @@ class TestParityWithOldParser:
         record: dict[str, Any] = {"name": "node1"}
         old = self._old_parse_node_api(record)
         new = parse_api_record(NODE_MAPPING, record, "[test]")
-        assert isinstance(new, NodeInfo)
-        for field_name in self._ORIGINAL_FIELDS:
-            old_val = getattr(old, field_name)
-            new_val = getattr(new, field_name)
-            assert old_val == new_val, (
-                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
-            )
-
-    def test_parity_cli_full_record(self, full_cli_record: dict[str, Any]) -> None:
-        """Framework and old parser produce identical NodeInfo for CLI."""
-        old = self._old_parse_node_cli(full_cli_record)
-        new = parse_cli_record(NODE_MAPPING, full_cli_record, "[test]")
         assert isinstance(new, NodeInfo)
         for field_name in self._ORIGINAL_FIELDS:
             old_val = getattr(old, field_name)

--- a/tests/unit/cache/mappings/test_volume.py
+++ b/tests/unit/cache/mappings/test_volume.py
@@ -10,13 +10,10 @@ import pytest
 from pynetappfoundry.cache.field_mapping import (
     parse_api_record,
     parse_api_response,
-    parse_cli_record,
-    parse_cli_records,
 )
 from pynetappfoundry.cache.mappings.volume import (
     VOLUME_MAPPING,
     _api_aggregates_list,
-    _cli_aggregates_list,
 )
 from pynetappfoundry.cache.models import VolumeInfo
 
@@ -55,34 +52,6 @@ def full_api_record() -> dict[str, Any]:
             "path": "/PRODVOL1",
             "security_style": "ntfs",
         },
-    }
-
-
-@pytest.fixture
-def full_cli_record() -> dict[str, Any]:
-    """Full CLI volume record with all fields."""
-    return {
-        "instance-uuid": "09d308eb-1234-5678-9abc-def012345678",
-        "volume": "PRODVOL1",
-        "vserver": "svm_PRODCL1",
-        "state": "online",
-        "type": "RW",
-        "volume-style-extended": "flexvol",
-        "size": "9064378368",
-        "autosize-mode": "grow_shrink",
-        "autosize-grow-threshold-percent": "90%",
-        "autosize-shrink-threshold-percent": "50%",
-        "max-autosize": "18128756736",
-        "min-autosize": "4532189184",
-        "files": "31122",
-        "tiering-policy": "none",
-        "tiering-minimum-cooling-days": "2",
-        "aggregate": "PRODAGGR1",
-        "aggr-list": "PRODAGGR1,PRODAGGR2",
-        "snapshot-policy": "none",
-        "policy": "default",
-        "junction-path": "/PRODVOL1",
-        "security-style": "ntfs",
     }
 
 
@@ -248,84 +217,6 @@ class TestVolumeApiParsing:
 
 
 # ---------------------------------------------------------------------------
-# CLI parsing tests
-# ---------------------------------------------------------------------------
-
-
-class TestVolumeCliParsing:
-    """Tests for parsing CLI volume records."""
-
-    def test_full_record(self, full_cli_record: dict[str, Any]) -> None:
-        """Full CLI record parses to complete VolumeInfo."""
-        vol = parse_cli_record(VOLUME_MAPPING, full_cli_record, "[test]")
-        assert isinstance(vol, VolumeInfo)
-        assert vol.uuid == "09d308eb-1234-5678-9abc-def012345678"
-        assert vol.name == "PRODVOL1"
-        assert vol.svm == "svm_PRODCL1"
-        assert vol.state == "online"
-        assert vol.type == "RW"
-        assert vol.style == "flexvol"
-        assert vol.size == 9064378368
-        assert vol.autosize_mode == "grow_shrink"
-        assert vol.autosize_grow_threshold == 90
-        assert vol.autosize_shrink_threshold == 50
-        assert vol.autosize_maximum == 18128756736
-        assert vol.autosize_minimum == 4532189184
-        assert vol.files_maximum == 31122
-        assert vol.tiering_policy == "none"
-        assert vol.tiering_minimum_cooling_days == 2
-        assert vol.aggregate == "PRODAGGR1"
-        assert vol.aggregates == ["PRODAGGR1", "PRODAGGR2"]
-        assert vol.snapshot_policy == "none"
-        assert vol.export_policy == "default"
-        assert vol.junction_path == "/PRODVOL1"
-        assert vol.nas_security_style == "ntfs"
-
-    def test_int_coercion_with_percent(self) -> None:
-        """CLI percentage values have % stripped before int conversion."""
-        record = {
-            "autosize-grow-threshold-percent": "85%",
-            "autosize-shrink-threshold-percent": "45%",
-        }
-        vol = parse_cli_record(VOLUME_MAPPING, record, "[test]")
-        assert vol.autosize_grow_threshold == 85
-        assert vol.autosize_shrink_threshold == 45
-
-    def test_dash_values_use_defaults(self) -> None:
-        """CLI dash values coerce to default."""
-        record = {
-            "tiering-minimum-cooling-days": "-",
-            "junction-path": "-",
-        }
-        vol = parse_cli_record(VOLUME_MAPPING, record, "[test]")
-        assert vol.tiering_minimum_cooling_days == 0
-        assert vol.junction_path == ""
-
-    def test_cli_aggregates_transform(self) -> None:
-        """CLI aggr-list parsed into list."""
-        record = {"aggr-list": "aggr1, aggr2, aggr3"}
-        vol = parse_cli_record(VOLUME_MAPPING, record, "[test]")
-        assert vol.aggregates == ["aggr1", "aggr2", "aggr3"]
-
-    def test_cli_aggregates_empty(self) -> None:
-        """Empty aggr-list returns empty list."""
-        record: dict[str, Any] = {"aggr-list": "-"}
-        vol = parse_cli_record(VOLUME_MAPPING, record, "[test]")
-        assert vol.aggregates == []
-
-    def test_parse_cli_records_multiple(self) -> None:
-        """parse_cli_records handles multiple records."""
-        records = [
-            {"volume": "vol1", "instance-uuid": "a"},
-            {"volume": "vol2", "instance-uuid": "b"},
-        ]
-        results = parse_cli_records(VOLUME_MAPPING, records, "[test]", MagicMock())
-        assert len(results) == 2
-        assert results[0].name == "vol1"
-        assert results[1].name == "vol2"
-
-
-# ---------------------------------------------------------------------------
 # Transform unit tests
 # ---------------------------------------------------------------------------
 
@@ -357,25 +248,6 @@ class TestTransformFunctions:
         """Aggregates with empty/missing names are filtered."""
         record = {"aggregates": [{"name": ""}, {"name": "a"}, {"uuid": "b"}]}
         assert _api_aggregates_list(record) == ["a"]
-
-    def test_cli_aggregates_list_comma_separated(self) -> None:
-        """Comma-separated aggr-list."""
-        record = {"aggr-list": "aggr1,aggr2,aggr3"}
-        assert _cli_aggregates_list(record) == ["aggr1", "aggr2", "aggr3"]
-
-    def test_cli_aggregates_list_space_separated(self) -> None:
-        """Space-separated aggr-list."""
-        record = {"aggr-list": "aggr1 aggr2"}
-        assert _cli_aggregates_list(record) == ["aggr1", "aggr2"]
-
-    def test_cli_aggregates_list_dash(self) -> None:
-        """Dash means no aggregates."""
-        assert _cli_aggregates_list({"aggr-list": "-"}) == []
-
-    def test_cli_aggregates_list_empty(self) -> None:
-        """Empty string means no aggregates."""
-        assert _cli_aggregates_list({"aggr-list": ""}) == []
-        assert _cli_aggregates_list({}) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -15,12 +15,7 @@ from pynetappfoundry.cache.collector import (
 )
 from pynetappfoundry.cache.models import (
     CloudMetadata,
-    HAInfo,
-    LicenseInfo,
-    NetworkInfo,
     ProtocolsInfo,
-    RelationshipsInfo,
-    StorageInfo,
 )
 
 
@@ -291,30 +286,22 @@ class TestClusterInfoCollection:
         assert "9.14.1" in result.ontap_version
         api_client.call_endpoint.assert_called_with("/cluster?fields=*", method="GET")
 
-    def test_collect_cluster_info_fallback_to_cli(
-        self, mock_cluster_cli_output: tuple[list[dict[str, str]], dict[str, str]]
-    ) -> None:
-        """Test cluster info falls back to CLI when API fails."""
+    def test_collect_cluster_info_api_failure_propagates(self) -> None:
+        """Test cluster info raises when API call fails (no CLI fallback)."""
         api_client = MagicMock()
         api_client.call_endpoint.side_effect = Exception("API unavailable")
 
-        cli_client = MagicMock()
-        cli_client.run_a_show_command_and_parse_seperator.return_value = mock_cluster_cli_output
-
-        collector = MetadataCollector(api_client=api_client, cli_client=cli_client)
-        result = collector.collect_cluster_info()
-
-        assert result.cluster_name == "mycluster"
-        assert result.cluster_uuid == "abc-123-def-456"
-        cli_client.run_a_show_command_and_parse_seperator.assert_called()
+        collector = MetadataCollector(api_client=api_client)
+        with pytest.raises(Exception, match="API unavailable"):
+            collector.collect_cluster_info()
 
     def test_collect_cluster_info_no_clients(self) -> None:
-        """Test cluster info returns empty when no clients."""
-        collector = MetadataCollector()
-        result = collector.collect_cluster_info()
+        """Test cluster info raises CollectionError when no API client."""
+        from pynetappfoundry.cache.collector import CollectionError
 
-        assert result.cluster_name == ""
-        assert result.cluster_uuid == ""
+        collector = MetadataCollector()
+        with pytest.raises(CollectionError, match="API_FAILURE"):
+            collector.collect_cluster_info()
 
 
 class TestNodesCollection:
@@ -362,11 +349,12 @@ class TestNodesCollection:
         assert result[1].membership == "available"
 
     def test_collect_nodes_no_clients(self) -> None:
-        """Test nodes returns empty list when no clients."""
-        collector = MetadataCollector()
-        result = collector.collect_nodes()
+        """Test nodes raises CollectionError when no API client."""
+        from pynetappfoundry.cache.collector import CollectionError
 
-        assert result == []
+        collector = MetadataCollector()
+        with pytest.raises(CollectionError, match="API_FAILURE"):
+            collector.collect_nodes()
 
 
 class TestNetworkCollection:
@@ -460,12 +448,12 @@ class TestNetworkCollection:
         assert result.subnets[0].ip_ranges == ["10.0.0.10-10.0.0.50"]
 
     def test_collect_network_no_clients(self) -> None:
-        """Test network returns empty when no clients."""
-        collector = MetadataCollector()
-        result = collector.collect_network()
+        """Test network raises CollectionError when no API client."""
+        from pynetappfoundry.cache.collector import CollectionError
 
-        assert isinstance(result, NetworkInfo)
-        assert result.data_lifs == []
+        collector = MetadataCollector()
+        with pytest.raises(CollectionError, match="API_FAILURE"):
+            collector.collect_network()
 
 
 class TestStorageCollection:
@@ -679,12 +667,12 @@ class TestStorageCollection:
         assert result.flexcaches[0].global_file_locking_enabled is True
 
     def test_collect_storage_no_clients(self) -> None:
-        """Test storage returns empty when no clients."""
-        collector = MetadataCollector()
-        result = collector.collect_storage()
+        """Test storage raises CollectionError when no API client."""
+        from pynetappfoundry.cache.collector import CollectionError
 
-        assert isinstance(result, StorageInfo)
-        assert result.aggregates == []
+        collector = MetadataCollector()
+        with pytest.raises(CollectionError, match="API_FAILURE"):
+            collector.collect_storage()
 
 
 class TestCloudTargetsCollection:
@@ -807,65 +795,6 @@ class TestCloudTargetsCollection:
         assert len(result.aggregates) == 1
         assert result.cloud_targets == []
 
-    def test_collect_cloud_targets_via_cli(self) -> None:
-        """Test collecting cloud targets via CLI fallback."""
-        cli_client = MagicMock()
-        cli_client.run_a_show_command_and_parse_seperator.side_effect = [
-            # aggr show
-            ([{"aggregate": "aggr1", "node": "node1", "state": "online", "type": "ssd"}], {}),
-            # vserver show
-            ([{"vserver": "svm1", "admin-state": "running", "type": "default"}], {}),
-            # storage aggregate object-store config show
-            (
-                [
-                    {
-                        "object-store-name": "s3-target-1",
-                        "provider-type": "AWS_S3",
-                        "server": "s3.us-east-1.amazonaws.com",
-                        "container": "my-bucket",
-                        "owner": "fabricpool",
-                        "ssl-enabled": "true",
-                        "auth-type": "key",
-                        "ipspace": "Default",
-                    }
-                ],
-                {},
-            ),
-            # volume show
-            ([], {}),
-        ]
-
-        collector = MetadataCollector(cli_client=cli_client)
-        result = collector.collect_storage()
-
-        assert len(result.cloud_targets) == 1
-        target = result.cloud_targets[0]
-        assert target.name == "s3-target-1"
-        assert target.provider_type == "AWS_S3"
-        assert target.container == "my-bucket"
-        assert target.ssl_enabled is True
-
-    def test_collect_cloud_targets_cli_not_available(self) -> None:
-        """Test that CLI fallback handles command not available."""
-        cli_client = MagicMock()
-
-        def side_effect(cmd: str) -> tuple[list[dict[str, Any]], dict[str, str]]:
-            if "object-store" in cmd:
-                raise Exception("Command not available")
-            if "aggr" in cmd:
-                return ([{"aggregate": "aggr1", "node": "node1", "state": "online"}], {})
-            if "vserver" in cmd:
-                return ([{"vserver": "svm1", "admin-state": "running"}], {})
-            return ([], {})
-
-        cli_client.run_a_show_command_and_parse_seperator.side_effect = side_effect
-
-        collector = MetadataCollector(cli_client=cli_client)
-        result = collector.collect_storage()
-
-        assert len(result.aggregates) == 1
-        assert result.cloud_targets == []
-
     def test_collect_cloud_targets_empty(self) -> None:
         """Test collecting when no cloud targets exist."""
         api_client = MagicMock()
@@ -917,12 +846,12 @@ class TestLicenseCollection:
         assert result.capacity_licenses[0].name == "Cloud Volumes ONTAP"
 
     def test_collect_licenses_no_clients(self) -> None:
-        """Test licenses returns empty when no clients."""
-        collector = MetadataCollector()
-        result = collector.collect_licenses()
+        """Test licenses raises CollectionError when no API client."""
+        from pynetappfoundry.cache.collector import CollectionError
 
-        assert isinstance(result, LicenseInfo)
-        assert result.feature_licenses == []
+        collector = MetadataCollector()
+        with pytest.raises(CollectionError, match="API_FAILURE"):
+            collector.collect_licenses()
 
 
 class TestHAInfoCollection:
@@ -956,12 +885,12 @@ class TestHAInfoCollection:
         assert result.mediator_address == "10.0.0.100"
 
     def test_collect_ha_info_no_clients(self) -> None:
-        """Test HA info returns defaults when no clients."""
-        collector = MetadataCollector()
-        result = collector.collect_ha_info()
+        """Test HA info raises CollectionError when no API client."""
+        from pynetappfoundry.cache.collector import CollectionError
 
-        assert isinstance(result, HAInfo)
-        assert result.is_ha is False
+        collector = MetadataCollector()
+        with pytest.raises(CollectionError, match="API_FAILURE"):
+            collector.collect_ha_info()
 
 
 class TestRelationshipsCollection:
@@ -1037,12 +966,12 @@ class TestRelationshipsCollection:
         assert result.svm_peers[0].applications == ["snapmirror"]
 
     def test_collect_relationships_no_clients(self) -> None:
-        """Test relationships returns empty when no clients."""
-        collector = MetadataCollector()
-        result = collector.collect_relationships()
+        """Test relationships raises CollectionError when no API client."""
+        from pynetappfoundry.cache.collector import CollectionError
 
-        assert isinstance(result, RelationshipsInfo)
-        assert result.snapmirror_destinations == []
+        collector = MetadataCollector()
+        with pytest.raises(CollectionError, match="API_FAILURE"):
+            collector.collect_relationships()
 
     def test_collect_relationships_with_string_paths(self) -> None:
         """Test relationships handles string paths from API (instead of dicts)."""
@@ -1339,31 +1268,21 @@ class TestProtocolsCollection:
         assert result.s3_buckets == []
 
     def test_collect_protocols_no_clients(self) -> None:
-        """Test protocols returns empty when no clients."""
+        """Test protocols raises CollectionError when no API client."""
+        from pynetappfoundry.cache.collector import CollectionError
+
         collector = MetadataCollector()
-        result = collector.collect_protocols()
+        with pytest.raises(CollectionError, match="API_FAILURE"):
+            collector.collect_protocols()
 
-        assert isinstance(result, ProtocolsInfo)
-        assert result.export_policies == []
-        assert result.cifs_shares == []
-        assert result.nfs_services == []
-        assert result.cifs_services == []
-        assert result.s3_buckets == []
-
-    def test_collect_protocols_api_failure_fallback(self) -> None:
-        """Test protocols returns empty on API failure."""
+    def test_collect_protocols_api_failure_propagates(self) -> None:
+        """Test protocols raises when API call fails (no silent fallback)."""
         api_client = MagicMock()
         api_client.call_endpoint.side_effect = Exception("API error")
 
         collector = MetadataCollector(api_client=api_client)
-        result = collector.collect_protocols()
-
-        assert isinstance(result, ProtocolsInfo)
-        assert result.export_policies == []
-        assert result.cifs_shares == []
-        assert result.nfs_services == []
-        assert result.cifs_services == []
-        assert result.s3_buckets == []
+        with pytest.raises(Exception, match="API error"):
+            collector.collect_protocols()
 
     def test_collect_protocols_policy_without_rules(self) -> None:
         """Test protocols handles policy records with no rules."""
@@ -1759,7 +1678,7 @@ class TestUpdateAzureCloudLinks:
 
 
 class TestLogMissingFields:
-    """Tests for MISSING_FIELD debug logging."""
+    """Tests for MISSING_FIELD error logging."""
 
     @pytest.fixture
     def collector(self) -> MetadataCollector:
@@ -1771,9 +1690,9 @@ class TestLogMissingFields:
     def test_logs_missing_field(
         self, collector: MetadataCollector, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Test that absent keys produce MISSING_FIELD log entries."""
+        """Test that absent keys produce MISSING_FIELD log entries at error level."""
         record: dict[str, Any] = {"name": "vol1", "uuid": "abc-123"}
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging.ERROR):
             collector._log_missing_fields(
                 record, ["name", "uuid", "autosize", "tiering"], "Volume", "vol1"
             )
@@ -1781,6 +1700,10 @@ class TestLogMissingFields:
         assert len(missing_messages) == 2
         assert any("'autosize'" in m for m in missing_messages)
         assert any("'tiering'" in m for m in missing_messages)
+        # Verify error level
+        for rec in caplog.records:
+            if "MISSING_FIELD" in rec.message:
+                assert rec.levelno == logging.ERROR
 
     def test_no_log_for_present_fields(
         self, collector: MetadataCollector, caplog: pytest.LogCaptureFixture
@@ -1793,7 +1716,7 @@ class TestLogMissingFields:
             "size": 0,
             "enabled": False,
         }
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging.ERROR):
             collector._log_missing_fields(
                 record,
                 ["name", "uuid", "autosize", "size", "enabled"],
@@ -1808,7 +1731,7 @@ class TestLogMissingFields:
     ) -> None:
         """Test that log messages include cluster name in prefix."""
         record: dict[str, Any] = {"name": "vol1"}
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging.ERROR):
             collector._log_missing_fields(record, ["autosize"], "Volume", "vol1")
         missing_messages = [r.message for r in caplog.records if "MISSING_FIELD" in r.message]
         assert len(missing_messages) == 1
@@ -1819,7 +1742,7 @@ class TestLogMissingFields:
     ) -> None:
         """Test that log messages include record type and identifier."""
         record: dict[str, Any] = {}
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging.ERROR):
             collector._log_missing_fields(record, ["uuid"], "Aggregate", "aggr1")
         missing_messages = [r.message for r in caplog.records if "MISSING_FIELD" in r.message]
         assert len(missing_messages) == 1
@@ -1849,7 +1772,7 @@ class TestLogMissingFields:
                 }
             ]
         }
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging.ERROR):
             collector._parse_volumes_response(response)
         missing_messages = [r.message for r in caplog.records if "MISSING_FIELD" in r.message]
         missing_fields = {m.split("'")[-2] for m in missing_messages}
@@ -1889,7 +1812,7 @@ class TestLogMissingFields:
                 }
             ]
         }
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging.ERROR):
             collector._parse_volumes_response(response)
         missing_messages = [r.message for r in caplog.records if "MISSING_FIELD" in r.message]
         assert len(missing_messages) == 0
@@ -1899,52 +1822,77 @@ class TestLogMissingFields:
     ) -> None:
         """Test that the MISSING_FIELD tag is consistently present for grepping."""
         record: dict[str, Any] = {}
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging.ERROR):
             collector._log_missing_fields(record, ["field_a", "field_b"], "TestType", "test-id")
         for rec in caplog.records:
             if "MISSING_FIELD" in rec.message:
                 assert "MISSING_FIELD:" in rec.message
+                assert rec.levelno == logging.ERROR
 
-    def test_cli_collection_logs_missing_fields(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Test that CLI collection methods log missing fields."""
-        cli_client = MagicMock()
-        cli_client.run_a_show_command_and_parse_seperator.return_value = (
-            [{"node": "node1"}],  # missing serial-number, system-id, model
-            None,
-        )
-        collector = MetadataCollector(cli_client=cli_client)
+
+class TestGrepableLogTags:
+    """Tests for grepable error log tags (API_FAILURE, CLI_FAILURE, COLLECTION_ABORTED)."""
+
+    def test_api_failure_tag_on_no_client(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that API_FAILURE tag is emitted when no API client."""
+        from pynetappfoundry.cache.collector import CollectionError
+
+        collector = MetadataCollector()
+        with pytest.raises(CollectionError, match="API_FAILURE"):
+            collector.collect_nodes()
+
+    def test_api_failure_tag_on_api_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that API_FAILURE tag is logged at error level on API call failure."""
+        api_client = MagicMock()
+        api_client.call_endpoint.side_effect = ConnectionError("Connection refused")
+
+        collector = MetadataCollector(api_client=api_client)
         collector._cluster_name = "testcluster"
+        with caplog.at_level(logging.ERROR), pytest.raises(ConnectionError):
+            collector.collect_nodes()
+        api_failure_msgs = [r for r in caplog.records if "API_FAILURE" in r.message]
+        assert len(api_failure_msgs) >= 1
+        assert api_failure_msgs[0].levelno == logging.ERROR
+        assert "Nodes" in api_failure_msgs[0].message
+        assert "ConnectionError" in api_failure_msgs[0].message
 
-        with caplog.at_level(logging.DEBUG):
-            collector._collect_nodes_via_cli()
-        missing_messages = [r.message for r in caplog.records if "MISSING_FIELD" in r.message]
-        missing_fields = {m.split("'")[-2] for m in missing_messages}
-        assert "serial-number" in missing_fields
-        assert "system-id" in missing_fields
-        assert "model" in missing_fields
-        # "node" should NOT be missing
-        assert "node" not in missing_fields
-
-    def test_cli_collection_no_log_for_complete_record(
+    def test_cli_failure_tag_on_cloud_metadata_error(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Test that complete CLI records produce no MISSING_FIELD logs."""
+        """Test that CLI_FAILURE tag is logged at error level on cloud metadata failure."""
         cli_client = MagicMock()
-        cli_client.run_a_show_command_and_parse_seperator.return_value = (
-            [
-                {
-                    "node": "node1",
-                    "serial-number": "ABC123",
-                    "system-id": "12345",
-                    "model": "FAS8200",
-                }
-            ],
-            None,
-        )
+        cli_client.run_command.side_effect = Exception("SSH timeout")
+
         collector = MetadataCollector(cli_client=cli_client)
         collector._cluster_name = "testcluster"
+        with caplog.at_level(logging.ERROR):
+            result = collector.collect_cloud_metadata()
+        assert result == []
+        cli_failure_msgs = [r for r in caplog.records if "CLI_FAILURE" in r.message]
+        assert len(cli_failure_msgs) == 1
+        assert cli_failure_msgs[0].levelno == logging.ERROR
+        assert "Cloud metadata" in cli_failure_msgs[0].message
 
-        with caplog.at_level(logging.DEBUG):
-            collector._collect_nodes_via_cli()
-        missing_messages = [r.message for r in caplog.records if "MISSING_FIELD" in r.message]
-        assert len(missing_messages) == 0
+    def test_collection_aborted_tag_sequential(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that COLLECTION_ABORTED is logged when sequential collection fails."""
+        from pynetappfoundry.cache.collector import CollectionError
+
+        collector = MetadataCollector(parallel=False)
+        collector._cluster_name = "testcluster"
+        with caplog.at_level(logging.ERROR), pytest.raises((CollectionError, Exception)):
+            collector.collect_all("testcluster")
+        aborted_msgs = [r for r in caplog.records if "COLLECTION_ABORTED" in r.message]
+        assert len(aborted_msgs) >= 1
+        assert aborted_msgs[0].levelno == logging.ERROR
+
+    def test_collection_aborted_tag_parallel(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that COLLECTION_ABORTED is logged when parallel collection fails."""
+        from pynetappfoundry.cache.collector import CollectionError
+
+        collector = MetadataCollector(parallel=True)
+        collector._cluster_name = "testcluster"
+        with caplog.at_level(logging.ERROR), pytest.raises(CollectionError):
+            collector.collect_all("testcluster")
+        aborted_msgs = [r for r in caplog.records if "COLLECTION_ABORTED" in r.message]
+        assert len(aborted_msgs) >= 1
+        assert aborted_msgs[0].levelno == logging.ERROR

--- a/tests/unit/cache/test_field_mapping.py
+++ b/tests/unit/cache/test_field_mapping.py
@@ -256,8 +256,8 @@ class TestParseApiRecord:
         result = parse_api_record(tm, {"wrong": "original"}, "[test]")
         assert result.name == "custom"
 
-    def test_transform_exception_uses_default(self) -> None:
-        """Transform exception falls back to default."""
+    def test_transform_exception_propagates(self) -> None:
+        """Transform exception propagates (not caught) with TRANSFORM_FAILURE log."""
 
         def bad_transform(_: dict[str, Any]) -> str:
             raise ValueError("boom")
@@ -269,8 +269,8 @@ class TestParseApiRecord:
             cli_command="t",
             fields=(FieldMapping(cache_attr="name", default="fallback", transform=bad_transform),),
         )
-        result = parse_api_record(tm, {}, "[test]")
-        assert result.name == "fallback"
+        with pytest.raises(ValueError, match="boom"):
+            parse_api_record(tm, {}, "[test]")
 
     def test_no_api_path_no_transform_uses_default(self) -> None:
         """Field with neither api_path nor transform uses default."""
@@ -351,8 +351,8 @@ class TestParseCliRecord:
         result = parse_cli_record(tm, {"raw": "a,b,c"}, "[test]")
         assert result.items == ["a", "b", "c"]
 
-    def test_cli_transform_exception_uses_default(self) -> None:
-        """cli_transform exception falls back to default."""
+    def test_cli_transform_exception_propagates(self) -> None:
+        """cli_transform exception propagates (not caught) with TRANSFORM_FAILURE log."""
 
         def bad_cli_transform(_: dict[str, Any]) -> list[str]:
             raise ValueError("boom")
@@ -364,8 +364,8 @@ class TestParseCliRecord:
             cli_command="t",
             fields=(FieldMapping(cache_attr="items", default=[], cli_transform=bad_cli_transform),),
         )
-        result = parse_cli_record(tm, {}, "[test]")
-        assert result.items == []
+        with pytest.raises(ValueError, match="boom"):
+            parse_cli_record(tm, {}, "[test]")
 
     def test_non_string_value_passthrough(self) -> None:
         """Non-string CLI values are passed through without coercion."""
@@ -482,3 +482,54 @@ class TestParseCliRecords:
         call_args = mock_log.call_args_list[0]
         assert call_args[0][1] == ["name", "val"]  # cli_expected_fields()
         assert call_args[0][2] == "Test(CLI)"
+
+
+# ---------------------------------------------------------------------------
+# TRANSFORM_FAILURE log tag tests
+# ---------------------------------------------------------------------------
+
+
+class TestTransformFailureLogTag:
+    """Tests for TRANSFORM_FAILURE error log tag."""
+
+    def test_api_transform_logs_transform_failure(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Transform exception logs TRANSFORM_FAILURE at error level before propagating."""
+        import logging
+
+        def bad_transform(_: dict[str, Any]) -> str:
+            raise ValueError("data error")
+
+        tm = TypeMapping(
+            name="Volume",
+            model_class=_SampleModel,
+            api_endpoint="/t",
+            cli_command="t",
+            fields=(FieldMapping(cache_attr="name", default="", transform=bad_transform),),
+        )
+        with caplog.at_level(logging.ERROR), pytest.raises(ValueError, match="data error"):
+            parse_api_record(tm, {"name": "vol1"}, "[testcluster:collector]")
+        tf_msgs = [r for r in caplog.records if "TRANSFORM_FAILURE" in r.message]
+        assert len(tf_msgs) == 1
+        assert tf_msgs[0].levelno == logging.ERROR
+        assert "Volume" in tf_msgs[0].message
+        assert "name" in tf_msgs[0].message
+
+    def test_cli_transform_logs_transform_failure(self, caplog: pytest.LogCaptureFixture) -> None:
+        """CLI transform exception logs TRANSFORM_FAILURE at error level before propagating."""
+        import logging
+
+        def bad_cli_transform(_: dict[str, Any]) -> list[str]:
+            raise KeyError("aggregates")
+
+        tm = TypeMapping(
+            name="Volume",
+            model_class=_SampleModel,
+            api_endpoint="/t",
+            cli_command="t",
+            fields=(FieldMapping(cache_attr="items", default=[], cli_transform=bad_cli_transform),),
+        )
+        with caplog.at_level(logging.ERROR), pytest.raises(KeyError, match="aggregates"):
+            parse_cli_record(tm, {}, "[testcluster:collector]")
+        tf_msgs = [r for r in caplog.records if "TRANSFORM_FAILURE" in r.message]
+        assert len(tf_msgs) == 1
+        assert tf_msgs[0].levelno == logging.ERROR


### PR DESCRIPTION
## Description

Implement all-or-nothing collection semantics for the metadata collector. Collection now either succeeds completely or fails entirely — no partial cache updates with degraded CLI data. The only CLI-only data is cloud metadata (`virtual-machine instance show`), which is optional; all other phases are API-only and must succeed.

Transform exceptions in the field mapping framework now propagate instead of being silently caught and replaced with defaults, preventing bugs from hiding as valid-looking data.

Addresses #237

## Type of Change

- [x] Code refactoring
- [x] Test improvement

## Changes Made

- **collector.py**: Remove CLI fallback from all 8 API-based `collect_*` methods — raise `CollectionError` if no API client, let API exceptions propagate with `API_FAILURE` log tag
- **collector.py**: Keep `collect_cloud_metadata()` as CLI-only and optional — failure logs `CLI_FAILURE` at error level, returns empty list
- **collector.py**: Add `COLLECTION_ABORTED` log tag in both sequential and parallel collection modes
- **collector.py**: Promote `MISSING_FIELD` log from debug to error level
- **collector.py**: Delete 8 `_via_cli` fallback methods and remove `parse_cli_records` import
- **field_mapping.py**: Transform exceptions now log `TRANSFORM_FAILURE` at error level and re-raise (no fallback to default)
- **volume.py**: Remove `cli_field` from all 20 FieldMapping entries, delete `_cli_aggregates_list()`
- **aggregate.py**: Remove `cli_field` from 5 FieldMapping entries
- **node.py**: Remove `cli_field` from 4 FieldMapping entries
- **refresh.py**: Add per-cluster failure summary with API/CLI categorization to `nf cache refresh` output
- **Tests**: Delete CLI fallback tests, update `_no_clients` tests to assert `CollectionError`, add grepable log tag tests, update MISSING_FIELD assertions to error level

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (format, lint, type-check, security, spell, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
