### PR TITLE
refactor: migrate BroadcastDomain to declarative field mapping framework

### DIFF
--- a/docs/decisions/0004-declarative-field-mapping-framework.md
+++ b/docs/decisions/0004-declarative-field-mapping-framework.md
@@ -67,6 +67,7 @@ The pilot migration (VolumeInfo) was completed in PR #189.
 - Issue #192: refactor: migrate SVMInfo to field mapping framework
 - Issue #205: refactor: migrate DNSInfo to field mapping framework
 - Issue #213: refactor: migrate LicenseInfo/LicenseFeature to field mapping framework
+- Issue #212: refactor: migrate BroadcastDomain to field mapping framework
 
 ## Related Documentation
 

--- a/docs/development/field-mapping.md
+++ b/docs/development/field-mapping.md
@@ -229,6 +229,7 @@ For CLI-only types, also test:
 | ClusterPeer | `CLUSTER_PEER_MAPPING` | `ClusterPeer` | 7 | API-only. Uses transform for dict-vs-string fallback on `remote`, `authentication`, and `encryption`. |
 | Cluster | `CLUSTER_MAPPING` | `ClusterInfo` | 18 | API-only. Single-object endpoint (no `records` list), uses `parse_api_record()` directly. `is_ha` derived post-collection. |
 | CloudMetadata | `CLOUD_METADATA_MAPPING` | `CloudMetadata` | 19 | CLI-only (no API endpoint). Computed link fields built as post-processing in collector. |
+| BroadcastDomain | `BROADCAST_DOMAIN_MAPPING` | `BroadcastDomain` | 5 | API-only. Wildcard `[*]` syntax for `port_uuids`. Nested dot-path for `ipspace_uuid`. |
 
 ## Reference: Field Mapping Patterns
 

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -44,6 +44,9 @@ from pynetappfoundry.cache.field_mapping import (
 )
 from pynetappfoundry.cache.name_services.dns.mapping import DNS_MAPPING
 from pynetappfoundry.cache.name_services.dns.model import DNSInfo
+from pynetappfoundry.cache.network.ethernet.broadcast_domains.mapping import (
+    BROADCAST_DOMAIN_MAPPING,
+)
 from pynetappfoundry.cache.network.ethernet.broadcast_domains.model import (
     BroadcastDomain,
 )
