### PR TITLE
refactor: migrate ClusterInfo to declarative field mapping framework

### DIFF
--- a/docs/decisions/0004-declarative-field-mapping-framework.md
+++ b/docs/decisions/0004-declarative-field-mapping-framework.md
@@ -62,6 +62,7 @@ The pilot migration (VolumeInfo) was completed in PR #189.
 - Issue #214: refactor: migrate HAInfo to field mapping framework
 - Issue #237: refactor: all-or-nothing collection with no CLI fallback
 - Issue #259: feat: generalize field mapping framework for multi-API data collection
+- Issue #209: refactor: migrate ClusterInfo to field mapping framework
 - Issue #257: refactor: deep URL-tree structure with automatic model and mapping discovery
 
 ## Related Documentation

--- a/docs/development/field-mapping.md
+++ b/docs/development/field-mapping.md
@@ -227,6 +227,7 @@ For CLI-only types, also test:
 | Aggregate | `AGGREGATE_MAPPING` | `AggregateInfo` | 28 | API-only. Deeply nested API paths (`block_storage.primary.*`). Explicit `?fields=*,is_spare_low,sidl_enabled`. |
 | Node | `NODE_MAPPING` | `NodeInfo` | 20 | API-only. Wildcard `[*]` syntax for list fields. `field_validator` for int→str coercion. |
 | ClusterPeer | `CLUSTER_PEER_MAPPING` | `ClusterPeer` | 7 | API-only. Uses transform for dict-vs-string fallback on `remote`, `authentication`, and `encryption`. |
+| Cluster | `CLUSTER_MAPPING` | `ClusterInfo` | 18 | API-only. Single-object endpoint (no `records` list), uses `parse_api_record()` directly. `is_ha` derived post-collection. |
 | CloudMetadata | `CLOUD_METADATA_MAPPING` | `CloudMetadata` | 19 | CLI-only (no API endpoint). Computed link fields built as post-processing in collector. |
 
 ## Reference: Field Mapping Patterns

--- a/src/pynetappfoundry/cache/cluster/__init__.py
+++ b/src/pynetappfoundry/cache/cluster/__init__.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from pynetappfoundry.cache.cluster.mapping import CLUSTER_MAPPING
 from pynetappfoundry.cache.cluster.model import ClusterInfo
 
 __all__ = [
+    "CLUSTER_MAPPING",
     "ClusterInfo",
 ]

--- a/src/pynetappfoundry/cache/cluster/mapping.py
+++ b/src/pynetappfoundry/cache/cluster/mapping.py
@@ -1,0 +1,109 @@
+"""Cluster type mapping definition for the declarative field mapping framework.
+
+Defines CLUSTER_MAPPING which maps ONTAP REST API /cluster data to
+ClusterInfo cache model attributes.
+
+Note: ``is_ha`` is derived post-collection from node count and is
+intentionally excluded from the mapping.
+"""
+
+from __future__ import annotations
+
+from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache.cluster.model import ClusterInfo
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+
+CLUSTER_MAPPING = TypeMapping(
+    name="Cluster",
+    model_class=ClusterInfo,
+    api_endpoint="/cluster?fields=*",
+    cli_command="",
+    id_field="name",
+    fields=(
+        FieldMapping(
+            cache_attr="cluster_name",
+            api_path="name",
+        ),
+        FieldMapping(
+            cache_attr="cluster_uuid",
+            api_path="uuid",
+        ),
+        FieldMapping(
+            cache_attr="ontap_version",
+            api_path="version.full",
+        ),
+        FieldMapping(
+            cache_attr="model",
+            api_path="version.generation",
+        ),
+        FieldMapping(
+            cache_attr="contact",
+            api_path="contact",
+        ),
+        FieldMapping(
+            cache_attr="location",
+            api_path="location",
+        ),
+        FieldMapping(
+            cache_attr="san_optimized",
+            api_path="san_optimized",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="timezone",
+            api_path="timezone.name",
+        ),
+        FieldMapping(
+            cache_attr="dns_domains",
+            api_path="dns_domains",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="name_servers",
+            api_path="name_servers",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="ntp_servers",
+            api_path="ntp_servers",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="peering_policy_authentication_required",
+            api_path="peering_policy.authentication_required",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="peering_policy_encryption_required",
+            api_path="peering_policy.encryption_required",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="peering_policy_minimum_passphrase_length",
+            api_path="peering_policy.minimum_passphrase_length",
+            default=0,
+        ),
+        FieldMapping(
+            cache_attr="management_interface_uuids",
+            api_path="management_interfaces[*].uuid",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="disaggregated",
+            api_path="disaggregated",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="auto_enable_activity_tracking",
+            api_path="auto_enable_activity_tracking",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="auto_enable_analytics",
+            api_path="auto_enable_analytics",
+            default=False,
+        ),
+    ),
+)
+
+model_registry.register_mapping("Cluster", CLUSTER_MAPPING)

