### PR TITLE
feat: format cache query output with color-coded values and shared formatter

### DIFF
--- a/src/pynetappfoundry/cli/commands/cache/inspect.py
+++ b/src/pynetappfoundry/cli/commands/cache/inspect.py
@@ -21,7 +21,12 @@ from pynetappfoundry.cache.field_mapping import TypeMapping
 from pynetappfoundry.cache.storage.aggregates.mapping import AGGREGATE_MAPPING
 from pynetappfoundry.cache.storage.volumes.mapping import VOLUME_MAPPING
 from pynetappfoundry.cache.svm.mapping import SVM_MAPPING
-from pynetappfoundry.cli.utils import print_error, print_exception, print_warning
+from pynetappfoundry.cli.utils import (
+    format_value_markup,
+    print_error,
+    print_exception,
+    print_warning,
+)
 from pynetappfoundry.clients.ontap import ONTAPCLI, ONTAPAPIClient
 from pynetappfoundry.core.config import Config
 
@@ -72,14 +77,9 @@ def _format_value(value: object) -> str:
     Returns:
         Rich-formatted string.
     """
-    if isinstance(value, bool):
-        return f"[yellow]{value}[/yellow]"
-    if isinstance(value, (int, float)):
-        return f"[magenta]{value}[/magenta]"
-    if isinstance(value, str):
-        if not value:
-            return "[dim](empty)[/dim]"
-        return f"[green]{value}[/green]"
+    result = format_value_markup(value)
+    if result is not None:
+        return result
     if isinstance(value, list):
         if not value:
             return "[dim](empty list)[/dim]"

--- a/src/pynetappfoundry/cli/commands/cache/query.py
+++ b/src/pynetappfoundry/cli/commands/cache/query.py
@@ -12,7 +12,12 @@ import click
 from rich.console import Console
 
 from pynetappfoundry.cache import ClusterMetadataDB
-from pynetappfoundry.cli.utils import print_error, print_exception, print_warning
+from pynetappfoundry.cli.utils import (
+    format_value_markup,
+    print_error,
+    print_exception,
+    print_warning,
+)
 from pynetappfoundry.core.config import Config
 from pynetappfoundry.utils.dict_path import PathNotFoundError, get_nested_value
 
@@ -50,6 +55,26 @@ def _format_value(value: Any) -> str:
         return str(value).lower()
     if isinstance(value, (dict, list)):
         return json.dumps(value)
+    return str(value)
+
+
+def _format_display_value(value: Any) -> str:
+    """Format a value for default display output with Rich markup.
+
+    Uses shared ``format_value_markup`` for scalar types and adds
+    indented JSON formatting for dicts/lists.
+
+    Args:
+        value: Value to format.
+
+    Returns:
+        String with Rich markup for colored display.
+    """
+    result = format_value_markup(value)
+    if result is not None:
+        return result
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, indent=2, default=str)
     return str(value)
 
 
@@ -342,4 +367,10 @@ def query(
             console.print(f"[bold]{name}:[/bold]")
             for field in effective_fields:
                 if field in cluster_result:
-                    console.print(f"  {field}: {_format_value(cluster_result[field])}")
+                    formatted = _format_display_value(cluster_result[field])
+                    if "\n" in formatted:
+                        console.print(f"  [cyan]{field}[/cyan]:")
+                        for line in formatted.split("\n"):
+                            console.print(f"    {line}")
+                    else:
+                        console.print(f"  [cyan]{field}[/cyan]: {formatted}")

--- a/src/pynetappfoundry/cli/commands/cache/show.py
+++ b/src/pynetappfoundry/cli/commands/cache/show.py
@@ -11,7 +11,12 @@ from rich.panel import Panel
 from rich.tree import Tree
 
 from pynetappfoundry.cache import ClusterMetadataDB
-from pynetappfoundry.cli.utils import print_error, print_exception, print_warning
+from pynetappfoundry.cli.utils import (
+    format_value_markup,
+    print_error,
+    print_exception,
+    print_warning,
+)
 from pynetappfoundry.core.config import Config
 
 logger = logging.getLogger(__name__)
@@ -27,15 +32,10 @@ def _format_value(value: object) -> str:
     Returns:
         Formatted string.
     """
