### PR TITLE
refactor: migrate LicenseInfo to declarative field mapping framework

### DIFF
--- a/docs/decisions/0004-declarative-field-mapping-framework.md
+++ b/docs/decisions/0004-declarative-field-mapping-framework.md
@@ -66,6 +66,7 @@ The pilot migration (VolumeInfo) was completed in PR #189.
 - Issue #257: refactor: deep URL-tree structure with automatic model and mapping discovery
 - Issue #192: refactor: migrate SVMInfo to field mapping framework
 - Issue #205: refactor: migrate DNSInfo to field mapping framework
+- Issue #213: refactor: migrate LicenseInfo/LicenseFeature to field mapping framework
 
 ## Related Documentation
 

--- a/src/pynetappfoundry/cache/__init__.py
+++ b/src/pynetappfoundry/cache/__init__.py
@@ -20,6 +20,7 @@ Infrastructure (DB, collector, diff, registry) is imported from here::
 # Models are already registered via CacheModel.__init_subclass__ when
 # _metadata.py transitively imports all leaf model.py files above.
 import pynetappfoundry.cache.cloud.metadata
+import pynetappfoundry.cache.cluster.licensing
 import pynetappfoundry.cache.cluster.mediators
 import pynetappfoundry.cache.cluster.nodes
 import pynetappfoundry.cache.cluster.peers

--- a/src/pynetappfoundry/cache/_metadata.py
+++ b/src/pynetappfoundry/cache/_metadata.py
@@ -19,7 +19,7 @@ from pynetappfoundry.cache._base import (
     _utcnow,
 )
 from pynetappfoundry.cache.cloud.metadata.model import CloudMetadata
-from pynetappfoundry.cache.cluster.licensing.model import LicenseInfo
+from pynetappfoundry.cache.cluster.licensing.model import LicensePackage
 from pynetappfoundry.cache.cluster.mediators.model import MediatorInfo
 from pynetappfoundry.cache.cluster.model import ClusterInfo
 from pynetappfoundry.cache.cluster.nodes.model import NodeInfo
@@ -77,7 +77,7 @@ class CachedClusterMetadata(CacheModel, register=False):
     nodes: list[NodeInfo] = Field(default_factory=list)
     network: NetworkInfo = Field(default_factory=NetworkInfo)
     storage: StorageInfo = Field(default_factory=StorageInfo)
-    licenses: LicenseInfo = Field(default_factory=LicenseInfo)
+    license_packages: list[LicensePackage] = Field(default_factory=list)
     mediator: MediatorInfo = Field(default_factory=MediatorInfo)
     relationships: RelationshipsInfo = Field(default_factory=RelationshipsInfo)
     protocols: ProtocolsInfo = Field(default_factory=ProtocolsInfo)

--- a/src/pynetappfoundry/cache/cluster/licensing/__init__.py
+++ b/src/pynetappfoundry/cache/cluster/licensing/__init__.py
@@ -1,15 +1,15 @@
-"""Re-export cluster licensing cache models."""
+"""Re-export cluster licensing cache models and mapping."""
 
 from __future__ import annotations
 
+from pynetappfoundry.cache.cluster.licensing.mapping import LICENSE_PACKAGE_MAPPING
 from pynetappfoundry.cache.cluster.licensing.model import (
-    CapacityLicense,
-    LicenseFeature,
-    LicenseInfo,
+    LicenseInstance,
+    LicensePackage,
 )
 
 __all__ = [
-    "CapacityLicense",
-    "LicenseFeature",
-    "LicenseInfo",
+    "LICENSE_PACKAGE_MAPPING",
+    "LicenseInstance",
+    "LicensePackage",
 ]

