### PR TITLE
feat: integrate get_all_records() into MetadataCollector._cached_api_call()

### DIFF
--- a/docs/decisions/0006-generalize-field-mapping-for-multi-api.md
+++ b/docs/decisions/0006-generalize-field-mapping-for-multi-api.md
@@ -24,8 +24,11 @@ The changes are non-breaking — all existing ONTAP mappings work without modifi
 
 Issue #260 added `get_all_records()` to `APIWrapper`, enabling automatic pagination across all API types. The method uses a configurable `PaginationConfig` and pluggable `NextPageExtractor` callable, defaulting to ONTAP's `_links.next.href` HAL convention. This complements the field mapping framework by ensuring all records are collected before mapping is applied.
 
+Issue #263 integrated `get_all_records()` into `MetadataCollector._cached_api_call()`, making pagination the default for all collection endpoints. A `paginate` keyword argument allows single-object endpoints (e.g., `/cluster`) to opt out.
+
 ## Related Issues
 
+- Issue #263: feat: integrate get_all_records() into MetadataCollector._cached_api_call()
 - Issue #260: feat: add configurable pagination support to APIWrapper
 - Issue #259: feat: generalize field mapping framework for multi-API data collection
 - Issue #258: feat: multi-API data collection strategy (superseded by #259)

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -204,12 +204,16 @@ class MetadataCollector:
             )
             self.progress_callback(info)
 
