### PR TITLE
refactor: migrate DNSInfo to declarative field mapping framework

### DIFF
--- a/docs/decisions/0004-declarative-field-mapping-framework.md
+++ b/docs/decisions/0004-declarative-field-mapping-framework.md
@@ -64,6 +64,7 @@ The pilot migration (VolumeInfo) was completed in PR #189.
 - Issue #259: feat: generalize field mapping framework for multi-API data collection
 - Issue #209: refactor: migrate ClusterInfo to field mapping framework
 - Issue #257: refactor: deep URL-tree structure with automatic model and mapping discovery
+- Issue #205: refactor: migrate DNSInfo to field mapping framework
 
 ## Related Documentation
 

--- a/src/pynetappfoundry/cache/__init__.py
+++ b/src/pynetappfoundry/cache/__init__.py
@@ -23,6 +23,7 @@ import pynetappfoundry.cache.cloud.metadata
 import pynetappfoundry.cache.cluster.mediators
 import pynetappfoundry.cache.cluster.nodes
 import pynetappfoundry.cache.cluster.peers
+import pynetappfoundry.cache.name_services.dns
 import pynetappfoundry.cache.snapmirror.relationships
 import pynetappfoundry.cache.storage.aggregates
 import pynetappfoundry.cache.storage.volumes  # noqa: F401

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -45,6 +45,7 @@ from pynetappfoundry.cache.field_mapping import (
     parse_api_response,
     parse_cli_records,
 )
+from pynetappfoundry.cache.name_services.dns.mapping import DNS_MAPPING
 from pynetappfoundry.cache.name_services.dns.model import DNSInfo
 from pynetappfoundry.cache.network.ethernet.broadcast_domains.model import (
     BroadcastDomain,
@@ -937,7 +938,7 @@ class MetadataCollector:
             "/network/ip/interfaces?fields=*",
             "/network/ethernet/broadcast-domains?fields=*",
             "/network/ipspaces?fields=*",
-            "/name-services/dns?fields=*",
+            DNS_MAPPING.api_endpoint,
             "/network/ip/subnets?fields=*",
         ]
 
@@ -1021,7 +1022,15 @@ class MetadataCollector:
         ipspaces = [r.get("name", "") for r in ipspace_response.get("records", [])]
 
         # Process DNS response
-        dns = self._parse_dns_response(responses.get(endpoints[3]))
+        dns = cast(
+            list[DNSInfo],
+            parse_api_response(
+                DNS_MAPPING,
+                responses.get(endpoints[3]),
+                self._log_prefix,
+                self._log_missing_fields,
+            ),
+        )
 
         # Process subnets response
         subnets = self._parse_subnets_response(responses.get(endpoints[4]))
@@ -2011,45 +2020,6 @@ class MetadataCollector:
             )
             services.append(service)
         return services
