### PR TITLE
refactor: add authentication_in_use and encryption_state to ClusterPeer mapping

### DIFF
--- a/docs/development/field-mapping.md
+++ b/docs/development/field-mapping.md
@@ -192,7 +192,7 @@ For CLI-only types, also test:
 | Volume | `VOLUME_MAPPING` | `VolumeInfo` | 21 | API-only. Uses transform for aggregate list extraction. |
 | Aggregate | `AGGREGATE_MAPPING` | `AggregateInfo` | 28 | API-only. Deeply nested API paths (`block_storage.primary.*`). Explicit `?fields=*,is_spare_low,sidl_enabled`. |
 | Node | `NODE_MAPPING` | `NodeInfo` | 20 | API-only. Wildcard `[*]` syntax for list fields. `field_validator` for int→str coercion. |
-| ClusterPeer | `CLUSTER_PEER_MAPPING` | `ClusterPeer` | 5 | API-only. Uses transform for dict-vs-string fallback on `remote` and `authentication`. |
+| ClusterPeer | `CLUSTER_PEER_MAPPING` | `ClusterPeer` | 7 | API-only. Uses transform for dict-vs-string fallback on `remote`, `authentication`, and `encryption`. |
 | CloudMetadata | `CLOUD_METADATA_MAPPING` | `CloudMetadata` | 19 | CLI-only (no API endpoint). Computed link fields built as post-processing in collector. |
 
 ## Reference: Field Mapping Patterns

--- a/src/pynetappfoundry/cache/mappings/cluster_peer.py
+++ b/src/pynetappfoundry/cache/mappings/cluster_peer.py
@@ -71,6 +71,36 @@ def _api_authentication_state(record: dict[str, Any]) -> str:
     return str(auth or "")
 
 
+def _api_authentication_in_use(record: dict[str, Any]) -> str:
+    """Extract authentication method in use from API response.
+
+    Args:
+        record: Full API cluster peer record.
+
+    Returns:
+        Authentication method in use string.
+    """
+    auth = record.get("authentication")
+    if isinstance(auth, dict):
+        return str(auth.get("in_use", ""))
+    return ""
+
+
+def _api_encryption_state(record: dict[str, Any]) -> str:
+    """Extract encryption state from API response.
+
+    Args:
+        record: Full API cluster peer record.
+
+    Returns:
+        Encryption state string.
+    """
+    encryption = record.get("encryption")
+    if isinstance(encryption, dict):
+        return str(encryption.get("state", ""))
+    return str(encryption or "")
+
+
 CLUSTER_PEER_MAPPING = TypeMapping(
     name="ClusterPeer",
     model_class=ClusterPeer,
@@ -97,6 +127,14 @@ CLUSTER_PEER_MAPPING = TypeMapping(
         FieldMapping(
             cache_attr="authentication_state",
             transform=_api_authentication_state,
+        ),
+        FieldMapping(
+            cache_attr="authentication_in_use",
+            transform=_api_authentication_in_use,
+        ),
+        FieldMapping(
+            cache_attr="encryption_state",
+            transform=_api_encryption_state,
         ),
     ),
 )

--- a/src/pynetappfoundry/cache/models.py
+++ b/src/pynetappfoundry/cache/models.py
@@ -554,6 +554,8 @@ class ClusterPeer(BaseModel):
     remote_cluster_name: str = ""
     peer_addresses: list[str] = Field(default_factory=list)
     authentication_state: str = ""
+    authentication_in_use: str = ""
+    encryption_state: str = ""
 
 
 class SVMPeerInfo(BaseModel):

--- a/tests/unit/cache/mappings/test_cluster_peer.py
+++ b/tests/unit/cache/mappings/test_cluster_peer.py
@@ -13,7 +13,9 @@ from pynetappfoundry.cache.field_mapping import (
 )
 from pynetappfoundry.cache.mappings.cluster_peer import (
     CLUSTER_PEER_MAPPING,
+    _api_authentication_in_use,
     _api_authentication_state,
+    _api_encryption_state,
     _api_peer_addresses,
     _api_remote_cluster_name,
 )
