### PR TITLE
fix: derive diff tracked fields dynamically from model_fields

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -286,8 +286,9 @@ When modifying the cache schema:
 5. **Update collector** if new fields need to be populated:
    - `src/pynetappfoundry/cache/collector.py`
 
-6. **Update diff logic** if new fields should be tracked:
-   - `src/pynetappfoundry/cache/diff.py`
+6. **Diff logic updates automatically** — tracked fields are derived at runtime from
+   each model's `model_fields`, so new fields on cache models are picked up without
+   manual changes to `src/pynetappfoundry/cache/diff.py`.
 
 7. **Add tests** for new fields:
    - `tests/unit/cache/test_models.py`

--- a/src/pynetappfoundry/cache/diff.py
+++ b/src/pynetappfoundry/cache/diff.py
@@ -2,13 +2,47 @@
 
 Computes differences between two CachedClusterMetadata snapshots
 for change history tracking.
+
+Tracked fields are derived dynamically from each model's ``model_fields``,
+so new fields added to cache models are automatically tracked without
+manual updates to this module.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
+
+from pynetappfoundry.cache._base import CacheModel
+from pynetappfoundry.cache.cloud.metadata.model import CloudMetadata
+from pynetappfoundry.cache.cloud.targets.model import CloudTargetInfo
+from pynetappfoundry.cache.cluster.licensing.model import CapacityLicense, LicenseFeature
+from pynetappfoundry.cache.cluster.model import ClusterInfo
+from pynetappfoundry.cache.cluster.nodes.model import NodeInfo
+from pynetappfoundry.cache.cluster.peers.model import ClusterPeer
+from pynetappfoundry.cache.cluster.schedules.model import ScheduleInfo
+from pynetappfoundry.cache.name_services.dns.model import DNSInfo
+from pynetappfoundry.cache.network.ethernet.broadcast_domains.model import BroadcastDomain
+from pynetappfoundry.cache.network.ip.interfaces.model import NetworkLIF
+from pynetappfoundry.cache.network.ip.subnets.model import IPSubnetInfo
+from pynetappfoundry.cache.protocols.cifs.services.model import CIFSServiceInfo
+from pynetappfoundry.cache.protocols.cifs.shares.model import CIFSShareInfo
+from pynetappfoundry.cache.protocols.nfs.export_policies.model import ExportPolicyInfo
+from pynetappfoundry.cache.protocols.nfs.services.model import NFSServiceInfo
+from pynetappfoundry.cache.protocols.s3.buckets.model import S3BucketInfo
+from pynetappfoundry.cache.protocols.san.igroups.model import IgroupInfo
+from pynetappfoundry.cache.snapmirror.relationships.model import SnapMirrorRelationship
+from pynetappfoundry.cache.storage.aggregates.model import AggregateInfo
+from pynetappfoundry.cache.storage.flexcache.model import FlexCacheInfo
+from pynetappfoundry.cache.storage.luns.model import LunInfo
+from pynetappfoundry.cache.storage.qos.model import QosPolicyInfo
+from pynetappfoundry.cache.storage.qtrees.model import QtreeInfo
+from pynetappfoundry.cache.storage.snapshot_policies.model import SnapshotPolicyInfo
+from pynetappfoundry.cache.storage.volumes.model import VolumeInfo
+from pynetappfoundry.cache.svm.model import SVMInfo
+from pynetappfoundry.cache.svm.peers.model import SVMPeerInfo
 
 if TYPE_CHECKING:
     from pynetappfoundry.cache._metadata import CachedClusterMetadata
@@ -34,134 +68,212 @@ class ChangeEntry(BaseModel):
     new_value: Any = None
 
 