@@ -934,7 +937,7 @@ class MetadataCollector:
         # Make all 5 API calls in parallel using cached calls
         endpoints = [
             "/network/ip/interfaces?fields=*",
-            "/network/ethernet/broadcast-domains?fields=*",
+            BROADCAST_DOMAIN_MAPPING.api_endpoint,
             "/network/ipspaces?fields=*",
             DNS_MAPPING.api_endpoint,
             "/network/ip/subnets?fields=*",
@@ -987,28 +990,15 @@ class MetadataCollector:
                 management_lifs.append(lif)
 
         # Process broadcast domains response
-        bd_response = responses.get(endpoints[1]) or {}
-        logger.debug(
-            "%s API response: %d broadcast domains",
-            self._log_prefix,
-            len(bd_response.get("records", [])),
+        broadcast_domains = cast(
+            list[BroadcastDomain],
+            parse_api_response(
+                BROADCAST_DOMAIN_MAPPING,
+                responses.get(endpoints[1]),
+                self._log_prefix,
+                self._log_missing_fields,
+            ),
         )
-        broadcast_domains = []
-        for record in bd_response.get("records", []):
-            self._log_missing_fields(
-                record,
-                ["uuid", "name", "ipspace", "mtu", "ports"],
-                "BroadcastDomain",
-                record.get("name", record.get("uuid", "unknown")),
-            )
-            bd = BroadcastDomain(
-                uuid=record.get("uuid", ""),
-                name=record.get("name", ""),
-                ipspace=record.get("ipspace", {}).get("name", ""),
-                mtu=record.get("mtu", 0),
-                ports=[p.get("name", "") for p in record.get("ports", []) if p.get("name")],
-            )
-            broadcast_domains.append(bd)
 
         # Process IPspaces response
         ipspace_response = responses.get(endpoints[2]) or {}

--- a/src/pynetappfoundry/cache/network/ethernet/broadcast_domains/__init__.py
+++ b/src/pynetappfoundry/cache/network/ethernet/broadcast_domains/__init__.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from pynetappfoundry.cache.network.ethernet.broadcast_domains.mapping import (
+    BROADCAST_DOMAIN_MAPPING,
+)
 from pynetappfoundry.cache.network.ethernet.broadcast_domains.model import (
     BroadcastDomain,
 )
 
 __all__ = [
+    "BROADCAST_DOMAIN_MAPPING",
     "BroadcastDomain",
 ]

--- a/src/pynetappfoundry/cache/network/ethernet/broadcast_domains/mapping.py
+++ b/src/pynetappfoundry/cache/network/ethernet/broadcast_domains/mapping.py
@@ -1,0 +1,47 @@
+"""BroadcastDomain type mapping definition for the declarative field mapping framework.
+
+Defines BROADCAST_DOMAIN_MAPPING which maps ONTAP REST API broadcast domain
+data to BroadcastDomain cache model attributes. BroadcastDomain is API-only --
+there is no CLI command for this data.
+
+All fields use simple dot-path extraction; no transform functions are needed.
+"""
+
+from __future__ import annotations
+
+from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.cache.network.ethernet.broadcast_domains.model import BroadcastDomain
+
+BROADCAST_DOMAIN_MAPPING = TypeMapping(
+    name="BroadcastDomain",
+    model_class=BroadcastDomain,
+    api_endpoint="/network/ethernet/broadcast-domains?fields=*",
+    cli_command="",
+    fields=(
+        FieldMapping(
+            cache_attr="uuid",
+            api_path="uuid",
+        ),
+        FieldMapping(
+            cache_attr="name",
+            api_path="name",
+        ),
+        FieldMapping(
+            cache_attr="mtu",
+            api_path="mtu",
+            default=0,
+        ),
+        FieldMapping(
+            cache_attr="ipspace_uuid",
+            api_path="ipspace.uuid",
+        ),
+        FieldMapping(
+            cache_attr="port_uuids",
+            api_path="ports[*].uuid",
+            default=[],
+        ),
+    ),
+)
+
+model_registry.register_mapping("BroadcastDomain", BROADCAST_DOMAIN_MAPPING)

--- a/src/pynetappfoundry/cache/network/ethernet/broadcast_domains/model.py
+++ b/src/pynetappfoundry/cache/network/ethernet/broadcast_domains/model.py
@@ -12,6 +12,6 @@ class BroadcastDomain(CacheModel):
 
     uuid: str = ""
     name: str = ""
-    ipspace: str = ""
     mtu: int = 0
-    ports: list[str] = Field(default_factory=list)
+    ipspace_uuid: str = ""
+    port_uuids: list[str] = Field(default_factory=list)

--- a/src/pynetappfoundry/cli/commands/cache/inspect.py
+++ b/src/pynetappfoundry/cli/commands/cache/inspect.py
@@ -18,6 +18,9 @@ from pynetappfoundry.cache.cluster.licensing.mapping import LICENSE_PACKAGE_MAPP
 from pynetappfoundry.cache.cluster.nodes.mapping import NODE_MAPPING
 from pynetappfoundry.cache.cluster.peers.mapping import CLUSTER_PEER_MAPPING
 from pynetappfoundry.cache.field_mapping import TypeMapping
+from pynetappfoundry.cache.network.ethernet.broadcast_domains.mapping import (
+    BROADCAST_DOMAIN_MAPPING,
+)
 from pynetappfoundry.cache.storage.aggregates.mapping import AGGREGATE_MAPPING
 from pynetappfoundry.cache.storage.volumes.mapping import VOLUME_MAPPING
 from pynetappfoundry.cache.svm.mapping import SVM_MAPPING
@@ -38,6 +41,7 @@ console = Console()
 # dot-path to the list of objects in CachedClusterMetadata.
 INSPECT_TYPES: dict[str, tuple[TypeMapping, str]] = {
     "aggregate": (AGGREGATE_MAPPING, "storage.aggregates"),
+    "broadcast_domain": (BROADCAST_DOMAIN_MAPPING, "network.broadcast_domains"),
     "cloud_metadata": (CLOUD_METADATA_MAPPING, "cloud"),
     "cluster_peer": (CLUSTER_PEER_MAPPING, "relationships.cluster_peers"),
     "license": (LICENSE_PACKAGE_MAPPING, "license_packages"),

--- a/tests/unit/cache/mappings/test_broadcast_domain.py
+++ b/tests/unit/cache/mappings/test_broadcast_domain.py
@@ -1,0 +1,259 @@
+"""Tests for the BroadcastDomain type mapping definition."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pynetappfoundry.cache.field_mapping import (
+    parse_api_record,
+    parse_api_response,
+)
+from pynetappfoundry.cache.network.ethernet.broadcast_domains.mapping import (
+    BROADCAST_DOMAIN_MAPPING,
+)
+from pynetappfoundry.cache.network.ethernet.broadcast_domains.model import (
+    BroadcastDomain,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def full_api_record() -> dict[str, Any]:
+    """Full API broadcast domain record with all fields populated."""
+    return {
+        "uuid": "bd-uuid-1234",
+        "name": "Default",
+        "mtu": 1500,
+        "ipspace": {"name": "Default", "uuid": "ipspace-uuid-1"},
+        "ports": [
+            {"name": "node1:e0c", "uuid": "port-uuid-1"},
+            {"name": "node1:e0d", "uuid": "port-uuid-2"},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mapping definition tests
+# ---------------------------------------------------------------------------
+
+
+class TestBroadcastDomainMappingDefinition:
+    """Tests for BROADCAST_DOMAIN_MAPPING structure."""
+
+    def test_all_cache_attrs_exist_on_model(self) -> None:
+        """Every cache_attr in the mapping is a valid BroadcastDomain field."""
+        model_fields = set(BroadcastDomain.model_fields.keys())
+        for field in BROADCAST_DOMAIN_MAPPING.fields:
+            assert field.cache_attr in model_fields, (
+                f"cache_attr '{field.cache_attr}' not on BroadcastDomain"
+            )
+
+    def test_no_duplicate_cache_attrs(self) -> None:
+        """No duplicate cache_attr values."""
+        attrs = [f.cache_attr for f in BROADCAST_DOMAIN_MAPPING.fields]
+        assert len(attrs) == len(set(attrs))
+
+    def test_field_count(self) -> None:
+        """Mapping has expected number of fields (5)."""
+        assert len(BROADCAST_DOMAIN_MAPPING.fields) == 5
+
+    def test_model_class(self) -> None:
+        """Model class is BroadcastDomain."""
+        assert BROADCAST_DOMAIN_MAPPING.model_class is BroadcastDomain
+
+    def test_endpoint(self) -> None:
+        """API endpoint is correct."""
+        assert BROADCAST_DOMAIN_MAPPING.api_endpoint == (
+            "/network/ethernet/broadcast-domains?fields=*"
+        )
+
+    def test_cli_command_empty(self) -> None:
+        """CLI command is empty (API-only type)."""
+        assert BROADCAST_DOMAIN_MAPPING.cli_command == ""
+
+    def test_api_expected_fields(self) -> None:
+        """api_expected_fields returns correct top-level keys."""
+        expected = BROADCAST_DOMAIN_MAPPING.api_expected_fields()
+        assert expected == [
+            "ipspace",
+            "mtu",
+            "name",
+            "ports",
+            "uuid",
+        ]
+
+    def test_id_field(self) -> None:
+        """id_field is name (default)."""
+        assert BROADCAST_DOMAIN_MAPPING.id_field == "name"
+
+
+# ---------------------------------------------------------------------------
+# API parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestBroadcastDomainApiParsing:
+    """Tests for parsing API broadcast domain records."""
+
+    def test_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Full API record parses correctly."""
+        result = parse_api_record(BROADCAST_DOMAIN_MAPPING, full_api_record, "[test]")
+        assert isinstance(result, BroadcastDomain)
+        assert result.uuid == "bd-uuid-1234"
+        assert result.name == "Default"
+        assert result.mtu == 1500
+        assert result.ipspace_uuid == "ipspace-uuid-1"
+        assert result.port_uuids == ["port-uuid-1", "port-uuid-2"]
+
+    def test_minimal_record(self) -> None:
+        """Minimal record uses defaults for missing fields."""
+        record: dict[str, Any] = {"uuid": "bd-min", "name": "Minimal"}
+        result = parse_api_record(BROADCAST_DOMAIN_MAPPING, record, "[test]")
+        assert isinstance(result, BroadcastDomain)
+        assert result.uuid == "bd-min"
+        assert result.name == "Minimal"
+        assert result.mtu == 0
+        assert result.ipspace_uuid == ""
+        assert result.port_uuids == []
+
+    def test_missing_nested_ipspace(self) -> None:
+        """Record without ipspace defaults ipspace_uuid to empty string."""
+        record: dict[str, Any] = {
+            "uuid": "bd-no-ipspace",
+            "name": "NoIpspace",
+            "mtu": 9000,
+        }
+        result = parse_api_record(BROADCAST_DOMAIN_MAPPING, record, "[test]")
+        assert isinstance(result, BroadcastDomain)
+        assert result.ipspace_uuid == ""
+
+    def test_missing_ports(self) -> None:
+        """Record without ports defaults port_uuids to empty list."""
+        record: dict[str, Any] = {
+            "uuid": "bd-no-ports",
+            "name": "NoPorts",
+            "mtu": 1500,
+            "ipspace": {"name": "Default", "uuid": "ipspace-uuid-1"},
+        }
+        result = parse_api_record(BROADCAST_DOMAIN_MAPPING, record, "[test]")
+        assert isinstance(result, BroadcastDomain)
+        assert result.port_uuids == []
+
+    def test_parse_api_response_multiple(self) -> None:
+        """parse_api_response handles multiple records."""
+        response = {
+            "records": [
+                {
+                    "uuid": "bd-1",
+                    "name": "Default",
+                    "mtu": 1500,
+                    "ipspace": {"name": "Default", "uuid": "ipspace-uuid-1"},
+                    "ports": [{"name": "node1:e0c", "uuid": "port-uuid-1"}],
+                },
+                {
+                    "uuid": "bd-2",
+                    "name": "Cluster",
+                    "mtu": 9000,
+                    "ipspace": {"name": "Cluster", "uuid": "ipspace-uuid-2"},
+                    "ports": [{"name": "node1:e0a", "uuid": "port-uuid-3"}],
+                },
+            ],
+        }
+        results = parse_api_response(BROADCAST_DOMAIN_MAPPING, response, "[test]", MagicMock())
+        assert len(results) == 2
+        assert results[0].uuid == "bd-1"  # type: ignore[union-attr]
+        assert results[1].uuid == "bd-2"  # type: ignore[union-attr]
+
+    def test_parse_api_response_empty(self) -> None:
+        """parse_api_response handles empty/None response."""
+        assert parse_api_response(BROADCAST_DOMAIN_MAPPING, None, "[test]", MagicMock()) == []
+        assert parse_api_response(BROADCAST_DOMAIN_MAPPING, {}, "[test]", MagicMock()) == []
+
+
+# ---------------------------------------------------------------------------
+# Parity test: old parser vs new framework
+# ---------------------------------------------------------------------------
+
+
+class TestParityWithOldParser:
+    """Verify framework produces same output as old hand-written inline parser.
+
+    Parity is checked for the original 3 shared fields only (uuid, name, mtu).
+    The old parser extracted ``ipspace.name`` and port names; the new mapping
+    extracts ``ipspace.uuid`` and port UUIDs, so those fields differ by design.
+    """
+
+    _ORIGINAL_SHARED_FIELDS = (
+        "uuid",
+        "name",
+        "mtu",
+    )
+
+    @staticmethod
+    def _old_parse_broadcast_domain(record: dict[str, Any]) -> BroadcastDomain:
+        """Reproduce old inline broadcast domain parsing logic from collector.
+
+        This is a static copy of the code that was in
+        ``_collect_network_via_api`` before migration, adapted to the
+        new model field names where applicable.
+        """
+        return BroadcastDomain(
+            uuid=record.get("uuid", ""),
+            name=record.get("name", ""),
+            mtu=record.get("mtu", 0),
+            # Old parser stored ipspace name; new stores ipspace uuid
+            ipspace_uuid=record.get("ipspace", {}).get("name", ""),
+            # Old parser stored port names; new stores port uuids
+            port_uuids=[p.get("name", "") for p in record.get("ports", []) if p.get("name")],
+        )
+
+    def test_parity_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Framework and old parser produce identical results for shared fields."""
+        old = self._old_parse_broadcast_domain(full_api_record)
+        new = parse_api_record(BROADCAST_DOMAIN_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, BroadcastDomain)
+        for field_name in self._ORIGINAL_SHARED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_minimal_record(self) -> None:
+        """Framework and old parser match on minimal record."""
+        record: dict[str, Any] = {"uuid": "bd-1", "name": "Default"}
+        old = self._old_parse_broadcast_domain(record)
+        new = parse_api_record(BROADCAST_DOMAIN_MAPPING, record, "[test]")
+        assert isinstance(new, BroadcastDomain)
+        for field_name in self._ORIGINAL_SHARED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_ipspace_name_vs_uuid(self, full_api_record: dict[str, Any]) -> None:
+        """Old parser used ipspace.name; new mapping uses ipspace.uuid."""
+        old = self._old_parse_broadcast_domain(full_api_record)
+        new = parse_api_record(BROADCAST_DOMAIN_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, BroadcastDomain)
+        # Old parser stored ipspace name
+        assert old.ipspace_uuid == "Default"
+        # New mapping stores ipspace uuid
+        assert new.ipspace_uuid == "ipspace-uuid-1"
+
+    def test_parity_ports_names_vs_uuids(self, full_api_record: dict[str, Any]) -> None:
+        """Old parser used port names; new mapping uses port UUIDs."""
+        old = self._old_parse_broadcast_domain(full_api_record)
+        new = parse_api_record(BROADCAST_DOMAIN_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, BroadcastDomain)
+        # Old parser stored port names
+        assert old.port_uuids == ["node1:e0c", "node1:e0d"]
+        # New mapping stores port uuids
+        assert new.port_uuids == ["port-uuid-1", "port-uuid-2"]

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -419,10 +419,14 @@ class TestNetworkCollection:
             "/network/ethernet/broadcast-domains?fields=*": {
                 "records": [
                     {
+                        "uuid": "bd-uuid-1",
                         "name": "Default",
-                        "ipspace": {"name": "Default"},
+                        "ipspace": {"name": "Default", "uuid": "ipspace-uuid-1"},
                         "mtu": 1500,
-                        "ports": [{"name": "node1:e0c"}, {"name": "node1:e0d"}],
+                        "ports": [
+                            {"name": "node1:e0c", "uuid": "port-uuid-1"},
+                            {"name": "node1:e0d", "uuid": "port-uuid-2"},
+                        ],
                     }
                 ]
             },
@@ -481,6 +485,10 @@ class TestNetworkCollection:
         assert result.data_lifs[0].name == "data_lif1"
         assert len(result.broadcast_domains) == 1
         assert result.broadcast_domains[0].name == "Default"
+        assert result.broadcast_domains[0].uuid == "bd-uuid-1"
+        assert result.broadcast_domains[0].ipspace_uuid == "ipspace-uuid-1"
+        assert result.broadcast_domains[0].mtu == 1500
+        assert result.broadcast_domains[0].port_uuids == ["port-uuid-1", "port-uuid-2"]
         assert "Default" in result.ipspaces
         assert len(result.dns) == 1
         assert result.dns[0].svm_uuid == "svm-uuid-1"

--- a/tests/unit/cache/test_models.py
+++ b/tests/unit/cache/test_models.py
@@ -186,18 +186,20 @@ class TestBroadcastDomain:
         """Test default values."""
         bd = BroadcastDomain()
         assert bd.name == ""
-        assert bd.ports == []
+        assert bd.ipspace_uuid == ""
+        assert bd.port_uuids == []
 
     def test_with_values(self) -> None:
         """Test with broadcast domain data."""
         bd = BroadcastDomain(
             name="Default",
-            ipspace="Default",
+            ipspace_uuid="ipspace-uuid-1",
             mtu=1500,
-            ports=["node1:e0c", "node1:e0d"],
+            port_uuids=["port-uuid-1", "port-uuid-2"],
         )
         assert bd.name == "Default"
-        assert len(bd.ports) == 2
+        assert bd.ipspace_uuid == "ipspace-uuid-1"
+        assert len(bd.port_uuids) == 2
 
 
 class TestNetworkInfo:

--- a/tests/unit/cache/test_registry_integration.py
+++ b/tests/unit/cache/test_registry_integration.py
@@ -84,6 +84,7 @@ class TestMappingRegistration:
         """All 11 type mappings should be registered."""
         expected_mappings = {
             "Aggregate",
+            "BroadcastDomain",
             "CloudMetadata",
             "Cluster",
             "ClusterPeer",
@@ -100,8 +101,8 @@ class TestMappingRegistration:
         assert not missing, f"Mappings not registered: {missing}"
 
     def test_mapping_count(self) -> None:
-        """Registry should contain exactly 11 mappings."""
-        assert len(model_registry.mappings) == 11
+        """Registry should contain exactly 12 mappings."""
+        assert len(model_registry.mappings) == 12
 
     def test_mapping_lookup_by_name(self) -> None:
         """get_mapping() should return the correct TypeMapping for known names."""


### PR DESCRIPTION
## Description

Migrate BroadcastDomain from hand-written inline parsing in the collector to the declarative field mapping framework. This replaces manual field extraction with a data-driven `BROADCAST_DOMAIN_MAPPING` definition and the generic `parse_api_response()` parser.

## Related Issue

Addresses #212

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Created `BROADCAST_DOMAIN_MAPPING` in `src/pynetappfoundry/cache/network/ethernet/broadcast_domains/mapping.py` with 5 API-only fields (uuid, name, mtu, ipspace_uuid, port_uuids)
- Renamed model fields for consistency: `ipspace` to `ipspace_uuid`, `ports` to `port_uuids` (now stores UUIDs via `ipspace.uuid` dot-path and `ports[*].uuid` wildcard extraction instead of names)
- Replaced inline broadcast domain parsing in `collector.py` with `parse_api_response(BROADCAST_DOMAIN_MAPPING, ...)`
- Exported `BROADCAST_DOMAIN_MAPPING` from the broadcast_domains package `__init__.py`
- Registered `broadcast_domain` in the cache inspect command
- Updated ADR-0004 with issue #212 link
- Updated `docs/development/field-mapping.md` Migrated Types table with BroadcastDomain entry
- Added comprehensive mapping tests in `tests/unit/cache/mappings/test_broadcast_domain.py`
- Updated existing tests (`test_collector.py`, `test_models.py`, `test_registry_integration.py`) for renamed fields

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes (tests, lint, type-check, security, spell-check).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The field renaming (`ipspace` to `ipspace_uuid`, `ports` to `port_uuids`) reflects a semantic shift: the mapping now extracts UUIDs from the nested API response (`ipspace.uuid`, `ports[*].uuid`) rather than names, aligning with the convention used by other migrated types that store references as UUIDs.