--- a/src/pynetappfoundry/cache/cluster/model.py
+++ b/src/pynetappfoundry/cache/cluster/model.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 
 from pynetappfoundry.cache._base import CacheModel
 
@@ -20,6 +20,18 @@ class ClusterInfo(CacheModel):
     contact: str = ""
     location: str = ""
     is_ha: bool = False
+    san_optimized: bool = False
+    timezone: str = ""
+    dns_domains: list[str] = Field(default_factory=list)
+    name_servers: list[str] = Field(default_factory=list)
+    ntp_servers: list[str] = Field(default_factory=list)
+    peering_policy_authentication_required: bool = False
+    peering_policy_encryption_required: bool = False
+    peering_policy_minimum_passphrase_length: int = 0
+    management_interface_uuids: list[str] = Field(default_factory=list)
+    disaggregated: bool = False
+    auto_enable_activity_tracking: bool = False
+    auto_enable_analytics: bool = False
 
     @field_validator("model", mode="before")
     @classmethod

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -31,6 +31,7 @@ from pynetappfoundry.cache.cluster.licensing.model import (
     LicenseFeature,
     LicenseInfo,
 )
+from pynetappfoundry.cache.cluster.mapping import CLUSTER_MAPPING
 from pynetappfoundry.cache.cluster.mediators.mapping import MEDIATOR_MAPPING
 from pynetappfoundry.cache.cluster.mediators.model import MediatorInfo
 from pynetappfoundry.cache.cluster.model import ClusterInfo
@@ -39,7 +40,11 @@ from pynetappfoundry.cache.cluster.nodes.model import NodeInfo
 from pynetappfoundry.cache.cluster.peers.mapping import CLUSTER_PEER_MAPPING
 from pynetappfoundry.cache.cluster.peers.model import ClusterPeer
 from pynetappfoundry.cache.cluster.schedules.model import ScheduleInfo
-from pynetappfoundry.cache.field_mapping import parse_api_response, parse_cli_records
+from pynetappfoundry.cache.field_mapping import (
+    parse_api_record,
+    parse_api_response,
+    parse_cli_records,
+)
 from pynetappfoundry.cache.name_services.dns.model import DNSInfo
 from pynetappfoundry.cache.network.ethernet.broadcast_domains.model import (
     BroadcastDomain,
@@ -819,7 +824,7 @@ class MetadataCollector:
             logger.debug("%s No API client available for cluster info collection", self._log_prefix)
             return ClusterInfo()
 
-        response = self._cached_api_call("/cluster?fields=*", paginate=False)
+        response = self._cached_api_call(CLUSTER_MAPPING.api_endpoint, paginate=False)
         if not response:
             return ClusterInfo()
 
@@ -828,17 +833,13 @@ class MetadataCollector:
         )
         self._log_missing_fields(
             response,
-            ["name", "uuid", "version", "contact", "location"],
+            CLUSTER_MAPPING.api_expected_fields(),
             "Cluster",
             response.get("name", "unknown"),
         )