-# Entity configurations: (key_field, tracked_fields)
-# key_field is the attribute used to identify unique entities
-# tracked_fields are the fields we compare for modifications
-_ENTITY_CONFIGS: dict[str, tuple[str, list[str]]] = {
-    "cloud": ("node", ["instance_id", "instance_type", "region", "provider"]),
-    "nodes": (
-        "name",
-        ["uuid", "serial_number", "model", "membership", "location"],
+@dataclass(frozen=True, slots=True)
+class EntityConfig:
+    """Configuration for diffing a category of entities.
+
+    Attributes:
+        key_field: Field used to uniquely identify entities (usually 'uuid' or 'name').
+        model_class: The Pydantic model class. Tracked fields are derived from
+            model_class.model_fields at runtime, excluding key_field.
+        display_field: Field or format string for human-readable entity names
+            in change output. If it contains '{', it is treated as a format
+            template (e.g., '{source_path}->{destination_path}'); otherwise
+            it is a plain attribute name.
+    """
+
+    key_field: str
+    model_class: type[CacheModel]
+    display_field: str
+
+
+def _get_tracked_fields(config: EntityConfig) -> list[str]:
+    """Derive tracked fields from model_class.model_fields, excluding key_field.
+
+    Args:
+        config: Entity configuration.
+
+    Returns:
+        List of field names to compare for modifications.
+    """
+    return [f for f in config.model_class.model_fields if f != config.key_field]
+
+
+def _get_display_name(entity: Any, display_field: str) -> str:
+    """Get a human-readable display name for an entity.
+
+    If *display_field* contains ``{``, it is treated as a format template
+    where placeholders are resolved from entity attributes.  Otherwise it
+    is a simple attribute name lookup.
+
+    Args:
+        entity: The model instance.
+        display_field: Attribute name or format string.
+
+    Returns:
+        Display name string, or ``str(entity)`` as fallback.
+    """
+    if "{" in display_field:
+        try:
+            fmt_dict = {field: getattr(entity, field, "") for field in type(entity).model_fields}
+            return display_field.format(**fmt_dict)
+        except (KeyError, AttributeError):
+            return str(entity)
+    value = getattr(entity, display_field, "") or ""
+    return value or str(entity)
+
+
+# Entity configurations: maps category path -> EntityConfig.
+# key_field is used for identity matching between snapshots.
+# display_field is the human-readable label shown in change output.
+# Tracked fields are derived automatically from model_class.model_fields.
+_ENTITY_CONFIGS: dict[str, EntityConfig] = {
+    # --- Models WITH uuid (use uuid as stable identity key) ---
+    "nodes": EntityConfig(
+        key_field="uuid",
+        model_class=NodeInfo,
+        display_field="name",
     ),
-    "network.intercluster_lifs": (
-        "name",
-        ["ip_address", "home_node"],
+    "network.broadcast_domains": EntityConfig(
+        key_field="uuid",
+        model_class=BroadcastDomain,
+        display_field="name",
     ),
-    "network.data_lifs": (
-        "name",
-        ["ip_address", "home_node"],
+    "network.subnets": EntityConfig(
+        key_field="uuid",
+        model_class=IPSubnetInfo,
+        display_field="name",
     ),
-    "network.management_lifs": (
-        "name",
-        ["ip_address", "home_node"],
+    "network.dns": EntityConfig(
+        key_field="uuid",
+        model_class=DNSInfo,
+        display_field="svm",
     ),
-    "network.broadcast_domains": (
-        "name",
-        ["uuid", "ipspace", "mtu"],
+    "storage.aggregates": EntityConfig(
+        key_field="uuid",
+        model_class=AggregateInfo,
+        display_field="name",
     ),
-    "storage.aggregates": (
-        "name",
-        ["uuid", "state", "type", "total_size", "disk_count", "disk_type", "raid_type"],
+    "storage.svms": EntityConfig(
+        key_field="uuid",
+        model_class=SVMInfo,
+        display_field="name",
     ),
-    "storage.svms": (
-        "name",
-        ["uuid", "state", "subtype", "allowed_protocols", "language"],
+    "storage.cloud_targets": EntityConfig(
+        key_field="uuid",
+        model_class=CloudTargetInfo,
+        display_field="name",
     ),
-    "storage.cloud_targets": (
-        "name",
-        ["uuid", "provider_type", "container"],
+    "storage.volumes": EntityConfig(
+        key_field="uuid",
+        model_class=VolumeInfo,
+        display_field="name",
     ),
-    "storage.volumes": (
-        "name",
-        [
-            "uuid",
-            "svm",
-            "state",
-            "type",
-            "style",
-            "size",
-            "aggregate",
-            "snapshot_policy",
-            "export_policy",
-            "junction_path",
-            "nas_security_style",
-        ],
+    "storage.snapshot_policies": EntityConfig(
+        key_field="uuid",
+        model_class=SnapshotPolicyInfo,
+        display_field="name",
     ),
-    "storage.qtrees": (
-        "name",
-        ["id", "svm", "volume", "security_style", "export_policy"],
+    "storage.schedules": EntityConfig(
+        key_field="uuid",
+        model_class=ScheduleInfo,
+        display_field="name",
     ),
-    "storage.snapshot_policies": (
-        "name",
-        ["uuid", "svm", "enabled", "scope"],
+    "storage.luns": EntityConfig(
+        key_field="uuid",
+        model_class=LunInfo,
+        display_field="name",
     ),
-    "storage.schedules": (
-        "name",
-        ["uuid", "type", "scope", "svm"],
+    "storage.igroups": EntityConfig(
+        key_field="uuid",
+        model_class=IgroupInfo,
+        display_field="name",
     ),
-    "storage.luns": (
-        "name",
-        ["uuid", "svm", "volume", "size", "os_type", "enabled"],
+    "storage.qos_policies": EntityConfig(
+        key_field="uuid",
+        model_class=QosPolicyInfo,
+        display_field="name",
     ),
-    "storage.igroups": (
-        "name",
-        ["uuid", "svm", "protocol", "os_type"],
+    "storage.flexcaches": EntityConfig(
+        key_field="uuid",
+        model_class=FlexCacheInfo,
+        display_field="name",
     ),
-    "storage.qos_policies": (
-        "name",
-        ["uuid", "svm", "scope", "policy_class"],
+    "protocols.s3_buckets": EntityConfig(
+        key_field="uuid",
+        model_class=S3BucketInfo,
+        display_field="name",
     ),
-    "storage.flexcaches": (
-        "name",
-        ["uuid", "svm", "size", "origins", "global_file_locking_enabled"],
+    "relationships.snapmirror_destinations": EntityConfig(
+        key_field="uuid",
+        model_class=SnapMirrorRelationship,
+        display_field="{source_path}->{destination_path}",
     ),
-    "protocols.export_policies": (
-        "name",
-        ["id", "svm"],
+    "relationships.cluster_peers": EntityConfig(
+        key_field="uuid",
+        model_class=ClusterPeer,
+        display_field="name",
     ),
-    "protocols.cifs_shares": (
-        "name",
-        ["path", "svm", "home_directory", "oplocks", "encryption"],
+    "relationships.svm_peers": EntityConfig(
+        key_field="uuid",
+        model_class=SVMPeerInfo,
+        display_field="name",
     ),
-    "protocols.nfs_services": (
-        "svm",
-        ["enabled", "protocol_v3_enabled", "protocol_v4_enabled", "protocol_v41_enabled"],
+    # --- Models WITHOUT uuid (keep current key) ---
+    "cloud": EntityConfig(
+        key_field="node",
+        model_class=CloudMetadata,
+        display_field="node",
     ),
-    "protocols.cifs_services": (
-        "svm",
-        ["name", "enabled", "ad_domain"],
+    "network.intercluster_lifs": EntityConfig(
+        key_field="name",
+        model_class=NetworkLIF,
+        display_field="name",
     ),
-    "protocols.s3_buckets": (
-        "name",
-        ["uuid", "svm", "type", "size", "versioning_state"],
+    "network.data_lifs": EntityConfig(
+        key_field="name",
+        model_class=NetworkLIF,
+        display_field="name",
     ),
-    "network.dns": (
-        "svm",
-        ["uuid", "scope", "domains", "servers"],
+    "network.management_lifs": EntityConfig(
+        key_field="name",
+        model_class=NetworkLIF,
+        display_field="name",
     ),
-    "network.subnets": (
-        "name",
-        ["uuid", "ipspace", "broadcast_domain", "subnet", "gateway"],
+    "storage.qtrees": EntityConfig(
+        key_field="name",
+        model_class=QtreeInfo,
+        display_field="name",
     ),
-    "licenses.feature_licenses": (
-        "name",
-        ["state"],
+    "protocols.export_policies": EntityConfig(
+        key_field="name",
+        model_class=ExportPolicyInfo,
+        display_field="name",
     ),
-    "licenses.capacity_licenses": (
-        "name",
-        ["licensed_capacity", "used_capacity"],
+    "protocols.cifs_shares": EntityConfig(
+        key_field="name",
+        model_class=CIFSShareInfo,
+        display_field="name",
     ),
-    "relationships.snapmirror_destinations": (
-        "destination_path",
-        ["uuid", "state"],
+    "protocols.nfs_services": EntityConfig(
+        key_field="svm",
+        model_class=NFSServiceInfo,
+        display_field="svm",
     ),
-    "relationships.cluster_peers": (
-        "name",
-        ["authentication_state"],
+    "protocols.cifs_services": EntityConfig(
+        key_field="svm",
+        model_class=CIFSServiceInfo,
+        display_field="svm",
     ),
-    "relationships.svm_peers": (
-        "name",
-        ["uuid", "svm", "peer_svm", "peer_cluster", "state"],
+    "licenses.feature_licenses": EntityConfig(
+        key_field="name",
+        model_class=LicenseFeature,
+        display_field="name",
+    ),
+    "licenses.capacity_licenses": EntityConfig(
+        key_field="name",
+        model_class=CapacityLicense,
+        display_field="name",
     ),
 }
 
@@ -180,7 +292,7 @@ def compute_diff(
         List of change dictionaries with keys:
         - category: The category path (e.g., 'nodes', 'storage.aggregates')
         - type: 'added', 'removed', or 'modified'
-        - entity: The entity identifier
+        - entity: The entity display name
         - field: (for modified) Which field changed
         - old: (for modified) The old value
         - new: (for modified) The new value
@@ -190,15 +302,15 @@ def compute_diff(
     # Handle initial capture (no before)
     if before is None:
         # Record all entities as "added"
-        for category, (key_field, _) in _ENTITY_CONFIGS.items():
+        for category, config in _ENTITY_CONFIGS.items():
             entities = _get_entities(after, category)
             for entity in entities:
-                entity_key = getattr(entity, key_field, "") or str(entity)
+                display = _get_display_name(entity, config.display_field)
                 changes.append(
                     {
                         "category": category,
                         "type": "added",
-                        "entity": entity_key,
+                        "entity": display,
                     }
                 )
         # Also check singleton categories
@@ -207,7 +319,7 @@ def compute_diff(
         return changes
 
     # Compare each category
-    for category, (key_field, tracked_fields) in _ENTITY_CONFIGS.items():
+    for category, config in _ENTITY_CONFIGS.items():
         before_entities = _get_entities(before, category)
         after_entities = _get_entities(after, category)
         changes.extend(
@@ -215,8 +327,7 @@ def compute_diff(
                 category=category,
                 before_list=before_entities,
                 after_list=after_entities,
-                key_field=key_field,
-                tracked_fields=tracked_fields,
+                config=config,
             )
         )
 
@@ -256,8 +367,7 @@ def _diff_entity_list(
     category: str,
     before_list: list[Any],
     after_list: list[Any],
-    key_field: str,
-    tracked_fields: list[str],
+    config: EntityConfig,
 ) -> list[dict[str, Any]]:
     """Diff two lists of entities.
 
@@ -265,13 +375,14 @@ def _diff_entity_list(
         category: Category name for the change entries.
         before_list: Entities from before snapshot.
         after_list: Entities from after snapshot.
-        key_field: Field to use as entity identifier.
-        tracked_fields: Fields to compare for modifications.
+        config: EntityConfig with key_field, model_class, and display_field.
 
     Returns:
         List of change dictionaries.
     """
     changes: list[dict[str, Any]] = []
+    key_field = config.key_field
+    tracked_fields = _get_tracked_fields(config)
 
     # Build lookup maps by key
     before_map: dict[str, Any] = {}
@@ -293,7 +404,7 @@ def _diff_entity_list(
                 {
                     "category": category,
                     "type": "removed",
-                    "entity": key,
+                    "entity": _get_display_name(before_map[key], config.display_field),
                 }
             )
 
@@ -304,7 +415,7 @@ def _diff_entity_list(
                 {
                     "category": category,
                     "type": "added",
-                    "entity": key,
+                    "entity": _get_display_name(after_map[key], config.display_field),
                 }
             )
 
@@ -323,7 +434,7 @@ def _diff_entity_list(
                         {
                             "category": category,
                             "type": "modified",
-                            "entity": key,
+                            "entity": _get_display_name(after_entity, config.display_field),
                             "field": field,
                             "old": old_val,
                             "new": new_val,
@@ -339,6 +450,8 @@ def _diff_cluster_info(
 ) -> list[dict[str, Any]]:
     """Diff cluster info (singleton).
 
+    Tracked fields are derived dynamically from ClusterInfo.model_fields.
+
     Args:
         before: Previous snapshot (None for initial).
         after: New snapshot.
@@ -348,14 +461,7 @@ def _diff_cluster_info(
     """
     changes: list[dict[str, Any]] = []
     category = "cluster"
-    tracked_fields = [
-        "cluster_name",
-        "cluster_uuid",
-        "ontap_version",
-        "model",
-        "contact",
-        "location",
-    ]
+    tracked_fields = list(ClusterInfo.model_fields)
 
     if before is None:
         # Initial capture - just record existence
@@ -397,6 +503,8 @@ def _diff_ha_info(
 ) -> list[dict[str, Any]]:
     """Diff HA info (singleton).
 
+    Tracked fields are derived dynamically from HAInfo.model_fields.
+
     Args:
         before: Previous snapshot (None for initial).
         after: New snapshot.
@@ -404,14 +512,11 @@ def _diff_ha_info(
     Returns:
         List of change dictionaries.
     """
+    from pynetappfoundry.cache._metadata import HAInfo
+
     changes: list[dict[str, Any]] = []
     category = "ha"
-    tracked_fields = [
-        "is_ha",
-        "partner_node",
-        "ha_state",
-        "mediator_address",
-    ]
+    tracked_fields = list(HAInfo.model_fields)
 
     if before is None:
         # Initial capture - just record existence if HA is configured

--- a/tests/unit/cache/test_diff.py
+++ b/tests/unit/cache/test_diff.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
-import pytest
-
 from pynetappfoundry.cache import CachedClusterMetadata, HAInfo, RelationshipsInfo
 from pynetappfoundry.cache.cloud.metadata.model import CloudMetadata
 from pynetappfoundry.cache.cluster.licensing.model import LicenseFeature, LicenseInfo
 from pynetappfoundry.cache.cluster.model import ClusterInfo
 from pynetappfoundry.cache.cluster.nodes.model import NodeInfo
+from pynetappfoundry.cache.cluster.peers.model import ClusterPeer
 from pynetappfoundry.cache.cluster.schedules.model import ScheduleInfo
 from pynetappfoundry.cache.diff import (
     ChangeEntry,
+    EntityConfig,
+    _get_display_name,
+    _get_tracked_fields,
     compute_diff,
     format_diff_summary,
 )
@@ -41,6 +43,47 @@ from pynetappfoundry.cache.svm.model import SVMInfo
 from pynetappfoundry.cache.svm.peers.model import SVMPeerInfo
 
 
+class TestEntityConfig:
+    """Tests for EntityConfig and helpers."""
+
+    def test_get_tracked_fields_excludes_key(self) -> None:
+        """Tracked fields include all model fields except the key."""
+        config = EntityConfig(key_field="uuid", model_class=NodeInfo, display_field="name")
+        tracked = _get_tracked_fields(config)
+        assert "uuid" not in tracked
+        assert "name" in tracked
+        assert "serial_number" in tracked
+
+    def test_get_tracked_fields_includes_all_non_key(self) -> None:
+        """All model fields except key are tracked."""
+        config = EntityConfig(key_field="uuid", model_class=NodeInfo, display_field="name")
+        tracked = _get_tracked_fields(config)
+        expected = [f for f in NodeInfo.model_fields if f != "uuid"]
+        assert tracked == expected
+
+    def test_get_display_name_simple(self) -> None:
+        """Simple display field returns attribute value."""
+        node = NodeInfo(uuid="u1", name="node1")
+        assert _get_display_name(node, "name") == "node1"
+
+    def test_get_display_name_format_string(self) -> None:
+        """Format string display field resolves placeholders."""
+        sm = SnapMirrorRelationship(
+            uuid="u1",
+            source_path="svm1:vol1",
+            destination_path="svm2:vol2",
+        )
+        result = _get_display_name(sm, "{source_path}->{destination_path}")
+        assert result == "svm1:vol1->svm2:vol2"
+
+    def test_get_display_name_fallback(self) -> None:
+        """Empty display field falls back to str(entity)."""
+        node = NodeInfo(uuid="u1", name="")
+        result = _get_display_name(node, "name")
+        # Falls back to str(entity) when name is empty
+        assert result != ""
+
+
 class TestComputeDiffInitialCapture:
     """Tests for initial capture (no before snapshot)."""
 
@@ -56,8 +99,8 @@ class TestComputeDiffInitialCapture:
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             nodes=[
-                NodeInfo(name="node1", serial_number="123"),
-                NodeInfo(name="node2", serial_number="456"),
+                NodeInfo(uuid="uuid-1", name="node1", serial_number="123"),
+                NodeInfo(uuid="uuid-2", name="node2", serial_number="456"),
             ],
         )
         changes = compute_diff(None, after)
@@ -118,7 +161,7 @@ class TestComputeDiffNoChanges:
         metadata = CachedClusterMetadata(
             cluster_name="test-cluster",
             nodes=[
-                NodeInfo(name="node1", serial_number="123"),
+                NodeInfo(uuid="uuid-1", name="node1", serial_number="123"),
             ],
             cluster=ClusterInfo(
                 cluster_name="test-cluster",
@@ -140,13 +183,13 @@ class TestComputeDiffAddedEntities:
         """Test detecting a new node."""
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
-            nodes=[NodeInfo(name="node1")],
+            nodes=[NodeInfo(uuid="uuid-1", name="node1")],
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             nodes=[
-                NodeInfo(name="node1"),
-                NodeInfo(name="node2"),
+                NodeInfo(uuid="uuid-1", name="node1"),
+                NodeInfo(uuid="uuid-2", name="node2"),
             ],
         )
         changes = compute_diff(before, after)
@@ -161,15 +204,15 @@ class TestComputeDiffAddedEntities:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
-                aggregates=[AggregateInfo(name="aggr1", state="online")],
+                aggregates=[AggregateInfo(uuid="aggr-uuid-1", name="aggr1", state="online")],
             ),
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
                 aggregates=[
-                    AggregateInfo(name="aggr1", state="online"),
-                    AggregateInfo(name="aggr2", state="online"),
+                    AggregateInfo(uuid="aggr-uuid-1", name="aggr1", state="online"),
+                    AggregateInfo(uuid="aggr-uuid-2", name="aggr2", state="online"),
                 ],
             ),
         )
@@ -189,13 +232,13 @@ class TestComputeDiffRemovedEntities:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             nodes=[
-                NodeInfo(name="node1"),
-                NodeInfo(name="node2"),
+                NodeInfo(uuid="uuid-1", name="node1"),
+                NodeInfo(uuid="uuid-2", name="node2"),
             ],
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
-            nodes=[NodeInfo(name="node1")],
+            nodes=[NodeInfo(uuid="uuid-1", name="node1")],
         )
         changes = compute_diff(before, after)
 
@@ -210,15 +253,15 @@ class TestComputeDiffRemovedEntities:
             cluster_name="test-cluster",
             storage=StorageInfo(
                 svms=[
-                    SVMInfo(name="svm1", state="running"),
-                    SVMInfo(name="svm2", state="running"),
+                    SVMInfo(uuid="svm-uuid-1", name="svm1", state="running"),
+                    SVMInfo(uuid="svm-uuid-2", name="svm2", state="running"),
                 ],
             ),
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
-                svms=[SVMInfo(name="svm1", state="running")],
+                svms=[SVMInfo(uuid="svm-uuid-1", name="svm1", state="running")],
             ),
         )
         changes = compute_diff(before, after)
@@ -236,11 +279,11 @@ class TestComputeDiffModifiedEntities:
         """Test detecting node serial number change."""
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
-            nodes=[NodeInfo(name="node1", serial_number="OLD123")],
+            nodes=[NodeInfo(uuid="uuid-1", name="node1", serial_number="OLD123")],
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
-            nodes=[NodeInfo(name="node1", serial_number="NEW456")],
+            nodes=[NodeInfo(uuid="uuid-1", name="node1", serial_number="NEW456")],
         )
         changes = compute_diff(before, after)
 
@@ -257,13 +300,13 @@ class TestComputeDiffModifiedEntities:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
-                aggregates=[AggregateInfo(name="aggr1", disk_count=12)],
+                aggregates=[AggregateInfo(uuid="aggr-uuid-1", name="aggr1", disk_count=12)],
             ),
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
-                aggregates=[AggregateInfo(name="aggr1", disk_count=24)],
+                aggregates=[AggregateInfo(uuid="aggr-uuid-1", name="aggr1", disk_count=24)],
             ),
         )
         changes = compute_diff(before, after)
@@ -355,15 +398,17 @@ class TestComputeDiffMultipleChanges:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             nodes=[
-                NodeInfo(name="node1", serial_number="123"),
-                NodeInfo(name="node2", serial_number="456"),
+                NodeInfo(uuid="uuid-1", name="node1", serial_number="123"),
+                NodeInfo(uuid="uuid-2", name="node2", serial_number="456"),
             ],
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             nodes=[
-                NodeInfo(name="node1", serial_number="999"),  # Modified
-                NodeInfo(name="node3", serial_number="789"),  # Added (node2 removed)
+                NodeInfo(uuid="uuid-1", name="node1", serial_number="999"),  # Modified
+                NodeInfo(
+                    uuid="uuid-3", name="node3", serial_number="789"
+                ),  # Added (uuid-2 removed)
             ],
         )
         changes = compute_diff(before, after)
@@ -438,8 +483,10 @@ class TestComputeDiffAllCategories:
             relationships=RelationshipsInfo(
                 snapmirror_destinations=[
                     SnapMirrorRelationship(
-                        destination_path="svm1:vol1",
-                        state="snapmirrored",
+                        uuid="sm-uuid-1",
+                        source_path="svm1:vol1",
+                        destination_path="svm2:vol2",
+                        relationship_type="async",
                     ),
                 ],
             ),
@@ -449,8 +496,10 @@ class TestComputeDiffAllCategories:
             relationships=RelationshipsInfo(
                 snapmirror_destinations=[
                     SnapMirrorRelationship(
-                        destination_path="svm1:vol1",
-                        state="broken-off",
+                        uuid="sm-uuid-1",
+                        source_path="svm1:vol1",
+                        destination_path="svm2:vol2",
+                        relationship_type="sync",
                     ),
                 ],
             ),
@@ -461,11 +510,50 @@ class TestComputeDiffAllCategories:
             c for c in changes if c["category"] == "relationships.snapmirror_destinations"
         ]
         assert len(sm_changes) == 1
+        assert sm_changes[0]["type"] == "modified"
+        assert sm_changes[0]["field"] == "relationship_type"
+        assert sm_changes[0]["old"] == "async"
+        assert sm_changes[0]["new"] == "sync"
+        # Display name uses composite format
+        assert sm_changes[0]["entity"] == "svm1:vol1->svm2:vol2"
 
-        state_change = [c for c in sm_changes if c["field"] == "state"]
-        assert len(state_change) == 1
-        assert state_change[0]["old"] == "snapmirrored"
-        assert state_change[0]["new"] == "broken-off"
+    def test_snapmirror_transfer_schedule_change(self) -> None:
+        """Test SnapMirror transfer_schedule_uuid change is detected (original bug)."""
+        before = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            relationships=RelationshipsInfo(
+                snapmirror_destinations=[
+                    SnapMirrorRelationship(
+                        uuid="sm-uuid-1",
+                        source_path="svm1:vol1",
+                        destination_path="svm2:vol2",
+                        transfer_schedule_uuid="schedule-old",
+                    ),
+                ],
+            ),
+        )
+        after = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            relationships=RelationshipsInfo(
+                snapmirror_destinations=[
+                    SnapMirrorRelationship(
+                        uuid="sm-uuid-1",
+                        source_path="svm1:vol1",
+                        destination_path="svm2:vol2",
+                        transfer_schedule_uuid="schedule-new",
+                    ),
+                ],
+            ),
+        )
+        changes = compute_diff(before, after)
+
+        sm_changes = [
+            c for c in changes if c["category"] == "relationships.snapmirror_destinations"
+        ]
+        assert len(sm_changes) == 1
+        assert sm_changes[0]["field"] == "transfer_schedule_uuid"
+        assert sm_changes[0]["old"] == "schedule-old"
+        assert sm_changes[0]["new"] == "schedule-new"
 
     def test_volume_changes(self) -> None:
         """Test volume change detection."""
@@ -473,7 +561,13 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             storage=StorageInfo(
                 volumes=[
-                    VolumeInfo(name="vol1", svm="svm1", state="online", size=1073741824),
+                    VolumeInfo(
+                        uuid="vol-uuid-1",
+                        name="vol1",
+                        svm="svm1",
+                        state="online",
+                        size=1073741824,
+                    ),
                 ],
             ),
         )
@@ -481,7 +575,13 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             storage=StorageInfo(
                 volumes=[
-                    VolumeInfo(name="vol1", svm="svm1", state="online", size=2147483648),
+                    VolumeInfo(
+                        uuid="vol-uuid-1",
+                        name="vol1",
+                        svm="svm1",
+                        state="online",
+                        size=2147483648,
+                    ),
                 ],
             ),
         )
@@ -499,15 +599,15 @@ class TestComputeDiffAllCategories:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
-                volumes=[VolumeInfo(name="vol1", svm="svm1")],
+                volumes=[VolumeInfo(uuid="vol-uuid-1", name="vol1", svm="svm1")],
             ),
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
                 volumes=[
-                    VolumeInfo(name="vol1", svm="svm1"),
-                    VolumeInfo(name="vol2", svm="svm1"),
+                    VolumeInfo(uuid="vol-uuid-1", name="vol1", svm="svm1"),
+                    VolumeInfo(uuid="vol-uuid-2", name="vol2", svm="svm1"),
                 ],
             ),
         )
@@ -601,7 +701,9 @@ class TestComputeDiffAllCategories:
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
-                snapshot_policies=[SnapshotPolicyInfo(name="default", uuid="sp-uuid-1")],
+                snapshot_policies=[
+                    SnapshotPolicyInfo(uuid="sp-uuid-1", name="default"),
+                ],
             ),
         )
         changes = compute_diff(before, after)
@@ -616,13 +718,22 @@ class TestComputeDiffAllCategories:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
-                schedules=[ScheduleInfo(name="hourly", type="cron", scope="cluster")],
+                schedules=[
+                    ScheduleInfo(uuid="sched-uuid-1", name="hourly", type="cron", scope="cluster"),
+                ],
             ),
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
-                schedules=[ScheduleInfo(name="hourly", type="interval", scope="cluster")],
+                schedules=[
+                    ScheduleInfo(
+                        uuid="sched-uuid-1",
+                        name="hourly",
+                        type="interval",
+                        scope="cluster",
+                    ),
+                ],
             ),
         )
         changes = compute_diff(before, after)
@@ -679,13 +790,27 @@ class TestComputeDiffAllCategories:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
-                luns=[LunInfo(name="/vol/vol1/lun1", svm="svm1", size=10737418240)],
+                luns=[
+                    LunInfo(
+                        uuid="lun-uuid-1",
+                        name="/vol/vol1/lun1",
+                        svm="svm1",
+                        size=10737418240,
+                    ),
+                ],
             ),
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
-                luns=[LunInfo(name="/vol/vol1/lun1", svm="svm1", size=21474836480)],
+                luns=[
+                    LunInfo(
+                        uuid="lun-uuid-1",
+                        name="/vol/vol1/lun1",
+                        svm="svm1",
+                        size=21474836480,
+                    ),
+                ],
             ),
         )
         changes = compute_diff(before, after)
@@ -704,7 +829,9 @@ class TestComputeDiffAllCategories:
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
-                igroups=[IgroupInfo(name="igroup1", svm="svm1", protocol="iscsi")],
+                igroups=[
+                    IgroupInfo(uuid="ig-uuid-1", name="igroup1", svm="svm1", protocol="iscsi"),
+                ],
             ),
         )
         changes = compute_diff(before, after)
@@ -720,7 +847,7 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             storage=StorageInfo(
                 qos_policies=[
-                    QosPolicyInfo(name="qos1", svm="svm1", scope="svm"),
+                    QosPolicyInfo(uuid="qos-uuid-1", name="qos1", svm="svm1", scope="svm"),
                 ],
             ),
         )
@@ -728,7 +855,7 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             storage=StorageInfo(
                 qos_policies=[
-                    QosPolicyInfo(name="qos1", svm="svm1", scope="cluster"),
+                    QosPolicyInfo(uuid="qos-uuid-1", name="qos1", svm="svm1", scope="cluster"),
                 ],
             ),
         )
@@ -820,7 +947,7 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             network=NetworkInfo(
                 dns=[
-                    DNSInfo(svm="svm1", scope="svm", servers=["10.0.0.1"]),
+                    DNSInfo(uuid="dns-uuid-1", svm="svm1", scope="svm", servers=["10.0.0.1"]),
                 ],
             ),
         )
@@ -828,7 +955,12 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             network=NetworkInfo(
                 dns=[
-                    DNSInfo(svm="svm1", scope="svm", servers=["10.0.0.1", "10.0.0.2"]),
+                    DNSInfo(
+                        uuid="dns-uuid-1",
+                        svm="svm1",
+                        scope="svm",
+                        servers=["10.0.0.1", "10.0.0.2"],
+                    ),
                 ],
             ),
         )
@@ -850,7 +982,9 @@ class TestComputeDiffAllCategories:
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                dns=[DNSInfo(svm="svm1", scope="svm", domains=["example.com"])],
+                dns=[
+                    DNSInfo(uuid="dns-uuid-1", svm="svm1", scope="svm", domains=["example.com"]),
+                ],
             ),
         )
         changes = compute_diff(before, after)