--- a/src/pynetappfoundry/cache/cluster/licensing/mapping.py
+++ b/src/pynetappfoundry/cache/cluster/licensing/mapping.py
@@ -1,0 +1,95 @@
+"""License package type mapping definition for the declarative field mapping framework.
+
+Defines LICENSE_PACKAGE_MAPPING which maps ONTAP REST API license data to
+LicensePackage cache model attributes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache.cluster.licensing.model import LicenseInstance, LicensePackage
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+
+
+def _api_instances(record: dict[str, Any]) -> list[LicenseInstance]:
+    """Transform the nested ``licenses[]`` array into LicenseInstance objects.
+
+    The API returns per-node license instances under the ``licenses`` key.
+    Each instance has nested ``capacity.maximum_size`` and
+    ``compliance.state`` sub-objects that need flattening.
+
+    Args:
+        record: A single license package API record.
+
+    Returns:
+        List of LicenseInstance objects parsed from the nested array.
+    """
+    raw_list = record.get("licenses", [])
+    if not isinstance(raw_list, list):
+        return []
+
+    instances: list[LicenseInstance] = []
+    for entry in raw_list:
+        if not isinstance(entry, dict):
+            continue
+        capacity = entry.get("capacity", {}) or {}
+        compliance = entry.get("compliance", {}) or {}
+        instances.append(
+            LicenseInstance(
+                active=entry.get("active", False),
+                capacity_max=capacity.get("maximum_size", 0) or 0,
+                compliance_state=compliance.get("state", ""),
+                evaluation=entry.get("evaluation", False),
+                expiry_time=entry.get("expiry_time", ""),
+                host_id=entry.get("host_id", ""),
+                installed_license=entry.get("installed_license", ""),
+                owner=entry.get("owner", ""),
+                serial_number=entry.get("serial_number", ""),
+                shutdown_imminent=entry.get("shutdown_imminent", False),
+                start_time=entry.get("start_time", ""),
+            )
+        )
+    return instances
+
+
+LICENSE_PACKAGE_MAPPING = TypeMapping(
+    name="LicensePackage",
+    model_class=LicensePackage,
+    api_endpoint="/cluster/licensing/licenses?fields=name,scope,state,description,entitlement,licenses",
+    cli_command="",
+    fields=(
+        FieldMapping(
+            cache_attr="name",
+            api_path="name",
+        ),
+        FieldMapping(
+            cache_attr="scope",
+            api_path="scope",
+        ),
+        FieldMapping(
+            cache_attr="state",
+            api_path="state",
+        ),
+        FieldMapping(
+            cache_attr="description",
+            api_path="description",
+        ),
+        FieldMapping(
+            cache_attr="entitlement_action",
+            api_path="entitlement.action",
+        ),
+        FieldMapping(
+            cache_attr="entitlement_risk",
+            api_path="entitlement.risk",
+        ),
+        FieldMapping(
+            cache_attr="instances",
+            transform=_api_instances,
+            default=[],
+        ),
+    ),
+)
+
+model_registry.register_mapping("LicensePackage", LICENSE_PACKAGE_MAPPING)

--- a/src/pynetappfoundry/cache/cluster/licensing/model.py
+++ b/src/pynetappfoundry/cache/cluster/licensing/model.py
@@ -7,27 +7,37 @@ from pydantic import Field
 from pynetappfoundry.cache._base import CacheModel
 
 
-class LicenseFeature(CacheModel):
-    """License feature information."""
+class LicenseInstance(CacheModel):
+    """Per-node license instance within a license package.
 
-    name: str = ""
-    state: str = ""  # compliant, noncompliant
-    scope: str = ""  # cluster, node
-
-
-class CapacityLicense(CacheModel):
-    """Capacity-based license information."""
-
-    name: str = ""
-    licensed_capacity: int = 0  # bytes
-    used_capacity: int = 0  # bytes
-
-
-class LicenseInfo(CacheModel):
-    """Licensing information.
-
-    Contains feature and capacity licenses.
+    Each entry in the API ``licenses[]`` array represents a license
+    installed on a specific node.
     """
 
