### PR TITLE
refactor: migrate ClusterPeer to field mapping framework

### DIFF
--- a/docs/decisions/0004-declarative-field-mapping-framework.md
+++ b/docs/decisions/0004-declarative-field-mapping-framework.md
@@ -57,6 +57,7 @@ The pilot migration (VolumeInfo) was completed in PR #189.
 - Issue #191: refactor: migrate AggregateInfo to field mapping framework
 - Issue #210: refactor: migrate NodeInfo to field mapping framework
 - Issue #217: refactor: migrate CloudMetadata to field mapping framework
+- Issue #216: refactor: migrate ClusterPeer to field mapping framework
 - Issue #237: refactor: all-or-nothing collection with no CLI fallback
 
 ## Related Documentation

--- a/docs/development/field-mapping.md
+++ b/docs/development/field-mapping.md
@@ -192,6 +192,7 @@ For CLI-only types, also test:
 | Volume | `VOLUME_MAPPING` | `VolumeInfo` | 21 | API-only. Uses transform for aggregate list extraction. |
 | Aggregate | `AGGREGATE_MAPPING` | `AggregateInfo` | 28 | API-only. Deeply nested API paths (`block_storage.primary.*`). Explicit `?fields=*,is_spare_low,sidl_enabled`. |
 | Node | `NODE_MAPPING` | `NodeInfo` | 20 | API-only. Wildcard `[*]` syntax for list fields. `field_validator` for int→str coercion. |
+| ClusterPeer | `CLUSTER_PEER_MAPPING` | `ClusterPeer` | 5 | API-only. Uses transform for dict-vs-string fallback on `remote` and `authentication`. |
 | CloudMetadata | `CLOUD_METADATA_MAPPING` | `CloudMetadata` | 19 | CLI-only (no API endpoint). Computed link fields built as post-processing in collector. |
 
 ## Reference: Field Mapping Patterns

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 from pynetappfoundry.cache.field_mapping import parse_api_response, parse_cli_records
 from pynetappfoundry.cache.mappings.aggregate import AGGREGATE_MAPPING
 from pynetappfoundry.cache.mappings.cloud_metadata import CLOUD_METADATA_MAPPING
+from pynetappfoundry.cache.mappings.cluster_peer import CLUSTER_PEER_MAPPING
 from pynetappfoundry.cache.mappings.node import NODE_MAPPING
 from pynetappfoundry.cache.mappings.volume import VOLUME_MAPPING
 from pynetappfoundry.cache.models import (
@@ -1468,35 +1469,7 @@ class MetadataCollector:
             snapmirror_destinations.append(sm)
 
         # Process cluster peers
-        peer_response = responses.get(endpoints[1]) or {}
-        logger.debug(
-            "%s API response: %d cluster peers",
-            self._log_prefix,
-            len(peer_response.get("records", [])),
-        )
-        cluster_peers = []
-        for record in peer_response.get("records", []):
-            self._log_missing_fields(
-                record,
-                ["name", "uuid", "remote", "authentication"],
-                "ClusterPeer",
-                record.get("name", record.get("uuid", "unknown")),
-            )
-            # Handle fields that may be dicts or strings depending on API version
-            remote = record.get("remote")
-            remote_name = remote.get("name", "") if isinstance(remote, dict) else str(remote or "")
-            auth = record.get("authentication")
-            auth_state = auth.get("state", "") if isinstance(auth, dict) else str(auth or "")
-            # Get peer addresses from remote.ip_addresses (not peer_applications)
-            peer_addresses = remote.get("ip_addresses", []) if isinstance(remote, dict) else []
-            peer = ClusterPeer(
-                name=record.get("name", ""),
-                uuid=record.get("uuid", ""),
-                remote_cluster_name=remote_name,
-                peer_addresses=[addr for addr in peer_addresses if addr],
-                authentication_state=auth_state,
-            )
-            cluster_peers.append(peer)
+        cluster_peers = self._parse_cluster_peers_response(responses.get(endpoints[1]))
 
         # Process SVM peers
         svm_peers = self._parse_svm_peers_response(responses.get(endpoints[2]))
@@ -1526,6 +1499,26 @@ class MetadataCollector:
             VOLUME_MAPPING, response, self._log_prefix, self._log_missing_fields
         )
         return cast(list[VolumeInfo], results)