@@ -866,7 +1000,7 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             storage=StorageInfo(
                 flexcaches=[
-                    FlexCacheInfo(name="fc1", svm="svm1", size=1073741824),
+                    FlexCacheInfo(uuid="fc-uuid-1", name="fc1", svm="svm1", size=1073741824),
                 ],
             ),
         )
@@ -874,7 +1008,7 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             storage=StorageInfo(
                 flexcaches=[
-                    FlexCacheInfo(name="fc1", svm="svm1", size=2147483648),
+                    FlexCacheInfo(uuid="fc-uuid-1", name="fc1", svm="svm1", size=2147483648),
                 ],
             ),
         )
@@ -896,7 +1030,7 @@ class TestComputeDiffAllCategories:
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             storage=StorageInfo(
-                flexcaches=[FlexCacheInfo(name="fc1", svm="svm1")],
+                flexcaches=[FlexCacheInfo(uuid="fc-uuid-1", name="fc1", svm="svm1")],
             ),
         )
         changes = compute_diff(before, after)
@@ -912,7 +1046,7 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             relationships=RelationshipsInfo(
                 svm_peers=[
-                    SVMPeerInfo(name="svm1_to_svm2", state="peered"),
+                    SVMPeerInfo(uuid="peer-uuid-1", name="svm1_to_svm2", state="peered"),
                 ],
             ),
         )
