### PR TITLE
refactor: replace ClusterInfo.model with version fields

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -378,7 +378,7 @@ All models use `ConfigDict(extra="allow")` for forward compatibility with new AP
 | Model | Key Fields | Description |
 |-------|------------|-------------|
 | `CloudMetadata` | node, instance_id, provider, region, instance_type | Cloud provider metadata per node |
-| `ClusterInfo` | cluster_name, cluster_uuid, ontap_version, model, contact, location, is_ha | Core cluster identity |
+| `ClusterInfo` | cluster_name, cluster_uuid, ontap_version, version_generation, version_major, version_minor, contact, location, is_ha | Core cluster identity |
 | `NodeInfo` | uuid, name, serial_number, system_id, model, location, membership, version_full, storage_configuration, system_machine_type, controller_board, controller_memory_size, controller_cpu_count, vm_provider_type, ha_enabled, ha_auto_giveback, ha_partner_uuids, system_aggregate_uuid, cluster_interface_uuids, management_interface_uuids | Cluster node information |
 
 ### Network

--- a/src/pynetappfoundry/cache/_metadata.py
+++ b/src/pynetappfoundry/cache/_metadata.py
@@ -114,7 +114,7 @@ class CachedClusterMetadata(CacheModel, register=False):
             # Cluster info
             "cluster_uuid": self.cluster.cluster_uuid,
             "ontap_version": self.cluster.ontap_version,
-            "model": self.cluster.model,
+            "version_generation": self.cluster.version_generation,
             # Cache metadata
             "_cached_at": self.cached_at.isoformat(),
             "_cache_version": self.cache_version,

--- a/src/pynetappfoundry/cache/cluster/mapping.py
+++ b/src/pynetappfoundry/cache/cluster/mapping.py
@@ -33,8 +33,18 @@ CLUSTER_MAPPING = TypeMapping(
             api_path="version.full",
         ),
         FieldMapping(
-            cache_attr="model",
+            cache_attr="version_generation",
             api_path="version.generation",
+        ),
+        FieldMapping(
+            cache_attr="version_major",
+            api_path="version.major",
+            default=0,
+        ),
+        FieldMapping(
+            cache_attr="version_minor",
+            api_path="version.minor",
+            default=0,
         ),
         FieldMapping(
             cache_attr="contact",

--- a/src/pynetappfoundry/cache/cluster/model.py
+++ b/src/pynetappfoundry/cache/cluster/model.py
@@ -16,7 +16,9 @@ class ClusterInfo(CacheModel):
     cluster_name: str = ""
     cluster_uuid: str = ""
     ontap_version: str = ""
-    model: str = ""
+    version_generation: str = ""
+    version_major: int = 0
+    version_minor: int = 0
     contact: str = ""
     location: str = ""
     is_ha: bool = False
@@ -33,8 +35,8 @@ class ClusterInfo(CacheModel):
     auto_enable_activity_tracking: bool = False
     auto_enable_analytics: bool = False
 
-    @field_validator("model", mode="before")
+    @field_validator("version_generation", mode="before")
     @classmethod
-    def coerce_model_to_str(cls, v: object) -> str:
-        """Coerce model field to string (API sometimes returns int)."""
+    def coerce_version_generation_to_str(cls, v: object) -> str:
+        """Coerce version_generation to string (API sometimes returns int)."""
         return str(v) if v is not None else ""

--- a/tests/unit/cache/mappings/test_cluster.py
+++ b/tests/unit/cache/mappings/test_cluster.py
@@ -26,6 +26,8 @@ def full_api_record() -> dict[str, Any]:
         "version": {
             "full": "NetApp Release 9.14.1",
             "generation": "SIMULATED",
+            "major": 14,
+            "minor": 1,
         },
         "contact": "admin@example.com",
         "location": "datacenter-1",
@@ -71,8 +73,8 @@ class TestClusterMappingDefinition:
         assert len(attrs) == len(set(attrs))
 
     def test_field_count(self) -> None:
-        """Mapping has expected number of fields (18)."""
-        assert len(CLUSTER_MAPPING.fields) == 18
+        """Mapping has expected number of fields (20)."""
+        assert len(CLUSTER_MAPPING.fields) == 20
 
     def test_model_class(self) -> None:
         """Model class is ClusterInfo."""
@@ -129,7 +131,9 @@ class TestClusterApiParsing:
         assert result.cluster_name == "mycluster"
         assert result.cluster_uuid == "abc-123-def-456"
         assert result.ontap_version == "NetApp Release 9.14.1"
-        assert result.model == "SIMULATED"
+        assert result.version_generation == "SIMULATED"
+        assert result.version_major == 14
+        assert result.version_minor == 1
         assert result.contact == "admin@example.com"
         assert result.location == "datacenter-1"
         assert result.san_optimized is True
@@ -153,7 +157,9 @@ class TestClusterApiParsing:
         assert result.cluster_name == "minimal"
         assert result.cluster_uuid == "xyz"
         assert result.ontap_version == ""
-        assert result.model == ""
+        assert result.version_generation == ""
+        assert result.version_major == 0
+        assert result.version_minor == 0
         assert result.contact == ""
         assert result.location == ""
         assert result.san_optimized is False
@@ -177,19 +183,22 @@ class TestClusterApiParsing:
         assert result.cluster_name == ""
         assert result.cluster_uuid == ""
         assert result.ontap_version == ""
-        assert result.model == ""
+        assert result.version_generation == ""
+        assert result.version_major == 0
+        assert result.version_minor == 0
 
     def test_nested_version_fields(self) -> None:
-        """Nested version.full and version.generation parse correctly."""
+        """Nested version.full, version.generation, version.major, version.minor parse correctly."""
         record: dict[str, Any] = {
             "name": "test",
-            "version": {"full": "9.15.0", "generation": 9},
+            "version": {"full": "9.15.0", "generation": 9, "major": 15, "minor": 0},
         }
         result = parse_api_record(CLUSTER_MAPPING, record, "[test]")
         assert isinstance(result, ClusterInfo)
         assert result.ontap_version == "9.15.0"
-        # model field_validator coerces int to str
-        assert result.model == "9"
+        assert result.version_generation == "9"
+        assert result.version_major == 15
+        assert result.version_minor == 0
 
     def test_nested_timezone_field(self) -> None:
         """Nested timezone.name parses correctly."""
@@ -289,7 +298,7 @@ class TestParityWithOldParser:
             cluster_name=record.get("name", ""),
             cluster_uuid=record.get("uuid", ""),
             ontap_version=record.get("version", {}).get("full", ""),
-            model=record.get("version", {}).get("generation", ""),
+            version_generation=record.get("version", {}).get("generation", ""),
             contact=record.get("contact", ""),
             location=record.get("location", ""),
         )