+
+    # -------------------------------------------------------------------------
+    # Cluster Peer Parsing
+    # -------------------------------------------------------------------------
+
+    def _parse_cluster_peers_response(self, response: Any) -> list[ClusterPeer]:
+        """Parse cluster peers API response.
+
+        Delegates to the declarative field mapping framework.
+
+        Args:
+            response: API response dict or None.
+
+        Returns:
+            List of ClusterPeer objects.
+        """
+        results = parse_api_response(
+            CLUSTER_PEER_MAPPING, response, self._log_prefix, self._log_missing_fields
+        )
+        return cast(list[ClusterPeer], results)
 
     def _parse_qtrees_response(self, response: Any) -> list[QtreeInfo]:
         """Parse qtrees API response.

--- a/src/pynetappfoundry/cache/mappings/__init__.py
+++ b/src/pynetappfoundry/cache/mappings/__init__.py
@@ -5,7 +5,14 @@ Each sub-module defines a TypeMapping constant for one ONTAP object type.
 
 from pynetappfoundry.cache.mappings.aggregate import AGGREGATE_MAPPING
 from pynetappfoundry.cache.mappings.cloud_metadata import CLOUD_METADATA_MAPPING
+from pynetappfoundry.cache.mappings.cluster_peer import CLUSTER_PEER_MAPPING
 from pynetappfoundry.cache.mappings.node import NODE_MAPPING
 from pynetappfoundry.cache.mappings.volume import VOLUME_MAPPING
 
-__all__ = ["AGGREGATE_MAPPING", "CLOUD_METADATA_MAPPING", "NODE_MAPPING", "VOLUME_MAPPING"]
+__all__ = [
+    "AGGREGATE_MAPPING",
+    "CLOUD_METADATA_MAPPING",
+    "CLUSTER_PEER_MAPPING",
+    "NODE_MAPPING",
+    "VOLUME_MAPPING",
+]

--- a/src/pynetappfoundry/cache/mappings/cluster_peer.py
+++ b/src/pynetappfoundry/cache/mappings/cluster_peer.py
@@ -1,0 +1,102 @@
+"""ClusterPeer type mapping definition for the declarative field mapping framework.
+
+Defines CLUSTER_PEER_MAPPING which maps ONTAP REST API cluster peer data
+to ClusterPeer cache model attributes. ClusterPeer is API-only — there is
+no CLI command for this data.
+
+The ``remote`` and ``authentication`` fields can be either dicts or strings
+depending on the ONTAP API version, so transform functions handle both
+shapes safely.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.cache.models import ClusterPeer
+
+
+def _api_remote_cluster_name(record: dict[str, Any]) -> str:
+    """Extract remote cluster name from API response.
+
+    Handles API version differences where ``remote`` can be a dict
+    (with a ``name`` key) or a plain string.
+
+    Args:
+        record: Full API cluster peer record.
+
+    Returns:
+        Remote cluster name string.
+    """
+    remote = record.get("remote")
+    if isinstance(remote, dict):
+        return str(remote.get("name", ""))
+    return str(remote or "")
+
+
+def _api_peer_addresses(record: dict[str, Any]) -> list[str]:
+    """Extract peer IP addresses from API response.
+
+    Extracts ``remote.ip_addresses`` when ``remote`` is a dict,
+    filtering out empty/falsy values.
+
+    Args:
+        record: Full API cluster peer record.
+
+    Returns:
+        List of non-empty peer IP address strings.
+    """
+    remote = record.get("remote")
+    if isinstance(remote, dict):
+        return [addr for addr in remote.get("ip_addresses", []) if addr]
+    return []
+
+
+def _api_authentication_state(record: dict[str, Any]) -> str:
+    """Extract authentication state from API response.
+
+    Handles API version differences where ``authentication`` can be a
+    dict (with a ``state`` key) or a plain string.
+
+    Args:
+        record: Full API cluster peer record.
+
+    Returns:
+        Authentication state string.
+    """
+    auth = record.get("authentication")
+    if isinstance(auth, dict):
+        return str(auth.get("state", ""))
+    return str(auth or "")
+
+
+CLUSTER_PEER_MAPPING = TypeMapping(
+    name="ClusterPeer",
+    model_class=ClusterPeer,
+    api_endpoint="/cluster/peers?fields=*",
+    cli_command="",
+    fields=(
+        FieldMapping(
+            cache_attr="name",
+            api_path="name",
+        ),
+        FieldMapping(
+            cache_attr="uuid",
+            api_path="uuid",
+        ),
+        FieldMapping(
+            cache_attr="remote_cluster_name",
+            transform=_api_remote_cluster_name,
+        ),
+        FieldMapping(
+            cache_attr="peer_addresses",
+            default=[],
+            transform=_api_peer_addresses,
+        ),
+        FieldMapping(
+            cache_attr="authentication_state",
+            transform=_api_authentication_state,
+        ),
+    ),
+)