@@ -920,7 +1054,7 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             relationships=RelationshipsInfo(
                 svm_peers=[
-                    SVMPeerInfo(name="svm1_to_svm2", state="initiated"),
+                    SVMPeerInfo(uuid="peer-uuid-1", name="svm1_to_svm2", state="initiated"),
                 ],
             ),
         )
@@ -942,7 +1076,14 @@ class TestComputeDiffAllCategories:
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             relationships=RelationshipsInfo(
-                svm_peers=[SVMPeerInfo(name="svm1_to_svm2", svm="svm1", state="peered")],
+                svm_peers=[
+                    SVMPeerInfo(
+                        uuid="peer-uuid-1",
+                        name="svm1_to_svm2",
+                        svm="svm1",
+                        state="peered",
+                    ),
+                ],
             ),
         )
         changes = compute_diff(before, after)
@@ -958,7 +1099,7 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             protocols=ProtocolsInfo(
                 s3_buckets=[
-                    S3BucketInfo(name="mybucket", svm="svm1", size=1073741824),
+                    S3BucketInfo(uuid="s3-uuid-1", name="mybucket", svm="svm1", size=1073741824),
                 ],
             ),
         )
@@ -966,7 +1107,7 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             protocols=ProtocolsInfo(
                 s3_buckets=[
-                    S3BucketInfo(name="mybucket", svm="svm1", size=2147483648),
+                    S3BucketInfo(uuid="s3-uuid-1", name="mybucket", svm="svm1", size=2147483648),
                 ],
             ),
         )
