### PR TITLE
feat: add configurable pagination support to APIWrapper

### DIFF
--- a/docs/decisions/0006-generalize-field-mapping-for-multi-api.md
+++ b/docs/decisions/0006-generalize-field-mapping-for-multi-api.md
@@ -20,8 +20,13 @@ With DII, AIQUM, BlueXP, and StorageGrid planned as future data sources, the map
 
 The changes are non-breaking — all existing ONTAP mappings work without modification because the new fields have defaults that preserve current behavior.
 
+## Pagination Support
+
+Issue #260 added `get_all_records()` to `APIWrapper`, enabling automatic pagination across all API types. The method uses a configurable `PaginationConfig` and pluggable `NextPageExtractor` callable, defaulting to ONTAP's `_links.next.href` HAL convention. This complements the field mapping framework by ensuring all records are collected before mapping is applied.
+
 ## Related Issues
 
+- Issue #260: feat: add configurable pagination support to APIWrapper
 - Issue #259: feat: generalize field mapping framework for multi-API data collection
 - Issue #258: feat: multi-API data collection strategy (superseded by #259)
 

--- a/src/pynetappfoundry/clients/__init__.py
+++ b/src/pynetappfoundry/clients/__init__.py
@@ -3,7 +3,7 @@
 from pynetappfoundry.clients.dii.api import DIIAPIClient
 from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
 from pynetappfoundry.clients.ontap.cli import ONTAPCLI, CLICommandError, CLITimeoutError
-from pynetappfoundry.clients.openapi import APIWrapper
+from pynetappfoundry.clients.openapi import APIWrapper, NextPageExtractor, ontap_next_page_extractor
 
 __all__ = [
     "ONTAPCLI",
@@ -11,5 +11,7 @@ __all__ = [
     "CLICommandError",
     "CLITimeoutError",
     "DIIAPIClient",
+    "NextPageExtractor",
     "ONTAPAPIClient",
+    "ontap_next_page_extractor",
 ]

--- a/src/pynetappfoundry/clients/openapi.py
+++ b/src/pynetappfoundry/clients/openapi.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlencode
 
@@ -20,7 +21,26 @@ from tenacity import (
     wait_exponential,
 )
 
-from pynetappfoundry.core.models import RetryConfig, ValidationConfig
+from pynetappfoundry.core.models import PaginationConfig, RetryConfig, ValidationConfig
+
+NextPageExtractor = Callable[[dict[str, Any]], str | None]
+"""Callable that receives a JSON response dict and returns the next page URL or None."""
+
+
+def ontap_next_page_extractor(response: dict[str, Any]) -> str | None:
+    """Extract next page URL from ONTAP/AIQUM HAL _links.next.href.
+
+    Args:
+        response: The JSON response dictionary.
+
+    Returns:
+        The next page URL string, or None if no next page.
+    """
+    try:
+        href: str = response["_links"]["next"]["href"]
+    except (KeyError, TypeError):
+        return None
+    return href
 
 
 class ResponseValidationError(Exception):
@@ -680,3 +700,162 @@ class APIWrapper:
         )
 
         return response_data