-    feature_licenses: list[LicenseFeature] = Field(default_factory=list)
-    capacity_licenses: list[CapacityLicense] = Field(default_factory=list)
+    active: bool = False
+    capacity_max: int = 0
+    compliance_state: str = ""
+    evaluation: bool = False
+    expiry_time: str = ""
+    host_id: str = ""
+    installed_license: str = ""
+    owner: str = ""
+    serial_number: str = ""
+    shutdown_imminent: bool = False
+    start_time: str = ""
+
+
+class LicensePackage(CacheModel):
+    """License package from /cluster/licensing/licenses.
+
+    Represents a top-level license package (e.g. NFS, CIFS) with
+    nested per-node license instances.
+    """
+
+    name: str = ""
+    scope: str = ""
+    state: str = ""
+    description: str = ""
+    entitlement_action: str = ""
+    entitlement_risk: str = ""
+    instances: list[LicenseInstance] = Field(default_factory=list)

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -26,11 +26,8 @@ from pynetappfoundry.cache._metadata import (
 from pynetappfoundry.cache.cloud.metadata.mapping import CLOUD_METADATA_MAPPING
 from pynetappfoundry.cache.cloud.metadata.model import CloudMetadata
 from pynetappfoundry.cache.cloud.targets.model import CloudTargetInfo
-from pynetappfoundry.cache.cluster.licensing.model import (
-    CapacityLicense,
-    LicenseFeature,
-    LicenseInfo,
-)
+from pynetappfoundry.cache.cluster.licensing.mapping import LICENSE_PACKAGE_MAPPING
+from pynetappfoundry.cache.cluster.licensing.model import LicensePackage
 from pynetappfoundry.cache.cluster.mapping import CLUSTER_MAPPING
 from pynetappfoundry.cache.cluster.mediators.mapping import MEDIATOR_MAPPING
 from pynetappfoundry.cache.cluster.mediators.model import MediatorInfo
@@ -310,7 +307,7 @@ class MetadataCollector:
             nodes=results["nodes"],
             network=results["network"],
             storage=results["storage"],
-            licenses=results["licenses"],
+            license_packages=results["licenses"],
             mediator=results["mediator"],
             relationships=results["relationships"],
             protocols=results["protocols"],
@@ -1245,11 +1242,11 @@ class MetadataCollector:
     # License Collection
     # -------------------------------------------------------------------------
 
-    def collect_licenses(self) -> LicenseInfo:
+    def collect_licenses(self) -> list[LicensePackage]:
         """Collect licensing information (API-only).
 
         Returns:
-            LicenseInfo object.
+            List of LicensePackage objects.
 
         Raises:
             CollectionError: If no API client is available.
@@ -1270,51 +1267,23 @@ class MetadataCollector:
             )
             raise
 
-    def _collect_licenses_via_api(self) -> LicenseInfo:
+    def _collect_licenses_via_api(self) -> list[LicensePackage]:
         """Collect licenses using REST API.
 
         Returns:
-            LicenseInfo from /cluster/licensing/licenses endpoint.
+            List of LicensePackage from /cluster/licensing/licenses endpoint.
         """
         if not self.api_client:
             logger.debug("%s No API client available for license collection", self._log_prefix)
-            return LicenseInfo()
+            return []
 
-        response = self._cached_api_call("/cluster/licensing/licenses?fields=*")
-        if not response:
-            return LicenseInfo()
-
-        logger.debug(
-            "%s API response: %d licenses", self._log_prefix, len(response.get("records", []))
+        response = self._cached_api_call(LICENSE_PACKAGE_MAPPING.api_endpoint)
+        return cast(
+            list[LicensePackage],
+            parse_api_response(
+                LICENSE_PACKAGE_MAPPING, response, self._log_prefix, self._log_missing_fields
+            ),
         )
-        feature_licenses = []
-        capacity_licenses = []
-
-        for record in response.get("records", []):
-            self._log_missing_fields(
-                record,
-                ["name", "state", "scope", "capacity"],
-                "License",
-                record.get("name", "unknown"),
-            )
-            name = record.get("name", "")
-            state = record.get("state", "")
-            scope = record.get("scope", "")
-
-            # Check if it's a capacity license
-            capacity = record.get("capacity", {})
-            if capacity.get("maximum_size"):
-                cap_license = CapacityLicense(
-                    name=name,
-                    licensed_capacity=capacity.get("maximum_size", 0),
-                    used_capacity=capacity.get("used_size", 0),
-                )
-                capacity_licenses.append(cap_license)
-            else:
-                feature = LicenseFeature(name=name, state=state, scope=scope)
-                feature_licenses.append(feature)
-
-        return LicenseInfo(feature_licenses=feature_licenses, capacity_licenses=capacity_licenses)
 
     # -------------------------------------------------------------------------
     # Mediator Collection

--- a/src/pynetappfoundry/cache/diff.py
+++ b/src/pynetappfoundry/cache/diff.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 from pynetappfoundry.cache._base import CacheModel
 from pynetappfoundry.cache.cloud.metadata.model import CloudMetadata
 from pynetappfoundry.cache.cloud.targets.model import CloudTargetInfo
-from pynetappfoundry.cache.cluster.licensing.model import CapacityLicense, LicenseFeature
+from pynetappfoundry.cache.cluster.licensing.model import LicensePackage
 from pynetappfoundry.cache.cluster.model import ClusterInfo
 from pynetappfoundry.cache.cluster.nodes.model import NodeInfo
 from pynetappfoundry.cache.cluster.peers.model import ClusterPeer
@@ -265,14 +265,9 @@ _ENTITY_CONFIGS: dict[str, EntityConfig] = {
         model_class=CIFSServiceInfo,
         display_field="svm",
     ),
-    "licenses.feature_licenses": EntityConfig(
+    "license_packages": EntityConfig(
         key_field="name",
-        model_class=LicenseFeature,
-        display_field="name",
-    ),
-    "licenses.capacity_licenses": EntityConfig(
-        key_field="name",
-        model_class=CapacityLicense,
+        model_class=LicensePackage,
         display_field="name",
     ),
 }

--- a/src/pynetappfoundry/cli/commands/cache/inspect.py
+++ b/src/pynetappfoundry/cli/commands/cache/inspect.py
@@ -14,6 +14,7 @@ from rich.tree import Tree
 
 from pynetappfoundry.cache import ClusterMetadataDB
 from pynetappfoundry.cache.cloud.metadata.mapping import CLOUD_METADATA_MAPPING
+from pynetappfoundry.cache.cluster.licensing.mapping import LICENSE_PACKAGE_MAPPING
 from pynetappfoundry.cache.cluster.nodes.mapping import NODE_MAPPING
 from pynetappfoundry.cache.cluster.peers.mapping import CLUSTER_PEER_MAPPING
 from pynetappfoundry.cache.field_mapping import TypeMapping
@@ -34,6 +35,7 @@ INSPECT_TYPES: dict[str, tuple[TypeMapping, str]] = {
     "aggregate": (AGGREGATE_MAPPING, "storage.aggregates"),
     "cloud_metadata": (CLOUD_METADATA_MAPPING, "cloud"),
     "cluster_peer": (CLUSTER_PEER_MAPPING, "relationships.cluster_peers"),
+    "license": (LICENSE_PACKAGE_MAPPING, "license_packages"),
     "node": (NODE_MAPPING, "nodes"),
     "svm": (SVM_MAPPING, "storage.svms"),
     "volume": (VOLUME_MAPPING, "storage.volumes"),

--- a/tests/unit/cache/mappings/test_license.py
+++ b/tests/unit/cache/mappings/test_license.py
@@ -1,0 +1,371 @@
+"""Tests for the LicensePackage type mapping definition."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pynetappfoundry.cache.cluster.licensing.mapping import (
+    LICENSE_PACKAGE_MAPPING,
+    _api_instances,
+)
+from pynetappfoundry.cache.cluster.licensing.model import LicenseInstance, LicensePackage
+from pynetappfoundry.cache.field_mapping import (
+    parse_api_record,
+    parse_api_response,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def full_api_record() -> dict[str, Any]:
+    """Full API license package record with all fields populated."""
+    return {
+        "name": "nfs",
+        "scope": "cluster",
+        "state": "compliant",
+        "description": "NFS License",
+        "entitlement": {
+            "action": "acquire_license",
+            "risk": "medium",
+        },
+        "licenses": [
+            {
+                "active": True,
+                "capacity": {"maximum_size": 109951162777600},
+                "compliance": {"state": "compliant"},
+                "evaluation": False,
+                "expiry_time": "2025-12-31T23:59:59+00:00",
+                "host_id": "4082368507",
+                "installed_license": "Enterprise",
+                "owner": "node1",
+                "serial_number": "1-23-456789",
+                "shutdown_imminent": False,
+                "start_time": "2024-01-01T00:00:00+00:00",
+            },
+            {
+                "active": True,
+                "capacity": {"maximum_size": 109951162777600},
+                "compliance": {"state": "compliant"},
+                "evaluation": False,
+                "host_id": "4082368508",
+                "installed_license": "Enterprise",
+                "owner": "node2",
+                "serial_number": "1-23-456790",
+                "shutdown_imminent": False,
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mapping definition tests
+# ---------------------------------------------------------------------------
+
+
+class TestLicensePackageMappingDefinition:
+    """Tests for LICENSE_PACKAGE_MAPPING structure."""
+
+    def test_all_cache_attrs_exist_on_model(self) -> None:
+        """Every cache_attr in the mapping is a valid LicensePackage field."""
+        model_fields = set(LicensePackage.model_fields.keys())
+        for field in LICENSE_PACKAGE_MAPPING.fields:
+            assert field.cache_attr in model_fields, (
+                f"cache_attr '{field.cache_attr}' not on LicensePackage"
+            )
+
+    def test_no_duplicate_cache_attrs(self) -> None:
+        """No duplicate cache_attr values."""
+        attrs = [f.cache_attr for f in LICENSE_PACKAGE_MAPPING.fields]
+        assert len(attrs) == len(set(attrs))
+
+    def test_field_count(self) -> None:
+        """Mapping has expected number of fields (7)."""
+        assert len(LICENSE_PACKAGE_MAPPING.fields) == 7
+
+    def test_model_class(self) -> None:
+        """Model class is LicensePackage."""
+        assert LICENSE_PACKAGE_MAPPING.model_class is LicensePackage
+
+    def test_endpoint(self) -> None:
+        """API endpoint is correct."""
+        assert LICENSE_PACKAGE_MAPPING.api_endpoint == (
+            "/cluster/licensing/licenses?fields=name,scope,state,description,entitlement,licenses"
+        )
+
+    def test_cli_command_empty(self) -> None:
+        """CLI command is empty (API-only type)."""
+        assert LICENSE_PACKAGE_MAPPING.cli_command == ""
+
+    def test_api_expected_fields(self) -> None:
+        """api_expected_fields returns correct top-level keys."""
+        expected = LICENSE_PACKAGE_MAPPING.api_expected_fields()
+        assert expected == [
+            "description",
+            "entitlement",
+            "name",
+            "scope",
+            "state",
+        ]
+
+    def test_id_field(self) -> None:
+        """id_field is name (default)."""
+        assert LICENSE_PACKAGE_MAPPING.id_field == "name"
+
+    def test_all_model_fields_have_mapping(self) -> None:
+        """Every LicensePackage model field has a corresponding mapping entry."""
+        mapped_attrs = {f.cache_attr for f in LICENSE_PACKAGE_MAPPING.fields}
+        model_fields = set(LicensePackage.model_fields.keys())
+        unmapped = model_fields - mapped_attrs
+        assert not unmapped, f"Model fields without mapping: {unmapped}"
+
+
+# ---------------------------------------------------------------------------
+# API parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestLicensePackageApiParsing:
+    """Tests for parsing API license package records."""
+
+    def test_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Full API record parses correctly."""
+        result = parse_api_record(LICENSE_PACKAGE_MAPPING, full_api_record, "[test]")
+        assert isinstance(result, LicensePackage)
+
+        assert result.name == "nfs"
+        assert result.scope == "cluster"
+        assert result.state == "compliant"
+        assert result.description == "NFS License"
+        assert result.entitlement_action == "acquire_license"
+        assert result.entitlement_risk == "medium"
+        assert len(result.instances) == 2
+
+        inst = result.instances[0]
+        assert inst.active is True
+        assert inst.capacity_max == 109951162777600
+        assert inst.compliance_state == "compliant"
+        assert inst.evaluation is False
+        assert inst.expiry_time == "2025-12-31T23:59:59+00:00"
+        assert inst.host_id == "4082368507"
+        assert inst.installed_license == "Enterprise"
+        assert inst.owner == "node1"
+        assert inst.serial_number == "1-23-456789"
+        assert inst.shutdown_imminent is False
+        assert inst.start_time == "2024-01-01T00:00:00+00:00"
+
+    def test_minimal_record(self) -> None:
+        """Minimal record uses defaults for missing fields."""
+        record: dict[str, Any] = {"name": "cifs", "state": "compliant"}
+        result = parse_api_record(LICENSE_PACKAGE_MAPPING, record, "[test]")
+        assert isinstance(result, LicensePackage)
+        assert result.name == "cifs"
+        assert result.state == "compliant"
+        assert result.scope == ""
+        assert result.description == ""
+        assert result.entitlement_action == ""
+        assert result.entitlement_risk == ""
+        assert result.instances == []
+
+    def test_missing_fields(self) -> None:
+        """Record with only name returns defaults for other fields."""
+        record: dict[str, Any] = {"name": "iscsi"}
+        result = parse_api_record(LICENSE_PACKAGE_MAPPING, record, "[test]")
+        assert isinstance(result, LicensePackage)
+        assert result.name == "iscsi"
+        assert result.scope == ""
+        assert result.state == ""
+        assert result.instances == []
+
+    def test_empty_instances(self) -> None:
+        """Record with empty licenses array produces empty instances."""
+        record: dict[str, Any] = {
+            "name": "nfs",
+            "state": "compliant",
+            "licenses": [],
+        }
+        result = parse_api_record(LICENSE_PACKAGE_MAPPING, record, "[test]")
+        assert isinstance(result, LicensePackage)
+        assert result.instances == []
+
+    def test_parse_api_response_multiple(self) -> None:
+        """parse_api_response handles multiple records."""
+        response = {
+            "records": [
+                {
+                    "name": "nfs",
+                    "state": "compliant",
+                    "scope": "cluster",
+                },
+                {
+                    "name": "cifs",
+                    "state": "compliant",
+                    "scope": "cluster",
+                },
+            ],
+        }
+        results = parse_api_response(LICENSE_PACKAGE_MAPPING, response, "[test]", MagicMock())
+        assert len(results) == 2
+        assert results[0].name == "nfs"  # type: ignore[union-attr]
+        assert results[1].name == "cifs"  # type: ignore[union-attr]
+
+    def test_parse_api_response_empty(self) -> None:
+        """parse_api_response handles empty/None response."""
+        assert parse_api_response(LICENSE_PACKAGE_MAPPING, None, "[test]", MagicMock()) == []
+        assert parse_api_response(LICENSE_PACKAGE_MAPPING, {}, "[test]", MagicMock()) == []
+
+
+# ---------------------------------------------------------------------------
+# Transform function tests
+# ---------------------------------------------------------------------------
+
+
+class TestTransformFunctions:
+    """Tests for the _api_instances transform function."""
+
+    def test_full_data(self) -> None:
+        """Transform with full nested data."""
+        record: dict[str, Any] = {
+            "name": "nfs",
+            "licenses": [
+                {
+                    "active": True,
+                    "capacity": {"maximum_size": 1024},
+                    "compliance": {"state": "compliant"},
+                    "evaluation": False,
+                    "expiry_time": "2025-12-31T00:00:00+00:00",
+                    "host_id": "12345",
+                    "installed_license": "Enterprise",
+                    "owner": "node1",
+                    "serial_number": "SN-001",
+                    "shutdown_imminent": False,
+                    "start_time": "2024-01-01T00:00:00+00:00",
+                },
+            ],
+        }
+        result = _api_instances(record)
+        assert len(result) == 1
+        inst = result[0]
+        assert isinstance(inst, LicenseInstance)
+        assert inst.active is True
+        assert inst.capacity_max == 1024
+        assert inst.compliance_state == "compliant"
+        assert inst.expiry_time == "2025-12-31T00:00:00+00:00"
+        assert inst.host_id == "12345"
+        assert inst.owner == "node1"
+
+    def test_missing_capacity_and_compliance(self) -> None:
+        """Transform handles missing capacity and compliance sub-objects."""
+        record: dict[str, Any] = {
+            "licenses": [
+                {
+                    "active": True,
+                    "owner": "node1",
+                },
+            ],
+        }
+        result = _api_instances(record)
+        assert len(result) == 1
+        assert result[0].capacity_max == 0
+        assert result[0].compliance_state == ""
+
+    def test_non_dict_entries_skipped(self) -> None:
+        """Transform skips non-dict entries in the licenses array."""
+        record: dict[str, Any] = {
+            "licenses": [
+                {"active": True, "owner": "node1"},
+                "not-a-dict",
+                42,
+                None,
+            ],
+        }
+        result = _api_instances(record)
+        assert len(result) == 1
+        assert result[0].owner == "node1"
+
+    def test_empty_licenses_array(self) -> None:
+        """Transform returns empty list for empty licenses array."""
+        assert _api_instances({"licenses": []}) == []
+
+    def test_missing_licenses_key(self) -> None:
+        """Transform returns empty list when licenses key is missing."""
+        assert _api_instances({"name": "nfs"}) == []
+
+    def test_licenses_not_a_list(self) -> None:
+        """Transform returns empty list when licenses is not a list."""
+        assert _api_instances({"licenses": "not-a-list"}) == []
+
+    def test_null_capacity_and_compliance(self) -> None:
+        """Transform handles None/null capacity and compliance gracefully."""
+        record: dict[str, Any] = {
+            "licenses": [
+                {
+                    "active": True,
+                    "capacity": None,
+                    "compliance": None,
+                    "owner": "node1",
+                },
+            ],
+        }
+        result = _api_instances(record)
+        assert len(result) == 1
+        assert result[0].capacity_max == 0
+        assert result[0].compliance_state == ""
+
+
+# ---------------------------------------------------------------------------
+# Parity test: old parser vs new framework
+# ---------------------------------------------------------------------------
+
+
+class TestParityWithOldParser:
+    """Verify framework produces same output as old hand-written inline parser.
+
+    Parity is checked for the original 3 package-level fields (name, state,
+    scope) that were present in the old LicenseFeature model.
+    """
+
+    _ORIGINAL_SHARED_FIELDS = ("name", "state", "scope")
+
+    @staticmethod
+    def _old_parse_license(record: dict[str, Any]) -> dict[str, str]:
+        """Reproduce old inline license parsing logic from collector.
+
+        The old collector extracted name, state, and scope from each record
+        and created a LicenseFeature with those three fields.
+        """
+        return {
+            "name": record.get("name", ""),
+            "state": record.get("state", ""),
+            "scope": record.get("scope", ""),
+        }
+
+    def test_parity_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Framework and old parser produce identical results for shared fields."""
+        old = self._old_parse_license(full_api_record)
+        new = parse_api_record(LICENSE_PACKAGE_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, LicensePackage)
+        for field_name in self._ORIGINAL_SHARED_FIELDS:
+            old_val = old[field_name]
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_minimal_record(self) -> None:
+        """Framework and old parser match on minimal record."""
+        record: dict[str, Any] = {"name": "nfs"}
+        old = self._old_parse_license(record)
+        new = parse_api_record(LICENSE_PACKAGE_MAPPING, record, "[test]")
+        assert isinstance(new, LicensePackage)
+        for field_name in self._ORIGINAL_SHARED_FIELDS:
+            old_val = old[field_name]
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -863,16 +863,41 @@ class TestLicenseCollection:
         """Mock API response for /cluster/licensing/licenses endpoint."""
         return {
             "records": [
-                {"name": "NFS", "state": "compliant", "scope": "cluster"},
-                {"name": "CIFS", "state": "compliant", "scope": "cluster"},
                 {
-                    "name": "Cloud Volumes ONTAP",
+                    "name": "NFS",
                     "state": "compliant",
                     "scope": "cluster",
-                    "capacity": {
-                        "maximum_size": 109951162777600,
-                        "used_size": 54975581388800,
-                    },
+                    "description": "NFS License",
+                    "entitlement": {"action": "none", "risk": "low"},
+                    "licenses": [
+                        {
+                            "active": True,
+                            "compliance": {"state": "compliant"},
+                            "evaluation": False,
+                            "host_id": "4082368507",
+                            "installed_license": "Enterprise",
+                            "owner": "node1",
+                            "serial_number": "1-23-456789",
+                        },
+                    ],
+                },
+                {
+                    "name": "CIFS",
+                    "state": "compliant",
+                    "scope": "cluster",
+                    "description": "CIFS License",
+                    "entitlement": {"action": "none", "risk": "low"},
+                    "licenses": [
+                        {
+                            "active": True,
+                            "compliance": {"state": "compliant"},
+                            "owner": "node1",
+                            "serial_number": "1-23-456789",
+                            "capacity": {
+                                "maximum_size": 109951162777600,
+                            },
+                        },
+                    ],
                 },
             ]
         }
@@ -885,10 +910,17 @@ class TestLicenseCollection:
         collector = MetadataCollector(api_client=api_client)
         result = collector.collect_licenses()
 
-        assert len(result.feature_licenses) == 2
-        assert result.feature_licenses[0].name == "NFS"
-        assert len(result.capacity_licenses) == 1
-        assert result.capacity_licenses[0].name == "Cloud Volumes ONTAP"
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0].name == "NFS"
+        assert result[0].state == "compliant"
+        assert result[0].scope == "cluster"
+        assert result[0].entitlement_action == "none"
+        assert len(result[0].instances) == 1
+        assert result[0].instances[0].owner == "node1"
+        assert result[0].instances[0].compliance_state == "compliant"
+        assert result[1].name == "CIFS"
+        assert result[1].instances[0].capacity_max == 109951162777600
 
     def test_collect_licenses_no_clients(self) -> None:
         """Test licenses raises CollectionError when no API client."""

--- a/tests/unit/cache/test_diff.py
+++ b/tests/unit/cache/test_diff.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pynetappfoundry.cache import CachedClusterMetadata, MediatorInfo, RelationshipsInfo
 from pynetappfoundry.cache.cloud.metadata.model import CloudMetadata
-from pynetappfoundry.cache.cluster.licensing.model import LicenseFeature, LicenseInfo
+from pynetappfoundry.cache.cluster.licensing.model import LicensePackage
 from pynetappfoundry.cache.cluster.model import ClusterInfo
 from pynetappfoundry.cache.cluster.nodes.model import NodeInfo
 from pynetappfoundry.cache.cluster.peers.model import ClusterPeer
@@ -455,23 +455,19 @@ class TestComputeDiffAllCategories:
         """Test license change detection."""
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
-            licenses=LicenseInfo(
-                feature_licenses=[
-                    LicenseFeature(name="NFS", state="compliant"),
-                ],
-            ),
+            license_packages=[
+                LicensePackage(name="NFS", state="compliant", scope="cluster"),
+            ],
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
-            licenses=LicenseInfo(
-                feature_licenses=[
-                    LicenseFeature(name="NFS", state="noncompliant"),
-                ],
-            ),
+            license_packages=[
+                LicensePackage(name="NFS", state="noncompliant", scope="cluster"),
+            ],
         )
         changes = compute_diff(before, after)
 
-        license_changes = [c for c in changes if c["category"] == "licenses.feature_licenses"]
+        license_changes = [c for c in changes if c["category"] == "license_packages"]
         assert len(license_changes) == 1
         assert license_changes[0]["type"] == "modified"
         assert license_changes[0]["field"] == "state"

--- a/tests/unit/cache/test_models.py
+++ b/tests/unit/cache/test_models.py
@@ -8,9 +8,8 @@ from pynetappfoundry.cache import CachedClusterMetadata, HasUUID, MediatorInfo, 
 from pynetappfoundry.cache.cloud.metadata.model import CloudMetadata
 from pynetappfoundry.cache.cloud.targets.model import CloudTargetInfo
 from pynetappfoundry.cache.cluster.licensing.model import (
-    CapacityLicense,
-    LicenseFeature,
-    LicenseInfo,
+    LicenseInstance,
+    LicensePackage,
 )
 from pynetappfoundry.cache.cluster.model import ClusterInfo
 from pynetappfoundry.cache.cluster.nodes.model import NodeInfo
@@ -1028,53 +1027,80 @@ class TestIPSubnetInfo:
         assert subnet.ip_ranges == ["10.0.0.10-10.0.0.50"]
 
 
-class TestLicenseFeature:
-    """Tests for LicenseFeature model."""
-
-    def test_with_values(self) -> None:
-        """Test with license data."""
-        license = LicenseFeature(
-            name="NFS",
-            state="compliant",
-            scope="cluster",
-        )
-        assert license.name == "NFS"
-        assert license.state == "compliant"
-
-
-class TestCapacityLicense:
-    """Tests for CapacityLicense model."""
-
-    def test_with_values(self) -> None:
-        """Test with capacity license data."""
-        cap = CapacityLicense(
-            name="Cloud Volumes ONTAP",
-            licensed_capacity=109951162777600,  # 100TB
-            used_capacity=54975581388800,  # 50TB
-        )
-        assert cap.licensed_capacity == 109951162777600
-        assert cap.used_capacity == 54975581388800
-
-
-class TestLicenseInfo:
-    """Tests for LicenseInfo model."""
+class TestLicenseInstance:
+    """Tests for LicenseInstance model."""
 
     def test_default_values(self) -> None:
         """Test default values."""
-        licenses = LicenseInfo()
-        assert licenses.feature_licenses == []
-        assert licenses.capacity_licenses == []
+        inst = LicenseInstance()
+        assert inst.active is False
+        assert inst.capacity_max == 0
+        assert inst.compliance_state == ""
+        assert inst.evaluation is False
+        assert inst.expiry_time == ""
+        assert inst.host_id == ""
+        assert inst.installed_license == ""
+        assert inst.owner == ""
+        assert inst.serial_number == ""
+        assert inst.shutdown_imminent is False
+        assert inst.start_time == ""
 
-    def test_with_data(self) -> None:
-        """Test with license data."""
-        feature = LicenseFeature(name="NFS", state="compliant", scope="cluster")
-        capacity = CapacityLicense(name="CVO", licensed_capacity=100)
-        licenses = LicenseInfo(
-            feature_licenses=[feature],
-            capacity_licenses=[capacity],
+    def test_with_values(self) -> None:
+        """Test with license instance data."""
+        inst = LicenseInstance(
+            active=True,
+            capacity_max=109951162777600,
+            compliance_state="compliant",
+            evaluation=False,
+            host_id="4082368507",
+            installed_license="Enterprise",
+            owner="node1",
+            serial_number="123456789",
+            shutdown_imminent=False,
         )
-        assert len(licenses.feature_licenses) == 1
-        assert len(licenses.capacity_licenses) == 1
+        assert inst.active is True
+        assert inst.capacity_max == 109951162777600
+        assert inst.compliance_state == "compliant"
+        assert inst.host_id == "4082368507"
+        assert inst.serial_number == "123456789"
+
+
+class TestLicensePackage:
+    """Tests for LicensePackage model."""
+
+    def test_default_values(self) -> None:
+        """Test default values."""
+        pkg = LicensePackage()
+        assert pkg.name == ""
+        assert pkg.scope == ""
+        assert pkg.state == ""
+        assert pkg.description == ""
+        assert pkg.entitlement_action == ""
+        assert pkg.entitlement_risk == ""
+        assert pkg.instances == []
+
+    def test_with_nested_instances(self) -> None:
+        """Test with nested license instances."""
+        inst = LicenseInstance(
+            active=True,
+            compliance_state="compliant",
+            owner="node1",
+            serial_number="123456789",
+        )
+        pkg = LicensePackage(
+            name="NFS",
+            scope="cluster",
+            state="compliant",
+            description="NFS License",
+            entitlement_action="none",
+            entitlement_risk="low",
+            instances=[inst],
+        )
+        assert pkg.name == "NFS"
+        assert pkg.scope == "cluster"
+        assert pkg.state == "compliant"
+        assert len(pkg.instances) == 1
+        assert pkg.instances[0].owner == "node1"
 
 
 class TestMediatorInfo:
@@ -1273,7 +1299,7 @@ class TestCachedClusterMetadata:
             "nodes": [],
             "network": {},
             "storage": {},
-            "licenses": {},
+            "license_packages": [],
             "ha": {},
             "relationships": {},
         }

--- a/tests/unit/cache/test_registry_integration.py
+++ b/tests/unit/cache/test_registry_integration.py
@@ -21,7 +21,6 @@ class TestModelRegistration:
             "BroadcastDomain",
             "CIFSServiceInfo",
             "CIFSShareInfo",
-            "CapacityLicense",
             "CloudMetadata",
             "CloudTargetInfo",
             "ClusterInfo",
@@ -33,8 +32,8 @@ class TestModelRegistration:
             "MediatorInfo",
             "IgroupInfo",
             "IPSubnetInfo",
-            "LicenseFeature",
-            "LicenseInfo",
+            "LicenseInstance",
+            "LicensePackage",
             "LunInfo",
             "NFSServiceInfo",
             "NetworkInfo",
@@ -82,13 +81,14 @@ class TestMappingRegistration:
     """Tests that all mappings are registered via register_mapping()."""
 
     def test_registry_contains_all_mappings(self) -> None:
-        """All 10 type mappings should be registered."""
+        """All 11 type mappings should be registered."""
         expected_mappings = {
             "Aggregate",
             "CloudMetadata",
             "Cluster",
             "ClusterPeer",
             "DNS",
+            "LicensePackage",
             "Mediator",
             "Node",
             "SnapMirror",
@@ -100,8 +100,8 @@ class TestMappingRegistration:
         assert not missing, f"Mappings not registered: {missing}"
 
     def test_mapping_count(self) -> None:
-        """Registry should contain exactly 10 mappings."""
-        assert len(model_registry.mappings) == 10
+        """Registry should contain exactly 11 mappings."""
+        assert len(model_registry.mappings) == 11
 
     def test_mapping_lookup_by_name(self) -> None:
         """get_mapping() should return the correct TypeMapping for known names."""

--- a/tests/unit/cli/commands/cache/test_schema.py
+++ b/tests/unit/cli/commands/cache/test_schema.py
@@ -65,7 +65,7 @@ class TestCacheSchemaCommand:
         assert "nodes[N]." in result.output
         assert "network." in result.output
         assert "storage." in result.output
-        assert "licenses." in result.output
+        assert "license_packages[N]." in result.output
         assert "mediator." in result.output
         assert "relationships." in result.output
 
@@ -77,7 +77,7 @@ class TestCacheSchemaCommand:
         # Check deeply nested paths
         assert "network.intercluster_lifs[N].ip_address" in result.output
         assert "storage.aggregates[N].name" in result.output
-        assert "licenses.feature_licenses[N].name" in result.output
+        assert "license_packages[N].name" in result.output
 
     def test_schema_shows_types(self, runner: CliRunner) -> None:
         """Test that schema shows field types."""


### PR DESCRIPTION
## Description

Migrate the license caching subsystem to the declarative field mapping framework (ADR-0004). Replaces 3 hand-written models (`LicenseFeature`, `CapacityLicense`, `LicenseInfo`) with 2 new models (`LicenseInstance`, `LicensePackage`) that accurately reflect the ONTAP `/cluster/licensing/licenses` API structure.

## Related Issue

Addresses #213

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Replaced `LicenseFeature`, `CapacityLicense`, and `LicenseInfo` models with `LicenseInstance` and `LicensePackage` models matching ONTAP API structure
- Created `LICENSE_PACKAGE_MAPPING` in `cache/cluster/licensing/mapping.py` with a `_api_instances` transform for the nested `licenses[]` array
- Updated collector, diff engine, cache metadata, and inspect CLI command to use the new models
- Updated ADR-0004 to reference issue #213
- Added comprehensive tests for the new mapping in `tests/unit/cache/mappings/test_license.py`
- Updated existing tests in `test_collector.py`, `test_diff.py`, `test_models.py`, `test_registry_integration.py`, and `test_schema.py`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes
- All checks pass via `doit check` (format, lint, type-check, security, spell-check, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This is part of the ongoing migration of all ONTAP object types to the declarative field mapping framework. The old models flattened license data into a single structure that didn't match the API's package/instance hierarchy. The new models faithfully represent the nested structure, with `LicensePackage` containing a list of `LicenseInstance` objects parsed via a custom transform function.