-
-    def _parse_dns_response(self, response: Any) -> list[DNSInfo]:
-        """Parse DNS API response.
-
-        Args:
-            response: API response dict or None.
-
-        Returns:
-            List of DNSInfo objects.
-        """
-        if not response:
-            return []
-
-        logger.debug(
-            "%s API response: %d DNS configs",
-            self._log_prefix,
-            len(response.get("records", [])),
-        )
-        dns_configs = []
-        for record in response.get("records", []):
-            self._log_missing_fields(
-                record,
-                ["uuid", "svm", "scope", "domains", "servers", "timeout", "attempts"],
-                "DNS",
-                record.get("svm", {}).get("name", record.get("uuid", "unknown"))
-                if isinstance(record.get("svm"), dict)
-                else record.get("uuid", "unknown"),
-            )
-            dns = DNSInfo(
-                uuid=record.get("uuid", ""),
-                svm=record.get("svm", {}).get("name", "") if record.get("svm") else "",
-                scope=record.get("scope", ""),
-                domains=record.get("domains", []) or [],
-                servers=record.get("servers", []) or [],
-                timeout=record.get("timeout", 0),
-                attempts=record.get("attempts", 0),
-            )
-            dns_configs.append(dns)
-        return dns_configs
 
     def _parse_subnets_response(self, response: Any) -> list[IPSubnetInfo]:
         """Parse IP subnets API response.

--- a/src/pynetappfoundry/cache/diff.py
+++ b/src/pynetappfoundry/cache/diff.py
@@ -147,7 +147,7 @@ _ENTITY_CONFIGS: dict[str, EntityConfig] = {
     "network.dns": EntityConfig(
         key_field="uuid",
         model_class=DNSInfo,
-        display_field="svm",
+        display_field="svm_uuid",
     ),
     "storage.aggregates": EntityConfig(
         key_field="uuid",

--- a/src/pynetappfoundry/cache/name_services/dns/__init__.py
+++ b/src/pynetappfoundry/cache/name_services/dns/__init__.py
@@ -1,9 +1,11 @@
-"""Re-export DNS cache models."""
+"""Re-export DNS cache models and mappings."""
 
 from __future__ import annotations
 
+from pynetappfoundry.cache.name_services.dns.mapping import DNS_MAPPING
 from pynetappfoundry.cache.name_services.dns.model import DNSInfo
 
 __all__ = [
+    "DNS_MAPPING",
     "DNSInfo",
 ]

--- a/src/pynetappfoundry/cache/name_services/dns/mapping.py
+++ b/src/pynetappfoundry/cache/name_services/dns/mapping.py
@@ -1,0 +1,100 @@
+"""DNS type mapping definition for the declarative field mapping framework.
+
+Defines DNS_MAPPING which maps ONTAP REST API DNS configuration data
+to DNSInfo cache model attributes. DNS is API-only -- there is no CLI
+command for this data.
+
+All fields use simple dot-path extraction; no transform functions are
+needed.
+
+Note: ``tld_query_enabled``, ``source_address_match``, and
+``packet_query_match`` must be explicitly requested (not included in
+``fields=*``). ``service_ips`` is only available on ONTAP 9.14+.
+"""
+
+from __future__ import annotations
+
+from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.cache.name_services.dns.model import DNSInfo
+
+DNS_MAPPING = TypeMapping(
+    name="DNS",
+    model_class=DNSInfo,
+    api_endpoint="/name-services/dns?fields=*,tld_query_enabled,source_address_match,packet_query_match",
+    cli_command="",
+    fields=(
+        FieldMapping(
+            cache_attr="uuid",
+            api_path="uuid",
+        ),
+        FieldMapping(
+            cache_attr="svm_uuid",
+            api_path="svm.uuid",
+        ),
+        FieldMapping(
+            cache_attr="scope",
+            api_path="scope",
+        ),
+        FieldMapping(
+            cache_attr="domains",
+            api_path="domains",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="servers",
+            api_path="servers",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="timeout",
+            api_path="timeout",
+            default=0,
+        ),
+        FieldMapping(
+            cache_attr="attempts",
+            api_path="attempts",
+            default=0,
+        ),
+        FieldMapping(
+            cache_attr="dynamic_dns_enabled",
+            api_path="dynamic_dns.enabled",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="dynamic_dns_fqdn",
+            api_path="dynamic_dns.fqdn",
+        ),
+        FieldMapping(
+            cache_attr="dynamic_dns_time_to_live",
+            api_path="dynamic_dns.time_to_live",
+        ),
+        FieldMapping(
+            cache_attr="dynamic_dns_use_secure",
+            api_path="dynamic_dns.use_secure",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="packet_query_match",
+            api_path="packet_query_match",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="source_address_match",
+            api_path="source_address_match",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="tld_query_enabled",
+            api_path="tld_query_enabled",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="service_ips",
+            api_path="service_ips",
+            default=[],
+        ),
+    ),
+)
+
+model_registry.register_mapping("DNS", DNS_MAPPING)

--- a/src/pynetappfoundry/cache/name_services/dns/model.py
+++ b/src/pynetappfoundry/cache/name_services/dns/model.py
@@ -1,4 +1,4 @@
-"""DNS configuration — /name-services/dns."""
+"""DNS configuration -- /name-services/dns."""
 
 from __future__ import annotations
 
@@ -11,9 +11,17 @@ class DNSInfo(CacheModel):
     """DNS configuration per SVM or cluster."""
 
     uuid: str = ""
-    svm: str = ""
+    svm_uuid: str = ""
     scope: str = ""  # cluster, svm
     domains: list[str] = Field(default_factory=list)
     servers: list[str] = Field(default_factory=list)
     timeout: int = 0
     attempts: int = 0
+    dynamic_dns_enabled: bool = False
+    dynamic_dns_fqdn: str = ""
+    dynamic_dns_time_to_live: str = ""
+    dynamic_dns_use_secure: bool = False
+    packet_query_match: bool = True
+    source_address_match: bool = True
+    tld_query_enabled: bool = True
+    service_ips: list[str] = Field(default_factory=list)

--- a/tests/unit/cache/mappings/test_dns.py
+++ b/tests/unit/cache/mappings/test_dns.py
@@ -1,0 +1,326 @@
+"""Tests for the DNS type mapping definition."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pynetappfoundry.cache.field_mapping import (
+    parse_api_record,
+    parse_api_response,
+)
+from pynetappfoundry.cache.name_services.dns.mapping import DNS_MAPPING
+from pynetappfoundry.cache.name_services.dns.model import DNSInfo
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def full_api_record() -> dict[str, Any]:
+    """Full API DNS record with all fields populated."""
+    return {
+        "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "svm": {"name": "svm1", "uuid": "svm-uuid-1"},
+        "scope": "svm",
+        "domains": ["example.com", "test.local"],
+        "servers": ["10.0.0.1", "10.0.0.2"],
+        "timeout": 2,
+        "attempts": 1,
+        "dynamic_dns": {
+            "enabled": True,
+            "fqdn": "host1.example.com",
+            "time_to_live": "24h",
+            "use_secure": True,
+        },
+        "packet_query_match": False,
+        "source_address_match": False,
+        "tld_query_enabled": False,
+        "service_ips": ["10.0.0.100", "10.0.0.101"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mapping definition tests
+# ---------------------------------------------------------------------------
+
+
+class TestDnsMappingDefinition:
+    """Tests for DNS_MAPPING structure."""
+
+    def test_all_cache_attrs_exist_on_model(self) -> None:
+        """Every cache_attr in the mapping is a valid DNSInfo field."""
+        model_fields = set(DNSInfo.model_fields.keys())
+        for field in DNS_MAPPING.fields:
+            assert field.cache_attr in model_fields, (
+                f"cache_attr '{field.cache_attr}' not on DNSInfo"
+            )
+
+    def test_no_duplicate_cache_attrs(self) -> None:
+        """No duplicate cache_attr values."""
+        attrs = [f.cache_attr for f in DNS_MAPPING.fields]
+        assert len(attrs) == len(set(attrs))
+
+    def test_field_count(self) -> None:
+        """Mapping has expected number of fields (15)."""
+        assert len(DNS_MAPPING.fields) == 15
+
+    def test_model_class(self) -> None:
+        """Model class is DNSInfo."""
+        assert DNS_MAPPING.model_class is DNSInfo
+
+    def test_endpoint(self) -> None:
+        """API endpoint is correct."""
+        assert DNS_MAPPING.api_endpoint == (
+            "/name-services/dns?fields=*,tld_query_enabled,source_address_match,packet_query_match"
+        )
+
+    def test_cli_command_empty(self) -> None:
+        """CLI command is empty (API-only type)."""
+        assert DNS_MAPPING.cli_command == ""
+
+    def test_api_expected_fields(self) -> None:
+        """api_expected_fields returns correct top-level keys."""
+        expected = DNS_MAPPING.api_expected_fields()
+        assert expected == [
+            "attempts",
+            "domains",
+            "dynamic_dns",
+            "packet_query_match",
+            "scope",
+            "servers",
+            "service_ips",
+            "source_address_match",
+            "svm",
+            "timeout",
+            "tld_query_enabled",
+            "uuid",
+        ]
+
+    def test_id_field(self) -> None:
+        """id_field is name (default)."""
+        assert DNS_MAPPING.id_field == "name"
+
+
+# ---------------------------------------------------------------------------
+# API parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestDnsApiParsing:
+    """Tests for parsing API DNS records."""
+
+    def test_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Full API record parses correctly."""
+        result = parse_api_record(DNS_MAPPING, full_api_record, "[test]")
+        assert isinstance(result, DNSInfo)
+        assert result.uuid == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        assert result.svm_uuid == "svm-uuid-1"
+        assert result.scope == "svm"
+        assert result.domains == ["example.com", "test.local"]
+        assert result.servers == ["10.0.0.1", "10.0.0.2"]
+        assert result.timeout == 2
+        assert result.attempts == 1
+        assert result.dynamic_dns_enabled is True
+        assert result.dynamic_dns_fqdn == "host1.example.com"
+        assert result.dynamic_dns_time_to_live == "24h"
+        assert result.dynamic_dns_use_secure is True
+        assert result.packet_query_match is False
+        assert result.source_address_match is False
+        assert result.tld_query_enabled is False
+        assert result.service_ips == ["10.0.0.100", "10.0.0.101"]
+
+    def test_minimal_record(self) -> None:
+        """Minimal record uses defaults for missing fields."""
+        record: dict[str, Any] = {"uuid": "abc", "scope": "cluster"}
+        result = parse_api_record(DNS_MAPPING, record, "[test]")
+        assert isinstance(result, DNSInfo)
+        assert result.uuid == "abc"
+        assert result.svm_uuid == ""
+        assert result.scope == "cluster"
+        assert result.domains == []
+        assert result.servers == []
+        assert result.timeout == 0
+        assert result.attempts == 0
+        assert result.dynamic_dns_enabled is False
+        assert result.dynamic_dns_fqdn == ""
+        assert result.dynamic_dns_time_to_live == ""
+        assert result.dynamic_dns_use_secure is False
+        assert result.packet_query_match is True
+        assert result.source_address_match is True
+        assert result.tld_query_enabled is True
+        assert result.service_ips == []
+
+    def test_missing_nested_dynamic_dns(self) -> None:
+        """Record without dynamic_dns uses defaults."""
+        record: dict[str, Any] = {
+            "uuid": "abc",
+            "svm": {"name": "svm1", "uuid": "svm-uuid-1"},
+            "scope": "svm",
+            "domains": ["example.com"],
+            "servers": ["10.0.0.1"],
+            "timeout": 2,
+            "attempts": 1,
+        }
+        result = parse_api_record(DNS_MAPPING, record, "[test]")
+        assert isinstance(result, DNSInfo)
+        assert result.svm_uuid == "svm-uuid-1"
+        assert result.dynamic_dns_enabled is False
+        assert result.dynamic_dns_fqdn == ""
+        assert result.dynamic_dns_time_to_live == ""
+        assert result.dynamic_dns_use_secure is False
+
+    def test_parse_api_response_multiple(self) -> None:
+        """parse_api_response handles multiple records."""
+        response = {
+            "records": [
+                {
+                    "uuid": "dns-1",
+                    "svm": {"name": "svm1", "uuid": "svm-uuid-1"},
+                    "scope": "svm",
+                    "domains": ["example.com"],
+                    "servers": ["10.0.0.1"],
+                    "timeout": 2,
+                    "attempts": 1,
+                },
+                {
+                    "uuid": "dns-2",
+                    "svm": {"name": "svm2", "uuid": "svm-uuid-2"},
+                    "scope": "svm",
+                    "domains": ["test.local"],
+                    "servers": ["10.0.0.2"],
+                    "timeout": 3,
+                    "attempts": 2,
+                },
+            ],
+        }
+        results = parse_api_response(DNS_MAPPING, response, "[test]", MagicMock())
+        assert len(results) == 2
+        assert results[0].uuid == "dns-1"  # type: ignore[union-attr]
+        assert results[1].uuid == "dns-2"  # type: ignore[union-attr]
+
+    def test_parse_api_response_empty(self) -> None:
+        """parse_api_response handles empty/None response."""
+        assert parse_api_response(DNS_MAPPING, None, "[test]", MagicMock()) == []
+        assert parse_api_response(DNS_MAPPING, {}, "[test]", MagicMock()) == []
+
+    def test_missing_svm_uuid(self) -> None:
+        """Record without svm field defaults svm_uuid to empty string."""
+        record: dict[str, Any] = {"uuid": "abc", "scope": "cluster"}
+        result = parse_api_record(DNS_MAPPING, record, "[test]")
+        assert isinstance(result, DNSInfo)
+        assert result.svm_uuid == ""
+
+    def test_service_ips_missing_for_older_ontap(self) -> None:
+        """service_ips defaults to empty list when not present (pre-9.14)."""
+        record: dict[str, Any] = {
+            "uuid": "abc",
+            "svm": {"name": "svm1", "uuid": "svm-uuid-1"},
+            "scope": "svm",
+        }
+        result = parse_api_record(DNS_MAPPING, record, "[test]")
+        assert isinstance(result, DNSInfo)
+        assert result.service_ips == []
+
+
+# ---------------------------------------------------------------------------
+# Parity test: old parser vs new framework
+# ---------------------------------------------------------------------------
+
+
+class TestParityWithOldParser:
+    """Verify framework produces same output as old hand-written inline parser.
+
+    Parity is checked for the original 7 fields only. The new fields
+    were not in the old parser. The old parser extracted ``svm.name``;
+    the new mapping extracts ``svm.uuid``, so parity compares the
+    remaining 6 shared fields.
+    """
+
+    _ORIGINAL_SHARED_FIELDS = (
+        "uuid",
+        "scope",
+        "domains",
+        "servers",
+        "timeout",
+        "attempts",
+    )
+
+    @staticmethod
+    def _old_parse_dns(record: dict[str, Any]) -> DNSInfo:
+        """Reproduce old inline DNS parsing logic from collector.
+
+        This is a static copy of the code that was in
+        ``_parse_dns_response`` before migration, adapted to the
+        new model field names where applicable.
+        """
+        return DNSInfo(
+            uuid=record.get("uuid", ""),
+            svm_uuid=record.get("svm", {}).get("name", "") if record.get("svm") else "",
+            scope=record.get("scope", ""),
+            domains=record.get("domains", []) or [],
+            servers=record.get("servers", []) or [],
+            timeout=record.get("timeout", 0),
+            attempts=record.get("attempts", 0),
+        )
+
+    def test_parity_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Framework and old parser produce identical results for shared fields."""
+        old = self._old_parse_dns(full_api_record)
+        new = parse_api_record(DNS_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, DNSInfo)
+        for field_name in self._ORIGINAL_SHARED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_minimal_record(self) -> None:
+        """Framework and old parser match on minimal record."""
+        record: dict[str, Any] = {"uuid": "dns-1"}
+        old = self._old_parse_dns(record)
+        new = parse_api_record(DNS_MAPPING, record, "[test]")
+        assert isinstance(new, DNSInfo)
+        for field_name in self._ORIGINAL_SHARED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_svm_name_vs_uuid(self, full_api_record: dict[str, Any]) -> None:
+        """Old parser used svm.name; new mapping uses svm.uuid."""
+        old = self._old_parse_dns(full_api_record)
+        new = parse_api_record(DNS_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, DNSInfo)
+        # Old parser stored svm name in svm_uuid (adapted field)
+        assert old.svm_uuid == "svm1"
+        # New mapping stores svm uuid
+        assert new.svm_uuid == "svm-uuid-1"
+
+    def test_parity_no_svm(self) -> None:
+        """Both parsers handle missing svm field."""
+        record: dict[str, Any] = {
+            "uuid": "dns-1",
+            "scope": "cluster",
+            "domains": ["example.com"],
+            "servers": ["10.0.0.1"],
+            "timeout": 2,
+            "attempts": 1,
+        }
+        old = self._old_parse_dns(record)
+        new = parse_api_record(DNS_MAPPING, record, "[test]")
+        assert isinstance(new, DNSInfo)
+        for field_name in self._ORIGINAL_SHARED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+        # Both default svm_uuid to empty string when svm missing
+        assert old.svm_uuid == ""
+        assert new.svm_uuid == ""

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -427,16 +427,26 @@ class TestNetworkCollection:
                 ]
             },
             "/network/ipspaces?fields=*": {"records": [{"name": "Default"}, {"name": "Cluster"}]},