@@ -986,7 +1127,7 @@ class TestComputeDiffAllCategories:
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             protocols=ProtocolsInfo(
-                s3_buckets=[S3BucketInfo(name="mybucket", svm="svm1")],
+                s3_buckets=[S3BucketInfo(uuid="s3-uuid-1", name="mybucket", svm="svm1")],
             ),
         )
         changes = compute_diff(before, after)
@@ -1002,7 +1143,12 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             network=NetworkInfo(
                 subnets=[
-                    IPSubnetInfo(name="data-subnet", subnet="10.0.0.0/24", gateway="10.0.0.1"),
+                    IPSubnetInfo(
+                        uuid="sub-uuid-1",
+                        name="data-subnet",
+                        subnet="10.0.0.0/24",
+                        gateway="10.0.0.1",
+                    ),
                 ],
             ),
         )
@@ -1010,7 +1156,12 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             network=NetworkInfo(
                 subnets=[
-                    IPSubnetInfo(name="data-subnet", subnet="10.0.0.0/24", gateway="10.0.0.254"),
+                    IPSubnetInfo(
+                        uuid="sub-uuid-1",
+                        name="data-subnet",
+                        subnet="10.0.0.0/24",
+                        gateway="10.0.0.254",
+                    ),
                 ],
             ),
         )