-    def _cached_api_call(self, endpoint: str, method: str = "GET") -> Any:
+    def _cached_api_call(self, endpoint: str, method: str = "GET", *, paginate: bool = True) -> Any:
         """Make an API call with caching to avoid duplicate requests.
 
         Args:
             endpoint: The API endpoint to call.
             method: HTTP method (default GET).
+            paginate: When True (default), use ``get_all_records()`` to
+                follow pagination and merge all pages.  When False, use
+                ``call_endpoint()`` which returns only the first page
+                (suitable for single-object endpoints like ``/cluster``).
 
         Returns:
             API response data (from cache if available).
@@ -226,7 +230,10 @@ class MetadataCollector:
 
         # Make the actual API call (outside the lock to allow parallel calls)
         logger.debug("%s API call: %s %s", self._log_prefix, method, endpoint)
-        response = self.api_client.call_endpoint(endpoint, method=method)
+        if paginate:
+            response = self.api_client.get_all_records(endpoint, method=method)
+        else:
+            response = self.api_client.call_endpoint(endpoint, method=method)
 
         with self._cache_lock:
             self._api_cache[cache_key] = response
@@ -798,7 +805,7 @@ class MetadataCollector:
             logger.debug("%s No API client available for cluster info collection", self._log_prefix)
             return ClusterInfo()
 
-        response = self._cached_api_call("/cluster?fields=*")
+        response = self._cached_api_call("/cluster?fields=*", paginate=False)
         if not response:
             return ClusterInfo()
 

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -336,7 +336,7 @@ class TestNodesCollection:
     def test_collect_nodes_via_api(self, mock_nodes_api_response: dict[str, Any]) -> None:
         """Test collecting nodes via API."""
         api_client = MagicMock()
-        api_client.call_endpoint.return_value = mock_nodes_api_response
+        api_client.get_all_records.return_value = mock_nodes_api_response
 
         collector = MetadataCollector(api_client=api_client)
         result = collector.collect_nodes()
@@ -425,8 +425,8 @@ class TestNetworkCollection:
     ) -> None:
         """Test collecting network info via API."""
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = lambda endpoint, **_: mock_network_api_responses.get(
-            endpoint, {}
+        api_client.get_all_records.side_effect = lambda endpoint, **_: (
+            mock_network_api_responses.get(endpoint, {})
         )
 
         collector = MetadataCollector(api_client=api_client)
@@ -618,8 +618,8 @@ class TestStorageCollection:
     ) -> None:
         """Test collecting storage info via API."""
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = lambda endpoint, **_: mock_storage_api_responses.get(
-            endpoint, {}
+        api_client.get_all_records.side_effect = lambda endpoint, **_: (
+            mock_storage_api_responses.get(endpoint, {})
         )
 
         collector = MetadataCollector(api_client=api_client)
@@ -749,7 +749,7 @@ class TestCloudTargetsCollection:
     ) -> None:
         """Test collecting cloud targets via API."""
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = lambda endpoint, **_: (
+        api_client.get_all_records.side_effect = lambda endpoint, **_: (
             mock_storage_with_cloud_targets_api_responses.get(endpoint, {})
         )
 
@@ -786,7 +786,7 @@ class TestCloudTargetsCollection:
                 return {"records": [{"name": "svm1", "state": "running"}]}
             return {}
 
-        api_client.call_endpoint.side_effect = side_effect
+        api_client.get_all_records.side_effect = side_effect
 
         collector = MetadataCollector(api_client=api_client)
         result = collector.collect_storage()
@@ -798,7 +798,7 @@ class TestCloudTargetsCollection:
     def test_collect_cloud_targets_empty(self) -> None:
         """Test collecting when no cloud targets exist."""
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = lambda endpoint, **_: {
+        api_client.get_all_records.side_effect = lambda endpoint, **_: {
             "/storage/aggregates?fields=*,is_spare_low,sidl_enabled": {"records": []},
             "/svm/svms?fields=*": {"records": []},
             "/cloud/targets?fields=*": {"records": []},
@@ -835,7 +835,7 @@ class TestLicenseCollection:
     def test_collect_licenses_via_api(self, mock_licenses_api_response: dict[str, Any]) -> None:
         """Test collecting licenses via API."""
         api_client = MagicMock()
-        api_client.call_endpoint.return_value = mock_licenses_api_response
+        api_client.get_all_records.return_value = mock_licenses_api_response
 
         collector = MetadataCollector(api_client=api_client)
         result = collector.collect_licenses()
@@ -860,7 +860,7 @@ class TestHAInfoCollection:
     def test_collect_ha_info_single_node(self) -> None:
         """Test HA info for single-node cluster."""
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = [
+        api_client.get_all_records.side_effect = [
             {"records": [{"name": "node1"}]},  # /cluster/nodes
             {"records": []},  # /cluster/mediators
         ]
@@ -873,7 +873,7 @@ class TestHAInfoCollection:
     def test_collect_ha_info_ha_pair(self) -> None:
         """Test HA info for HA pair."""
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = [
+        api_client.get_all_records.side_effect = [
             {"records": [{"name": "node1"}, {"name": "node2"}]},  # /cluster/nodes
             {"records": [{"ip_address": "10.0.0.100", "reachable": True}]},  # /cluster/mediators
         ]
@@ -949,7 +949,7 @@ class TestRelationshipsCollection:
     ) -> None:
         """Test collecting relationships via API."""
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = lambda endpoint, **_: (
+        api_client.get_all_records.side_effect = lambda endpoint, **_: (
             mock_relationships_api_responses.get(endpoint, {})
         )
 
@@ -996,7 +996,9 @@ class TestRelationshipsCollection:
         }
 
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = lambda endpoint, **_: api_responses.get(endpoint, {})
+        api_client.get_all_records.side_effect = lambda endpoint, **_: api_responses.get(
+            endpoint, {}
+        )
 
         collector = MetadataCollector(api_client=api_client)
         result = collector.collect_relationships()
@@ -1028,7 +1030,9 @@ class TestRelationshipsCollection:
         }
 
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = lambda endpoint, **_: api_responses.get(endpoint, {})
+        api_client.get_all_records.side_effect = lambda endpoint, **_: api_responses.get(
+            endpoint, {}
+        )
 
         collector = MetadataCollector(api_client=api_client)
         result = collector.collect_relationships()
@@ -1061,7 +1065,9 @@ class TestRelationshipsCollection:
         }
 
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = lambda endpoint, **_: api_responses.get(endpoint, {})
+        api_client.get_all_records.side_effect = lambda endpoint, **_: api_responses.get(
+            endpoint, {}
+        )
 
         collector = MetadataCollector(api_client=api_client)
         result = collector.collect_relationships()
@@ -1191,7 +1197,7 @@ class TestProtocolsCollection:
     ) -> None:
         """Test collecting protocols via API."""
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = lambda endpoint, **_: (
+        api_client.get_all_records.side_effect = lambda endpoint, **_: (
             mock_protocols_api_responses.get(endpoint, {"records": []})
         )
 
@@ -1260,7 +1266,7 @@ class TestProtocolsCollection:
     def test_collect_protocols_empty_response(self) -> None:
         """Test protocols handles empty API response."""
         api_client = MagicMock()
-        api_client.call_endpoint.return_value = {"records": []}
+        api_client.get_all_records.return_value = {"records": []}
 
         collector = MetadataCollector(api_client=api_client)
         result = collector.collect_protocols()
@@ -1283,7 +1289,7 @@ class TestProtocolsCollection:
     def test_collect_protocols_api_failure_propagates(self) -> None:
         """Test protocols raises when API call fails (no silent fallback)."""
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = Exception("API error")
+        api_client.get_all_records.side_effect = Exception("API error")
 
         collector = MetadataCollector(api_client=api_client)
         with pytest.raises(Exception, match="API error"):
@@ -1307,7 +1313,7 @@ class TestProtocolsCollection:
             "/protocols/s3/buckets?fields=*": {"records": []},
         }
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = lambda endpoint, **_: responses.get(
+        api_client.get_all_records.side_effect = lambda endpoint, **_: responses.get(
             endpoint, {"records": []}
         )
 
@@ -1325,6 +1331,7 @@ class TestCollectAll:
     def test_collect_all_returns_complete_metadata(self) -> None:
         """Test collect_all returns CachedClusterMetadata."""
         api_client = MagicMock()
+        api_client.get_all_records.return_value = {"records": []}
         api_client.call_endpoint.return_value = {"records": []}
 
         cli_client = MagicMock()
@@ -1337,6 +1344,36 @@ class TestCollectAll:
         assert result.cluster_name == "test-cluster"
         assert result.cached_at is not None
         assert result.cache_version == "1.0"
+
+
+class TestCachedApiCallPagination:
+    """Tests for _cached_api_call pagination dispatch."""
+
+    def test_cached_api_call_uses_get_all_records_by_default(self) -> None:
+        """Verify get_all_records is called when paginate=True (default)."""
+        api_client = MagicMock()
+        api_client.get_all_records.return_value = {"records": [{"name": "vol1"}]}
+
+        collector = MetadataCollector(api_client=api_client)
+        result = collector._cached_api_call("/storage/volumes?fields=*")
+
+        api_client.get_all_records.assert_called_once_with(
+            "/storage/volumes?fields=*", method="GET"
+        )
+        api_client.call_endpoint.assert_not_called()
+        assert result == {"records": [{"name": "vol1"}]}
+
+    def test_cached_api_call_uses_call_endpoint_when_paginate_false(self) -> None:
+        """Verify call_endpoint is called when paginate=False."""
+        api_client = MagicMock()
+        api_client.call_endpoint.return_value = {"name": "mycluster", "uuid": "abc-123"}
+
+        collector = MetadataCollector(api_client=api_client)
+        result = collector._cached_api_call("/cluster?fields=*", paginate=False)
+
+        api_client.call_endpoint.assert_called_once_with("/cluster?fields=*", method="GET")
+        api_client.get_all_records.assert_not_called()
+        assert result == {"name": "mycluster", "uuid": "abc-123"}
 
 
 class TestNormalizeCliKey:
@@ -1368,6 +1405,7 @@ class TestProgressCallback:
     def test_progress_callback_called_for_each_phase(self) -> None:
         """Test that progress callback is called for each collection phase."""
         api_client = MagicMock()
+        api_client.get_all_records.return_value = {"records": []}
         api_client.call_endpoint.return_value = {"records": []}
 
         cli_client = MagicMock()
@@ -1393,6 +1431,7 @@ class TestProgressCallback:
     def test_progress_callback_receives_correct_phases(self) -> None:
         """Test that progress callback receives all expected phases."""
         api_client = MagicMock()
+        api_client.get_all_records.return_value = {"records": []}
         api_client.call_endpoint.return_value = {"records": []}
 
         cli_client = MagicMock()
@@ -1426,6 +1465,7 @@ class TestProgressCallback:
     def test_progress_callback_elapsed_time(self) -> None:
         """Test that progress callback receives elapsed time on completion."""
         api_client = MagicMock()
+        api_client.get_all_records.return_value = {"records": []}
         api_client.call_endpoint.return_value = {"records": []}
 
         cli_client = MagicMock()
@@ -1452,6 +1492,7 @@ class TestProgressCallback:
     def test_progress_callback_source_tracking(self) -> None:
         """Test that progress callback receives correct source information."""
         api_client = MagicMock()
+        api_client.get_all_records.return_value = {"records": []}
         api_client.call_endpoint.return_value = {"records": []}
 
         cli_client = MagicMock()
@@ -1478,6 +1519,7 @@ class TestProgressCallback:
     def test_progress_callback_none_no_error(self) -> None:
         """Test that no callback (None) doesn't cause errors."""
         api_client = MagicMock()