-    if isinstance(value, bool):
-        return f"[yellow]{value}[/yellow]"
-    elif isinstance(value, (int, float)):
-        return f"[magenta]{value}[/magenta]"
-    elif isinstance(value, str):
-        if not value:
-            return "[dim](empty)[/dim]"
-        return f"[green]{value}[/green]"
-    elif isinstance(value, list):
+    result = format_value_markup(value)
+    if result is not None:
+        return result
+    if isinstance(value, list):
         if not value:
             return "[dim](empty list)[/dim]"
         return f"[cyan]{len(value)} items[/cyan]"

--- a/src/pynetappfoundry/cli/utils.py
+++ b/src/pynetappfoundry/cli/utils.py
@@ -107,6 +107,38 @@ def print_exception(message: str, exc: BaseException | None = None) -> None:
         console.print("[dim]" + "".join(traceback.format_exception(exc)) + "[/dim]")
 
 
+def format_value_markup(value: object) -> str | None:
+    """Format a scalar value with Rich markup for display.
+
+    Provides consistent color-coding across CLI commands:
+    - ``None`` → ``[yellow]null[/yellow]``
+    - ``bool`` → ``[yellow]true/false[/yellow]``
+    - ``int/float`` → ``[magenta]value[/magenta]``
+    - ``str`` → ``[green]value[/green]`` (empty → ``[dim](empty)[/dim]``)
+
+    Returns ``None`` for non-scalar types (dict, list, etc.) so callers can
+    apply context-specific formatting.
+
+    Args:
+        value: Value to format.
+
+    Returns:
+        Rich-formatted string for scalars, or None if the value is not a
+        supported scalar type.
+    """
+    if value is None:
+        return "[yellow]null[/yellow]"
+    if isinstance(value, bool):
+        return f"[yellow]{str(value).lower()}[/yellow]"
+    if isinstance(value, (int, float)):
+        return f"[magenta]{value}[/magenta]"
+    if isinstance(value, str):
+        if not value:
+            return "[dim](empty)[/dim]"
+        return f"[green]{value}[/green]"
+    return None
+
+
 def print_debug(message: str) -> None:
     """Print debug message to console (if debug mode) and always log to file.
 

--- a/tests/unit/cli/commands/cache/test_inspect.py
+++ b/tests/unit/cli/commands/cache/test_inspect.py
@@ -54,7 +54,7 @@ class TestFormatValue:
 
     def test_format_bool(self) -> None:
         """Test boolean formatting."""
-        assert "True" in _format_value(True)
+        assert "true" in _format_value(True)
 
     def test_format_int(self) -> None:
         """Test integer formatting."""

--- a/tests/unit/cli/commands/cache/test_query.py
+++ b/tests/unit/cli/commands/cache/test_query.py
@@ -645,7 +645,9 @@ base_api_path = "/api"
 
         assert result.exit_code == 0
         assert "test-cluster:" in result.output
-        assert '["node-01", "node-02"]' in result.output
+        assert "nodes[*].name:" in result.output
+        assert '"node-01"' in result.output
+        assert '"node-02"' in result.output
 
     @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
     def test_wildcard_json_output(
@@ -915,3 +917,93 @@ base_api_path = "/api"
         lines = result.output.strip().split("\n")
         assert lines[0] == "cluster,cloud[0].provider,cloud[0].region"
         assert lines[1] == "test-cluster,AWS,"
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_default_output_nested_dict_formatting(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test that nested dicts display as indented JSON in default output."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "query", "test-cluster", "cloud[0]"],
+        )
+
+        assert result.exit_code == 0
+        assert "cloud[0]:" in result.output
+        # Indented JSON should have the key on separate lines
+        assert '"provider"' in result.output
+        assert '"region"' in result.output
+        # Should NOT be compact single-line JSON
+        assert '{"provider"' not in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_default_output_scalar_values(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test that scalar values display inline in default output."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "test-cluster",
+                "cloud[0].provider",
+                "cluster.ontap_version",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Scalars should be inline (field: value on same line)
+        assert "cloud[0].provider: AWS" in result.output
+        assert "cluster.ontap_version: 9.14.1" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_raw_output_unchanged_with_dict(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_metadata: CachedClusterMetadata,
+    ) -> None:
+        """Test that --raw output still uses compact JSON for dicts."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = sample_metadata
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "test-cluster",
+                "cloud[0]",
+                "--raw",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Raw output should be compact single-line JSON
+        output = result.output.strip()
+        parsed = json.loads(output)
+        assert parsed["provider"] == "AWS"
+        assert parsed["region"] == "us-east-1"

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -1,0 +1,62 @@
+"""Tests for CLI utility functions."""
+
+from __future__ import annotations
+
+import pytest
+
+from pynetappfoundry.cli.utils import format_value_markup
+
+
+class TestFormatValueMarkup:
+    """Tests for format_value_markup shared formatter."""
+
+    def test_none_value(self) -> None:
+        """Test None formats as yellow null."""
+        assert format_value_markup(None) == "[yellow]null[/yellow]"
+
+    def test_bool_true(self) -> None:
+        """Test True formats as yellow true."""
+        assert format_value_markup(True) == "[yellow]true[/yellow]"
+
+    def test_bool_false(self) -> None:
+        """Test False formats as yellow false."""
+        assert format_value_markup(False) == "[yellow]false[/yellow]"
+
+    def test_integer(self) -> None:
+        """Test integer formats as magenta."""
+        assert format_value_markup(42) == "[magenta]42[/magenta]"
+
+    def test_float(self) -> None:
+        """Test float formats as magenta."""
+        assert format_value_markup(3.14) == "[magenta]3.14[/magenta]"
+
+    def test_string(self) -> None:
+        """Test non-empty string formats as green."""
+        assert format_value_markup("hello") == "[green]hello[/green]"
+
+    def test_empty_string(self) -> None:
+        """Test empty string formats as dim (empty)."""
+        assert format_value_markup("") == "[dim](empty)[/dim]"
+
+    def test_list_returns_none(self) -> None:
+        """Test list returns None for caller-specific handling."""
+        assert format_value_markup([1, 2, 3]) is None
+
+    def test_dict_returns_none(self) -> None:
+        """Test dict returns None for caller-specific handling."""
+        assert format_value_markup({"key": "value"}) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [set(), frozenset(), (1, 2), object()],
+    )
+    def test_other_types_return_none(self, value: object) -> None:
+        """Test unsupported types return None."""
+        assert format_value_markup(value) is None
+
+    def test_bool_before_int(self) -> None:
+        """Test that bool is checked before int (bool is subclass of int)."""
+        # This ensures True doesn't get formatted as magenta 1
+        result = format_value_markup(True)
+        assert "yellow" in result  # type: ignore[operator]
+        assert "magenta" not in result  # type: ignore[operator]