@@ -36,7 +38,10 @@ def full_api_record() -> dict[str, Any]:
         },
         "authentication": {
             "state": "ok",
-            "in_use": "ok",
+            "in_use": "pre_shared_key",
+        },
+        "encryption": {
+            "state": "tls_psk",
         },
     }
 
@@ -63,8 +68,8 @@ class TestClusterPeerMappingDefinition:
         assert len(attrs) == len(set(attrs))
 
     def test_field_count(self) -> None:
-        """Mapping has expected number of fields (5)."""
-        assert len(CLUSTER_PEER_MAPPING.fields) == 5
+        """Mapping has expected number of fields (7)."""
+        assert len(CLUSTER_PEER_MAPPING.fields) == 7
 
     def test_model_class(self) -> None:
         """Model class is ClusterPeer."""
@@ -105,6 +110,8 @@ class TestClusterPeerApiParsing:
         assert result.remote_cluster_name == "DRCL1"
         assert result.peer_addresses == ["10.0.1.10", "10.0.1.11"]
         assert result.authentication_state == "ok"
+        assert result.authentication_in_use == "pre_shared_key"
+        assert result.encryption_state == "tls_psk"
 
     def test_minimal_record(self) -> None:
         """Minimal record uses defaults for missing fields."""
@@ -116,6 +123,8 @@ class TestClusterPeerApiParsing:
         assert result.remote_cluster_name == ""
         assert result.peer_addresses == []
         assert result.authentication_state == ""
+        assert result.authentication_in_use == ""
+        assert result.encryption_state == ""
 
     def test_remote_as_string(self) -> None:
         """When remote is a string, remote_cluster_name gets the string value."""
@@ -152,6 +161,8 @@ class TestClusterPeerApiParsing:
         assert result.remote_cluster_name == ""
         assert result.peer_addresses == []
         assert result.authentication_state == ""
+        assert result.authentication_in_use == ""
+        assert result.encryption_state == ""
 
     def test_address_filtering(self) -> None:
         """Empty/falsy addresses are filtered out."""
@@ -280,6 +291,53 @@ class TestTransformFunctions:
         """Missing authentication key returns empty string."""
         assert _api_authentication_state({}) == ""
 
+    # -- _api_authentication_in_use --
+
+    def test_authentication_in_use_dict(self) -> None:
+        """Dict authentication returns in_use."""
+        assert (
+            _api_authentication_in_use({"authentication": {"in_use": "pre_shared_key"}})
+            == "pre_shared_key"
+        )
+
+    def test_authentication_in_use_dict_missing_key(self) -> None:
+        """Dict authentication without in_use key returns empty string."""
+        assert _api_authentication_in_use({"authentication": {"state": "ok"}}) == ""
+
+    def test_authentication_in_use_string(self) -> None:
+        """String authentication returns empty string."""
+        assert _api_authentication_in_use({"authentication": "pending"}) == ""
+
+    def test_authentication_in_use_none(self) -> None:
+        """None authentication returns empty string."""
+        assert _api_authentication_in_use({"authentication": None}) == ""
+
+    def test_authentication_in_use_missing(self) -> None:
+        """Missing authentication key returns empty string."""
+        assert _api_authentication_in_use({}) == ""
+
+    # -- _api_encryption_state --
+
+    def test_encryption_state_dict(self) -> None:
+        """Dict encryption returns state."""
+        assert _api_encryption_state({"encryption": {"state": "tls_psk"}}) == "tls_psk"
+
+    def test_encryption_state_dict_missing_key(self) -> None:
+        """Dict encryption without state key returns empty string."""
+        assert _api_encryption_state({"encryption": {"protocol": "tls"}}) == ""
+
+    def test_encryption_state_string(self) -> None:
+        """String encryption returns the string."""
+        assert _api_encryption_state({"encryption": "none"}) == "none"
+
+    def test_encryption_state_none(self) -> None:
+        """None encryption returns empty string."""
+        assert _api_encryption_state({"encryption": None}) == ""
+
+    def test_encryption_state_missing(self) -> None:
+        """Missing encryption key returns empty string."""
+        assert _api_encryption_state({}) == ""
+
 
 # ---------------------------------------------------------------------------
 # Parity test: old parser vs new framework