-        return ClusterInfo(
-            cluster_name=response.get("name", ""),
-            cluster_uuid=response.get("uuid", ""),
-            ontap_version=response.get("version", {}).get("full", ""),
-            model=response.get("version", {}).get("generation", ""),
-            contact=response.get("contact", ""),
-            location=response.get("location", ""),
+        return cast(
+            ClusterInfo,
+            parse_api_record(CLUSTER_MAPPING, response, self._log_prefix),
         )
 
     # -------------------------------------------------------------------------

--- a/tests/unit/cache/mappings/test_cluster.py
+++ b/tests/unit/cache/mappings/test_cluster.py
@@ -1,0 +1,342 @@
+"""Tests for the cluster type mapping definition."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pynetappfoundry.cache.cluster.mapping import CLUSTER_MAPPING
+from pynetappfoundry.cache.cluster.model import ClusterInfo
+from pynetappfoundry.cache.field_mapping import (
+    parse_api_record,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def full_api_record() -> dict[str, Any]:
+    """Full API cluster record with all fields."""
+    return {
+        "name": "mycluster",
+        "uuid": "abc-123-def-456",
+        "version": {
+            "full": "NetApp Release 9.14.1",
+            "generation": "SIMULATED",
+        },
+        "contact": "admin@example.com",
+        "location": "datacenter-1",
+        "san_optimized": True,
+        "timezone": {"name": "America/New_York"},
+        "dns_domains": ["example.com", "corp.example.com"],
+        "name_servers": ["10.0.0.1", "10.0.0.2"],
+        "ntp_servers": ["time.nist.gov", "pool.ntp.org"],
+        "peering_policy": {
+            "authentication_required": True,
+            "encryption_required": True,
+            "minimum_passphrase_length": 8,
+        },
+        "management_interfaces": [
+            {"uuid": "mgmt-uuid-1"},
+            {"uuid": "mgmt-uuid-2"},
+        ],
+        "disaggregated": True,
+        "auto_enable_activity_tracking": True,
+        "auto_enable_analytics": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mapping definition tests
+# ---------------------------------------------------------------------------
+
+
+class TestClusterMappingDefinition:
+    """Tests for CLUSTER_MAPPING structure."""
+
+    def test_all_cache_attrs_exist_on_model(self) -> None:
+        """Every cache_attr in the mapping is a valid ClusterInfo field."""
+        model_fields = set(ClusterInfo.model_fields.keys())
+        for field in CLUSTER_MAPPING.fields:
+            assert field.cache_attr in model_fields, (
+                f"cache_attr '{field.cache_attr}' not on ClusterInfo"
+            )
+
+    def test_no_duplicate_cache_attrs(self) -> None:
+        """No duplicate cache_attr values."""
+        attrs = [f.cache_attr for f in CLUSTER_MAPPING.fields]
+        assert len(attrs) == len(set(attrs))
+
+    def test_field_count(self) -> None:
+        """Mapping has expected number of fields (18)."""
+        assert len(CLUSTER_MAPPING.fields) == 18
+
+    def test_model_class(self) -> None:
+        """Model class is ClusterInfo."""
+        assert CLUSTER_MAPPING.model_class is ClusterInfo
+
+    def test_endpoint(self) -> None:
+        """API endpoint is /cluster?fields=*."""
+        assert CLUSTER_MAPPING.api_endpoint == "/cluster?fields=*"
+
+    def test_cli_command_empty(self) -> None:
+        """CLI command is empty (API-only)."""
+        assert CLUSTER_MAPPING.cli_command == ""
+
+    def test_id_field(self) -> None:
+        """ID field is name."""
+        assert CLUSTER_MAPPING.id_field == "name"
+
+    def test_api_expected_fields(self) -> None:
+        """api_expected_fields returns correct top-level keys."""
+        expected = CLUSTER_MAPPING.api_expected_fields()
+        assert expected == sorted(
+            [
+                "auto_enable_activity_tracking",
+                "auto_enable_analytics",
+                "contact",
+                "disaggregated",
+                "dns_domains",
+                "location",
+                "management_interfaces",
+                "name",
+                "name_servers",
+                "ntp_servers",
+                "peering_policy",
+                "san_optimized",
+                "timezone",
+                "uuid",
+                "version",
+            ]
+        )
+
+
+# ---------------------------------------------------------------------------
+# API parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestClusterApiParsing:
+    """Tests for parsing API cluster records."""
+
+    def test_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Full API record parses to complete ClusterInfo."""
+        result = parse_api_record(CLUSTER_MAPPING, full_api_record, "[test]")
+        assert isinstance(result, ClusterInfo)
+        assert result.cluster_name == "mycluster"
+        assert result.cluster_uuid == "abc-123-def-456"
+        assert result.ontap_version == "NetApp Release 9.14.1"
+        assert result.model == "SIMULATED"
+        assert result.contact == "admin@example.com"
+        assert result.location == "datacenter-1"
+        assert result.san_optimized is True
+        assert result.timezone == "America/New_York"
+        assert result.dns_domains == ["example.com", "corp.example.com"]
+        assert result.name_servers == ["10.0.0.1", "10.0.0.2"]
+        assert result.ntp_servers == ["time.nist.gov", "pool.ntp.org"]
+        assert result.peering_policy_authentication_required is True
+        assert result.peering_policy_encryption_required is True
+        assert result.peering_policy_minimum_passphrase_length == 8
+        assert result.management_interface_uuids == ["mgmt-uuid-1", "mgmt-uuid-2"]
+        assert result.disaggregated is True
+        assert result.auto_enable_activity_tracking is True
+        assert result.auto_enable_analytics is True
+
+    def test_minimal_record(self) -> None:
+        """Minimal record uses defaults for missing fields."""
+        record: dict[str, Any] = {"name": "minimal", "uuid": "xyz"}
+        result = parse_api_record(CLUSTER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterInfo)
+        assert result.cluster_name == "minimal"
+        assert result.cluster_uuid == "xyz"
+        assert result.ontap_version == ""
+        assert result.model == ""
+        assert result.contact == ""
+        assert result.location == ""
+        assert result.san_optimized is False
+        assert result.timezone == ""
+        assert result.dns_domains == []
+        assert result.name_servers == []
+        assert result.ntp_servers == []
+        assert result.peering_policy_authentication_required is False
+        assert result.peering_policy_encryption_required is False
+        assert result.peering_policy_minimum_passphrase_length == 0
+        assert result.management_interface_uuids == []
+        assert result.disaggregated is False
+        assert result.auto_enable_activity_tracking is False
+        assert result.auto_enable_analytics is False
+
+    def test_empty_record(self) -> None:
+        """Empty record uses all defaults."""
+        record: dict[str, Any] = {}
+        result = parse_api_record(CLUSTER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterInfo)
+        assert result.cluster_name == ""
+        assert result.cluster_uuid == ""
+        assert result.ontap_version == ""
+        assert result.model == ""
+
+    def test_nested_version_fields(self) -> None:
+        """Nested version.full and version.generation parse correctly."""
+        record: dict[str, Any] = {
+            "name": "test",
+            "version": {"full": "9.15.0", "generation": 9},
+        }
+        result = parse_api_record(CLUSTER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterInfo)
+        assert result.ontap_version == "9.15.0"
+        # model field_validator coerces int to str
+        assert result.model == "9"
+
+    def test_nested_timezone_field(self) -> None:
+        """Nested timezone.name parses correctly."""
+        record: dict[str, Any] = {
+            "name": "test",
+            "timezone": {"name": "UTC"},
+        }
+        result = parse_api_record(CLUSTER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterInfo)
+        assert result.timezone == "UTC"
+
+    def test_nested_peering_policy_fields(self) -> None:
+        """Nested peering_policy.* fields parse correctly."""
+        record: dict[str, Any] = {
+            "name": "test",
+            "peering_policy": {
+                "authentication_required": True,
+                "encryption_required": False,
+                "minimum_passphrase_length": 12,
+            },
+        }
+        result = parse_api_record(CLUSTER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterInfo)
+        assert result.peering_policy_authentication_required is True
+        assert result.peering_policy_encryption_required is False
+        assert result.peering_policy_minimum_passphrase_length == 12
+
+    def test_wildcard_management_interfaces(self) -> None:
+        """Wildcard management_interfaces[*].uuid parses correctly."""
+        record: dict[str, Any] = {
+            "name": "test",
+            "management_interfaces": [
+                {"uuid": "uuid-1", "name": "mgmt1"},
+                {"uuid": "uuid-2", "name": "mgmt2"},
+                {"uuid": "uuid-3", "name": "mgmt3"},
+            ],
+        }
+        result = parse_api_record(CLUSTER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterInfo)
+        assert result.management_interface_uuids == ["uuid-1", "uuid-2", "uuid-3"]
+
+    def test_wildcard_empty_management_interfaces(self) -> None:
+        """Empty management_interfaces list returns default."""
+        record: dict[str, Any] = {
+            "name": "test",
+            "management_interfaces": [],
+        }
+        result = parse_api_record(CLUSTER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterInfo)
+        assert result.management_interface_uuids == []
+
+    def test_missing_management_interfaces_uses_default(self) -> None:
+        """Missing management_interfaces key uses default empty list."""
+        record: dict[str, Any] = {"name": "test"}
+        result = parse_api_record(CLUSTER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterInfo)
+        assert result.management_interface_uuids == []
+
+    def test_list_fields(self) -> None:
+        """Top-level list fields (dns_domains, name_servers, ntp_servers) parse correctly."""
+        record: dict[str, Any] = {
+            "name": "test",
+            "dns_domains": ["a.com", "b.com"],
+            "name_servers": ["1.1.1.1"],
+            "ntp_servers": ["ntp1", "ntp2", "ntp3"],
+        }
+        result = parse_api_record(CLUSTER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterInfo)
+        assert result.dns_domains == ["a.com", "b.com"]
+        assert result.name_servers == ["1.1.1.1"]
+        assert result.ntp_servers == ["ntp1", "ntp2", "ntp3"]
+
+    def test_is_ha_not_set_by_mapping(self) -> None:
+        """is_ha is not set by the mapping (derived post-collection)."""
+        record: dict[str, Any] = {"name": "test"}
+        result = parse_api_record(CLUSTER_MAPPING, record, "[test]")
+        assert isinstance(result, ClusterInfo)
+        assert result.is_ha is False
+
+
+# ---------------------------------------------------------------------------
+# Parity test: old parser vs new framework
+# ---------------------------------------------------------------------------
+
+
+class TestParityWithOldParser:
+    """Verify framework produces same output as old hand-written parser.
+
+    Reproduces the manual .get() logic from the collector to confirm the
+    declarative mapping produces identical results for the original 6 fields.
+    """
+
+    @staticmethod
+    def _old_parse_cluster(record: dict[str, Any]) -> ClusterInfo:
+        """Reproduce old inline cluster parsing logic."""
+        return ClusterInfo(
+            cluster_name=record.get("name", ""),
+            cluster_uuid=record.get("uuid", ""),
+            ontap_version=record.get("version", {}).get("full", ""),
+            model=record.get("version", {}).get("generation", ""),
+            contact=record.get("contact", ""),
+            location=record.get("location", ""),
+        )
+
+    _ORIGINAL_FIELDS = (
+        "cluster_name",
+        "cluster_uuid",
+        "ontap_version",
+        "model",
+        "contact",
+        "location",
+    )
+
+    def test_parity_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Framework and old parser produce identical ClusterInfo for full record."""
+        old = self._old_parse_cluster(full_api_record)
+        new = parse_api_record(CLUSTER_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, ClusterInfo)
+        for field_name in self._ORIGINAL_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_minimal_record(self) -> None:
+        """Framework and old parser match on minimal record."""
+        record: dict[str, Any] = {"name": "test", "uuid": "xyz"}
+        old = self._old_parse_cluster(record)
+        new = parse_api_record(CLUSTER_MAPPING, record, "[test]")
+        assert isinstance(new, ClusterInfo)
+        for field_name in self._ORIGINAL_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_empty_record(self) -> None:
+        """Framework and old parser match on empty record."""
+        record: dict[str, Any] = {}
+        old = self._old_parse_cluster(record)
+        new = parse_api_record(CLUSTER_MAPPING, record, "[test]")
+        assert isinstance(new, ClusterInfo)
+        for field_name in self._ORIGINAL_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -261,6 +261,24 @@ class TestClusterInfoCollection:
                 "full": "NetApp Release 9.14.1",
                 "generation": "SIMULATED",
             },
+            "contact": "admin@example.com",
+            "location": "datacenter-1",
+            "san_optimized": True,
+            "timezone": {"name": "America/New_York"},
+            "dns_domains": ["example.com"],
+            "name_servers": ["10.0.0.1"],
+            "ntp_servers": ["time.nist.gov"],
+            "peering_policy": {
+                "authentication_required": True,
+                "encryption_required": False,
+                "minimum_passphrase_length": 8,
+            },
+            "management_interfaces": [
+                {"uuid": "mgmt-uuid-1"},
+            ],
+            "disaggregated": False,
+            "auto_enable_activity_tracking": True,
+            "auto_enable_analytics": False,
         }
 
     @pytest.fixture
@@ -282,6 +300,20 @@ class TestClusterInfoCollection:
         assert result.cluster_name == "mycluster"
         assert result.cluster_uuid == "abc-123-def-456"
         assert "9.14.1" in result.ontap_version
+        assert result.contact == "admin@example.com"
+        assert result.location == "datacenter-1"
+        assert result.san_optimized is True
+        assert result.timezone == "America/New_York"
+        assert result.dns_domains == ["example.com"]
+        assert result.name_servers == ["10.0.0.1"]
+        assert result.ntp_servers == ["time.nist.gov"]
+        assert result.peering_policy_authentication_required is True
+        assert result.peering_policy_encryption_required is False
+        assert result.peering_policy_minimum_passphrase_length == 8
+        assert result.management_interface_uuids == ["mgmt-uuid-1"]
+        assert result.disaggregated is False
+        assert result.auto_enable_activity_tracking is True
+        assert result.auto_enable_analytics is False
         api_client.call_endpoint.assert_called_with("/cluster?fields=*", method="GET")
 
     def test_collect_cluster_info_api_failure_propagates(self) -> None:

--- a/tests/unit/cache/test_registry_integration.py
+++ b/tests/unit/cache/test_registry_integration.py
@@ -82,10 +82,11 @@ class TestMappingRegistration:
     """Tests that all mappings are registered via register_mapping()."""
 
     def test_registry_contains_all_mappings(self) -> None:
-        """All 7 type mappings should be registered."""
+        """All 8 type mappings should be registered."""
         expected_mappings = {
             "Aggregate",
             "CloudMetadata",
+            "Cluster",
             "ClusterPeer",
             "Mediator",
             "Node",
@@ -97,8 +98,8 @@ class TestMappingRegistration:
         assert not missing, f"Mappings not registered: {missing}"
 
     def test_mapping_count(self) -> None:
-        """Registry should contain exactly 7 mappings."""
-        assert len(model_registry.mappings) == 7
+        """Registry should contain exactly 8 mappings."""
+        assert len(model_registry.mappings) == 8
 
     def test_mapping_lookup_by_name(self) -> None:
         """get_mapping() should return the correct TypeMapping for known names."""


### PR DESCRIPTION
## Description

Migrate `ClusterInfo` from hand-written `.get()` extraction in `_collect_cluster_info_via_api()` to the declarative field mapping framework (ADR-0004). The `/cluster` endpoint returns a single object (no `records` list), so the collector uses `parse_api_record()` directly instead of `parse_api_response()`.

Added 12 new fields from the `/cluster` API response: `san_optimized`, `timezone`, `dns_domains`, `name_servers`, `ntp_servers`, `peering_policy_*` (3 fields), `management_interface_uuids`, `disaggregated`, `auto_enable_activity_tracking`, and `auto_enable_analytics`. The `is_ha` field remains derived post-collection from node count and is intentionally excluded from the mapping.

## Related Issue

Addresses #209

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `src/pynetappfoundry/cache/cluster/mapping.py` with `CLUSTER_MAPPING` TypeMapping (18 fields)
- Updated `src/pynetappfoundry/cache/cluster/model.py` with 12 new fields from the `/cluster` API
- Updated `src/pynetappfoundry/cache/cluster/__init__.py` to export `CLUSTER_MAPPING`
- Replaced hand-written `.get()` parsing in `collector.py` with `parse_api_record(CLUSTER_MAPPING, ...)`
- Added `tests/unit/cache/mappings/test_cluster.py` with comprehensive tests (mapping definition, API parsing, parity with old parser)
- Updated `tests/unit/cache/test_collector.py` with expanded fixture and assertions for all 18 fields
- Updated `tests/unit/cache/test_registry_integration.py` mapping count 7 to 8
- Updated ADR-0004 with Issue #209 link
- Updated `docs/development/field-mapping.md` Migrated Types table with Cluster entry

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes (format, lint, type-check, security, spell-check, tests).

New test coverage in `tests/unit/cache/mappings/test_cluster.py`:
- Mapping definition validation (model attrs, no duplicates, field count, endpoint, CLI command, id_field, expected fields)
- Full API record parsing with all 18 fields
- Minimal and empty record defaults
- Nested field parsing (version, timezone, peering_policy)
- Wildcard management_interfaces extraction
- Parity tests confirming identical output to old hand-written parser for original 6 fields

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- The `/cluster` endpoint is a single-object endpoint (no `records` list), so the collector uses `parse_api_record()` directly rather than `parse_api_response()`. This is the same pattern used for other single-object endpoints.
- ADR-0004 updated with Issue #209 link in Related Issues section.
- Field mapping developer guide updated with Cluster in Migrated Types table.