@@ -1032,7 +1183,9 @@ class TestComputeDiffAllCategories:
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                subnets=[IPSubnetInfo(name="data-subnet", subnet="10.0.0.0/24")],
+                subnets=[
+                    IPSubnetInfo(uuid="sub-uuid-1", name="data-subnet", subnet="10.0.0.0/24"),
+                ],
             ),
         )
         changes = compute_diff(before, after)
@@ -1041,6 +1194,184 @@ class TestComputeDiffAllCategories:
         assert len(subnet_changes) == 1
         assert subnet_changes[0]["type"] == "added"
         assert subnet_changes[0]["entity"] == "data-subnet"
+
+    def test_cluster_peer_changes(self) -> None:
+        """Test cluster peer change detection."""
+        before = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            relationships=RelationshipsInfo(
+                cluster_peers=[
+                    ClusterPeer(
+                        uuid="cp-uuid-1",
+                        name="peer1",
+                        authentication_state="ok",
+                    ),
+                ],
+            ),
+        )
+        after = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            relationships=RelationshipsInfo(
+                cluster_peers=[
+                    ClusterPeer(
+                        uuid="cp-uuid-1",
+                        name="peer1",
+                        authentication_state="expired",
+                    ),
+                ],
+            ),
+        )
+        changes = compute_diff(before, after)
+
+        peer_changes = [c for c in changes if c["category"] == "relationships.cluster_peers"]
+        assert len(peer_changes) == 1
+        assert peer_changes[0]["type"] == "modified"
+        assert peer_changes[0]["field"] == "authentication_state"
+
+
+class TestDynamicFieldTracking:
+    """Tests for dynamic field tracking (all model fields tracked automatically)."""
+
+    def test_previously_untracked_node_field_detected(self) -> None:
+        """Node version_full was previously untracked — now it is detected."""
+        before = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            nodes=[
+                NodeInfo(uuid="uuid-1", name="node1", version_full="9.14.1P1"),
+            ],
+        )
+        after = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            nodes=[
+                NodeInfo(uuid="uuid-1", name="node1", version_full="9.15.0"),
+            ],
+        )
+        changes = compute_diff(before, after)
+
+        node_changes = [c for c in changes if c["category"] == "nodes"]
+        assert len(node_changes) == 1
+        assert node_changes[0]["field"] == "version_full"
+
+    def test_uuid_keyed_rename_detected_as_modification(self) -> None:
+        """Renaming a uuid-keyed entity is a modification, not remove+add."""
+        before = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            nodes=[NodeInfo(uuid="uuid-1", name="old-name")],
+        )
+        after = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            nodes=[NodeInfo(uuid="uuid-1", name="new-name")],
+        )
+        changes = compute_diff(before, after)
+
+        node_changes = [c for c in changes if c["category"] == "nodes"]
+        assert len(node_changes) == 1
+        assert node_changes[0]["type"] == "modified"
+        assert node_changes[0]["field"] == "name"
+        assert node_changes[0]["old"] == "old-name"
+        assert node_changes[0]["new"] == "new-name"
+        # Display shows the new name
+        assert node_changes[0]["entity"] == "new-name"
+
+    def test_display_name_shows_name_not_uuid(self) -> None:
+        """Change entries for uuid-keyed models show name, not uuid."""
+        before = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            storage=StorageInfo(
+                aggregates=[
+                    AggregateInfo(uuid="aggr-uuid-1", name="aggr1", state="online"),
+                ],
+            ),
+        )
+        after = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            storage=StorageInfo(
+                aggregates=[
+                    AggregateInfo(uuid="aggr-uuid-1", name="aggr1", state="offline"),
+                ],
+            ),
+        )
+        changes = compute_diff(before, after)
+
+        aggr_changes = [c for c in changes if c["category"] == "storage.aggregates"]
+        assert len(aggr_changes) >= 1
+        # Entity should be the human-readable name, not the uuid
+        assert aggr_changes[0]["entity"] == "aggr1"
+        assert aggr_changes[0]["entity"] != "aggr-uuid-1"
+
+    def test_snapmirror_composite_display(self) -> None:
+        """SnapMirror entity display uses composite format."""
+        before = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            relationships=RelationshipsInfo(
+                snapmirror_destinations=[
+                    SnapMirrorRelationship(
+                        uuid="sm-uuid-1",
+                        source_path="src_svm:vol1",
+                        destination_path="dst_svm:vol1_dp",
+                        throttle=0,
+                    ),
+                ],
+            ),
+        )
+        after = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            relationships=RelationshipsInfo(
+                snapmirror_destinations=[
+                    SnapMirrorRelationship(
+                        uuid="sm-uuid-1",
+                        source_path="src_svm:vol1",
+                        destination_path="dst_svm:vol1_dp",
+                        throttle=1000,
+                    ),
+                ],
+            ),
+        )
+        changes = compute_diff(before, after)
+
+        sm_changes = [
+            c for c in changes if c["category"] == "relationships.snapmirror_destinations"
+        ]
+        assert len(sm_changes) == 1
+        assert sm_changes[0]["entity"] == "src_svm:vol1->dst_svm:vol1_dp"
+
+    def test_singleton_cluster_tracks_all_fields(self) -> None:
+        """Cluster info singleton tracks all ClusterInfo model fields."""
+        before = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            cluster=ClusterInfo(
+                cluster_name="test-cluster",
+                contact="old-contact",
+            ),
+        )
+        after = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            cluster=ClusterInfo(
+                cluster_name="test-cluster",
+                contact="new-contact",
+            ),
+        )
+        changes = compute_diff(before, after)
+
+        cluster_changes = [c for c in changes if c["category"] == "cluster"]
+        assert len(cluster_changes) == 1
+        assert cluster_changes[0]["field"] == "contact"
+
+    def test_singleton_ha_tracks_all_fields(self) -> None:
+        """HA info singleton tracks all HAInfo model fields."""
+        before = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            ha=HAInfo(is_ha=True, mediator_address="10.0.0.1"),
+        )
+        after = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            ha=HAInfo(is_ha=True, mediator_address="10.0.0.2"),
+        )
+        changes = compute_diff(before, after)
+
+        ha_changes = [c for c in changes if c["category"] == "ha"]
+        assert len(ha_changes) == 1
+        assert ha_changes[0]["field"] == "mediator_address"
 
 
 class TestFormatDiffSummary:
@@ -1142,22 +1473,39 @@ class TestChangeEntry:
 class TestComputeDiffEdgeCases:
     """Tests for edge cases in diff computation."""
 
-    @pytest.mark.parametrize(
-        "entity_key",
-        ["", None],
-    )
-    def test_entities_without_key_are_skipped(self, entity_key: str | None) -> None:
-        """Test that entities with empty/None keys don't cause errors."""
-        # Nodes without names should be handled gracefully
+    def test_entities_without_uuid_key_are_skipped(self) -> None:
+        """Entities with empty uuid keys don't cause errors."""
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
-            nodes=[NodeInfo(name="node1")],
+            nodes=[NodeInfo(uuid="uuid-1", name="node1")],
         )
-        # The after has same structure, no changes expected
+        # After has the same node plus one with empty uuid (should be skipped)
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
-            nodes=[NodeInfo(name="node1")],
+            nodes=[
+                NodeInfo(uuid="uuid-1", name="node1"),
+                NodeInfo(uuid="", name="phantom"),
+            ],
         )
-        # Should not raise
         changes = compute_diff(before, after)
-        assert len(changes) == 0
+        node_changes = [c for c in changes if c["category"] == "nodes"]
+        # The empty-uuid node should not appear as added
+        assert len(node_changes) == 0
+
+    def test_entities_without_name_key_are_skipped(self) -> None:
+        """Entities with empty name keys (for name-keyed models) are skipped."""
+        before = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            network=NetworkInfo(
+                intercluster_lifs=[NetworkLIF(name="lif1", ip_address="10.0.0.1")],
+            ),
+        )
+        after = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            network=NetworkInfo(
+                intercluster_lifs=[NetworkLIF(name="lif1", ip_address="10.0.0.1")],
+            ),
+        )
+        changes = compute_diff(before, after)
+        lif_changes = [c for c in changes if c["category"] == "network.intercluster_lifs"]
+        assert len(lif_changes) == 0