+
+    def get_all_records(
+        self,
+        path_template: str,
+        method: str = "GET",
+        path_params: dict[str, Any] | None = None,
+        query_params: dict[str, Any] | None = None,
+        body: dict[str, Any] | None = None,
+        additional_headers: dict[str, str] | None = None,
+        retry_config: RetryConfig | None = None,
+        validation_config: ValidationConfig | None = None,
+        pagination_config: PaginationConfig | None = None,
+        next_page_extractor: NextPageExtractor | None = None,
+    ) -> dict[str, Any]:
+        """Fetch all pages of a paginated API response and merge records.
+
+        Makes the initial request via call_endpoint(), then follows pagination
+        links using the next_page_extractor to collect all records across pages.
+
+        Args:
+            path_template: API path template.
+            method: HTTP method.
+            path_params: Values for path placeholders.
+            query_params: Query string parameters.
+            body: Request body (JSON).
+            additional_headers: Extra headers to include.
+            retry_config: Optional per-call retry configuration override.
+            validation_config: Optional per-call validation configuration override.
+            pagination_config: Configuration for pagination behavior.
+            next_page_extractor: Callable to extract next page URL from response.
+                Defaults to ontap_next_page_extractor.
+
+        Returns:
+            Merged response dict with all records combined, _links removed,
+            and num_records updated if present in original response.
+
+        Raises:
+            TypeError: If the response is not a dict.
+            ValueError: If request body validation fails.
+            requests.HTTPError: If any request fails.
+            ResponseValidationError: If response validation fails in strict mode.
+        """
+        config = pagination_config if pagination_config is not None else PaginationConfig()
+        extractor = (
+            next_page_extractor if next_page_extractor is not None else ontap_next_page_extractor
+        )
+
+        # Fetch first page via call_endpoint (full validation, URL building, retry)
+        first_response = self.call_endpoint(
+            path_template=path_template,
+            method=method,
+            path_params=path_params,
+            query_params=query_params,
+            body=body,
+            additional_headers=additional_headers,
+            retry_config=retry_config,
+            validation_config=validation_config,
+        )
+
+        if not isinstance(first_response, dict):
+            msg = f"Expected dict response for pagination, got {type(first_response).__name__}"
+            raise TypeError(msg)
+
+        if not config.enabled:
+            logging.debug(f"{self.log_prefix} Pagination disabled, returning first page")
+            return first_response
+
+        # Collect records from first page
+        all_records: list[Any] = list(first_response.get(config.records_key, []))
+        page_count = 1
+
+        logging.debug(
+            f"{self.log_prefix} Page {page_count}: {len(all_records)} records "
+            f"(total: {len(all_records)})"
+        )
+
+        # Pre-compute headers for subsequent pages
+        headers: dict[str, str | bytes] = dict(self.session.headers)
+        if additional_headers:
+            headers.update(additional_headers)
+
+        # Effective configs for subsequent pages
+        effective_retry = retry_config if retry_config is not None else self.retry_config
+        effective_validation = (
+            validation_config if validation_config is not None else self.validation_config
+        )
+
+        # Follow pagination links
+        current_response = first_response
+        while page_count < config.max_pages:
+            next_url = extractor(current_response)
+            if next_url is None:
+                break
+
+            page_count += 1
+
+            # Build full URL
+            if next_url.startswith(("http://", "https://")):
+                full_url = next_url
+            else:
+                full_url = f"{self.base_url}{next_url}"
+
+            logging.debug(f"{self.log_prefix} Fetching page {page_count}: {full_url}")
+
+            resp = self._execute_request_with_retry(
+                method=method.upper(),
+                url=full_url,
+                body=None,
+                headers=headers,
+                retry_config=effective_retry,
+            )
+
+            resp.raise_for_status()
+
+            try:
+                page_data = resp.json()
+            except ValueError as e:
+                logging.error(f"{self.log_prefix} Page {page_count}: failed to parse JSON response")
+                msg = f"Page {page_count}: failed to parse JSON response"
+                raise TypeError(msg) from e
+
+            # Validate subsequent page if enabled
+            if effective_validation.enabled:
+                self.validate_response(
+                    path_template=path_template,
+                    method=method,
+                    status_code=resp.status_code,
+                    response_data=page_data,
+                    validation_config=effective_validation,
+                )
+
+            page_records = page_data.get(config.records_key, [])
+            all_records.extend(page_records)
+            current_response = page_data
+
+            logging.debug(
+                f"{self.log_prefix} Page {page_count}: {len(page_records)} records "
+                f"(total: {len(all_records)})"
+            )
+        else:
+            if extractor(current_response) is not None:
+                logging.warning(
+                    f"{self.log_prefix} Pagination stopped at max_pages limit "
+                    f"({config.max_pages}). Some records may not have been fetched."
+                )
+
+        logging.info(
+            f"{self.log_prefix} Fetched {len(all_records)} total records across {page_count} pages"
+        )
+
+        # Build merged response
+        merged = dict(first_response)
+        merged[config.records_key] = all_records
+        merged.pop("_links", None)
+
+        if "num_records" in first_response:
+            merged["num_records"] = len(all_records)
+
+        return merged