@@ -298,7 +307,7 @@ class TestParityWithOldParser:
         "cluster_name",
         "cluster_uuid",
         "ontap_version",
-        "model",
+        "version_generation",
         "contact",
         "location",
     )

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -260,6 +260,8 @@ class TestClusterInfoCollection:
             "version": {
                 "full": "NetApp Release 9.14.1",
                 "generation": "SIMULATED",
+                "major": 9,
+                "minor": 14,
             },
             "contact": "admin@example.com",
             "location": "datacenter-1",
@@ -300,6 +302,9 @@ class TestClusterInfoCollection:
         assert result.cluster_name == "mycluster"
         assert result.cluster_uuid == "abc-123-def-456"
         assert "9.14.1" in result.ontap_version
+        assert result.version_generation == "SIMULATED"
+        assert result.version_major == 9
+        assert result.version_minor == 14
         assert result.contact == "admin@example.com"
         assert result.location == "datacenter-1"
         assert result.san_optimized is True

--- a/tests/unit/cache/test_models.py
+++ b/tests/unit/cache/test_models.py
@@ -118,7 +118,7 @@ class TestClusterInfo:
             cluster_name="mycluster",
             cluster_uuid="abc-123-def-456",
             ontap_version="NetApp Release 9.14.1",
-            model="SIMULATED",
+            version_generation="SIMULATED",
         )
         assert cluster.cluster_name == "mycluster"
         assert cluster.cluster_uuid == "abc-123-def-456"
@@ -1226,7 +1226,7 @@ class TestCachedClusterMetadata:
             cluster=ClusterInfo(
                 cluster_uuid="abc-123",
                 ontap_version="9.14.1",
-                model="SIMULATED",
+                version_generation="SIMULATED",
             ),
         )
         flat = metadata.to_flat_dict()
@@ -1237,7 +1237,7 @@ class TestCachedClusterMetadata:
         assert flat["instance_type"] == "m5.xlarge"
         assert flat["cluster_uuid"] == "abc-123"
         assert flat["ontap_version"] == "9.14.1"
-        assert flat["model"] == "SIMULATED"
+        assert flat["version_generation"] == "SIMULATED"
         assert "_cached_at" in flat
         assert "_cache_version" in flat
 


### PR DESCRIPTION
## Description

Replace the misnomer `model` field on `ClusterInfo` with three properly-named version fields (`version_generation`, `version_major`, `version_minor`) and update the declarative field mapping, flat-dict serialization, documentation, and all tests.

## Related Issue

Addresses #209

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Removed `model: str` from `ClusterInfo`; added `version_generation: str`, `version_major: int`, and `version_minor: int`
- Renamed the field validator from `coerce_model_to_str` to `coerce_version_generation_to_str`
- Added two `FieldMapping` entries to `CLUSTER_MAPPING` (18 -> 20 fields) for `version.major` and `version.minor`, both defaulting to `0`
- Updated `CachedClusterMetadata.to_flat_dict()` to emit `version_generation` instead of `model`
- Updated `docs/reference/cache.md` key-fields table to list the three new version fields
- Updated all unit tests: model construction, API parsing, parity checks, collector assertions, and flat-dict round-trip

## Breaking Change

`ClusterInfo.model` has been removed. Code that reads `cluster.model` must switch to `cluster.version_generation`. Two new integer fields (`version_major`, `version_minor`) are available for programmatic version comparison.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes (format, lint, type-check, security, spelling, tests).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

ADR-0004 already lists issue #209 in its Related Issues section; no ADR update needed.