-            "/name-services/dns?fields=*": {
+            "/name-services/dns?fields=*,"
+            "tld_query_enabled,source_address_match,packet_query_match": {
                 "records": [
                     {
                         "uuid": "dns-uuid-1",
-                        "svm": {"name": "svm1"},
+                        "svm": {"name": "svm1", "uuid": "svm-uuid-1"},
                         "scope": "svm",
                         "domains": ["example.com"],
                         "servers": ["10.0.0.1", "10.0.0.2"],
                         "timeout": 2,
                         "attempts": 1,
+                        "dynamic_dns": {
+                            "enabled": False,
+                            "fqdn": "",
+                            "time_to_live": "",
+                            "use_secure": False,
+                        },
+                        "packet_query_match": True,
+                        "source_address_match": True,
+                        "tld_query_enabled": True,
                     }
                 ]
             },
@@ -473,7 +483,7 @@ class TestNetworkCollection:
         assert result.broadcast_domains[0].name == "Default"
         assert "Default" in result.ipspaces
         assert len(result.dns) == 1
-        assert result.dns[0].svm == "svm1"
+        assert result.dns[0].svm_uuid == "svm-uuid-1"
         assert result.dns[0].domains == ["example.com"]
         assert result.dns[0].servers == ["10.0.0.1", "10.0.0.2"]
         assert len(result.subnets) == 1

--- a/tests/unit/cache/test_diff.py
+++ b/tests/unit/cache/test_diff.py
@@ -947,7 +947,9 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             network=NetworkInfo(
                 dns=[
-                    DNSInfo(uuid="dns-uuid-1", svm="svm1", scope="svm", servers=["10.0.0.1"]),
+                    DNSInfo(
+                        uuid="dns-uuid-1", svm_uuid="svm-uuid-1", scope="svm", servers=["10.0.0.1"]
+                    ),
                 ],
             ),
         )