### PR DESCRIPTION
## Description

Format `nf cache query` default output with the same color-coded Rich markup used by `nf cache show` and `nf cache inspect`, and extract the shared scalar-formatting logic into a reusable `format_value_markup` function in `cli/utils.py`.

## Related Issue

Addresses #284

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `format_value_markup()` to `src/pynetappfoundry/cli/utils.py` — shared scalar formatter providing consistent color-coding (None=yellow, bool=yellow lowercase, int/float=magenta, str=green, empty=dim) across all cache CLI commands
- Updated `nf cache query` default output to use colored field names (cyan) and color-coded values via the new shared formatter, with indented JSON for nested dicts/lists
- Refactored `show.py` and `inspect.py` `_format_value` functions to delegate scalar formatting to the shared `format_value_markup`, eliminating duplicated logic
- Normalized boolean display to lowercase (`true`/`false`) across all three commands for consistency with JSON conventions

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**New tests added:**
- `tests/unit/cli/test_utils.py` — 10 tests covering `format_value_markup` for all scalar types, non-scalar passthrough, bool-before-int precedence, and edge cases
- `tests/unit/cli/commands/cache/test_query.py` — 3 new tests: nested dict indented JSON formatting, scalar inline display, and `--raw` output unchanged for dicts
- Updated wildcard test assertion to match new multi-line output format
- Updated `test_inspect.py` boolean assertion to match lowercase `true`/`false`

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- The `--json`, `--raw`, and `--csv` output modes are unchanged; only the default (human-readable) output is affected.
- The `format_value_markup` function returns `None` for non-scalar types (dict, list), allowing each command to apply its own context-specific formatting for complex values.
- No documentation updates needed — the CLI reference documents command syntax and options, not output formatting details. The command interface is unchanged.
- No ADR needed — this is a visual enhancement and code deduplication, not an architectural decision.