--- a/src/pynetappfoundry/cli/commands/cache/inspect.py
+++ b/src/pynetappfoundry/cli/commands/cache/inspect.py
@@ -17,6 +17,7 @@ from pynetappfoundry.cache.field_mapping import TypeMapping
 from pynetappfoundry.cache.mappings import (
     AGGREGATE_MAPPING,
     CLOUD_METADATA_MAPPING,
+    CLUSTER_PEER_MAPPING,
     NODE_MAPPING,
     VOLUME_MAPPING,
 )
@@ -33,6 +34,7 @@ console = Console()
 INSPECT_TYPES: dict[str, tuple[TypeMapping, str]] = {
     "aggregate": (AGGREGATE_MAPPING, "storage.aggregates"),
     "cloud_metadata": (CLOUD_METADATA_MAPPING, "cloud"),
+    "cluster_peer": (CLUSTER_PEER_MAPPING, "relationships.cluster_peers"),
     "node": (NODE_MAPPING, "nodes"),
     "volume": (VOLUME_MAPPING, "storage.volumes"),
 }

--- a/tests/unit/cache/mappings/test_cluster_peer.py
+++ b/tests/unit/cache/mappings/test_cluster_peer.py
@@ -1,0 +1,392 @@
+"""Tests for the cluster peer type mapping definition."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pynetappfoundry.cache.field_mapping import (
+    parse_api_record,
+    parse_api_response,
+)
+from pynetappfoundry.cache.mappings.cluster_peer import (
+    CLUSTER_PEER_MAPPING,
+    _api_authentication_state,
+    _api_peer_addresses,
+    _api_remote_cluster_name,
+)
+from pynetappfoundry.cache.models import ClusterPeer
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def full_api_record() -> dict[str, Any]:
+    """Full API cluster peer record with dict remote and authentication."""
+    return {
+        "name": "DRCL1",
+        "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "remote": {
+            "name": "DRCL1",
+            "ip_addresses": ["10.0.1.10", "10.0.1.11"],
+        },
+        "authentication": {
+            "state": "ok",
+            "in_use": "ok",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mapping definition tests
+# ---------------------------------------------------------------------------
+
+
+class TestClusterPeerMappingDefinition:
+    """Tests for CLUSTER_PEER_MAPPING structure."""
+
+    def test_all_cache_attrs_exist_on_model(self) -> None:
+        """Every cache_attr in the mapping is a valid ClusterPeer field."""
+        model_fields = set(ClusterPeer.model_fields.keys())
+        for field in CLUSTER_PEER_MAPPING.fields:
+            assert field.cache_attr in model_fields, (
+                f"cache_attr '{field.cache_attr}' not on ClusterPeer"
+            )
+
+    def test_no_duplicate_cache_attrs(self) -> None:
+        """No duplicate cache_attr values."""
+        attrs = [f.cache_attr for f in CLUSTER_PEER_MAPPING.fields]
+        assert len(attrs) == len(set(attrs))
+
+    def test_field_count(self) -> None:
+        """Mapping has expected number of fields (5)."""
+        assert len(CLUSTER_PEER_MAPPING.fields) == 5
+
+    def test_model_class(self) -> None:
+        """Model class is ClusterPeer."""
+        assert CLUSTER_PEER_MAPPING.model_class is ClusterPeer
+
+    def test_endpoint(self) -> None:
+        """API endpoint is correct."""
+        assert CLUSTER_PEER_MAPPING.api_endpoint == "/cluster/peers?fields=*"
+
+    def test_cli_command_empty(self) -> None:
+        """CLI command is empty (API-only type)."""
+        assert CLUSTER_PEER_MAPPING.cli_command == ""
+
+    def test_api_expected_fields(self) -> None:
+        """api_expected_fields returns correct top-level keys."""
+        expected = CLUSTER_PEER_MAPPING.api_expected_fields()
+        assert expected == ["name", "uuid"]
+
+    def test_id_field(self) -> None:
+        """id_field is name (default)."""
+        assert CLUSTER_PEER_MAPPING.id_field == "name"
+
+
+# ---------------------------------------------------------------------------
+# API parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestClusterPeerApiParsing:
+    """Tests for parsing API cluster peer records."""
+
+    def test_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Full API record with dict remote/auth parses correctly."""
+        result = parse_api_record(CLUSTER_PEER_MAPPING, full_api_record, "[test]")
+        assert isinstance(result, ClusterPeer)
+        assert result.name == "DRCL1"
+        assert result.uuid == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        assert result.remote_cluster_name == "DRCL1"
+        assert result.peer_addresses == ["10.0.1.10", "10.0.1.11"]
+        assert result.authentication_state == "ok"
+
+    def test_minimal_record(self) -> None:
+        """Minimal record uses defaults for missing fields."""
+        record: dict[str, Any] = {"name": "PEER1", "uuid": "abc"}
+        result = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterPeer)
+        assert result.name == "PEER1"
+        assert result.uuid == "abc"
+        assert result.remote_cluster_name == ""
+        assert result.peer_addresses == []
+        assert result.authentication_state == ""
+
+    def test_remote_as_string(self) -> None:
+        """When remote is a string, remote_cluster_name gets the string value."""
+        record: dict[str, Any] = {
+            "name": "PEER1",
+            "uuid": "abc",
+            "remote": "REMOTECL1",
+            "authentication": {"state": "ok"},
+        }
+        result = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterPeer)
+        assert result.remote_cluster_name == "REMOTECL1"
+        assert result.peer_addresses == []
+
+    def test_authentication_as_string(self) -> None:
+        """When authentication is a string, authentication_state gets the string value."""
+        record: dict[str, Any] = {
+            "name": "PEER1",
+            "uuid": "abc",
+            "remote": {"name": "REMOTECL1", "ip_addresses": ["10.0.1.1"]},
+            "authentication": "pending",
+        }
+        result = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterPeer)
+        assert result.authentication_state == "pending"
+
+    def test_missing_fields(self) -> None:
+        """Record with no remote or authentication fields."""
+        record: dict[str, Any] = {"name": "PEER1"}
+        result = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterPeer)
+        assert result.name == "PEER1"
+        assert result.uuid == ""
+        assert result.remote_cluster_name == ""
+        assert result.peer_addresses == []
+        assert result.authentication_state == ""
+
+    def test_address_filtering(self) -> None:
+        """Empty/falsy addresses are filtered out."""
+        record: dict[str, Any] = {
+            "name": "PEER1",
+            "uuid": "abc",
+            "remote": {
+                "name": "REMOTECL1",
+                "ip_addresses": ["10.0.1.1", "", None, "10.0.1.2"],
+            },
+        }
+        result = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterPeer)
+        assert result.peer_addresses == ["10.0.1.1", "10.0.1.2"]
+
+    def test_parse_api_response_multiple(self) -> None:
+        """parse_api_response handles multiple records."""
+        response = {
+            "records": [
+                {
+                    "name": "PEER1",
+                    "uuid": "a",
+                    "remote": {"name": "CL1", "ip_addresses": ["10.0.1.1"]},
+                    "authentication": {"state": "ok"},
+                },
+                {
+                    "name": "PEER2",
+                    "uuid": "b",
+                    "remote": {"name": "CL2", "ip_addresses": ["10.0.2.1"]},
+                    "authentication": {"state": "ok"},
+                },
+            ],
+        }
+        results = parse_api_response(CLUSTER_PEER_MAPPING, response, "[test]", MagicMock())
+        assert len(results) == 2
+        assert results[0].name == "PEER1"
+        assert results[1].name == "PEER2"
+
+    def test_parse_api_response_empty(self) -> None:
+        """parse_api_response handles empty/None response."""
+        assert parse_api_response(CLUSTER_PEER_MAPPING, None, "[test]", MagicMock()) == []
+        assert parse_api_response(CLUSTER_PEER_MAPPING, {}, "[test]", MagicMock()) == []
+
+
+# ---------------------------------------------------------------------------
+# Transform unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTransformFunctions:
+    """Tests for cluster peer transform functions."""
+
+    # -- _api_remote_cluster_name --
+
+    def test_remote_cluster_name_dict(self) -> None:
+        """Dict remote returns name."""
+        assert _api_remote_cluster_name({"remote": {"name": "CL1"}}) == "CL1"
+
+    def test_remote_cluster_name_dict_missing_name(self) -> None:
+        """Dict remote without name key returns empty string."""
+        assert _api_remote_cluster_name({"remote": {"ip_addresses": []}}) == ""
+
+    def test_remote_cluster_name_string(self) -> None:
+        """String remote returns the string."""
+        assert _api_remote_cluster_name({"remote": "CL1"}) == "CL1"
+
+    def test_remote_cluster_name_none(self) -> None:
+        """None remote returns empty string."""
+        assert _api_remote_cluster_name({"remote": None}) == ""
+
+    def test_remote_cluster_name_missing(self) -> None:
+        """Missing remote key returns empty string."""
+        assert _api_remote_cluster_name({}) == ""
+
+    # -- _api_peer_addresses --
+
+    def test_peer_addresses_dict(self) -> None:
+        """Dict remote extracts ip_addresses."""
+        record = {"remote": {"name": "CL1", "ip_addresses": ["10.0.1.1", "10.0.1.2"]}}
+        assert _api_peer_addresses(record) == ["10.0.1.1", "10.0.1.2"]
+
+    def test_peer_addresses_dict_empty(self) -> None:
+        """Dict remote with empty ip_addresses."""
+        assert _api_peer_addresses({"remote": {"ip_addresses": []}}) == []
+
+    def test_peer_addresses_dict_no_key(self) -> None:
+        """Dict remote without ip_addresses key."""
+        assert _api_peer_addresses({"remote": {"name": "CL1"}}) == []
+
+    def test_peer_addresses_filters_falsy(self) -> None:
+        """Falsy addresses are filtered out."""
+        record = {"remote": {"ip_addresses": ["10.0.1.1", "", None, "10.0.1.2"]}}
+        assert _api_peer_addresses(record) == ["10.0.1.1", "10.0.1.2"]
+
+    def test_peer_addresses_string(self) -> None:
+        """String remote returns empty list."""
+        assert _api_peer_addresses({"remote": "CL1"}) == []
+
+    def test_peer_addresses_none(self) -> None:
+        """None remote returns empty list."""
+        assert _api_peer_addresses({"remote": None}) == []
+
+    def test_peer_addresses_missing(self) -> None:
+        """Missing remote key returns empty list."""
+        assert _api_peer_addresses({}) == []
+
+    # -- _api_authentication_state --
+
+    def test_authentication_state_dict(self) -> None:
+        """Dict authentication returns state."""
+        assert _api_authentication_state({"authentication": {"state": "ok"}}) == "ok"
+
+    def test_authentication_state_dict_missing_state(self) -> None:
+        """Dict authentication without state key returns empty string."""
+        assert _api_authentication_state({"authentication": {"in_use": "ok"}}) == ""
+
+    def test_authentication_state_string(self) -> None:
+        """String authentication returns the string."""
+        assert _api_authentication_state({"authentication": "pending"}) == "pending"
+
+    def test_authentication_state_none(self) -> None:
+        """None authentication returns empty string."""
+        assert _api_authentication_state({"authentication": None}) == ""
+
+    def test_authentication_state_missing(self) -> None:
+        """Missing authentication key returns empty string."""
+        assert _api_authentication_state({}) == ""
+
+
+# ---------------------------------------------------------------------------
+# Parity test: old parser vs new framework
+# ---------------------------------------------------------------------------
+
+
+class TestParityWithOldParser:
+    """Verify framework produces same output as old hand-written inline parser."""
+
+    @staticmethod
+    def _old_parse_cluster_peer(record: dict[str, Any]) -> ClusterPeer:
+        """Reproduce old inline ClusterPeer parsing logic from collector.
+
+        This is a static copy of the code that was in
+        ``_collect_relationships_via_api`` before migration.
+        """
+        remote = record.get("remote")
+        remote_name = remote.get("name", "") if isinstance(remote, dict) else str(remote or "")
+        auth = record.get("authentication")
+        auth_state = auth.get("state", "") if isinstance(auth, dict) else str(auth or "")
+        peer_addresses = remote.get("ip_addresses", []) if isinstance(remote, dict) else []
+        return ClusterPeer(
+            name=record.get("name", ""),
+            uuid=record.get("uuid", ""),
+            remote_cluster_name=remote_name,
+            peer_addresses=[addr for addr in peer_addresses if addr],
+            authentication_state=auth_state,
+        )
+
+    def test_parity_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Framework and old parser produce identical ClusterPeer."""
+        old = self._old_parse_cluster_peer(full_api_record)
+        new = parse_api_record(CLUSTER_PEER_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, ClusterPeer)
+        for field_name in ClusterPeer.model_fields:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_minimal_record(self) -> None:
+        """Framework and old parser match on minimal record."""
+        record: dict[str, Any] = {"name": "PEER1", "uuid": "xyz"}
+        old = self._old_parse_cluster_peer(record)
+        new = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
+        assert isinstance(new, ClusterPeer)
+        for field_name in ClusterPeer.model_fields:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_remote_as_string(self) -> None:
+        """Framework and old parser match when remote is a string."""
+        record: dict[str, Any] = {
+            "name": "PEER1",
+            "uuid": "abc",
+            "remote": "REMOTECL1",
+            "authentication": {"state": "ok"},
+        }
+        old = self._old_parse_cluster_peer(record)
+        new = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
+        assert isinstance(new, ClusterPeer)
+        for field_name in ClusterPeer.model_fields:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_auth_as_string(self) -> None:
+        """Framework and old parser match when authentication is a string."""
+        record: dict[str, Any] = {
+            "name": "PEER1",
+            "uuid": "abc",
+            "remote": {"name": "CL1", "ip_addresses": ["10.0.1.1"]},
+            "authentication": "pending",
+        }
+        old = self._old_parse_cluster_peer(record)
+        new = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
+        assert isinstance(new, ClusterPeer)
+        for field_name in ClusterPeer.model_fields:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_address_filtering(self) -> None:
+        """Framework and old parser match on address filtering."""
+        record: dict[str, Any] = {
+            "name": "PEER1",
+            "uuid": "abc",
+            "remote": {
+                "name": "CL1",
+                "ip_addresses": ["10.0.1.1", "", None, "10.0.1.2"],
+            },
+            "authentication": {"state": "ok"},
+        }
+        old = self._old_parse_cluster_peer(record)
+        new = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
+        assert isinstance(new, ClusterPeer)
+        for field_name in ClusterPeer.model_fields:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )


### PR DESCRIPTION
## Description

Migrate ClusterPeer from hand-written inline parsing in `collector.py` to the declarative field mapping framework introduced in ADR-0004. This replaces ~30 lines of imperative dict-traversal code with a 5-field `CLUSTER_PEER_MAPPING` definition and three focused transform functions that safely handle the dict-vs-string polymorphism in the `remote` and `authentication` API fields.

## Related Issue

Addresses #216

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `src/pynetappfoundry/cache/mappings/cluster_peer.py` — defines `CLUSTER_PEER_MAPPING` with 5 field mappings and 3 transform functions (`_api_remote_cluster_name`, `_api_peer_addresses`, `_api_authentication_state`) that handle ONTAP API version differences where `remote` and `authentication` can be dicts or strings
- Replaced ~30 lines of inline parsing in `collector.py` with a new `_parse_cluster_peers_response` method that delegates to `parse_api_response`
- Exported `CLUSTER_PEER_MAPPING` from `cache/mappings/__init__.py`
- Registered `cluster_peer` in the `INSPECT_TYPES` dict in `cli/commands/cache/inspect.py`
- Updated ADR-0004 with issue #216 link
- Updated `docs/development/field-mapping.md` Migrated Types table with ClusterPeer entry

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Added 34 tests in `tests/unit/cache/mappings/test_cluster_peer.py`:
- **Mapping definition tests** (8): field count, model class, endpoint, CLI command, expected fields, id field, no duplicates, all attrs exist on model
- **API parsing tests** (8): full record, minimal record, remote-as-string, auth-as-string, missing fields, address filtering, multi-record response, empty/None response
- **Transform unit tests** (15): each transform tested with dict, string, None, missing key, and edge cases
- **Parity tests** (5): old inline parser reproduced as static method, output compared field-by-field against framework for full, minimal, remote-string, auth-string, and address-filtering records

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

ClusterPeer is an API-only type (no CLI command), so the mapping sets `cli_command=""`. The three transform functions encapsulate the dict-vs-string polymorphism that was previously scattered across the inline parsing block, making the logic reusable and independently testable.
