### PR TITLE
chore: improve Gemini review-pr command

### DIFF
--- a/.gemini/commands/review-pr.md
+++ b/.gemini/commands/review-pr.md
@@ -16,12 +16,18 @@ gh pr view --json number,title,body,baseRefName,headRefName
 
 If no PR exists for the current branch, output an error message and stop.
 
-### Step 2: Read the project standards
+### Step 2: Identify the Issue
+Scan the PR for "Addresses #XXX" for the issue number
+```bash
+gh issue view {issue number} --json body,comments
+```
+
+### Step 3: Read the project standards
 
 - Read `AGENTS.md` — understand code style, testing requirements, and conventions
 - Read `.github/CONTRIBUTING.md` — understand contribution guidelines
 
-### Step 3: Get the changes
+### Step 4: Get the changes
 
 ```bash
 gh pr diff
@@ -29,19 +35,24 @@ gh pr diff
 
 Review the full diff carefully.
 
-### Step 4: Analyze the changes
+### Step 5: Analyze the changes
 
 Review the code for:
 
-1. **Correctness** — Does the logic work? Are there bugs or edge cases?
-2. **Code Style** — Does it follow project conventions from AGENTS.md?
-3. **Testing** — Are tests adequate? Are edge cases covered?
-4. **Security** — Any OWASP top 10 vulnerabilities? Command injection, path traversal, etc.?
-5. **Documentation** — Are docstrings/comments appropriate? Does behavior change need doc updates?
-6. **Architecture** — Does it follow existing patterns? Is there tight coupling?
-7. **Breaking Changes** — Does this change public APIs or default behavior?
+1. **Issue and Plan** - Does it fulfil the issue and plan?
+2. **Correctness** — Does the logic work? Are there bugs or edge cases?
+3. **Code Style** — Does it follow project conventions from AGENTS.md?
+4. **Testing** — Are tests adequate? Are edge cases covered?
+5. **Security** — Any OWASP top 10 vulnerabilities? Command injection, path traversal, etc.?
+6. **Documentation** — Are docstrings/comments appropriate? Does behavior change need doc updates?
+7. **Architecture** — Does it follow existing patterns? Is there tight coupling?
+8. **Breaking Changes** — Does this change public APIs or default behavior?
 
-### Step 5: Output the review
+If the diff alone is insufficient to evaluate a pattern or convention, read the
+relevant source file for context. Do not read every touched file upfront — only
+when a specific finding requires it.
+
+### Step 6: Output the review
 
 Output the review in this exact format:
 


### PR DESCRIPTION
## Description

Improve the Gemini `review-pr` command with bug fixes and enhancements to give Gemini better context for code reviews.

## Related Issue

Addresses #276

## Type of Change

- [x] Documentation update

## Changes Made

- Fixed step numbering (was duplicated/skipped)
- Fixed typo in documentation check item ("doc 7pdates" → "doc updates")
- Added Step 2 to fetch the linked issue and plan comment via `gh issue view --json body,comments`, so Gemini can evaluate whether the PR fulfils the plan
- Added guidance to read source files for context when a specific finding requires it (without reading every file upfront)

## Testing

- [x] All existing tests pass
- [x] Manually reviewed the command file

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