--- a/src/pynetappfoundry/core/models.py
+++ b/src/pynetappfoundry/core/models.py
@@ -158,6 +158,22 @@ class ValidationConfig(BaseModel):
     validate_success_only: bool = True
 
 
+class PaginationConfig(BaseModel):
+    """Configuration for API response pagination.
+
+    Attributes:
+        enabled: Whether pagination is enabled. Default True.
+        max_pages: Maximum number of pages to fetch (1-10000). Default 100.
+        records_key: Key in response dict containing the records list. Default "records".
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    max_pages: int = Field(default=100, ge=1, le=10000)
+    records_key: str = "records"
+
+
 class CacheConfig(BaseModel):
     """Configuration for cluster metadata caching.
 

--- a/tests/unit/test_openapi.py
+++ b/tests/unit/test_openapi.py
@@ -11,8 +11,12 @@ import pytest
 import requests
 from tenacity import RetryError
 
-from pynetappfoundry.clients.openapi import APIWrapper, ResponseValidationError
-from pynetappfoundry.core.models import RetryConfig, ValidationConfig
+from pynetappfoundry.clients.openapi import (
+    APIWrapper,
+    ResponseValidationError,
+    ontap_next_page_extractor,
+)
+from pynetappfoundry.core.models import PaginationConfig, RetryConfig, ValidationConfig
 
 
 @pytest.fixture
@@ -1042,3 +1046,572 @@ class TestAPIWrapperWithConfigs:
         )
         assert wrapper.validation_config.enabled is True
         assert wrapper.validation_config.strict is True