@@ -957,7 +959,7 @@ class TestComputeDiffAllCategories:
                 dns=[
                     DNSInfo(
                         uuid="dns-uuid-1",
-                        svm="svm1",
+                        svm_uuid="svm-uuid-1",
                         scope="svm",
                         servers=["10.0.0.1", "10.0.0.2"],
                     ),
@@ -983,7 +985,12 @@ class TestComputeDiffAllCategories:
             cluster_name="test-cluster",
             network=NetworkInfo(
                 dns=[
-                    DNSInfo(uuid="dns-uuid-1", svm="svm1", scope="svm", domains=["example.com"]),
+                    DNSInfo(
+                        uuid="dns-uuid-1",
+                        svm_uuid="svm-uuid-1",
+                        scope="svm",
+                        domains=["example.com"],
+                    ),
                 ],
             ),
         )
@@ -992,7 +999,7 @@ class TestComputeDiffAllCategories:
         dns_changes = [c for c in changes if c["category"] == "network.dns"]
         assert len(dns_changes) == 1
         assert dns_changes[0]["type"] == "added"
-        assert dns_changes[0]["entity"] == "svm1"
+        assert dns_changes[0]["entity"] == "svm-uuid-1"
 
     def test_flexcache_changes(self) -> None:
         """Test FlexCache change detection."""

