### PR TITLE
refactor: migrate CloudMetadata to field mapping framework

### DIFF
--- a/docs/decisions/0004-declarative-field-mapping-framework.md
+++ b/docs/decisions/0004-declarative-field-mapping-framework.md
@@ -56,6 +56,7 @@ The pilot migration (VolumeInfo) was completed in PR #189.
 - Issue #188: feat: add declarative field mapping framework
 - Issue #191: refactor: migrate AggregateInfo to field mapping framework
 - Issue #210: refactor: migrate NodeInfo to field mapping framework
+- Issue #217: refactor: migrate CloudMetadata to field mapping framework
 - Issue #237: refactor: all-or-nothing collection with no CLI fallback
 
 ## Related Documentation

--- a/docs/development/field-mapping.md
+++ b/docs/development/field-mapping.md
@@ -192,6 +192,7 @@ For CLI-only types, also test:
 | Volume | `VOLUME_MAPPING` | `VolumeInfo` | 21 | API-only. Uses transform for aggregate list extraction. |
 | Aggregate | `AGGREGATE_MAPPING` | `AggregateInfo` | 28 | API-only. Deeply nested API paths (`block_storage.primary.*`). Explicit `?fields=*,is_spare_low,sidl_enabled`. |
 | Node | `NODE_MAPPING` | `NodeInfo` | 20 | API-only. Wildcard `[*]` syntax for list fields. `field_validator` for int→str coercion. |
+| CloudMetadata | `CLOUD_METADATA_MAPPING` | `CloudMetadata` | 19 | CLI-only (no API endpoint). Computed link fields built as post-processing in collector. |
 
 ## Reference: Field Mapping Patterns
 

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -19,8 +19,9 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from pynetappfoundry.cache.field_mapping import parse_api_response
+from pynetappfoundry.cache.field_mapping import parse_api_response, parse_cli_records
 from pynetappfoundry.cache.mappings.aggregate import AGGREGATE_MAPPING