+
+
+class TestPaginationConfig:
+    """Tests for PaginationConfig model."""
+
+    def test_default_values(self) -> None:
+        """Test default configuration values."""
+        config = PaginationConfig()
+        assert config.enabled is True
+        assert config.max_pages == 100
+        assert config.records_key == "records"
+
+    def test_custom_values(self) -> None:
+        """Test custom configuration values."""
+        config = PaginationConfig(
+            enabled=False,
+            max_pages=50,
+            records_key="items",
+        )
+        assert config.enabled is False
+        assert config.max_pages == 50
+        assert config.records_key == "items"
+
+    def test_max_pages_minimum(self) -> None:
+        """Test max_pages validation rejects 0."""
+        with pytest.raises(ValueError):
+            PaginationConfig(max_pages=0)
+
+    def test_max_pages_maximum(self) -> None:
+        """Test max_pages validation rejects values above 10000."""
+        with pytest.raises(ValueError):
+            PaginationConfig(max_pages=10001)
+
+    def test_extra_fields_forbidden(self) -> None:
+        """Test that extra fields are rejected."""
+        with pytest.raises(ValueError):
+            PaginationConfig(unknown_field="value")  # type: ignore[call-arg]
+
+
+class TestOntapNextPageExtractor:
+    """Tests for ontap_next_page_extractor function."""
+
+    def test_extracts_next_href(self) -> None:
+        """Test extraction of next href from _links.next.href."""
+        response = {
+            "records": [],
+            "_links": {
+                "self": {"href": "/api/storage/aggregates"},
+                "next": {"href": "/api/storage/aggregates?start.name=aggr5&max_records=25"},
+            },
+        }
+        result = ontap_next_page_extractor(response)
+        assert result == "/api/storage/aggregates?start.name=aggr5&max_records=25"
+
+    def test_returns_none_when_no_links(self) -> None:
+        """Test returns None when _links key is missing."""
+        response: dict[str, Any] = {"records": []}
+        assert ontap_next_page_extractor(response) is None
+
+    def test_returns_none_when_no_next(self) -> None:
+        """Test returns None when _links has self but no next."""
+        response: dict[str, Any] = {
+            "records": [],
+            "_links": {"self": {"href": "/api/storage/aggregates"}},
+        }
+        assert ontap_next_page_extractor(response) is None
+
+    def test_returns_none_when_links_is_none(self) -> None:
+        """Test returns None when _links value is None."""
+        response: dict[str, Any] = {"records": [], "_links": None}
+        assert ontap_next_page_extractor(response) is None
+
+    def test_returns_none_for_empty_dict(self) -> None:
+        """Test returns None for empty response dict."""
+        assert ontap_next_page_extractor({}) is None
+
+    def test_returns_none_when_next_has_no_href(self) -> None:
+        """Test returns None when _links.next exists but has no href."""
+        response: dict[str, Any] = {
+            "records": [],
+            "_links": {"next": {"self": "/api/storage/aggregates"}},
+        }
+        assert ontap_next_page_extractor(response) is None
+
+
+class TestGetAllRecords:
+    """Tests for APIWrapper.get_all_records method."""
+
+    def _make_response(
+        self,
+        data: dict[str, Any],
+        status_code: int = 200,
+    ) -> MagicMock:
+        """Helper to create a mock HTTP response."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = status_code
+        mock_resp.json.return_value = data
+        mock_resp.raise_for_status.return_value = None
+        return mock_resp
+
+    def test_single_page_no_pagination_links(self, api_wrapper: APIWrapper) -> None:
+        """Test single page response without pagination links returns as-is."""
+        page_data = {
+            "records": [{"name": "vol1"}, {"name": "vol2"}],
+            "num_records": 2,
+        }
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.return_value = self._make_response(page_data)
+
+            result = api_wrapper.get_all_records("/users", "GET")
+
+            assert result["records"] == [{"name": "vol1"}, {"name": "vol2"}]
+            assert result["num_records"] == 2
+            assert mock_request.call_count == 1
+
+    def test_two_pages(self, api_wrapper: APIWrapper) -> None:
+        """Test following one next link and merging records."""
+        page1 = {
+            "records": [{"name": "vol1"}],
+            "num_records": 1,
+            "_links": {"next": {"href": "/api/v1/users?start=2&max_records=1"}},
+        }
+        page2 = {
+            "records": [{"name": "vol2"}],
+            "num_records": 1,
+        }
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                self._make_response(page2),
+            ]
+
+            result = api_wrapper.get_all_records("/users", "GET")
+
+            assert result["records"] == [{"name": "vol1"}, {"name": "vol2"}]
+            assert result["num_records"] == 2
+            assert "_links" not in result
+            assert mock_request.call_count == 2
+
+    def test_three_pages(self, api_wrapper: APIWrapper) -> None:
+        """Test following two next links with correct total."""
+        page1 = {
+            "records": [{"name": "a"}],
+            "num_records": 1,
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        page2 = {
+            "records": [{"name": "b"}],
+            "num_records": 1,
+            "_links": {"next": {"href": "/api/v1/users?start=3"}},
+        }
+        page3 = {
+            "records": [{"name": "c"}],
+            "num_records": 1,
+        }
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                self._make_response(page2),
+                self._make_response(page3),
+            ]
+
+            result = api_wrapper.get_all_records("/users", "GET")
+
+            assert len(result["records"]) == 3
+            assert result["num_records"] == 3
+            assert mock_request.call_count == 3
+
+    def test_subsequent_page_url_construction(self, api_wrapper: APIWrapper) -> None:
+        """Test that subsequent page URLs use base_url + href (no duplicate /api)."""
+        page1 = {
+            "records": [{"name": "vol1"}],
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        page2 = {"records": [{"name": "vol2"}]}
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                self._make_response(page2),
+            ]
+
+            api_wrapper.get_all_records("/users", "GET")
+
+            # Second call should use base_url + href directly
+            second_call = mock_request.call_args_list[1]
+            assert second_call[0][1] == "https://api.example.com/api/v1/users?start=2"
+
+    def test_absolute_url_in_next_link(self, api_wrapper: APIWrapper) -> None:
+        """Test that absolute URLs in next links are used as-is."""
+        page1 = {
+            "records": [{"name": "vol1"}],
+            "_links": {"next": {"href": "https://other.example.com/api/v1/users?start=2"}},
+        }
+        page2 = {"records": [{"name": "vol2"}]}
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                self._make_response(page2),
+            ]
+
+            api_wrapper.get_all_records("/users", "GET")
+
+            second_call = mock_request.call_args_list[1]
+            assert second_call[0][1] == "https://other.example.com/api/v1/users?start=2"
+
+    def test_pagination_disabled(self, api_wrapper: APIWrapper) -> None:
+        """Test that disabled pagination returns first page as-is with _links preserved."""
+        page_data = {
+            "records": [{"name": "vol1"}],
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.return_value = self._make_response(page_data)
+
+            result = api_wrapper.get_all_records(
+                "/users",
+                "GET",
+                pagination_config=PaginationConfig(enabled=False),
+            )
+
+            assert "_links" in result
+            assert mock_request.call_count == 1
+
+    def test_max_pages_limit(self, api_wrapper: APIWrapper) -> None:
+        """Test that pagination stops at max_pages and returns collected records."""
+
+        def make_page(n: int) -> dict[str, Any]:
+            return {
+                "records": [{"name": f"vol{n}"}],
+                "_links": {"next": {"href": f"/api/v1/users?start={n + 1}"}},
+            }
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [self._make_response(make_page(i)) for i in range(1, 5)]
+
+            result = api_wrapper.get_all_records(
+                "/users",
+                "GET",
+                pagination_config=PaginationConfig(max_pages=3),
+            )
+
+            assert len(result["records"]) == 3
+            assert mock_request.call_count == 3
+
+    def test_custom_records_key(self, api_wrapper: APIWrapper) -> None:
+        """Test pagination with custom records_key."""
+        page1 = {
+            "items": [{"name": "vol1"}],
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        page2 = {"items": [{"name": "vol2"}]}
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                self._make_response(page2),
+            ]
+
+            result = api_wrapper.get_all_records(
+                "/users",
+                "GET",
+                pagination_config=PaginationConfig(records_key="items"),
+            )
+
+            assert result["items"] == [{"name": "vol1"}, {"name": "vol2"}]
+
+    def test_non_dict_response_raises_type_error(self, api_wrapper: APIWrapper) -> None:
+        """Test that non-dict response raises TypeError."""
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = "plain text"
+            mock_resp.json.side_effect = ValueError("No JSON")
+            mock_resp.raise_for_status.return_value = None
+            mock_request.return_value = mock_resp
+
+            with pytest.raises(TypeError, match="Expected dict response"):
+                api_wrapper.get_all_records("/users", "GET")
+
+    def test_page2_json_parse_failure(self, api_wrapper: APIWrapper) -> None:
+        """Test that page 2 JSON parse failure raises TypeError."""
+        page1 = {
+            "records": [{"name": "vol1"}],
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        mock_page2 = MagicMock()
+        mock_page2.status_code = 200
+        mock_page2.json.side_effect = ValueError("No JSON")
+        mock_page2.raise_for_status.return_value = None
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                mock_page2,
+            ]
+
+            with pytest.raises(TypeError, match="failed to parse JSON"):
+                api_wrapper.get_all_records("/users", "GET")
+
+    def test_page2_http_error(self, api_wrapper: APIWrapper) -> None:
+        """Test that page 2 HTTP 500 raises HTTPError immediately."""
+        page1 = {
+            "records": [{"name": "vol1"}],
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        mock_page2 = MagicMock()
+        mock_page2.status_code = 500
+        mock_page2.raise_for_status.side_effect = requests.HTTPError("Server Error")
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                mock_page2,
+            ]
+
+            with pytest.raises(requests.HTTPError, match="Server Error"):
+                api_wrapper.get_all_records(
+                    "/users",
+                    "GET",
+                    retry_config=RetryConfig(enabled=False),
+                )
+
+    def test_custom_next_page_extractor(self, api_wrapper: APIWrapper) -> None:
+        """Test pagination with a custom next_page_extractor."""
+
+        def custom_extractor(response: dict[str, Any]) -> str | None:
+            return response.get("next_url")
+
+        page1 = {
+            "records": [{"name": "vol1"}],
+            "next_url": "/api/v1/users?page=2",
+        }
+        page2 = {"records": [{"name": "vol2"}]}
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                self._make_response(page2),
+            ]
+
+            result = api_wrapper.get_all_records(
+                "/users",
+                "GET",
+                next_page_extractor=custom_extractor,
+            )
+
+            assert result["records"] == [{"name": "vol1"}, {"name": "vol2"}]
+
+    def test_headers_include_additional_headers(self, api_wrapper: APIWrapper) -> None:
+        """Test that page 2 requests include additional_headers."""
+        page1 = {
+            "records": [{"name": "vol1"}],
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        page2 = {"records": [{"name": "vol2"}]}
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                self._make_response(page2),
+            ]
+
+            api_wrapper.get_all_records(
+                "/users",
+                "GET",
+                additional_headers={"X-Custom": "test-value"},
+            )
+
+            # Check page 2 headers include the custom header
+            second_call = mock_request.call_args_list[1]
+            assert second_call[1]["headers"]["X-Custom"] == "test-value"
+
+    def test_retry_config_applies_to_subsequent_pages(self, spec_file: Path) -> None:
+        """Test that per-call retry config is used for page 2."""
+        wrapper = APIWrapper(
+            api_json_file=str(spec_file),
+            base_url="https://api.example.com",
+            retry_config=RetryConfig(enabled=False),
+        )
+        page1 = {
+            "records": [{"name": "vol1"}],
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        # Page 2: first attempt 503, second attempt succeeds
+        mock_503 = MagicMock()
+        mock_503.status_code = 503
+
+        page2_data = {"records": [{"name": "vol2"}]}
+
+        with patch.object(wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                mock_503,
+                self._make_response(page2_data),
+            ]
+
+            result = wrapper.get_all_records(
+                "/users",
+                "GET",
+                retry_config=RetryConfig(
+                    enabled=True,
+                    max_attempts=3,
+                    initial_wait=0.1,
+                    max_wait=1.0,
+                ),
+            )
+
+            assert result["records"] == [{"name": "vol1"}, {"name": "vol2"}]
+            assert mock_request.call_count == 3
+
+    def test_validation_applies_to_subsequent_pages(self, tmp_path: Path) -> None:
+        """Test that validation is applied to subsequent pages in strict mode."""
+        spec = {
+            "swagger": "2.0",
+            "basePath": "/api/v1",
+            "paths": {
+                "/users": {
+                    "get": {
+                        "summary": "List users",
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "required": ["records"],
+                                            "properties": {
+                                                "records": {"type": "array"},
+                                            },
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                    }
+                }
+            },
+        }
+        spec_path = tmp_path / "spec.json"
+        spec_path.write_text(json.dumps(spec))
+
+        wrapper = APIWrapper(
+            api_json_file=str(spec_path),
+            base_url="https://api.example.com",
+            retry_config=RetryConfig(enabled=False),
+        )
+
+        page1 = {
+            "records": [{"name": "vol1"}],
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        # Page 2 has invalid data (missing required 'records')
+        page2_invalid = {"invalid": "data"}
+
+        with patch.object(wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                self._make_response(page2_invalid),
+            ]
+
+            with pytest.raises(ResponseValidationError):
+                wrapper.get_all_records(
+                    "/users",
+                    "GET",
+                    validation_config=ValidationConfig(enabled=True, strict=True),
+                )
+
+    def test_validation_skipped_when_disabled(self, api_wrapper: APIWrapper) -> None:
+        """Test that disabled validation does not raise on invalid data."""
+        page1 = {
+            "records": [{"name": "vol1"}],
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        page2 = {"records": [{"name": "vol2"}]}
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                self._make_response(page2),
+            ]
+
+            # Default validation is disabled, should not raise
+            result = api_wrapper.get_all_records("/users", "GET")
+
+            assert len(result["records"]) == 2
+
+    def test_empty_records_on_pages(self, api_wrapper: APIWrapper) -> None:
+        """Test that empty pages with next links are handled correctly."""
+        page1 = {
+            "records": [],
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        page2 = {
+            "records": [],
+            "_links": {"next": {"href": "/api/v1/users?start=3"}},
+        }
+        page3 = {"records": [{"name": "vol1"}]}
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                self._make_response(page2),
+                self._make_response(page3),
+            ]
+
+            result = api_wrapper.get_all_records("/users", "GET")
+
+            assert result["records"] == [{"name": "vol1"}]
+            assert mock_request.call_count == 3
+
+    def test_merged_response_preserves_other_keys(self, api_wrapper: APIWrapper) -> None:
+        """Test that extra top-level keys from first page are preserved."""
+        page1 = {
+            "records": [{"name": "vol1"}],
+            "extra_key": "preserved_value",
+            "another_key": 42,
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        page2 = {"records": [{"name": "vol2"}]}
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                self._make_response(page2),
+            ]
+
+            result = api_wrapper.get_all_records("/users", "GET")
+
+            assert result["extra_key"] == "preserved_value"
+            assert result["another_key"] == 42
+
+    def test_num_records_not_present_in_source(self, api_wrapper: APIWrapper) -> None:
+        """Test that num_records is not added if not in original response."""
+        page1 = {
+            "records": [{"name": "vol1"}],
+            "_links": {"next": {"href": "/api/v1/users?start=2"}},
+        }
+        page2 = {"records": [{"name": "vol2"}]}
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.side_effect = [
+                self._make_response(page1),
+                self._make_response(page2),
+            ]
+
+            result = api_wrapper.get_all_records("/users", "GET")
+
+            assert "num_records" not in result
+
+    def test_call_endpoint_params_forwarded(self, api_wrapper: APIWrapper) -> None:
+        """Test that path_params and query_params reach page 1."""
+        page_data = {"records": [{"name": "vol1"}]}
+
+        with patch.object(api_wrapper.session, "request") as mock_request:
+            mock_request.return_value = self._make_response(page_data)
+
+            api_wrapper.get_all_records(
+                "/users/{id}",
+                "GET",
+                path_params={"id": "123"},
+                query_params={"limit": 25},
+            )
+
+            call_args = mock_request.call_args
+            url = call_args[0][1]
+            assert "/users/123" in url
+            assert "limit=25" in url


### PR DESCRIPTION
## Description

Add `get_all_records()` method to `APIWrapper` with configurable pagination support. ONTAP clusters with thousands of volumes, LUNs, or SnapMirror relationships paginate via `_links.next.href` (HAL convention). This method automatically follows pagination links and merges all records into a single response.

The design uses a pluggable `NextPageExtractor` callable (defaulting to ONTAP's HAL convention) and a `PaginationConfig` model for runtime control, making it extensible to future APIs (DII, BlueXP, StorageGrid).

## Related Issue

Addresses #260

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `PaginationConfig` model to `core/models.py` with `enabled`, `max_pages`, and `records_key` fields
- Added `NextPageExtractor` type alias and `ontap_next_page_extractor()` function to `clients/openapi.py`
- Added `get_all_records()` method to `APIWrapper` that fetches all pages and merges records
- Exported `NextPageExtractor` and `ontap_next_page_extractor` from `clients/__init__.py`
- Updated ADR-0006 with pagination support section referencing #260
- Added 31 new tests across 3 test classes

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
