### PR TITLE
feat: generalize field mapping framework for multi-API data collection

### DIFF
--- a/docs/decisions/0004-declarative-field-mapping-framework.md
+++ b/docs/decisions/0004-declarative-field-mapping-framework.md
@@ -60,6 +60,7 @@ The pilot migration (VolumeInfo) was completed in PR #189.
 - Issue #217: refactor: migrate CloudMetadata to field mapping framework
 - Issue #216: refactor: migrate ClusterPeer to field mapping framework
 - Issue #237: refactor: all-or-nothing collection with no CLI fallback
+- Issue #259: feat: generalize field mapping framework for multi-API data collection
 
 ## Related Documentation
 

--- a/docs/decisions/0006-generalize-field-mapping-for-multi-api.md
+++ b/docs/decisions/0006-generalize-field-mapping-for-multi-api.md
@@ -1,0 +1,30 @@
+# ADR-0006: Generalize field mapping framework for multi-API data collection
+
+## Status
+
+Accepted
+
+## Decision
+
+Extend the declarative field mapping framework (ADR-0004) from ONTAP-only to multi-API by adding three changes to `TypeMapping`:
+
+1. **`records_path: str = "records"`** — configurable dot-notation path to the records list in the API response envelope. Defaults to `"records"` (preserving ONTAP behavior). Supports nested paths like `"_embedded.items"` for APIs with deeper envelopes.
+2. **`api_type: str = "ontap"`** — tag for routing to the correct API client and unit registry. Defaults to `"ontap"` (preserving existing behavior).
+3. **`cli_command` made optional** — changed from required positional to `cli_command: str = ""`. Non-ONTAP APIs typically have no CLI equivalent.
+
+The `parse_api_response()` function now uses `get_nested_value(response, mapping.records_path)` instead of `response.get("records", [])`, enabling it to extract records from any response envelope structure.
+
+## Rationale
+
+With DII, AIQUM, BlueXP, and StorageGrid planned as future data sources, the mapping framework needed to become API-agnostic so all APIs share the same declarative collection pattern. This avoids per-API SDK fragmentation and keeps a unified collection layer.
+
+The changes are non-breaking — all existing ONTAP mappings work without modification because the new fields have defaults that preserve current behavior.
+
+## Related Issues
+
+- Issue #259: feat: generalize field mapping framework for multi-API data collection
+- Issue #258: feat: multi-API data collection strategy (superseded by #259)
+
+## Related Documentation
+
+- [Field Mapping Framework Developer Guide](../development/field-mapping.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -70,3 +70,4 @@ Template-inherited ADRs (9XXX range) are maintained in [docs/template/decisions/
 | [0003](0003-use-base-sqlitedb-class-with-version-based-migrations.md) | Use base SQLiteDB class with version-based migrations | Accepted |
 | [0004](0004-declarative-field-mapping-framework.md) | Declarative field mapping framework for ONTAP collection | Accepted |
 | [0005](0005-uuid-index-for-cache-cross-references.md) | UUID index for cache cross-references | Accepted |
+| [0006](0006-generalize-field-mapping-for-multi-api.md) | Generalize field mapping framework for multi-API data collection | Accepted |

--- a/docs/development/field-mapping.md
+++ b/docs/development/field-mapping.md
@@ -1,6 +1,6 @@
 ---
 title: Field Mapping Framework
-description: Declarative framework for mapping ONTAP API/CLI data to cache models
+description: Declarative framework for mapping API/CLI data to cache models
 audience:
   - contributors
 tags:
@@ -11,17 +11,19 @@ tags:
 
 # Field Mapping Framework
 
-The declarative field mapping framework maps ONTAP REST API and CLI responses to cache model objects using data-driven definitions instead of hand-written parsing methods.
+The declarative field mapping framework maps API and CLI responses to cache model objects using data-driven definitions instead of hand-written parsing methods. While originally built for ONTAP, the framework is API-agnostic and supports any REST API through configurable response envelopes and API type tags.
 
-**ADR:** [ADR-0004](../decisions/0004-declarative-field-mapping-framework.md)
+**ADRs:** [ADR-0004](../decisions/0004-declarative-field-mapping-framework.md), [ADR-0006](../decisions/0006-generalize-field-mapping-for-multi-api.md)
 
 ## Architecture
 
 ```
-TypeMapping (one per ONTAP object type)
+TypeMapping (one per API object type)
 ├── api_endpoint    → REST API URL with ?fields= params
-├── cli_command     → CLI show command name
+├── cli_command     → CLI show command name (optional, default "")
 ├── model_class     → Pydantic model (e.g., VolumeInfo)
+├── records_path    → Dot-path to records in response envelope (default "records")
+├── api_type        → API client/registry tag (default "ontap")
 └── fields          → tuple of FieldMapping entries
     ├── FieldMapping(cache_attr, api_path, ...)
     ├── FieldMapping(cache_attr, api_path, ...)
@@ -57,16 +59,18 @@ Maps a single field across three domains: API response, CLI output, and cache mo
 
 ### TypeMapping
 
-Defines a complete ONTAP object type mapping.
+Defines a complete API object type mapping.
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `name` | `str` | Human-readable type name (e.g., `"Volume"`). |
 | `model_class` | `type[BaseModel]` | Pydantic model class for the cache object. |
 | `api_endpoint` | `str` | REST API endpoint including query params. |
-| `cli_command` | `str` | CLI show command name. |
+| `cli_command` | `str` | CLI show command name. Default: `""` (empty, optional). |
 | `fields` | `tuple[FieldMapping, ...]` | Tuple of field mapping definitions. |
 | `id_field` | `str` | Field used for log identification. Default: `"name"`. |
+| `records_path` | `str` | Dot-notation path to records list in the API response envelope. Default: `"records"`. Supports nested paths like `"_embedded.items"`. |
+| `api_type` | `str` | Tag identifying which API client/unit registry to use. Default: `"ontap"`. |
 
 Helper methods:
 
@@ -77,7 +81,7 @@ Helper methods:
 
 | Function | Input | Output |
 |----------|-------|--------|
-| `parse_api_response()` | Full API response dict (with `"records"` key) | `list[BaseModel]` |
+| `parse_api_response()` | Full API response dict (records extracted via `records_path`) | `list[BaseModel]` |
 | `parse_cli_records()` | List of CLI record dicts | `list[BaseModel]` |
 | `parse_api_record()` | Single API record dict | `BaseModel` |
 | `parse_cli_record()` | Single CLI record dict | `BaseModel` |
@@ -130,6 +134,32 @@ from pynetappfoundry.cache.models import <TypeModel>
 > **Note:** For API-collected types, use `api_path` only — do not add
 > `cli_field`. The `cli_field` and `cli_transform` attributes are reserved
 > for types that require CLI parsing (see [CLI Fields](#cli-fields) below).
+
+#### Non-ONTAP API example
+
+For APIs with different response envelopes, set `records_path` and `api_type`:
+
+```python
+"""AIQUM datacenter cluster mapping."""
+
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from mypackage.models import AiqumCluster
+
+AIQUM_CLUSTER_MAPPING = TypeMapping(
+    name="AiqumCluster",
+    model_class=AiqumCluster,
+    api_endpoint="/datacenter/cluster/clusters",
+    records_path="_embedded.items",  # AIQUM uses HAL-style envelopes
+    api_type="aiqum",
+    fields=(
+        FieldMapping(cache_attr="name", api_path="name"),
+        FieldMapping(cache_attr="uuid", api_path="uuid"),
+        FieldMapping(cache_attr="version", api_path="version.full"),
+    ),
+)
+```
+
+The `cli_command` defaults to `""` (empty) since non-ONTAP APIs typically have no CLI equivalent.
 
 ### Step 2: Export from the mappings package
 

--- a/src/pynetappfoundry/cache/field_mapping.py
+++ b/src/pynetappfoundry/cache/field_mapping.py
@@ -1,4 +1,4 @@
-"""Declarative field mapping framework for ONTAP data collection.
+"""Declarative field mapping framework for API data collection.
 
 Provides dataclasses and generic parsers that map API and CLI responses
 to cache model objects using declarative field definitions.
@@ -49,23 +49,30 @@ class FieldMapping:
 
 @dataclass(frozen=True)
 class TypeMapping:
-    """Declarative mapping definition for an ONTAP object type.
+    """Declarative mapping definition for an API object type.
 
     Attributes:
         name: Human-readable type name (e.g. ``"Volume"``).
         model_class: Pydantic model class for the cache object.
         api_endpoint: REST API endpoint including query params.
-        cli_command: CLI show command name.
+        cli_command: CLI show command name. Empty string if not applicable.
         fields: Tuple of field mapping definitions.
         id_field: Field used for log identification.
+        records_path: Dot-notation path to the records list in the API response
+            envelope (e.g. ``"records"`` for ONTAP, ``"_embedded.items"`` for
+            other APIs). Default: ``"records"``.
+        api_type: Tag identifying which API client/unit registry to use
+            (e.g. ``"ontap"``, ``"aiqum"``). Default: ``"ontap"``.
     """
 
     name: str
     model_class: type[BaseModel]
     api_endpoint: str
-    cli_command: str
-    fields: tuple[FieldMapping, ...]
+    cli_command: str = ""
+    fields: tuple[FieldMapping, ...] = ()
     id_field: str = "name"
+    records_path: str = "records"
+    api_type: str = "ontap"
 
     def api_expected_fields(self) -> list[str]:
         """Derive top-level API keys expected in a response record.
@@ -224,12 +231,13 @@ def parse_api_response(
 ) -> list[BaseModel]:
     """Parse a full API response into a list of model instances.
 
-    Iterates ``response["records"]``, logs missing fields via the provided
-    callback, and delegates each record to ``parse_api_record``.
+    Extracts the records list from the response using ``mapping.records_path``
+    (supports dot-notation for nested envelopes), logs missing fields via the
+    provided callback, and delegates each record to ``parse_api_record``.
 
     Args:
         mapping: Type mapping definition.
-        response: Full API response dict (with ``"records"`` key) or None.
+        response: Full API response dict or None.
         log_prefix: Prefix for log messages.
         log_missing_fn: Callback for logging missing fields.
 
@@ -239,7 +247,10 @@ def parse_api_response(
     if not response:
         return []
 
-    records = response.get("records", [])
+    try:
+        records = get_nested_value(response, mapping.records_path)
+    except PathNotFoundError:
+        records = []
     logger.debug("%s API response: %d %ss", log_prefix, len(records), mapping.name.lower())
 
     expected = mapping.api_expected_fields()

--- a/tests/unit/cache/test_field_mapping.py
+++ b/tests/unit/cache/test_field_mapping.py
@@ -139,6 +139,57 @@ class TestTypeMapping:
         with pytest.raises(AttributeError):
             sample_mapping.name = "other"  # type: ignore[misc]
 
+    def test_records_path_default(self, sample_mapping: TypeMapping) -> None:
+        """Default records_path is 'records'."""
+        assert sample_mapping.records_path == "records"
+
+    def test_records_path_custom(self) -> None:
+        """records_path can be set to a custom value."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/t",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+            records_path="_embedded.items",
+        )
+        assert tm.records_path == "_embedded.items"
+
+    def test_api_type_default(self, sample_mapping: TypeMapping) -> None:
+        """Default api_type is 'ontap'."""
+        assert sample_mapping.api_type == "ontap"
+
+    def test_api_type_custom(self) -> None:
+        """api_type can be set to other values."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/t",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+            api_type="aiqum",
+        )
+        assert tm.api_type == "aiqum"
+
+    def test_cli_command_default(self) -> None:
+        """Default cli_command is empty string."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/t",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+        )
+        assert tm.cli_command == ""
+
+    def test_cli_command_optional(self) -> None:
+        """TypeMapping can be constructed without cli_command."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/t",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+        )
+        assert isinstance(tm, TypeMapping)
+        assert tm.cli_command == ""
+
 
 # ---------------------------------------------------------------------------
 # _coerce_cli_value tests
@@ -434,6 +485,52 @@ class TestParseApiResponse:
         call_args = mock_log.call_args_list[0]
         assert call_args[0][1] == ["name", "value"]  # api_expected_fields()
         assert call_args[0][2] == "Test"  # mapping.name
+
+    def test_custom_records_path(self) -> None:
+        """Response with non-'records' key is parsed correctly."""
+        tm = TypeMapping(
+            name="Test",
+            model_class=_SampleModel,
+            api_endpoint="/test",
+            fields=(
+                FieldMapping(cache_attr="name", api_path="name"),
+                FieldMapping(cache_attr="value", api_path="value", default=0),
+            ),
+            records_path="hits",
+        )
+        response = {"hits": [{"name": "x", "value": 10}]}
+        results = parse_api_response(tm, response, "[t]", MagicMock())
+        assert len(results) == 1
+        assert results[0].name == "x"
+        assert results[0].value == 10
+
+    def test_nested_records_path(self) -> None:
+        """Dot-notation path like 'data.items' works."""
+        tm = TypeMapping(
+            name="Test",
+            model_class=_SampleModel,
+            api_endpoint="/test",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+            records_path="data.items",
+        )
+        response = {"data": {"items": [{"name": "nested1"}, {"name": "nested2"}]}}
+        results = parse_api_response(tm, response, "[t]", MagicMock())
+        assert len(results) == 2
+        assert results[0].name == "nested1"
+        assert results[1].name == "nested2"
+
+    def test_invalid_records_path_returns_empty(self) -> None:
+        """Bad records_path returns empty list (not crash)."""
+        tm = TypeMapping(
+            name="Test",
+            model_class=_SampleModel,
+            api_endpoint="/test",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+            records_path="nonexistent.path",
+        )
+        response = {"records": [{"name": "a"}]}
+        results = parse_api_response(tm, response, "[t]", MagicMock())
+        assert results == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Generalize the declarative field mapping framework from ONTAP-only to multi-API by adding three non-breaking changes to `TypeMapping`:

1. **`records_path: str = "records"`** -- configurable dot-notation path to the records list in the API response envelope. Supports nested paths like `"_embedded.items"` for APIs with deeper envelopes.
2. **`api_type: str = "ontap"`** -- tag for routing to the correct API client and unit registry.
3. **`cli_command` made optional** -- changed from required positional to `cli_command: str = ""`. Non-ONTAP APIs typically have no CLI equivalent.

The `parse_api_response()` function now uses `get_nested_value(response, mapping.records_path)` instead of `response.get("records", [])`, enabling it to extract records from any response envelope structure.

All existing ONTAP mappings work without modification because the new fields have defaults that preserve current behavior.

## Related Issue

Addresses #259

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Added `records_path` field to `TypeMapping` with default `"records"` for configurable response envelope extraction
- Added `api_type` field to `TypeMapping` with default `"ontap"` for API client/registry routing
- Made `cli_command` optional (default `""`) since non-ONTAP APIs have no CLI equivalent
- Updated `parse_api_response()` to use `get_nested_value()` with `mapping.records_path` instead of hardcoded `response.get("records", [])`
- Added 9 new tests covering `records_path` (custom, nested, invalid), `api_type` (default, custom), and `cli_command` (default, optional)
- Created ADR-0006 documenting the multi-API generalization decision
- Updated ADR-0004 with issue #259 reference
- Updated decisions README index with ADR-0006
- Updated field mapping developer guide with API-agnostic language, `records_path`/`api_type` documentation, and non-ONTAP example

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

New tests added to `tests/unit/cache/test_field_mapping.py`:
- `test_records_path_default` -- verifies default is `"records"`
- `test_records_path_custom` -- verifies custom path can be set
- `test_api_type_default` -- verifies default is `"ontap"`
- `test_api_type_custom` -- verifies custom api_type can be set
- `test_cli_command_default` -- verifies default is empty string
- `test_cli_command_optional` -- verifies TypeMapping construction without cli_command
- `test_custom_records_path` -- verifies `parse_api_response` with non-default records key
- `test_nested_records_path` -- verifies dot-notation path like `"data.items"` works
- `test_invalid_records_path_returns_empty` -- verifies bad path returns empty list gracefully

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- ADR-0006 created to satisfy the `needs-adr` label on issue #259
- ADR-0006 links to the field mapping developer guide (`docs/development/field-mapping.md`)
- ADR-0004 updated with issue #259 cross-reference
- All changes are non-breaking; existing ONTAP mappings require no modification