+        api_client.get_all_records.return_value = {"records": []}
         api_client.call_endpoint.return_value = {"records": []}
 
         cli_client = MagicMock()
@@ -1812,7 +1854,7 @@ class TestGrepableLogTags:
     def test_api_failure_tag_on_api_error(self, caplog: pytest.LogCaptureFixture) -> None:
         """Test that API_FAILURE tag is logged at error level on API call failure."""
         api_client = MagicMock()
-        api_client.call_endpoint.side_effect = ConnectionError("Connection refused")
+        api_client.get_all_records.side_effect = ConnectionError("Connection refused")
 
         collector = MetadataCollector(api_client=api_client)
         collector._cluster_name = "testcluster"


### PR DESCRIPTION
## Description

Integrate `get_all_records()` into `MetadataCollector._cached_api_call()` so that all collection endpoints automatically follow pagination. A new `paginate` keyword argument (default `True`) dispatches to `get_all_records()` for paginated list endpoints and falls back to `call_endpoint()` for single-object endpoints like `/cluster`.

## Related Issue

Addresses #263

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `paginate: bool = True` keyword argument to `_cached_api_call()`
- When `paginate=True` (default), dispatches to `api_client.get_all_records()` to follow pagination and merge all pages
- When `paginate=False`, dispatches to `api_client.call_endpoint()` for single-object endpoints (e.g., `/cluster?fields=*`)
- Updated `_collect_cluster_info()` to pass `paginate=False` since `/cluster` returns a single object
- Updated all test mocks from `call_endpoint` to `get_all_records` to match the new default dispatch
- Added two new tests in `TestCachedApiCallPagination` verifying the dispatch logic for both `paginate=True` and `paginate=False`
- Updated ADR-0006 Pagination Support section to document this integration step

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This is a non-breaking internal change. All existing collection call sites benefit from pagination automatically because `_cached_api_call()` defaults to `paginate=True`. The `/cluster` endpoint is the only call site that opts out with `paginate=False` since it returns a single object rather than a paginated list.