--- a/tests/unit/cache/test_history.py
+++ b/tests/unit/cache/test_history.py
@@ -330,7 +330,7 @@ class TestHistoryIntegration:
         # Initial state
         metadata_v1 = CachedClusterMetadata(
             cluster_name="test-cluster",
-            nodes=[NodeInfo(name="node1", serial_number="123")],
+            nodes=[NodeInfo(uuid="uuid-1", name="node1", serial_number="123")],
         )
         history_db.record_change(
             cluster_name="test-cluster",
@@ -342,7 +342,7 @@ class TestHistoryIntegration:
         # Updated state with changed serial
         metadata_v2 = CachedClusterMetadata(
             cluster_name="test-cluster",
-            nodes=[NodeInfo(name="node1", serial_number="456")],
+            nodes=[NodeInfo(uuid="uuid-1", name="node1", serial_number="456")],
         )
 
         # Get previous snapshot


### PR DESCRIPTION
## Description

The cache diff engine used hard-coded field lists to detect modifications between
metadata snapshots. When new fields were added to cache models (e.g.,
`transfer_schedule_uuid` on `SnapMirrorRelationship`, `version_full` on `NodeInfo`),
the diff engine silently ignored them, producing missing change events.

This fix replaces the static field lists with dynamic introspection of each model's
`model_fields` at runtime, ensuring every field on every cache model is automatically
tracked without manual maintenance.

## Related Issue

Addresses #269

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Replaced static `_ENTITY_CONFIGS` tuples of `(key_field, tracked_fields)` with
  `EntityConfig` dataclass that stores `key_field`, `model_class`, and `display_field`
- Added `_get_tracked_fields()` helper that derives tracked fields from
  `model_class.model_fields` at runtime, excluding the key field
- Added `_get_display_name()` helper supporting both simple attribute names and
  format-string templates (e.g., `{source_path}->{destination_path}` for SnapMirror)
- Switched uuid-bearing models from name-based to uuid-based identity keys for
  stable entity matching across renames
- Replaced hard-coded field lists in `_diff_cluster_info()` and `_diff_ha_info()`
  singletons with `ClusterInfo.model_fields` and `HAInfo.model_fields`
- Updated `docs/reference/cache.md` Schema Update Checklist to reflect that diff
  tracking is now automatic (step 6 no longer requires manual changes)
- Added `TestEntityConfig` class with tests for `_get_tracked_fields()` and
  `_get_display_name()` helpers
- Added `TestDynamicFieldTracking` class covering previously-untracked fields,
  uuid-keyed rename detection, display name resolution, and singleton field tracking
- Added regression test `test_snapmirror_transfer_schedule_change` verifying the
  original bug is fixed
- Updated all existing tests to supply uuid values where models now key on uuid

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The `ChangeEntry` Pydantic model that was already in the module is retained as-is;
`compute_diff()` still returns plain dicts for backward compatibility with the
history DB serialization format.