--- a/tests/unit/cache/test_models.py
+++ b/tests/unit/cache/test_models.py
@@ -771,25 +771,33 @@ class TestDNSInfo:
         """Test default values."""
         dns = DNSInfo()
         assert dns.uuid == ""
-        assert dns.svm == ""
+        assert dns.svm_uuid == ""
         assert dns.scope == ""
         assert dns.domains == []
         assert dns.servers == []
         assert dns.timeout == 0
         assert dns.attempts == 0
+        assert dns.dynamic_dns_enabled is False
+        assert dns.dynamic_dns_fqdn == ""
+        assert dns.dynamic_dns_time_to_live == ""
+        assert dns.dynamic_dns_use_secure is False
+        assert dns.packet_query_match is True
+        assert dns.source_address_match is True
+        assert dns.tld_query_enabled is True
+        assert dns.service_ips == []
 
     def test_with_values(self) -> None:
         """Test with DNS data."""
         dns = DNSInfo(
             uuid="dns-uuid-1",
-            svm="svm1",
+            svm_uuid="svm-uuid-1",
             scope="svm",
             domains=["example.com", "corp.example.com"],
             servers=["10.0.0.1", "10.0.0.2"],
             timeout=2,
             attempts=1,
         )
-        assert dns.svm == "svm1"
+        assert dns.svm_uuid == "svm-uuid-1"
         assert dns.scope == "svm"
         assert len(dns.domains) == 2
         assert len(dns.servers) == 2