@@ -287,7 +345,19 @@ class TestTransformFunctions:
 
 
 class TestParityWithOldParser:
-    """Verify framework produces same output as old hand-written inline parser."""
+    """Verify framework produces same output as old hand-written inline parser.
+
+    Parity is checked for the original 5 fields only. The new fields
+    (authentication_in_use, encryption_state) were not in the old parser.
+    """
+
+    _ORIGINAL_FIELDS = (
+        "name",
+        "uuid",
+        "remote_cluster_name",
+        "peer_addresses",
+        "authentication_state",
+    )
 
     @staticmethod
     def _old_parse_cluster_peer(record: dict[str, Any]) -> ClusterPeer:
@@ -314,7 +384,7 @@ class TestParityWithOldParser:
         old = self._old_parse_cluster_peer(full_api_record)
         new = parse_api_record(CLUSTER_PEER_MAPPING, full_api_record, "[test]")
         assert isinstance(new, ClusterPeer)
-        for field_name in ClusterPeer.model_fields:
+        for field_name in self._ORIGINAL_FIELDS:
             old_val = getattr(old, field_name)
             new_val = getattr(new, field_name)
             assert old_val == new_val, (
@@ -327,7 +397,7 @@ class TestParityWithOldParser:
         old = self._old_parse_cluster_peer(record)
         new = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
         assert isinstance(new, ClusterPeer)
-        for field_name in ClusterPeer.model_fields:
+        for field_name in self._ORIGINAL_FIELDS:
             old_val = getattr(old, field_name)
             new_val = getattr(new, field_name)
             assert old_val == new_val, (
@@ -345,7 +415,7 @@ class TestParityWithOldParser:
         old = self._old_parse_cluster_peer(record)
         new = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
         assert isinstance(new, ClusterPeer)
-        for field_name in ClusterPeer.model_fields:
+        for field_name in self._ORIGINAL_FIELDS:
             old_val = getattr(old, field_name)
             new_val = getattr(new, field_name)
             assert old_val == new_val, (
@@ -363,7 +433,7 @@ class TestParityWithOldParser:
         old = self._old_parse_cluster_peer(record)
         new = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
         assert isinstance(new, ClusterPeer)
-        for field_name in ClusterPeer.model_fields:
+        for field_name in self._ORIGINAL_FIELDS:
             old_val = getattr(old, field_name)
             new_val = getattr(new, field_name)
             assert old_val == new_val, (
@@ -384,7 +454,7 @@ class TestParityWithOldParser:
         old = self._old_parse_cluster_peer(record)
         new = parse_api_record(CLUSTER_PEER_MAPPING, record, "[test]")
         assert isinstance(new, ClusterPeer)
-        for field_name in ClusterPeer.model_fields:
+        for field_name in self._ORIGINAL_FIELDS:
             old_val = getattr(old, field_name)
             new_val = getattr(new, field_name)
             assert old_val == new_val, (


### PR DESCRIPTION
## Description

Add `authentication_in_use` and `encryption_state` fields to the ClusterPeer model and mapping, extending the initial migration (PR #249) with two additional API fields from the `/cluster/peers` endpoint.

Addresses #216

## Related Issue

Addresses #216

## Type of Change

- [x] Code refactoring

## Changes Made

- Added `authentication_in_use` and `encryption_state` fields to `ClusterPeer` model in `cache/models.py`
- Added `_api_authentication_in_use` and `_api_encryption_state` transform functions in `cache/mappings/cluster_peer.py`
- Added two new `FieldMapping` entries to `CLUSTER_PEER_MAPPING` (5 -> 7 fields)
- Updated field-mapping.md Migrated Types table (field count 5 -> 7, notes updated)
- Added 10 transform unit tests for the new fields
- Updated existing test assertions to cover the new fields (full record, minimal record, missing fields)

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (test, lint, type-check, security, spell-check, format)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
