### PR TITLE
refactor: migrate SVMInfo to declarative field mapping framework

### DIFF
--- a/docs/decisions/0004-declarative-field-mapping-framework.md
+++ b/docs/decisions/0004-declarative-field-mapping-framework.md
@@ -64,6 +64,7 @@ The pilot migration (VolumeInfo) was completed in PR #189.
 - Issue #259: feat: generalize field mapping framework for multi-API data collection
 - Issue #209: refactor: migrate ClusterInfo to field mapping framework
 - Issue #257: refactor: deep URL-tree structure with automatic model and mapping discovery
+- Issue #192: refactor: migrate SVMInfo to field mapping framework
 - Issue #205: refactor: migrate DNSInfo to field mapping framework
 
 ## Related Documentation

--- a/src/pynetappfoundry/cache/__init__.py
+++ b/src/pynetappfoundry/cache/__init__.py
@@ -26,7 +26,8 @@ import pynetappfoundry.cache.cluster.peers
 import pynetappfoundry.cache.name_services.dns
 import pynetappfoundry.cache.snapmirror.relationships
 import pynetappfoundry.cache.storage.aggregates
-import pynetappfoundry.cache.storage.volumes  # noqa: F401
+import pynetappfoundry.cache.storage.volumes
+import pynetappfoundry.cache.svm  # noqa: F401
 from pynetappfoundry.cache._base import (
     METADATA_SCHEMA_MIN_COMPATIBLE,
     METADATA_SCHEMA_VERSION,

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -78,6 +78,7 @@ from pynetappfoundry.cache.storage.snapshot_policies.model import (
 )
 from pynetappfoundry.cache.storage.volumes.mapping import VOLUME_MAPPING
 from pynetappfoundry.cache.storage.volumes.model import VolumeInfo
+from pynetappfoundry.cache.svm.mapping import SVM_MAPPING
 from pynetappfoundry.cache.svm.model import SVMInfo
 from pynetappfoundry.cache.svm.peers.model import SVMPeerInfo
 from pynetappfoundry.utils.cloud import (
@@ -1089,7 +1090,7 @@ class MetadataCollector:
         # Make all API calls in parallel using cached calls
         endpoints = [
             AGGREGATE_MAPPING.api_endpoint,
-            "/svm/svms?fields=*",
+            SVM_MAPPING.api_endpoint,
             "/cloud/targets?fields=*",
             "/storage/volumes?fields=*,autosize,files,nas.path,nas.security_style",
             "/storage/qtrees?fields=*",
@@ -1134,27 +1135,15 @@ class MetadataCollector:
         )
 
         # Process SVMs response
-        svm_response = responses.get(endpoints[1]) or {}
-        logger.debug(
-            "%s API response: %d SVMs", self._log_prefix, len(svm_response.get("records", []))
+        svms = cast(
+            list[SVMInfo],
+            parse_api_response(
+                SVM_MAPPING,
+                responses.get(endpoints[1]),
+                self._log_prefix,
+                self._log_missing_fields,
+            ),
         )
-        svms = []
-        for record in svm_response.get("records", []):
-            self._log_missing_fields(
-                record,
-                ["uuid", "name", "state", "subtype", "allowed_protocols", "language"],
-                "SVM",
-                record.get("name", record.get("uuid", "unknown")),
-            )
-            svm = SVMInfo(
-                uuid=record.get("uuid", ""),
-                name=record.get("name", ""),
-                state=record.get("state", ""),
-                subtype=record.get("subtype", ""),
-                allowed_protocols=record.get("allowed_protocols", []) or [],
-                language=record.get("language", ""),
-            )
-            svms.append(svm)
 
         # Process cloud targets response
         cloud_targets = self._parse_cloud_targets_response(responses.get(endpoints[2]))

--- a/src/pynetappfoundry/cache/svm/__init__.py
+++ b/src/pynetappfoundry/cache/svm/__init__.py
@@ -1,11 +1,13 @@
-"""Re-export SVM cache models and sub-package models."""
+"""Re-export SVM cache models, mappings, and sub-package models."""
 
 from __future__ import annotations
 
+from pynetappfoundry.cache.svm.mapping import SVM_MAPPING
 from pynetappfoundry.cache.svm.model import SVMInfo
 from pynetappfoundry.cache.svm.peers import SVMPeerInfo
 
 __all__ = [
+    "SVM_MAPPING",
     "SVMInfo",
     "SVMPeerInfo",
 ]

--- a/src/pynetappfoundry/cache/svm/mapping.py
+++ b/src/pynetappfoundry/cache/svm/mapping.py
@@ -1,0 +1,264 @@
+"""SVM type mapping definition for the declarative field mapping framework.
+
+Defines SVM_MAPPING which maps ONTAP REST API SVM data
+to SVMInfo cache model attributes. SVM is API-only -- there is no CLI
+command for this data.
+
+All fields use simple dot-path extraction; no transform functions are
+needed.
+
+Note: ``snapmirror.*`` is an expensive property and must be explicitly
+requested via ``?fields=*,snapmirror``.
+``anti_ransomware_auto_switch_minimum_incoming_data_percent`` exists
+as a filter param (integer, 9.13+) but is not in the OpenAPI
+definition body; it will default to 0 on older ONTAP versions.
+"""
+
+from __future__ import annotations
+
+from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.cache.svm.model import SVMInfo
+
+SVM_MAPPING = TypeMapping(
+    name="SVM",
+    model_class=SVMInfo,
+    api_endpoint="/svm/svms?fields=*,snapmirror",
+    cli_command="",
+    fields=(
+        # Core (4)
+        FieldMapping(
+            cache_attr="uuid",
+            api_path="uuid",
+        ),
+        FieldMapping(
+            cache_attr="name",
+            api_path="name",
+        ),
+        FieldMapping(
+            cache_attr="language",
+            api_path="language",
+        ),
+        FieldMapping(
+            cache_attr="subtype",
+            api_path="subtype",
+        ),
+        # References / Lists (4)
+        FieldMapping(
+            cache_attr="aggregate_uuids",
+            api_path="aggregates[*].uuid",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="ip_interface_uuids",
+            api_path="ip_interfaces[*].uuid",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="fc_interface_uuids",
+            api_path="fc_interfaces[*].uuid",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="snapshot_policy_uuid",
+            api_path="snapshot_policy.uuid",
+        ),
+        # Name Services (2)
+        FieldMapping(
+            cache_attr="nis_enabled",
+            api_path="nis.enabled",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="ldap_enabled",
+            api_path="ldap.enabled",
+            default=False,
+        ),
+        # Protocol Flags (13)
+        FieldMapping(
+            cache_attr="nfs_enabled",
+            api_path="nfs.enabled",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="nfs_allowed",
+            api_path="nfs.allowed",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="cifs_enabled",
+            api_path="cifs.enabled",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="cifs_allowed",
+            api_path="cifs.allowed",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="iscsi_enabled",
+            api_path="iscsi.enabled",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="iscsi_allowed",
+            api_path="iscsi.allowed",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="fcp_enabled",
+            api_path="fcp.enabled",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="fcp_allowed",
+            api_path="fcp.allowed",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="nvme_enabled",
+            api_path="nvme.enabled",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="nvme_allowed",
+            api_path="nvme.allowed",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="ndmp_allowed",
+            api_path="ndmp.allowed",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="s3_allowed",
+            api_path="s3.allowed",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="s3_enabled",
+            api_path="s3.enabled",
+            default=False,
+        ),
+        # SVM Settings (4)
+        FieldMapping(
+            cache_attr="aggregates_delegated",
+            api_path="aggregates_delegated",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="max_volumes",
+            api_path="max_volumes",
+        ),
+        FieldMapping(
+            cache_attr="auto_enable_analytics",
+            api_path="auto_enable_analytics",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="auto_enable_activity_tracking",
+            api_path="auto_enable_activity_tracking",
+            default=False,
+        ),
+        # Anti-Ransomware (6)
+        FieldMapping(
+            cache_attr="anti_ransomware_auto_switch_from_learning_to_enabled",
+            api_path="anti_ransomware_auto_switch_from_learning_to_enabled",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="anti_ransomware_auto_switch_minimum_incoming_data_percent",
+            api_path="anti_ransomware_auto_switch_minimum_incoming_data_percent",
+            default=0,
+        ),
+        FieldMapping(
+            cache_attr="anti_ransomware_auto_switch_duration_without_new_file_extension",
+            api_path="anti_ransomware_auto_switch_duration_without_new_file_extension",
+            default=3,
+        ),
+        FieldMapping(
+            cache_attr="anti_ransomware_auto_switch_minimum_learning_period",
+            api_path="anti_ransomware_auto_switch_minimum_learning_period",
+            default=10,
+        ),
+        FieldMapping(
+            cache_attr="anti_ransomware_auto_switch_minimum_file_count",
+            api_path="anti_ransomware_auto_switch_minimum_file_count",
+            default=200,
+        ),
+        FieldMapping(
+            cache_attr="anti_ransomware_auto_switch_minimum_file_extension",
+            api_path="anti_ransomware_auto_switch_minimum_file_extension",
+            default=10,
+        ),
+        # SnapMirror (2)
+        FieldMapping(
+            cache_attr="snapmirror_is_protected",
+            api_path="snapmirror.is_protected",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="snapmirror_protected_volumes_count",
+            api_path="snapmirror.protected_volumes_count",
+            default=0,
+        ),
+        # Storage (1)
+        FieldMapping(
+            cache_attr="storage_limit",
+            api_path="storage.limit",
+            default=0,
+        ),
+        # Space Management (2)
+        FieldMapping(
+            cache_attr="is_space_enforcement_logical",
+            api_path="is_space_enforcement_logical",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="is_space_reporting_logical",
+            api_path="is_space_reporting_logical",
+            default=False,
+        ),
+        # QoS References (3)
+        FieldMapping(
+            cache_attr="qos_adaptive_policy_group_template_uuid",
+            api_path="qos_adaptive_policy_group_template.uuid",
+        ),
+        FieldMapping(
+            cache_attr="qos_policy_uuid",
+            api_path="qos_policy.uuid",
+        ),
+        FieldMapping(
+            cache_attr="qos_policy_group_template_uuid",
+            api_path="qos_policy_group_template.uuid",
+        ),
+        # NSSwitch (5)
+        FieldMapping(
+            cache_attr="nsswitch_group",
+            api_path="nsswitch.group",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="nsswitch_hosts",
+            api_path="nsswitch.hosts",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="nsswitch_namemap",
+            api_path="nsswitch.namemap",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="nsswitch_netgroup",
+            api_path="nsswitch.netgroup",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="nsswitch_passwd",
+            api_path="nsswitch.passwd",
+            default=[],
+        ),
+    ),
+)
+
+model_registry.register_mapping("SVM", SVM_MAPPING)

--- a/src/pynetappfoundry/cache/svm/model.py
+++ b/src/pynetappfoundry/cache/svm/model.py
@@ -1,4 +1,4 @@
-"""SVM information — /svm/svms."""
+"""SVM information -- /svm/svms."""
 
 from __future__ import annotations
 
@@ -10,11 +10,70 @@ from pynetappfoundry.cache._base import CacheModel
 class SVMInfo(CacheModel):
     """Storage Virtual Machine information."""
 
+    # Core (4)
     uuid: str = ""
     name: str = ""
-    state: str = ""
-    subtype: str = ""  # default, dp_destination, sync_source
-    root_volume: str = ""
-    root_volume_aggregate: str = ""
-    allowed_protocols: list[str] = Field(default_factory=list)
     language: str = ""
+    subtype: str = ""  # default, dp_destination, sync_source
+
+    # References / Lists (4)
+    aggregate_uuids: list[str] = Field(default_factory=list)
+    ip_interface_uuids: list[str] = Field(default_factory=list)
+    fc_interface_uuids: list[str] = Field(default_factory=list)
+    snapshot_policy_uuid: str = ""
+
+    # Name Services (2)
+    nis_enabled: bool = False
+    ldap_enabled: bool = False
+
+    # Protocol Flags (13)
+    nfs_enabled: bool = False
+    nfs_allowed: bool = True
+    cifs_enabled: bool = False
+    cifs_allowed: bool = True
+    iscsi_enabled: bool = False
+    iscsi_allowed: bool = True
+    fcp_enabled: bool = False
+    fcp_allowed: bool = True
+    nvme_enabled: bool = False
+    nvme_allowed: bool = True
+    ndmp_allowed: bool = True
+    s3_allowed: bool = True
+    s3_enabled: bool = False
+
+    # SVM Settings (4)
+    aggregates_delegated: bool = False
+    max_volumes: str = ""
+    auto_enable_analytics: bool = False
+    auto_enable_activity_tracking: bool = False
+
+    # Anti-Ransomware (6)
+    anti_ransomware_auto_switch_from_learning_to_enabled: bool = True
+    anti_ransomware_auto_switch_minimum_incoming_data_percent: int = 0
+    anti_ransomware_auto_switch_duration_without_new_file_extension: int = 3
+    anti_ransomware_auto_switch_minimum_learning_period: int = 10
+    anti_ransomware_auto_switch_minimum_file_count: int = 200
+    anti_ransomware_auto_switch_minimum_file_extension: int = 10
+
+    # SnapMirror (2)
+    snapmirror_is_protected: bool = False
+    snapmirror_protected_volumes_count: int = 0
+
+    # Storage (1)
+    storage_limit: int = 0
+
+    # Space Management (2)
+    is_space_enforcement_logical: bool = False
+    is_space_reporting_logical: bool = False
+
+    # QoS References (3)
+    qos_adaptive_policy_group_template_uuid: str = ""
+    qos_policy_uuid: str = ""
+    qos_policy_group_template_uuid: str = ""
+
+    # NSSwitch (5)
+    nsswitch_group: list[str] = Field(default_factory=list)
+    nsswitch_hosts: list[str] = Field(default_factory=list)
+    nsswitch_namemap: list[str] = Field(default_factory=list)
+    nsswitch_netgroup: list[str] = Field(default_factory=list)
+    nsswitch_passwd: list[str] = Field(default_factory=list)

--- a/src/pynetappfoundry/cli/commands/cache/inspect.py
+++ b/src/pynetappfoundry/cli/commands/cache/inspect.py
@@ -19,6 +19,7 @@ from pynetappfoundry.cache.cluster.peers.mapping import CLUSTER_PEER_MAPPING
 from pynetappfoundry.cache.field_mapping import TypeMapping
 from pynetappfoundry.cache.storage.aggregates.mapping import AGGREGATE_MAPPING
 from pynetappfoundry.cache.storage.volumes.mapping import VOLUME_MAPPING
+from pynetappfoundry.cache.svm.mapping import SVM_MAPPING
 from pynetappfoundry.cli.utils import print_error, print_exception, print_warning
 from pynetappfoundry.clients.ontap import ONTAPCLI, ONTAPAPIClient
 from pynetappfoundry.core.config import Config
@@ -34,6 +35,7 @@ INSPECT_TYPES: dict[str, tuple[TypeMapping, str]] = {
     "cloud_metadata": (CLOUD_METADATA_MAPPING, "cloud"),
     "cluster_peer": (CLUSTER_PEER_MAPPING, "relationships.cluster_peers"),
     "node": (NODE_MAPPING, "nodes"),
+    "svm": (SVM_MAPPING, "storage.svms"),
     "volume": (VOLUME_MAPPING, "storage.volumes"),
 }
 

--- a/tests/unit/cache/mappings/test_svm.py
+++ b/tests/unit/cache/mappings/test_svm.py
@@ -1,0 +1,527 @@
+"""Tests for the SVM type mapping definition."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pynetappfoundry.cache.field_mapping import (
+    parse_api_record,
+    parse_api_response,
+)
+from pynetappfoundry.cache.svm.mapping import SVM_MAPPING
+from pynetappfoundry.cache.svm.model import SVMInfo
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def full_api_record() -> dict[str, Any]:
+    """Full API SVM record with all fields populated."""
+    return {
+        "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "name": "svm1",
+        "language": "en_us.utf_8",
+        "subtype": "default",
+        "aggregates": [
+            {"uuid": "aggr-uuid-1"},
+            {"uuid": "aggr-uuid-2"},
+        ],
+        "ip_interfaces": [
+            {"uuid": "lif-uuid-1"},
+            {"uuid": "lif-uuid-2"},
+        ],
+        "fc_interfaces": [
+            {"uuid": "fc-uuid-1"},
+        ],
+        "snapshot_policy": {"uuid": "snap-policy-uuid-1"},
+        "nis": {"enabled": True},
+        "ldap": {"enabled": True},
+        "nfs": {"enabled": True, "allowed": True},
+        "cifs": {"enabled": True, "allowed": True},
+        "iscsi": {"enabled": True, "allowed": True},
+        "fcp": {"enabled": True, "allowed": True},
+        "nvme": {"enabled": True, "allowed": True},
+        "ndmp": {"allowed": False},
+        "s3": {"allowed": False, "enabled": True},
+        "aggregates_delegated": True,
+        "max_volumes": "500",
+        "auto_enable_analytics": True,
+        "auto_enable_activity_tracking": True,
+        "anti_ransomware_auto_switch_from_learning_to_enabled": False,
+        "anti_ransomware_auto_switch_minimum_incoming_data_percent": 25,
+        "anti_ransomware_auto_switch_duration_without_new_file_extension": 5,
+        "anti_ransomware_auto_switch_minimum_learning_period": 14,
+        "anti_ransomware_auto_switch_minimum_file_count": 500,
+        "anti_ransomware_auto_switch_minimum_file_extension": 20,
+        "snapmirror": {
+            "is_protected": True,
+            "protected_volumes_count": 3,
+        },
+        "storage": {"limit": 1099511627776},
+        "is_space_enforcement_logical": True,
+        "is_space_reporting_logical": True,
+        "qos_adaptive_policy_group_template": {"uuid": "qos-adaptive-uuid-1"},
+        "qos_policy": {"uuid": "qos-policy-uuid-1"},
+        "qos_policy_group_template": {"uuid": "qos-group-uuid-1"},
+        "nsswitch": {
+            "group": ["files", "ldap"],
+            "hosts": ["files", "dns"],
+            "namemap": ["files"],
+            "netgroup": ["files", "ldap"],
+            "passwd": ["files", "ldap"],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mapping definition tests
+# ---------------------------------------------------------------------------
+
+
+class TestSvmMappingDefinition:
+    """Tests for SVM_MAPPING structure."""
+
+    def test_all_cache_attrs_exist_on_model(self) -> None:
+        """Every cache_attr in the mapping is a valid SVMInfo field."""
+        model_fields = set(SVMInfo.model_fields.keys())
+        for field in SVM_MAPPING.fields:
+            assert field.cache_attr in model_fields, (
+                f"cache_attr '{field.cache_attr}' not on SVMInfo"
+            )
+
+    def test_no_duplicate_cache_attrs(self) -> None:
+        """No duplicate cache_attr values."""
+        attrs = [f.cache_attr for f in SVM_MAPPING.fields]
+        assert len(attrs) == len(set(attrs))
+
+    def test_field_count(self) -> None:
+        """Mapping has expected number of fields (46)."""
+        assert len(SVM_MAPPING.fields) == 46
+
+    def test_model_field_count(self) -> None:
+        """SVMInfo model has expected number of fields (46)."""
+        assert len(SVMInfo.model_fields) == 46
+
+    def test_model_class(self) -> None:
+        """Model class is SVMInfo."""
+        assert SVM_MAPPING.model_class is SVMInfo
+
+    def test_endpoint(self) -> None:
+        """API endpoint is correct with snapmirror expansion."""
+        assert SVM_MAPPING.api_endpoint == "/svm/svms?fields=*,snapmirror"
+
+    def test_cli_command_empty(self) -> None:
+        """CLI command is empty (API-only type)."""
+        assert SVM_MAPPING.cli_command == ""
+
+    def test_id_field(self) -> None:
+        """id_field is name (default)."""
+        assert SVM_MAPPING.id_field == "name"
+
+    def test_api_expected_fields(self) -> None:
+        """api_expected_fields returns correct top-level keys."""
+        expected = SVM_MAPPING.api_expected_fields()
+        assert expected == [
+            "aggregates",
+            "aggregates_delegated",
+            "anti_ransomware_auto_switch_duration_without_new_file_extension",
+            "anti_ransomware_auto_switch_from_learning_to_enabled",
+            "anti_ransomware_auto_switch_minimum_file_count",
+            "anti_ransomware_auto_switch_minimum_file_extension",
+            "anti_ransomware_auto_switch_minimum_incoming_data_percent",
+            "anti_ransomware_auto_switch_minimum_learning_period",
+            "auto_enable_activity_tracking",
+            "auto_enable_analytics",
+            "cifs",
+            "fc_interfaces",
+            "fcp",
+            "ip_interfaces",
+            "is_space_enforcement_logical",
+            "is_space_reporting_logical",
+            "iscsi",
+            "language",
+            "ldap",
+            "max_volumes",
+            "name",
+            "ndmp",
+            "nfs",
+            "nis",
+            "nsswitch",
+            "nvme",
+            "qos_adaptive_policy_group_template",
+            "qos_policy",
+            "qos_policy_group_template",
+            "s3",
+            "snapmirror",
+            "snapshot_policy",
+            "storage",
+            "subtype",
+            "uuid",
+        ]
+
+    def test_all_model_fields_have_mapping(self) -> None:
+        """Every SVMInfo model field has a corresponding mapping entry."""
+        mapped_attrs = {f.cache_attr for f in SVM_MAPPING.fields}
+        model_fields = set(SVMInfo.model_fields.keys())
+        unmapped = model_fields - mapped_attrs
+        assert not unmapped, f"Model fields without mapping: {unmapped}"
+
+
+# ---------------------------------------------------------------------------
+# API parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestSvmApiParsing:
+    """Tests for parsing API SVM records."""
+
+    def test_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Full API record parses correctly."""
+        result = parse_api_record(SVM_MAPPING, full_api_record, "[test]")
+        assert isinstance(result, SVMInfo)
+
+        # Core
+        assert result.uuid == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        assert result.name == "svm1"
+        assert result.language == "en_us.utf_8"
+        assert result.subtype == "default"
+
+        # References / Lists
+        assert result.aggregate_uuids == ["aggr-uuid-1", "aggr-uuid-2"]
+        assert result.ip_interface_uuids == ["lif-uuid-1", "lif-uuid-2"]
+        assert result.fc_interface_uuids == ["fc-uuid-1"]
+        assert result.snapshot_policy_uuid == "snap-policy-uuid-1"
+
+        # Name Services
+        assert result.nis_enabled is True
+        assert result.ldap_enabled is True
+
+        # Protocol Flags
+        assert result.nfs_enabled is True
+        assert result.nfs_allowed is True
+        assert result.cifs_enabled is True
+        assert result.cifs_allowed is True
+        assert result.iscsi_enabled is True
+        assert result.iscsi_allowed is True
+        assert result.fcp_enabled is True
+        assert result.fcp_allowed is True
+        assert result.nvme_enabled is True
+        assert result.nvme_allowed is True
+        assert result.ndmp_allowed is False
+        assert result.s3_allowed is False
+        assert result.s3_enabled is True
+
+        # SVM Settings
+        assert result.aggregates_delegated is True
+        assert result.max_volumes == "500"
+        assert result.auto_enable_analytics is True
+        assert result.auto_enable_activity_tracking is True
+
+        # Anti-Ransomware
+        assert result.anti_ransomware_auto_switch_from_learning_to_enabled is False
+        assert result.anti_ransomware_auto_switch_minimum_incoming_data_percent == 25
+        assert result.anti_ransomware_auto_switch_duration_without_new_file_extension == 5
+        assert result.anti_ransomware_auto_switch_minimum_learning_period == 14
+        assert result.anti_ransomware_auto_switch_minimum_file_count == 500
+        assert result.anti_ransomware_auto_switch_minimum_file_extension == 20
+
+        # SnapMirror
+        assert result.snapmirror_is_protected is True
+        assert result.snapmirror_protected_volumes_count == 3
+
+        # Storage
+        assert result.storage_limit == 1099511627776
+
+        # Space Management
+        assert result.is_space_enforcement_logical is True
+        assert result.is_space_reporting_logical is True
+
+        # QoS References
+        assert result.qos_adaptive_policy_group_template_uuid == "qos-adaptive-uuid-1"
+        assert result.qos_policy_uuid == "qos-policy-uuid-1"
+        assert result.qos_policy_group_template_uuid == "qos-group-uuid-1"
+
+        # NSSwitch
+        assert result.nsswitch_group == ["files", "ldap"]
+        assert result.nsswitch_hosts == ["files", "dns"]
+        assert result.nsswitch_namemap == ["files"]
+        assert result.nsswitch_netgroup == ["files", "ldap"]
+        assert result.nsswitch_passwd == ["files", "ldap"]
+
+    def test_minimal_record(self) -> None:
+        """Minimal record uses defaults for missing fields."""
+        record: dict[str, Any] = {"uuid": "abc", "name": "svm-min"}
+        result = parse_api_record(SVM_MAPPING, record, "[test]")
+        assert isinstance(result, SVMInfo)
+        assert result.uuid == "abc"
+        assert result.name == "svm-min"
+        assert result.language == ""
+        assert result.subtype == ""
+
+        # Lists default to empty
+        assert result.aggregate_uuids == []
+        assert result.ip_interface_uuids == []
+        assert result.fc_interface_uuids == []
+        assert result.snapshot_policy_uuid == ""
+
+        # Name Services default to False
+        assert result.nis_enabled is False
+        assert result.ldap_enabled is False
+
+        # Protocol defaults
+        assert result.nfs_enabled is False
+        assert result.nfs_allowed is True
+        assert result.cifs_enabled is False
+        assert result.cifs_allowed is True
+        assert result.iscsi_enabled is False
+        assert result.iscsi_allowed is True
+        assert result.fcp_enabled is False
+        assert result.fcp_allowed is True
+        assert result.nvme_enabled is False
+        assert result.nvme_allowed is True
+        assert result.ndmp_allowed is True
+        assert result.s3_allowed is True
+        assert result.s3_enabled is False
+
+        # SVM Settings defaults
+        assert result.aggregates_delegated is False
+        assert result.max_volumes == ""
+        assert result.auto_enable_analytics is False
+        assert result.auto_enable_activity_tracking is False
+
+        # Anti-Ransomware defaults
+        assert result.anti_ransomware_auto_switch_from_learning_to_enabled is True
+        assert result.anti_ransomware_auto_switch_minimum_incoming_data_percent == 0
+        assert result.anti_ransomware_auto_switch_duration_without_new_file_extension == 3
+        assert result.anti_ransomware_auto_switch_minimum_learning_period == 10
+        assert result.anti_ransomware_auto_switch_minimum_file_count == 200
+        assert result.anti_ransomware_auto_switch_minimum_file_extension == 10
+
+        # SnapMirror defaults
+        assert result.snapmirror_is_protected is False
+        assert result.snapmirror_protected_volumes_count == 0
+
+        # Storage defaults
+        assert result.storage_limit == 0
+
+        # Space Management defaults
+        assert result.is_space_enforcement_logical is False
+        assert result.is_space_reporting_logical is False
+
+        # QoS defaults
+        assert result.qos_adaptive_policy_group_template_uuid == ""
+        assert result.qos_policy_uuid == ""
+        assert result.qos_policy_group_template_uuid == ""
+
+        # NSSwitch defaults
+        assert result.nsswitch_group == []
+        assert result.nsswitch_hosts == []
+        assert result.nsswitch_namemap == []
+        assert result.nsswitch_netgroup == []
+        assert result.nsswitch_passwd == []
+
+    def test_missing_nested_snapmirror(self) -> None:
+        """Record without snapmirror field uses defaults."""
+        record: dict[str, Any] = {
+            "uuid": "abc",
+            "name": "svm1",
+            "subtype": "default",
+        }
+        result = parse_api_record(SVM_MAPPING, record, "[test]")
+        assert isinstance(result, SVMInfo)
+        assert result.snapmirror_is_protected is False
+        assert result.snapmirror_protected_volumes_count == 0
+
+    def test_missing_nested_nsswitch(self) -> None:
+        """Record without nsswitch field uses defaults."""
+        record: dict[str, Any] = {
+            "uuid": "abc",
+            "name": "svm1",
+        }
+        result = parse_api_record(SVM_MAPPING, record, "[test]")
+        assert isinstance(result, SVMInfo)
+        assert result.nsswitch_group == []
+        assert result.nsswitch_hosts == []
+        assert result.nsswitch_namemap == []
+        assert result.nsswitch_netgroup == []
+        assert result.nsswitch_passwd == []
+
+    def test_missing_nested_protocols(self) -> None:
+        """Record without protocol sub-objects uses defaults."""
+        record: dict[str, Any] = {
+            "uuid": "abc",
+            "name": "svm1",
+        }
+        result = parse_api_record(SVM_MAPPING, record, "[test]")
+        assert isinstance(result, SVMInfo)
+        assert result.nfs_enabled is False
+        assert result.nfs_allowed is True
+        assert result.cifs_enabled is False
+        assert result.cifs_allowed is True
+        assert result.iscsi_enabled is False
+        assert result.iscsi_allowed is True
+        assert result.fcp_enabled is False
+        assert result.fcp_allowed is True
+        assert result.nvme_enabled is False
+        assert result.nvme_allowed is True
+        assert result.ndmp_allowed is True
+        assert result.s3_allowed is True
+        assert result.s3_enabled is False
+
+    def test_missing_qos_references(self) -> None:
+        """Record without QoS fields uses defaults."""
+        record: dict[str, Any] = {
+            "uuid": "abc",
+            "name": "svm1",
+        }
+        result = parse_api_record(SVM_MAPPING, record, "[test]")
+        assert isinstance(result, SVMInfo)
+        assert result.qos_adaptive_policy_group_template_uuid == ""
+        assert result.qos_policy_uuid == ""
+        assert result.qos_policy_group_template_uuid == ""
+
+    def test_empty_aggregates_list(self) -> None:
+        """Record with empty aggregates list produces empty uuid list."""
+        record: dict[str, Any] = {
+            "uuid": "abc",
+            "name": "svm1",
+            "aggregates": [],
+        }
+        result = parse_api_record(SVM_MAPPING, record, "[test]")
+        assert isinstance(result, SVMInfo)
+        assert result.aggregate_uuids == []
+
+    def test_parse_api_response_multiple(self) -> None:
+        """parse_api_response handles multiple records."""
+        response = {
+            "records": [
+                {
+                    "uuid": "svm-1",
+                    "name": "svm1",
+                    "subtype": "default",
+                    "language": "en_us.utf_8",
+                },
+                {
+                    "uuid": "svm-2",
+                    "name": "svm2",
+                    "subtype": "dp_destination",
+                    "language": "c.utf_8",
+                },
+            ],
+        }
+        results = parse_api_response(SVM_MAPPING, response, "[test]", MagicMock())
+        assert len(results) == 2
+        assert results[0].uuid == "svm-1"  # type: ignore[union-attr]
+        assert results[0].name == "svm1"  # type: ignore[union-attr]
+        assert results[1].uuid == "svm-2"  # type: ignore[union-attr]
+        assert results[1].name == "svm2"  # type: ignore[union-attr]
+
+    def test_parse_api_response_empty(self) -> None:
+        """parse_api_response handles empty/None response."""
+        assert parse_api_response(SVM_MAPPING, None, "[test]", MagicMock()) == []
+        assert parse_api_response(SVM_MAPPING, {}, "[test]", MagicMock()) == []
+
+    def test_anti_ransomware_missing_on_older_ontap(self) -> None:
+        """Anti-ransomware fields default when not present (pre-9.13)."""
+        record: dict[str, Any] = {
+            "uuid": "abc",
+            "name": "svm1",
+        }
+        result = parse_api_record(SVM_MAPPING, record, "[test]")
+        assert isinstance(result, SVMInfo)
+        assert result.anti_ransomware_auto_switch_from_learning_to_enabled is True
+        assert result.anti_ransomware_auto_switch_minimum_incoming_data_percent == 0
+        assert result.anti_ransomware_auto_switch_duration_without_new_file_extension == 3
+        assert result.anti_ransomware_auto_switch_minimum_learning_period == 10
+        assert result.anti_ransomware_auto_switch_minimum_file_count == 200
+        assert result.anti_ransomware_auto_switch_minimum_file_extension == 10
+
+    def test_storage_limit_missing(self) -> None:
+        """storage.limit defaults to 0 when storage object is missing."""
+        record: dict[str, Any] = {"uuid": "abc", "name": "svm1"}
+        result = parse_api_record(SVM_MAPPING, record, "[test]")
+        assert isinstance(result, SVMInfo)
+        assert result.storage_limit == 0
+
+
+# ---------------------------------------------------------------------------
+# Parity test: old parser vs new framework
+# ---------------------------------------------------------------------------
+
+
+class TestParityWithOldParser:
+    """Verify framework produces same output as old hand-written inline parser.
+
+    Parity is checked for the original shared fields only (uuid, name,
+    subtype, language). The old fields ``state``, ``root_volume``,
+    ``root_volume_aggregate``, and ``allowed_protocols`` have been removed.
+    """
+
+    _ORIGINAL_SHARED_FIELDS = (
+        "uuid",
+        "name",
+        "subtype",
+        "language",
+    )
+
+    @staticmethod
+    def _old_parse_svm(record: dict[str, Any]) -> SVMInfo:
+        """Reproduce old inline SVM parsing logic from collector.
+
+        This is a static copy of the code that was in
+        ``_collect_storage_via_api`` before migration, adapted to
+        the new model (removed fields are omitted).
+        """
+        return SVMInfo(
+            uuid=record.get("uuid", ""),
+            name=record.get("name", ""),
+            subtype=record.get("subtype", ""),
+            language=record.get("language", ""),
+        )
+
+    def test_parity_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Framework and old parser produce identical results for shared fields."""
+        old = self._old_parse_svm(full_api_record)
+        new = parse_api_record(SVM_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, SVMInfo)
+        for field_name in self._ORIGINAL_SHARED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_minimal_record(self) -> None:
+        """Framework and old parser match on minimal record."""
+        record: dict[str, Any] = {"uuid": "svm-1"}
+        old = self._old_parse_svm(record)
+        new = parse_api_record(SVM_MAPPING, record, "[test]")
+        assert isinstance(new, SVMInfo)
+        for field_name in self._ORIGINAL_SHARED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Removed fields tests
+# ---------------------------------------------------------------------------
+
+
+class TestRemovedFields:
+    """Verify that removed legacy fields no longer exist on SVMInfo."""
+
+    @pytest.mark.parametrize(
+        "field_name",
+        ["state", "root_volume", "root_volume_aggregate", "allowed_protocols"],
+    )
+    def test_removed_field_not_on_model(self, field_name: str) -> None:
+        """Legacy field is no longer a model attribute."""
+        assert field_name not in SVMInfo.model_fields

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -524,7 +524,7 @@ class TestStorageCollection:
                     }
                 ]
             },
-            "/svm/svms?fields=*": {
+            "/svm/svms?fields=*,snapmirror": {
                 "records": [{"name": "svm1", "state": "running", "subtype": "default"}]
             },
             "/cloud/targets?fields=*": {"records": []},
@@ -775,7 +775,7 @@ class TestCloudTargetsCollection:
                     }
                 ]
             },
-            "/svm/svms?fields=*": {
+            "/svm/svms?fields=*,snapmirror": {
                 "records": [{"name": "svm1", "state": "running", "subtype": "default"}]
             },
             "/cloud/targets?fields=*": mock_cloud_targets_api_response,
@@ -827,7 +827,7 @@ class TestCloudTargetsCollection:
                 return {
                     "records": [{"name": "aggr1", "node": {"name": "node1"}, "state": "online"}]
                 }
-            if endpoint == "/svm/svms?fields=*":
+            if endpoint == "/svm/svms?fields=*,snapmirror":
                 return {"records": [{"name": "svm1", "state": "running"}]}
             return {}
 
@@ -845,7 +845,7 @@ class TestCloudTargetsCollection:
         api_client = MagicMock()
         api_client.get_all_records.side_effect = lambda endpoint, **_: {
             "/storage/aggregates?fields=*,is_spare_low,sidl_enabled": {"records": []},
-            "/svm/svms?fields=*": {"records": []},
+            "/svm/svms?fields=*,snapmirror": {"records": []},
             "/cloud/targets?fields=*": {"records": []},
         }.get(endpoint, {})
 

--- a/tests/unit/cache/test_models.py
+++ b/tests/unit/cache/test_models.py
@@ -265,27 +265,30 @@ class TestSVMInfo:
         svm = SVMInfo()
         assert svm.uuid == ""
         assert svm.name == ""
-        assert svm.state == ""
-        assert svm.allowed_protocols == []
         assert svm.language == ""
+        assert svm.subtype == ""
+        assert svm.aggregate_uuids == []
+        assert svm.nfs_enabled is False
+        assert svm.nfs_allowed is True
 
     def test_with_values(self) -> None:
         """Test with SVM data."""
         svm = SVMInfo(
             uuid="svm-uuid-1",
             name="svm1",
-            state="running",
             subtype="default",
-            root_volume="svm1_root",
-            root_volume_aggregate="aggr1",
-            allowed_protocols=["nfs", "cifs"],
             language="c.utf_8",
+            nfs_enabled=True,
+            cifs_enabled=True,
+            aggregate_uuids=["aggr-uuid-1", "aggr-uuid-2"],
         )
         assert svm.uuid == "svm-uuid-1"
         assert svm.name == "svm1"
-        assert svm.state == "running"
-        assert svm.allowed_protocols == ["nfs", "cifs"]
+        assert svm.subtype == "default"
         assert svm.language == "c.utf_8"
+        assert svm.nfs_enabled is True
+        assert svm.cifs_enabled is True
+        assert svm.aggregate_uuids == ["aggr-uuid-1", "aggr-uuid-2"]
 
 
 class TestCloudTargetInfo:

--- a/tests/unit/cache/test_registry_integration.py
+++ b/tests/unit/cache/test_registry_integration.py
@@ -82,7 +82,7 @@ class TestMappingRegistration:
     """Tests that all mappings are registered via register_mapping()."""
 
     def test_registry_contains_all_mappings(self) -> None:
-        """All 9 type mappings should be registered."""
+        """All 10 type mappings should be registered."""
         expected_mappings = {
             "Aggregate",
             "CloudMetadata",
@@ -92,6 +92,7 @@ class TestMappingRegistration:
             "Mediator",
             "Node",
             "SnapMirror",
+            "SVM",
             "Volume",
         }
         registered = set(model_registry.mappings.keys())
@@ -99,8 +100,8 @@ class TestMappingRegistration:
         assert not missing, f"Mappings not registered: {missing}"
 
     def test_mapping_count(self) -> None:
-        """Registry should contain exactly 9 mappings."""
-        assert len(model_registry.mappings) == 9
+        """Registry should contain exactly 10 mappings."""
+        assert len(model_registry.mappings) == 10
 
     def test_mapping_lookup_by_name(self) -> None:
         """get_mapping() should return the correct TypeMapping for known names."""


### PR DESCRIPTION
## Description

Migrate SVMInfo from inline hand-written parsing in the collector to the declarative field mapping framework (ADR-0004). The new `SVM_MAPPING` replaces the old inline `record.get()` calls in `_collect_storage_via_api` with `parse_api_response(SVM_MAPPING, ...)`, and the SVMInfo model is expanded from 8 fields to 46 fields covering all SVM properties available in the `/svm/svms` REST API endpoint.

## Related Issue

Addresses #192

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `src/pynetappfoundry/cache/svm/mapping.py` with `SVM_MAPPING` TypeMapping definition (46 fields across core, references, name services, protocol flags, SVM settings, anti-ransomware, SnapMirror, storage, space management, QoS, and NSSwitch categories)
- Replaced the SVMInfo model (8 fields) with expanded 46-field model covering all `/svm/svms?fields=*,snapmirror` API properties; removed legacy fields (`state`, `root_volume`, `root_volume_aggregate`, `allowed_protocols`)
- Updated `collector.py` to use `parse_api_response(SVM_MAPPING, ...)` instead of inline parsing, and changed the SVM endpoint from `/svm/svms?fields=*` to `/svm/svms?fields=*,snapmirror` for expensive property expansion
- Registered `SVM_MAPPING` in the model registry (bumps mapping count from 9 to 10)
- Added SVM to the `cache inspect` command's `INSPECT_TYPES` registry
- Updated `cache/svm/__init__.py` to re-export the new mapping
- Updated `cache/__init__.py` to import the `svm` sub-package for mapping registration
- Added `tests/unit/cache/mappings/test_svm.py` with comprehensive tests (mapping definition, full/minimal API parsing, defaults, nested field handling, parity with old parser, removed field verification)
- Updated ADR-0004 with issue #192 link
- Updated existing tests in `test_collector.py`, `test_models.py`, and `test_registry_integration.py` for the new endpoint and model changes

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

New test file `tests/unit/cache/mappings/test_svm.py` covers:
- Mapping definition validation (field count, model class, endpoint, expected fields, no duplicates, all model fields mapped)
- Full API record parsing with all 46 fields verified
- Minimal record parsing verifying all defaults
- Missing nested field handling (snapmirror, nsswitch, protocols, QoS)
- Multi-record `parse_api_response` handling
- Parity tests comparing old inline parser output to new framework output
- Anti-ransomware field defaults for pre-9.13 ONTAP
- Verification that removed legacy fields no longer exist on model

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This is a **breaking change** for the SVMInfo model: the fields `state`, `root_volume`, `root_volume_aggregate`, and `allowed_protocols` have been removed. These fields were not actively used and are replaced by more comprehensive per-protocol `*_enabled`/`*_allowed` flags and aggregate UUID references.

The SVM endpoint now requests `?fields=*,snapmirror` to include the expensive `snapmirror` property, enabling `snapmirror_is_protected` and `snapmirror_protected_volumes_count` fields.