--- a/tests/unit/cache/test_registry_integration.py
+++ b/tests/unit/cache/test_registry_integration.py
@@ -82,12 +82,13 @@ class TestMappingRegistration:
     """Tests that all mappings are registered via register_mapping()."""
 
     def test_registry_contains_all_mappings(self) -> None:
-        """All 8 type mappings should be registered."""
+        """All 9 type mappings should be registered."""
         expected_mappings = {
             "Aggregate",
             "CloudMetadata",
             "Cluster",
             "ClusterPeer",
+            "DNS",
             "Mediator",
             "Node",
             "SnapMirror",
@@ -98,8 +99,8 @@ class TestMappingRegistration:
         assert not missing, f"Mappings not registered: {missing}"
 
     def test_mapping_count(self) -> None:
-        """Registry should contain exactly 8 mappings."""
-        assert len(model_registry.mappings) == 8
+        """Registry should contain exactly 9 mappings."""
+        assert len(model_registry.mappings) == 9
 
     def test_mapping_lookup_by_name(self) -> None:
         """get_mapping() should return the correct TypeMapping for known names."""


### PR DESCRIPTION
## Description

Migrate DNSInfo from hand-written inline parsing in `MetadataCollector._parse_dns_response` to the declarative field mapping framework. The new `DNS_MAPPING` replaces the old method with `parse_api_response`, following the same pattern established by the other eight migrated types. DNS is API-only (no CLI command).

The model gains eight new fields (`dynamic_dns_enabled`, `dynamic_dns_fqdn`, `dynamic_dns_time_to_live`, `dynamic_dns_use_secure`, `packet_query_match`, `source_address_match`, `tld_query_enabled`, `service_ips`) that the old parser did not extract. The `svm` field is renamed to `svm_uuid` and now stores the SVM UUID instead of the SVM name, consistent with other migrated models.

## Related Issue

Addresses #205

## Type of Change

- [x] Code refactoring

## Changes Made

- Added `src/pynetappfoundry/cache/name_services/dns/mapping.py` with `DNS_MAPPING` defining 15 field mappings for the `/name-services/dns` endpoint
- Replaced `DNSInfo.svm: str` with `DNSInfo.svm_uuid: str` and added 8 new fields to the model (`dynamic_dns_enabled`, `dynamic_dns_fqdn`, `dynamic_dns_time_to_live`, `dynamic_dns_use_secure`, `packet_query_match`, `source_address_match`, `tld_query_enabled`, `service_ips`)
- Removed `MetadataCollector._parse_dns_response` (~40 lines) and replaced the call site with `parse_api_response(DNS_MAPPING, ...)`
- Updated the API endpoint from `/name-services/dns?fields=*` to include `tld_query_enabled,source_address_match,packet_query_match` (fields not included in `*`)
- Registered `DNS_MAPPING` in the model registry (now 9 mappings total)
- Updated `diff.py` EntityConfig display field from `svm` to `svm_uuid`
- Updated `cache/__init__.py` to import the dns package for auto-registration
- Updated `dns/__init__.py` to re-export `DNS_MAPPING`
- Added `tests/unit/cache/mappings/test_dns.py` with mapping definition, API parsing, and parity tests
- Updated existing tests (`test_collector.py`, `test_diff.py`, `test_models.py`, `test_registry_integration.py`) for the renamed field and new fields
- Updated ADR-0004 with issue #205 link

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (format, lint, type-check, security, spell-check, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