+from pynetappfoundry.cache.mappings.cloud_metadata import CLOUD_METADATA_MAPPING
 from pynetappfoundry.cache.mappings.node import NODE_MAPPING
 from pynetappfoundry.cache.mappings.volume import VOLUME_MAPPING
 from pynetappfoundry.cache.models import (
@@ -559,6 +560,11 @@ class MetadataCollector:
     def _collect_cloud_metadata_via_cli(self) -> list[CloudMetadata]:
         """Collect cloud metadata using CLI.
 
+        Parses the raw CLI text into dict records, feeds them through
+        ``parse_cli_records`` via the ``CLOUD_METADATA_MAPPING``, and
+        then post-processes the results to build computed link fields
+        that depend on collector state (``aws_sso_config``).
+
         Returns:
             List of CloudMetadata from virtual-machine instance show.
         """
@@ -571,10 +577,42 @@ class MetadataCollector:
         logger.debug("%s CLI command: virtual-machine instance show", self._log_prefix)
         output = self.cli_client.run_command("virtual-machine instance show")
         logger.debug("%s CLI response: %d lines", self._log_prefix, len(output))
-        return self._parse_vm_instance_output(output)
 
-    def _parse_vm_instance_output(self, output: list[str]) -> list[CloudMetadata]:
-        """Parse virtual-machine instance show output.
+        records = self._parse_vm_instance_output(output)
+        items = parse_cli_records(
+            CLOUD_METADATA_MAPPING,
+            records,
+            self._log_prefix,
+            self._log_missing_fields,
+        )
+        results = cast(list[CloudMetadata], items)
+
+        # Post-process: build computed link fields
+        for cm in results:
+            region = cm.region or cm.availability_zone
+            cm.instance_link = build_cloud_instance_link(
+                provider=cm.provider,
+                instance_id=cm.instance_id,
+                region=region,
+                account_id=cm.account_id,
+                resource_group=cm.resource_group_name,
+            )
+            cm.instance_sso_link = build_cloud_instance_sso_link(
+                provider=cm.provider,
+                instance_link=cm.instance_link,
+                account_id=cm.account_id,
+                sso_config=self.aws_sso_config,
+            )
+            cm.resource_group_link = build_cloud_resource_group_link(
+                provider=cm.provider,
+                account_id=cm.account_id,
+                resource_group=cm.resource_group_name,
+            )
+
+        return results
+
+    def _parse_vm_instance_output(self, output: list[str]) -> list[dict[str, str]]:
+        """Parse virtual-machine instance show output into raw records.
 
         The CLI output contains entries for each node, separated by blank lines
         or new "Node:" entries. Each node has its own cloud metadata.
@@ -583,9 +621,9 @@ class MetadataCollector:
             output: Lines of CLI output.
 
         Returns:
-            List of CloudMetadata objects, one per node.
+            List of raw record dicts (one per node) with normalized keys.
         """
-        results: list[CloudMetadata] = []
+        results: list[dict[str, str]] = []
         current_data: dict[str, str] = {}
         current_node: str = ""
 
@@ -610,7 +648,8 @@ class MetadataCollector:
             if key_normalized == "node":
                 # Save previous node's data if we have any
                 if current_node and current_data:
-                    results.append(self._create_cloud_metadata(current_node, current_data))
+                    current_data["node"] = current_node
+                    results.append(current_data)
                 # Start new node
                 current_node = value
                 current_data = {}
@@ -619,87 +658,15 @@ class MetadataCollector:
 
         # Don't forget the last node
         if current_node and current_data:
-            results.append(self._create_cloud_metadata(current_node, current_data))
+            current_data["node"] = current_node
+            results.append(current_data)
 
         # If no node field was found but we have data, create single entry
         if not results and current_data:
-            results.append(self._create_cloud_metadata("", current_data))
+            current_data["node"] = ""
+            results.append(current_data)
 
         return results
-
-    def _create_cloud_metadata(self, node: str, data: dict[str, str]) -> CloudMetadata:
-        """Create a CloudMetadata object from parsed data.
-
-        Args:
-            node: Node name.
-            data: Parsed key-value data.
-
-        Returns:
-            CloudMetadata object.
-        """
-        self._log_missing_fields(
-            data,
-            [
-                "instance_id",
-                "account_id",
-                "instance_type",
-                "region",
-                "provider",
-                "primary_ip",
-            ],
-            "CloudMetadata",
-            node or "unknown",
-        )
-        provider = data.get("provider", "")
-        instance_id = data.get("instance_id", "")
-        account_id = data.get("account_id", "")
-        resource_group = data.get("resource_group_name", "")
-        region = data.get("region", "") or data.get("availability_zone", "")
-
-        # Build cloud console links
-        instance_link = build_cloud_instance_link(
-            provider=provider,
-            instance_id=instance_id,
-            region=region,
-            account_id=account_id,
-            resource_group=resource_group,
-        )
-        instance_sso_link = build_cloud_instance_sso_link(
-            provider=provider,
-            instance_link=instance_link,
-            account_id=account_id,
-            sso_config=self.aws_sso_config,
-        )
-        resource_group_link = build_cloud_resource_group_link(
-            provider=provider,
-            account_id=account_id,
-            resource_group=resource_group,
-        )
-
-        return CloudMetadata(
-            node=node,
-            instance_id=instance_id,
-            account_id=account_id,
-            image_id=data.get("image_id", ""),
-            instance_type=data.get("instance_type", ""),
-            cpu_platform=data.get("cpu_platform", ""),
-            region=data.get("region", ""),
-            provider=provider,
-            consumer=data.get("consumer", ""),
-            primary_ip=data.get("primary_ip", ""),
-            metadata_version=data.get("metadata_version", ""),
-            availability_zone=data.get("availability_zone", ""),
-            availability_zone_id=data.get("availability_zone_id", ""),
-            fault_domain=data.get("fault_domain", ""),
-            update_domain=data.get("update_domain", ""),
-            resource_group_name=resource_group,
-            offer=data.get("offer", ""),
-            sku=data.get("sku", ""),
-            sku_version=data.get("sku_version", ""),
-            instance_link=instance_link,
-            instance_sso_link=instance_sso_link,
-            resource_group_link=resource_group_link,
-        )
 
     def _update_azure_cloud_links(
         self,

--- a/src/pynetappfoundry/cache/mappings/__init__.py
+++ b/src/pynetappfoundry/cache/mappings/__init__.py
@@ -4,7 +4,8 @@ Each sub-module defines a TypeMapping constant for one ONTAP object type.
 """
 
 from pynetappfoundry.cache.mappings.aggregate import AGGREGATE_MAPPING
+from pynetappfoundry.cache.mappings.cloud_metadata import CLOUD_METADATA_MAPPING
 from pynetappfoundry.cache.mappings.node import NODE_MAPPING
 from pynetappfoundry.cache.mappings.volume import VOLUME_MAPPING
 
-__all__ = ["AGGREGATE_MAPPING", "NODE_MAPPING", "VOLUME_MAPPING"]
+__all__ = ["AGGREGATE_MAPPING", "CLOUD_METADATA_MAPPING", "NODE_MAPPING", "VOLUME_MAPPING"]

--- a/src/pynetappfoundry/cache/mappings/cloud_metadata.py
+++ b/src/pynetappfoundry/cache/mappings/cloud_metadata.py
@@ -1,0 +1,104 @@
+"""CloudMetadata type mapping definition for the declarative field mapping framework.
+
+Defines CLOUD_METADATA_MAPPING which maps ONTAP CLI virtual-machine instance
+data to CloudMetadata cache model attributes. CloudMetadata is CLI-only —
+there is no REST API endpoint for this data.
+
+The computed link fields (instance_link, instance_sso_link,
+resource_group_link) are not part of the mapping; they are built as
+post-processing in the collector using collector state (aws_sso_config)
+and cross-field logic.
+"""
+
+from __future__ import annotations
+
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.cache.models import CloudMetadata
+
+CLOUD_METADATA_MAPPING = TypeMapping(
+    name="CloudMetadata",
+    model_class=CloudMetadata,
+    api_endpoint="",
+    cli_command="virtual-machine instance show",
+    id_field="node",
+    fields=(
+        FieldMapping(
+            cache_attr="node",
+            cli_field="node",
+        ),
+        FieldMapping(
+            cache_attr="instance_id",
+            cli_field="instance_id",
+        ),
+        FieldMapping(
+            cache_attr="account_id",
+            cli_field="account_id",
+        ),
+        FieldMapping(
+            cache_attr="image_id",
+            cli_field="image_id",
+        ),
+        FieldMapping(
+            cache_attr="instance_type",
+            cli_field="instance_type",
+        ),
+        FieldMapping(
+            cache_attr="cpu_platform",
+            cli_field="cpu_platform",
+        ),
+        FieldMapping(
+            cache_attr="region",
+            cli_field="region",
+        ),
+        FieldMapping(
+            cache_attr="provider",
+            cli_field="provider",
+        ),
+        FieldMapping(
+            cache_attr="consumer",
+            cli_field="consumer",
+        ),
+        FieldMapping(
+            cache_attr="primary_ip",
+            cli_field="primary_ip",
+        ),
+        FieldMapping(
+            cache_attr="metadata_version",
+            cli_field="metadata_version",
+        ),
+        # AWS-specific
+        FieldMapping(
+            cache_attr="availability_zone",
+            cli_field="availability_zone",
+        ),
+        FieldMapping(
+            cache_attr="availability_zone_id",
+            cli_field="availability_zone_id",
+        ),
+        # Azure-specific
+        FieldMapping(
+            cache_attr="fault_domain",
+            cli_field="fault_domain",
+        ),
+        FieldMapping(
+            cache_attr="update_domain",
+            cli_field="update_domain",
+        ),
+        FieldMapping(
+            cache_attr="resource_group_name",
+            cli_field="resource_group_name",
+        ),
+        FieldMapping(
+            cache_attr="offer",
+            cli_field="offer",
+        ),
+        FieldMapping(
+            cache_attr="sku",
+            cli_field="sku",
+        ),
+        FieldMapping(
+            cache_attr="sku_version",
+            cli_field="sku_version",
+        ),
+    ),
+)

--- a/src/pynetappfoundry/cli/commands/cache/inspect.py
+++ b/src/pynetappfoundry/cli/commands/cache/inspect.py
@@ -14,7 +14,12 @@ from rich.tree import Tree
 
 from pynetappfoundry.cache import ClusterMetadataDB
 from pynetappfoundry.cache.field_mapping import TypeMapping
-from pynetappfoundry.cache.mappings import AGGREGATE_MAPPING, NODE_MAPPING, VOLUME_MAPPING
+from pynetappfoundry.cache.mappings import (
+    AGGREGATE_MAPPING,
+    CLOUD_METADATA_MAPPING,
+    NODE_MAPPING,
+    VOLUME_MAPPING,
+)
 from pynetappfoundry.cli.utils import print_error, print_exception, print_warning
 from pynetappfoundry.clients.ontap import ONTAPCLI, ONTAPAPIClient
 from pynetappfoundry.core.config import Config
@@ -27,6 +32,7 @@ console = Console()
 # dot-path to the list of objects in CachedClusterMetadata.
 INSPECT_TYPES: dict[str, tuple[TypeMapping, str]] = {
     "aggregate": (AGGREGATE_MAPPING, "storage.aggregates"),
+    "cloud_metadata": (CLOUD_METADATA_MAPPING, "cloud"),
     "node": (NODE_MAPPING, "nodes"),
     "volume": (VOLUME_MAPPING, "storage.volumes"),
 }

--- a/tests/unit/cache/mappings/test_cloud_metadata.py
+++ b/tests/unit/cache/mappings/test_cloud_metadata.py
@@ -1,0 +1,411 @@
+"""Tests for the cloud metadata type mapping definition."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pynetappfoundry.cache.field_mapping import (
+    parse_cli_record,
+    parse_cli_records,
+)
+from pynetappfoundry.cache.mappings.cloud_metadata import CLOUD_METADATA_MAPPING
+from pynetappfoundry.cache.models import CloudMetadata
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def full_cli_record() -> dict[str, str]:
+    """Full CLI record with all fields (normalized snake_case keys)."""
+    return {
+        "node": "PRODCL1-01",
+        "instance_id": "i-0abc123def456789",
+        "account_id": "123456789012",
+        "image_id": "ami-0abc123def456789",
+        "instance_type": "m5.2xlarge",
+        "cpu_platform": "Intel Cascade Lake",
+        "region": "us-east-1",
+        "provider": "AWS",
+        "consumer": "NetApp",
+        "primary_ip": "10.0.1.100",
+        "metadata_version": "V2",
+        "availability_zone": "us-east-1a",
+        "availability_zone_id": "use1-az1",
+        "fault_domain": "",
+        "update_domain": "",
+        "resource_group_name": "",
+        "offer": "",
+        "sku": "",
+        "sku_version": "",
+    }
+
+
+@pytest.fixture
+def azure_cli_record() -> dict[str, str]:
+    """CLI record for an Azure instance."""
+    return {
+        "node": "AZURECL1-01",
+        "instance_id": (
+            "/subscriptions/sub-id/resourceGroups/rg-1"
+            "/providers/Microsoft.Compute/virtualMachines/vm-1"
+        ),
+        "account_id": "sub-id",
+        "image_id": "Canonical:UbuntuServer:18.04-LTS:latest",
+        "instance_type": "Standard_DS3_v2",
+        "cpu_platform": "",
+        "region": "eastus",
+        "provider": "Azure",
+        "consumer": "NetApp",
+        "primary_ip": "10.0.2.50",
+        "metadata_version": "V1",
+        "availability_zone": "",
+        "availability_zone_id": "",
+        "fault_domain": "0",
+        "update_domain": "0",
+        "resource_group_name": "rg-1",
+        "offer": "netapp-ontap-cloud",
+        "sku": "ontap_cloud_byol",
+        "sku_version": "9.14.0",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mapping definition tests
+# ---------------------------------------------------------------------------
+
+
+class TestCloudMetadataMappingDefinition:
+    """Tests for CLOUD_METADATA_MAPPING structure."""
+
+    def test_all_cache_attrs_exist_on_model(self) -> None:
+        """Every cache_attr in the mapping is a valid CloudMetadata field."""
+        model_fields = set(CloudMetadata.model_fields.keys())
+        for field in CLOUD_METADATA_MAPPING.fields:
+            assert field.cache_attr in model_fields, (
+                f"cache_attr '{field.cache_attr}' not on CloudMetadata"
+            )
+
+    def test_no_duplicate_cache_attrs(self) -> None:
+        """No duplicate cache_attr values."""
+        attrs = [f.cache_attr for f in CLOUD_METADATA_MAPPING.fields]
+        assert len(attrs) == len(set(attrs))
+
+    def test_api_endpoint_empty(self) -> None:
+        """API endpoint is empty (CLI-only type)."""
+        assert CLOUD_METADATA_MAPPING.api_endpoint == ""
+
+    def test_cli_command(self) -> None:
+        """CLI command is virtual-machine instance show."""
+        assert CLOUD_METADATA_MAPPING.cli_command == "virtual-machine instance show"
+
+    def test_model_class(self) -> None:
+        """Model class is CloudMetadata."""
+        assert CLOUD_METADATA_MAPPING.model_class is CloudMetadata
+
+    def test_id_field(self) -> None:
+        """id_field is node."""
+        assert CLOUD_METADATA_MAPPING.id_field == "node"
+
+    def test_field_count(self) -> None:
+        """Mapping has expected number of fields (19 non-computed fields)."""
+        assert len(CLOUD_METADATA_MAPPING.fields) == 19
+
+    def test_cli_expected_fields(self) -> None:
+        """cli_expected_fields returns correct CLI field names."""
+        expected = CLOUD_METADATA_MAPPING.cli_expected_fields()
+        assert expected == [
+            "account_id",
+            "availability_zone",
+            "availability_zone_id",
+            "consumer",
+            "cpu_platform",
+            "fault_domain",
+            "image_id",
+            "instance_id",
+            "instance_type",
+            "metadata_version",
+            "node",
+            "offer",
+            "primary_ip",
+            "provider",
+            "region",
+            "resource_group_name",
+            "sku",
+            "sku_version",
+            "update_domain",
+        ]
+
+    def test_computed_link_fields_excluded(self) -> None:
+        """Computed link fields are NOT in the mapping."""
+        attrs = {f.cache_attr for f in CLOUD_METADATA_MAPPING.fields}
+        assert "instance_link" not in attrs
+        assert "instance_sso_link" not in attrs
+        assert "resource_group_link" not in attrs
+
+    def test_all_fields_use_cli_field_not_api_path(self) -> None:
+        """All fields use cli_field (not api_path) since this is CLI-only."""
+        for field in CLOUD_METADATA_MAPPING.fields:
+            assert field.cli_field is not None, (
+                f"Field '{field.cache_attr}' should have cli_field set"
+            )
+            assert field.api_path is None, (
+                f"Field '{field.cache_attr}' should not have api_path (CLI-only type)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# CLI parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestCloudMetadataCliParsing:
+    """Tests for parsing CLI cloud metadata records."""
+
+    def test_full_aws_record(self, full_cli_record: dict[str, str]) -> None:
+        """Full AWS CLI record parses to complete CloudMetadata."""
+        cm = parse_cli_record(CLOUD_METADATA_MAPPING, full_cli_record, "[test]")
+        assert isinstance(cm, CloudMetadata)
+        assert cm.node == "PRODCL1-01"
+        assert cm.instance_id == "i-0abc123def456789"
+        assert cm.account_id == "123456789012"
+        assert cm.image_id == "ami-0abc123def456789"
+        assert cm.instance_type == "m5.2xlarge"
+        assert cm.cpu_platform == "Intel Cascade Lake"
+        assert cm.region == "us-east-1"
+        assert cm.provider == "AWS"
+        assert cm.consumer == "NetApp"
+        assert cm.primary_ip == "10.0.1.100"
+        assert cm.metadata_version == "V2"
+        assert cm.availability_zone == "us-east-1a"
+        assert cm.availability_zone_id == "use1-az1"
+
+    def test_full_azure_record(self, azure_cli_record: dict[str, str]) -> None:
+        """Full Azure CLI record parses to complete CloudMetadata."""
+        cm = parse_cli_record(CLOUD_METADATA_MAPPING, azure_cli_record, "[test]")
+        assert isinstance(cm, CloudMetadata)
+        assert cm.node == "AZURECL1-01"
+        assert cm.provider == "Azure"
+        assert cm.fault_domain == "0"
+        assert cm.update_domain == "0"
+        assert cm.resource_group_name == "rg-1"
+        assert cm.offer == "netapp-ontap-cloud"
+        assert cm.sku == "ontap_cloud_byol"
+        assert cm.sku_version == "9.14.0"
+
+    def test_minimal_record(self) -> None:
+        """Minimal record uses defaults for missing fields."""
+        record: dict[str, str] = {"node": "node1"}
+        cm = parse_cli_record(CLOUD_METADATA_MAPPING, record, "[test]")
+        assert isinstance(cm, CloudMetadata)
+        assert cm.node == "node1"
+        assert cm.instance_id == ""
+        assert cm.account_id == ""
+        assert cm.image_id == ""
+        assert cm.instance_type == ""
+        assert cm.cpu_platform == ""
+        assert cm.region == ""
+        assert cm.provider == ""
+        assert cm.consumer == ""
+        assert cm.primary_ip == ""
+        assert cm.metadata_version == ""
+        assert cm.availability_zone == ""
+        assert cm.availability_zone_id == ""
+        assert cm.fault_domain == ""
+        assert cm.update_domain == ""
+        assert cm.resource_group_name == ""
+        assert cm.offer == ""
+        assert cm.sku == ""
+        assert cm.sku_version == ""
+
+    def test_empty_record(self) -> None:
+        """Empty record uses defaults for all fields."""
+        record: dict[str, str] = {}
+        cm = parse_cli_record(CLOUD_METADATA_MAPPING, record, "[test]")
+        assert isinstance(cm, CloudMetadata)
+        assert cm.node == ""
+        assert cm.instance_id == ""
+        assert cm.provider == ""
+
+    def test_dash_coercion(self) -> None:
+        """CLI dash value is coerced to default (empty string)."""
+        record: dict[str, str] = {
+            "node": "node1",
+            "instance_id": "-",
+            "region": "-",
+            "provider": "-",
+        }
+        cm = parse_cli_record(CLOUD_METADATA_MAPPING, record, "[test]")
+        assert isinstance(cm, CloudMetadata)
+        assert cm.instance_id == ""
+        assert cm.region == ""
+        assert cm.provider == ""
+
+    def test_empty_string_coercion(self) -> None:
+        """CLI empty string is coerced to default."""
+        record: dict[str, str] = {
+            "node": "node1",
+            "instance_id": "",
+            "region": "",
+        }
+        cm = parse_cli_record(CLOUD_METADATA_MAPPING, record, "[test]")
+        assert isinstance(cm, CloudMetadata)
+        assert cm.instance_id == ""
+        assert cm.region == ""
+
+    def test_whitespace_coercion(self) -> None:
+        """CLI whitespace-only value is coerced properly (stripped then empty)."""
+        record: dict[str, str] = {
+            "node": "node1",
+            "instance_id": "  ",
+        }
+        cm = parse_cli_record(CLOUD_METADATA_MAPPING, record, "[test]")
+        assert isinstance(cm, CloudMetadata)
+        assert cm.instance_id == ""
+
+    def test_parse_cli_records_multiple(self) -> None:
+        """parse_cli_records handles multiple records."""
+        records = [
+            {"node": "node1", "provider": "AWS", "region": "us-east-1"},
+            {"node": "node2", "provider": "AWS", "region": "us-east-1"},
+        ]
+        results = parse_cli_records(CLOUD_METADATA_MAPPING, records, "[test]", MagicMock())
+        assert len(results) == 2
+        assert isinstance(results[0], CloudMetadata)
+        assert isinstance(results[1], CloudMetadata)
+        assert results[0].node == "node1"
+        assert results[1].node == "node2"
+
+    def test_parse_cli_records_empty(self) -> None:
+        """parse_cli_records handles empty list."""
+        results = parse_cli_records(CLOUD_METADATA_MAPPING, [], "[test]", MagicMock())
+        assert results == []
+
+    def test_computed_link_fields_default_empty(self, full_cli_record: dict[str, str]) -> None:
+        """Computed link fields default to empty (not set by mapping)."""
+        cm = parse_cli_record(CLOUD_METADATA_MAPPING, full_cli_record, "[test]")
+        assert isinstance(cm, CloudMetadata)
+        assert cm.instance_link == ""
+        assert cm.instance_sso_link == ""
+        assert cm.resource_group_link == ""
+
+
+# ---------------------------------------------------------------------------
+# Parity test: old parser vs new framework
+# ---------------------------------------------------------------------------
+
+
+class TestParityWithOldParser:
+    """Verify framework produces same output as old hand-written _create_cloud_metadata.
+
+    Note: parity tests cover the non-computed fields only. The computed link
+    fields (instance_link, instance_sso_link, resource_group_link) are built
+    as post-processing in the collector, not by the mapping.
+    """
+
+    _NON_COMPUTED_FIELDS = (
+        "node",
+        "instance_id",
+        "account_id",
+        "image_id",
+        "instance_type",
+        "cpu_platform",
+        "region",
+        "provider",
+        "consumer",
+        "primary_ip",
+        "metadata_version",
+        "availability_zone",
+        "availability_zone_id",
+        "fault_domain",
+        "update_domain",
+        "resource_group_name",
+        "offer",
+        "sku",
+        "sku_version",
+    )
+
+    @staticmethod
+    def _old_create_cloud_metadata(node: str, data: dict[str, str]) -> CloudMetadata:
+        """Reproduce old _create_cloud_metadata logic (without links)."""
+        return CloudMetadata(
+            node=node,
+            instance_id=data.get("instance_id", ""),
+            account_id=data.get("account_id", ""),
+            image_id=data.get("image_id", ""),
+            instance_type=data.get("instance_type", ""),
+            cpu_platform=data.get("cpu_platform", ""),
+            region=data.get("region", ""),
+            provider=data.get("provider", ""),
+            consumer=data.get("consumer", ""),
+            primary_ip=data.get("primary_ip", ""),
+            metadata_version=data.get("metadata_version", ""),
+            availability_zone=data.get("availability_zone", ""),
+            availability_zone_id=data.get("availability_zone_id", ""),
+            fault_domain=data.get("fault_domain", ""),
+            update_domain=data.get("update_domain", ""),
+            resource_group_name=data.get("resource_group_name", ""),
+            offer=data.get("offer", ""),
+            sku=data.get("sku", ""),
+            sku_version=data.get("sku_version", ""),
+        )
+
+    def test_parity_full_aws_record(self, full_cli_record: dict[str, str]) -> None:
+        """Framework and old parser produce identical CloudMetadata for AWS."""
+        old = self._old_create_cloud_metadata(full_cli_record["node"], full_cli_record)
+        new = parse_cli_record(CLOUD_METADATA_MAPPING, full_cli_record, "[test]")
+        assert isinstance(new, CloudMetadata)
+        for field_name in self._NON_COMPUTED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_full_azure_record(self, azure_cli_record: dict[str, str]) -> None:
+        """Framework and old parser produce identical CloudMetadata for Azure."""
+        old = self._old_create_cloud_metadata(azure_cli_record["node"], azure_cli_record)
+        new = parse_cli_record(CLOUD_METADATA_MAPPING, azure_cli_record, "[test]")
+        assert isinstance(new, CloudMetadata)
+        for field_name in self._NON_COMPUTED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_minimal_record(self) -> None:
+        """Framework and old parser match on minimal record."""
+        data: dict[str, str] = {}
+        old = self._old_create_cloud_metadata("node1", data)
+        record = dict(data)
+        record["node"] = "node1"
+        new = parse_cli_record(CLOUD_METADATA_MAPPING, record, "[test]")
+        assert isinstance(new, CloudMetadata)
+        for field_name in self._NON_COMPUTED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_missing_fields(self) -> None:
+        """Framework and old parser match when most fields are missing."""
+        data: dict[str, str] = {
+            "provider": "AWS",
+            "instance_id": "i-12345",
+        }
+        old = self._old_create_cloud_metadata("testnode", data)
+        record = dict(data)
+        record["node"] = "testnode"
+        new = parse_cli_record(CLOUD_METADATA_MAPPING, record, "[test]")
+        assert isinstance(new, CloudMetadata)
+        for field_name in self._NON_COMPUTED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )


### PR DESCRIPTION
## Description

Migrate `CloudMetadata` to the declarative field-mapping framework introduced in ADR-0004. This replaces hand-written CLI parsing in the collector with the shared `parse_cli_records` utility and a declarative `CLOUD_METADATA_MAPPING` definition.

Addresses #217

## Related Issue

Addresses #217

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Created `src/pynetappfoundry/cache/mappings/cloud_metadata.py` with the `CLOUD_METADATA_MAPPING` definition covering all CloudMetadata fields (provider name, account ID, instance ID, instance type, availability zone, subnet)
- Refactored `src/pynetappfoundry/cache/collector.py` to use `parse_cli_records` instead of hand-written CLI-output parsing for cloud metadata collection
- Exported `CLOUD_METADATA_MAPPING` from `src/pynetappfoundry/cache/mappings/__init__.py`
- Registered `cloud_metadata` in the `INSPECT_TYPES` dictionary in `src/pynetappfoundry/cli/commands/cache/inspect.py`
- Updated `docs/development/field-mapping.md` to add CloudMetadata to the Migrated Types table
- Updated `docs/decisions/0004-declarative-field-mapping-framework.md` with issue #217 link

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Added 24 unit tests in `tests/unit/cache/mappings/test_cloud_metadata.py` covering:
- Mapping structure validation (field count, required keys, CLI column names)
- Individual field mappings for all six CloudMetadata fields
- Round-trip integration with `parse_cli_records`
- Edge cases: empty input, missing fields, extra columns, whitespace handling

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
