### PR TITLE
refactor: migrate NetworkLIF to declarative field mapping framework

### DIFF
--- a/docs/decisions/0004-declarative-field-mapping-framework.md
+++ b/docs/decisions/0004-declarative-field-mapping-framework.md
@@ -67,6 +67,7 @@ The pilot migration (VolumeInfo) was completed in PR #189.
 - Issue #192: refactor: migrate SVMInfo to field mapping framework
 - Issue #205: refactor: migrate DNSInfo to field mapping framework
 - Issue #213: refactor: migrate LicenseInfo/LicenseFeature to field mapping framework
+- Issue #211: refactor: migrate NetworkLIF to field mapping framework
 - Issue #212: refactor: migrate BroadcastDomain to field mapping framework
 
 ## Related Documentation

--- a/docs/development/field-mapping.md
+++ b/docs/development/field-mapping.md
@@ -230,6 +230,7 @@ For CLI-only types, also test:
 | Cluster | `CLUSTER_MAPPING` | `ClusterInfo` | 18 | API-only. Single-object endpoint (no `records` list), uses `parse_api_record()` directly. `is_ha` derived post-collection. |
 | CloudMetadata | `CLOUD_METADATA_MAPPING` | `CloudMetadata` | 19 | CLI-only (no API endpoint). Computed link fields built as post-processing in collector. |
 | BroadcastDomain | `BROADCAST_DOMAIN_MAPPING` | `BroadcastDomain` | 5 | API-only. Wildcard `[*]` syntax for `port_uuids`. Nested dot-path for `ipspace_uuid`. |
+| NetworkLIF | `NETWORK_LIF_MAPPING` | `NetworkLIF` | 25 | API-only. UUID-only nested refs for svm, ipspace, service_policy, subnet, and location nodes/ports. Scope-based sorting in collector. |
 
 ## Reference: Field Mapping Patterns
 

--- a/src/pynetappfoundry/cache/__init__.py
+++ b/src/pynetappfoundry/cache/__init__.py
@@ -25,6 +25,7 @@ import pynetappfoundry.cache.cluster.mediators
 import pynetappfoundry.cache.cluster.nodes
 import pynetappfoundry.cache.cluster.peers
 import pynetappfoundry.cache.name_services.dns
+import pynetappfoundry.cache.network.ip.interfaces
 import pynetappfoundry.cache.snapmirror.relationships
 import pynetappfoundry.cache.storage.aggregates
 import pynetappfoundry.cache.storage.volumes

--- a/src/pynetappfoundry/cache/_base.py
+++ b/src/pynetappfoundry/cache/_base.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, ConfigDict
 # Increment MINOR for backward-compatible changes (new optional fields).
 # Increment MAJOR for breaking changes (removed/renamed fields, type changes).
 # Format: "MAJOR.MINOR"
-METADATA_SCHEMA_VERSION = "1.0"
+METADATA_SCHEMA_VERSION = "1.1"
 
 # Minimum schema version that can be loaded without migration.
 # Snapshots older than this may fail to deserialize or have missing data.

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -50,6 +50,7 @@ from pynetappfoundry.cache.network.ethernet.broadcast_domains.mapping import (
 from pynetappfoundry.cache.network.ethernet.broadcast_domains.model import (
     BroadcastDomain,
 )
+from pynetappfoundry.cache.network.ip.interfaces.mapping import NETWORK_LIF_MAPPING
 from pynetappfoundry.cache.network.ip.interfaces.model import NetworkLIF
 from pynetappfoundry.cache.network.ip.subnets.model import IPSubnetInfo
 from pynetappfoundry.cache.network.model import NetworkInfo
@@ -936,7 +937,7 @@ class MetadataCollector:
 
         # Make all 5 API calls in parallel using cached calls
         endpoints = [
-            "/network/ip/interfaces?fields=*",
+            NETWORK_LIF_MAPPING.api_endpoint,
             BROADCAST_DOMAIN_MAPPING.api_endpoint,
             "/network/ipspaces?fields=*",
             DNS_MAPPING.api_endpoint,
@@ -954,38 +955,24 @@ class MetadataCollector:
             responses = {ep: self._cached_api_call(ep) for ep in endpoints}
 
         # Process LIFs response
-        lifs_response = responses.get(endpoints[0]) or {}
-        logger.debug(
-            "%s API response: %d LIFs", self._log_prefix, len(lifs_response.get("records", []))
+        all_lifs = cast(
+            list[NetworkLIF],
+            parse_api_response(
+                NETWORK_LIF_MAPPING,
+                responses.get(endpoints[0]),
+                self._log_prefix,
+                self._log_missing_fields,
+            ),
         )
-        intercluster_lifs = []
-        data_lifs = []
-        management_lifs = []
+        intercluster_lifs: list[NetworkLIF] = []
+        data_lifs: list[NetworkLIF] = []
+        management_lifs: list[NetworkLIF] = []
 
-        for record in lifs_response.get("records", []):
-            self._log_missing_fields(
-                record,
-                ["name", "ip", "location", "svm", "scope", "services"],
-                "LIF",
-                record.get("name", record.get("uuid", "unknown")),
-            )
-            lif = NetworkLIF(
-                name=record.get("name", ""),
-                ip_address=record.get("ip", {}).get("address", ""),
-                netmask=record.get("ip", {}).get("netmask", ""),
-                home_node=record.get("location", {}).get("home_node", {}).get("name", ""),
-                home_port=record.get("location", {}).get("home_port", {}).get("name", ""),
-                svm=record.get("svm", {}).get("name", ""),
-            )
-            # Determine role from service_policy or scope
-            scope = record.get("scope", "")
-            if scope == "cluster":
+        for lif in all_lifs:
+            if lif.scope == "cluster":
                 intercluster_lifs.append(lif)
-            elif scope == "svm":
-                if "data" in record.get("services", []):
-                    data_lifs.append(lif)
-                else:
-                    data_lifs.append(lif)  # Default to data
+            elif lif.scope == "svm":
+                data_lifs.append(lif)
             else:
                 management_lifs.append(lif)
 

--- a/src/pynetappfoundry/cache/diff.py
+++ b/src/pynetappfoundry/cache/diff.py
@@ -226,17 +226,17 @@ _ENTITY_CONFIGS: dict[str, EntityConfig] = {
         display_field="node",
     ),
     "network.intercluster_lifs": EntityConfig(
-        key_field="name",
+        key_field="uuid",
         model_class=NetworkLIF,
         display_field="name",
     ),
     "network.data_lifs": EntityConfig(
-        key_field="name",
+        key_field="uuid",
         model_class=NetworkLIF,
         display_field="name",
     ),
     "network.management_lifs": EntityConfig(
-        key_field="name",
+        key_field="uuid",
         model_class=NetworkLIF,
         display_field="name",
     ),

--- a/src/pynetappfoundry/cache/network/__init__.py
+++ b/src/pynetappfoundry/cache/network/__init__.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from pynetappfoundry.cache.network.ethernet.broadcast_domains import BroadcastDomain
-from pynetappfoundry.cache.network.ip.interfaces import NetworkLIF
+from pynetappfoundry.cache.network.ip.interfaces import NETWORK_LIF_MAPPING, NetworkLIF
 from pynetappfoundry.cache.network.ip.subnets import IPSubnetInfo
 from pynetappfoundry.cache.network.model import NetworkInfo
 
 __all__ = [
+    "NETWORK_LIF_MAPPING",
     "BroadcastDomain",
     "IPSubnetInfo",
     "NetworkInfo",

--- a/src/pynetappfoundry/cache/network/ip/__init__.py
+++ b/src/pynetappfoundry/cache/network/ip/__init__.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from pynetappfoundry.cache.network.ip.interfaces import NetworkLIF
+from pynetappfoundry.cache.network.ip.interfaces import NETWORK_LIF_MAPPING, NetworkLIF
 from pynetappfoundry.cache.network.ip.subnets import IPSubnetInfo
 
 __all__ = [
+    "NETWORK_LIF_MAPPING",
     "IPSubnetInfo",
     "NetworkLIF",
 ]

--- a/src/pynetappfoundry/cache/network/ip/interfaces/__init__.py
+++ b/src/pynetappfoundry/cache/network/ip/interfaces/__init__.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from pynetappfoundry.cache.network.ip.interfaces.mapping import NETWORK_LIF_MAPPING
 from pynetappfoundry.cache.network.ip.interfaces.model import NetworkLIF
 
 __all__ = [
+    "NETWORK_LIF_MAPPING",
     "NetworkLIF",
 ]

--- a/src/pynetappfoundry/cache/network/ip/interfaces/mapping.py
+++ b/src/pynetappfoundry/cache/network/ip/interfaces/mapping.py
@@ -1,0 +1,133 @@
+"""NetworkLIF type mapping definition for the declarative field mapping framework.
+
+Defines NETWORK_LIF_MAPPING which maps ONTAP REST API network IP interface
+data to NetworkLIF cache model attributes. NetworkLIF is API-only --
+there is no CLI command for this data.
+
+All fields use simple dot-path extraction; no transform functions are needed.
+"""
+
+from __future__ import annotations
+
+from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.cache.network.ip.interfaces.model import NetworkLIF
+
+NETWORK_LIF_MAPPING = TypeMapping(
+    name="NetworkLIF",
+    model_class=NetworkLIF,
+    api_endpoint="/network/ip/interfaces?fields=*",
+    cli_command="",
+    fields=(
+        FieldMapping(
+            cache_attr="uuid",
+            api_path="uuid",
+        ),
+        FieldMapping(
+            cache_attr="name",
+            api_path="name",
+        ),
+        FieldMapping(
+            cache_attr="ip_address",
+            api_path="ip.address",
+        ),
+        FieldMapping(
+            cache_attr="netmask",
+            api_path="ip.netmask",
+        ),
+        FieldMapping(
+            cache_attr="ip_family",
+            api_path="ip.family",
+        ),
+        FieldMapping(
+            cache_attr="enabled",
+            api_path="enabled",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="state",
+            api_path="state",
+        ),
+        FieldMapping(
+            cache_attr="scope",
+            api_path="scope",
+        ),
+        FieldMapping(
+            cache_attr="vip",
+            api_path="vip",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="svm_uuid",
+            api_path="svm.uuid",
+        ),
+        FieldMapping(
+            cache_attr="ipspace_uuid",
+            api_path="ipspace.uuid",
+        ),
+        FieldMapping(
+            cache_attr="service_policy_uuid",
+            api_path="service_policy.uuid",
+        ),
+        FieldMapping(
+            cache_attr="services",
+            api_path="services",
+            default=[],
+        ),
+        FieldMapping(
+            cache_attr="auto_revert",
+            api_path="location.auto_revert",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="failover",
+            api_path="location.failover",
+        ),
+        FieldMapping(
+            cache_attr="is_home",
+            api_path="location.is_home",
+            default=True,
+        ),
+        FieldMapping(
+            cache_attr="home_node_uuid",
+            api_path="location.home_node.uuid",
+        ),
+        FieldMapping(
+            cache_attr="home_port_uuid",
+            api_path="location.home_port.uuid",
+        ),
+        FieldMapping(
+            cache_attr="current_node_uuid",
+            api_path="location.node.uuid",
+        ),
+        FieldMapping(
+            cache_attr="current_port_uuid",
+            api_path="location.port.uuid",
+        ),
+        FieldMapping(
+            cache_attr="dns_zone",
+            api_path="dns_zone",
+        ),
+        FieldMapping(
+            cache_attr="ddns_enabled",
+            api_path="ddns_enabled",
+            default=False,
+        ),
+        FieldMapping(
+            cache_attr="subnet_uuid",
+            api_path="subnet.uuid",
+        ),
+        FieldMapping(
+            cache_attr="probe_port",
+            api_path="probe_port",
+            default=0,
+        ),
+        FieldMapping(
+            cache_attr="rdma_protocols",
+            api_path="rdma_protocols",
+            default=[],
+        ),
+    ),
+)
+
+model_registry.register_mapping("NetworkLIF", NETWORK_LIF_MAPPING)

--- a/src/pynetappfoundry/cache/network/ip/interfaces/model.py
+++ b/src/pynetappfoundry/cache/network/ip/interfaces/model.py
@@ -2,16 +2,36 @@
 
 from __future__ import annotations
 
+from pydantic import Field
+
 from pynetappfoundry.cache._base import CacheModel
 
 
 class NetworkLIF(CacheModel):
     """Network logical interface information."""
 
+    uuid: str = ""
     name: str = ""
     ip_address: str = ""
     netmask: str = ""
-    home_node: str = ""
-    home_port: str = ""
-    role: str = ""  # data, cluster, intercluster, management
-    svm: str = ""
+    ip_family: str = ""
+    enabled: bool = True
+    state: str = ""
+    scope: str = ""
+    vip: bool = False
+    svm_uuid: str = ""
+    ipspace_uuid: str = ""
+    service_policy_uuid: str = ""
+    services: list[str] = Field(default_factory=list)
+    auto_revert: bool = False
+    failover: str = ""
+    is_home: bool = True
+    home_node_uuid: str = ""
+    home_port_uuid: str = ""
+    current_node_uuid: str = ""
+    current_port_uuid: str = ""
+    dns_zone: str = ""
+    ddns_enabled: bool = False
+    subnet_uuid: str = ""
+    probe_port: int = 0
+    rdma_protocols: list[str] = Field(default_factory=list)

--- a/src/pynetappfoundry/cli/commands/cache/inspect.py
+++ b/src/pynetappfoundry/cli/commands/cache/inspect.py
@@ -21,6 +21,7 @@ from pynetappfoundry.cache.field_mapping import TypeMapping
 from pynetappfoundry.cache.network.ethernet.broadcast_domains.mapping import (
     BROADCAST_DOMAIN_MAPPING,
 )
+from pynetappfoundry.cache.network.ip.interfaces.mapping import NETWORK_LIF_MAPPING
 from pynetappfoundry.cache.storage.aggregates.mapping import AGGREGATE_MAPPING
 from pynetappfoundry.cache.storage.volumes.mapping import VOLUME_MAPPING
 from pynetappfoundry.cache.svm.mapping import SVM_MAPPING
@@ -47,6 +48,7 @@ INSPECT_TYPES: dict[str, tuple[TypeMapping, str]] = {
     "license": (LICENSE_PACKAGE_MAPPING, "license_packages"),
     "node": (NODE_MAPPING, "nodes"),
     "svm": (SVM_MAPPING, "storage.svms"),
+    "network_lif": (NETWORK_LIF_MAPPING, "network.data_lifs"),
     "volume": (VOLUME_MAPPING, "storage.volumes"),
 }
 

--- a/tests/unit/cache/mappings/test_network_lif.py
+++ b/tests/unit/cache/mappings/test_network_lif.py
@@ -1,0 +1,331 @@
+"""Tests for the NetworkLIF type mapping definition."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pynetappfoundry.cache.field_mapping import (
+    parse_api_record,
+    parse_api_response,
+)
+from pynetappfoundry.cache.network.ip.interfaces.mapping import (
+    NETWORK_LIF_MAPPING,
+)
+from pynetappfoundry.cache.network.ip.interfaces.model import (
+    NetworkLIF,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def full_api_record() -> dict[str, Any]:
+    """Full API network LIF record with all fields populated."""
+    return {
+        "uuid": "lif-uuid-1234",
+        "name": "data_lif1",
+        "ip": {
+            "address": "10.0.0.10",
+            "netmask": "255.255.255.0",
+            "family": "ipv4",
+        },
+        "enabled": True,
+        "state": "up",
+        "scope": "svm",
+        "vip": False,
+        "svm": {"name": "svm1", "uuid": "svm-uuid-1"},
+        "ipspace": {"name": "Default", "uuid": "ipspace-uuid-1"},
+        "service_policy": {"name": "default-data-files", "uuid": "sp-uuid-1"},
+        "services": ["data_core", "data_nfs"],
+        "location": {
+            "auto_revert": True,
+            "failover": "sfo-partner-only",
+            "is_home": True,
+            "home_node": {"name": "node1", "uuid": "home-node-uuid-1"},
+            "home_port": {"name": "e0d", "uuid": "home-port-uuid-1"},
+            "node": {"name": "node1", "uuid": "current-node-uuid-1"},
+            "port": {"name": "e0d", "uuid": "current-port-uuid-1"},
+        },
+        "dns_zone": "example.com",
+        "ddns_enabled": False,
+        "subnet": {"name": "data-subnet", "uuid": "subnet-uuid-1"},
+        "probe_port": 8080,
+        "rdma_protocols": ["roce"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mapping definition tests
+# ---------------------------------------------------------------------------
+
+
+class TestNetworkLIFMappingDefinition:
+    """Tests for NETWORK_LIF_MAPPING structure."""
+
+    def test_all_cache_attrs_exist_on_model(self) -> None:
+        """Every cache_attr in the mapping is a valid NetworkLIF field."""
+        model_fields = set(NetworkLIF.model_fields.keys())
+        for field in NETWORK_LIF_MAPPING.fields:
+            assert field.cache_attr in model_fields, (
+                f"cache_attr '{field.cache_attr}' not on NetworkLIF"
+            )
+
+    def test_no_duplicate_cache_attrs(self) -> None:
+        """No duplicate cache_attr values."""
+        attrs = [f.cache_attr for f in NETWORK_LIF_MAPPING.fields]
+        assert len(attrs) == len(set(attrs))
+
+    def test_field_count(self) -> None:
+        """Mapping has expected number of fields (25)."""
+        assert len(NETWORK_LIF_MAPPING.fields) == 25
+
+    def test_model_class(self) -> None:
+        """Model class is NetworkLIF."""
+        assert NETWORK_LIF_MAPPING.model_class is NetworkLIF
+
+    def test_endpoint(self) -> None:
+        """API endpoint is correct."""
+        assert NETWORK_LIF_MAPPING.api_endpoint == "/network/ip/interfaces?fields=*"
+
+    def test_cli_command_empty(self) -> None:
+        """CLI command is empty (API-only type)."""
+        assert NETWORK_LIF_MAPPING.cli_command == ""
+
+    def test_api_expected_fields(self) -> None:
+        """api_expected_fields returns correct top-level keys."""
+        expected = NETWORK_LIF_MAPPING.api_expected_fields()
+        assert expected == [
+            "ddns_enabled",
+            "dns_zone",
+            "enabled",
+            "ip",
+            "ipspace",
+            "location",
+            "name",
+            "probe_port",
+            "rdma_protocols",
+            "scope",
+            "service_policy",
+            "services",
+            "state",
+            "subnet",
+            "svm",
+            "uuid",
+            "vip",
+        ]
+
+    def test_id_field(self) -> None:
+        """id_field is name (default)."""
+        assert NETWORK_LIF_MAPPING.id_field == "name"
+
+
+# ---------------------------------------------------------------------------
+# API parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestNetworkLIFApiParsing:
+    """Tests for parsing API network LIF records."""
+
+    def test_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Full API record parses correctly."""
+        result = parse_api_record(NETWORK_LIF_MAPPING, full_api_record, "[test]")
+        assert isinstance(result, NetworkLIF)
+        assert result.uuid == "lif-uuid-1234"
+        assert result.name == "data_lif1"
+        assert result.ip_address == "10.0.0.10"
+        assert result.netmask == "255.255.255.0"
+        assert result.ip_family == "ipv4"
+        assert result.enabled is True
+        assert result.state == "up"
+        assert result.scope == "svm"
+        assert result.vip is False
+        assert result.svm_uuid == "svm-uuid-1"
+        assert result.ipspace_uuid == "ipspace-uuid-1"
+        assert result.service_policy_uuid == "sp-uuid-1"
+        assert result.services == ["data_core", "data_nfs"]
+        assert result.auto_revert is True
+        assert result.failover == "sfo-partner-only"
+        assert result.is_home is True
+        assert result.home_node_uuid == "home-node-uuid-1"
+        assert result.home_port_uuid == "home-port-uuid-1"
+        assert result.current_node_uuid == "current-node-uuid-1"
+        assert result.current_port_uuid == "current-port-uuid-1"
+        assert result.dns_zone == "example.com"
+        assert result.ddns_enabled is False
+        assert result.subnet_uuid == "subnet-uuid-1"
+        assert result.probe_port == 8080
+        assert result.rdma_protocols == ["roce"]
+
+    def test_minimal_record(self) -> None:
+        """Minimal record uses defaults for missing fields."""
+        record: dict[str, Any] = {"uuid": "lif-min", "name": "minimal_lif"}
+        result = parse_api_record(NETWORK_LIF_MAPPING, record, "[test]")
+        assert isinstance(result, NetworkLIF)
+        assert result.uuid == "lif-min"
+        assert result.name == "minimal_lif"
+        assert result.ip_address == ""
+        assert result.netmask == ""
+        assert result.ip_family == ""
+        assert result.enabled is True
+        assert result.state == ""
+        assert result.scope == ""
+        assert result.vip is False
+        assert result.svm_uuid == ""
+        assert result.ipspace_uuid == ""
+        assert result.service_policy_uuid == ""
+        assert result.services == []
+        assert result.auto_revert is False
+        assert result.failover == ""
+        assert result.is_home is True
+        assert result.home_node_uuid == ""
+        assert result.home_port_uuid == ""
+        assert result.current_node_uuid == ""
+        assert result.current_port_uuid == ""
+        assert result.dns_zone == ""
+        assert result.ddns_enabled is False
+        assert result.subnet_uuid == ""
+        assert result.probe_port == 0
+        assert result.rdma_protocols == []
+
+    def test_missing_nested_objects(self) -> None:
+        """Record without nested objects defaults nested fields to empty strings."""
+        record: dict[str, Any] = {
+            "uuid": "lif-no-nested",
+            "name": "no_nested_lif",
+            "ip": {"address": "10.0.0.1"},
+        }
+        result = parse_api_record(NETWORK_LIF_MAPPING, record, "[test]")
+        assert isinstance(result, NetworkLIF)
+        assert result.ip_address == "10.0.0.1"
+        assert result.netmask == ""
+        assert result.svm_uuid == ""
+        assert result.ipspace_uuid == ""
+        assert result.service_policy_uuid == ""
+        assert result.home_node_uuid == ""
+        assert result.home_port_uuid == ""
+        assert result.current_node_uuid == ""
+        assert result.current_port_uuid == ""
+        assert result.subnet_uuid == ""
+
+    def test_parse_api_response_multiple(self) -> None:
+        """parse_api_response handles multiple records."""
+        response = {
+            "records": [
+                {
+                    "uuid": "lif-1",
+                    "name": "data_lif1",
+                    "ip": {"address": "10.0.0.10", "netmask": "255.255.255.0"},
+                    "scope": "svm",
+                    "svm": {"uuid": "svm-uuid-1"},
+                },
+                {
+                    "uuid": "lif-2",
+                    "name": "ic_lif1",
+                    "ip": {"address": "10.0.1.1", "netmask": "255.255.255.0"},
+                    "scope": "cluster",
+                    "svm": {"uuid": "svm-uuid-2"},
+                },
+            ],
+        }
+        results = parse_api_response(NETWORK_LIF_MAPPING, response, "[test]", MagicMock())
+        assert len(results) == 2
+        assert results[0].uuid == "lif-1"  # type: ignore[union-attr]
+        assert results[1].uuid == "lif-2"  # type: ignore[union-attr]
+
+    def test_parse_api_response_empty(self) -> None:
+        """parse_api_response handles empty/None response."""
+        assert parse_api_response(NETWORK_LIF_MAPPING, None, "[test]", MagicMock()) == []
+        assert parse_api_response(NETWORK_LIF_MAPPING, {}, "[test]", MagicMock()) == []
+
+
+# ---------------------------------------------------------------------------
+# Parity test: old parser vs new framework
+# ---------------------------------------------------------------------------
+
+
+class TestParityWithOldParser:
+    """Verify framework produces same output as old hand-written inline parser.
+
+    Parity is checked for the 3 shared fields only (name, ip_address, netmask).
+    The old parser extracted ``svm.name``, ``home_node.name``, ``home_port.name``;
+    the new mapping extracts UUIDs instead, so those fields differ by design.
+    The old ``role`` field was dead code (never set by collector) and is removed.
+    """
+
+    _ORIGINAL_SHARED_FIELDS = (
+        "name",
+        "ip_address",
+        "netmask",
+    )
+
+    @staticmethod
+    def _old_parse_lif(record: dict[str, Any]) -> NetworkLIF:
+        """Reproduce old inline LIF parsing logic from collector.
+
+        This is a static copy of the code that was in
+        ``_collect_network_via_api`` before migration, adapted to the
+        new model field names where applicable.
+        """
+        return NetworkLIF(
+            name=record.get("name", ""),
+            ip_address=record.get("ip", {}).get("address", ""),
+            netmask=record.get("ip", {}).get("netmask", ""),
+        )
+
+    def test_parity_full_record(self, full_api_record: dict[str, Any]) -> None:
+        """Framework and old parser produce identical results for shared fields."""
+        old = self._old_parse_lif(full_api_record)
+        new = parse_api_record(NETWORK_LIF_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, NetworkLIF)
+        for field_name in self._ORIGINAL_SHARED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_minimal_record(self) -> None:
+        """Framework and old parser match on minimal record."""
+        record: dict[str, Any] = {"uuid": "lif-1", "name": "data_lif1"}
+        old = self._old_parse_lif(record)
+        new = parse_api_record(NETWORK_LIF_MAPPING, record, "[test]")
+        assert isinstance(new, NetworkLIF)
+        for field_name in self._ORIGINAL_SHARED_FIELDS:
+            old_val = getattr(old, field_name)
+            new_val = getattr(new, field_name)
+            assert old_val == new_val, (
+                f"Field '{field_name}' differs: old={old_val!r}, new={new_val!r}"
+            )
+
+    def test_parity_old_stored_svm_name_new_stores_uuid(
+        self, full_api_record: dict[str, Any]
+    ) -> None:
+        """Old parser used svm.name; new mapping uses svm.uuid."""
+        new = parse_api_record(NETWORK_LIF_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, NetworkLIF)
+        # New mapping stores svm uuid
+        assert new.svm_uuid == "svm-uuid-1"
+
+    def test_parity_old_stored_node_name_new_stores_uuid(
+        self, full_api_record: dict[str, Any]
+    ) -> None:
+        """Old parser used home_node.name; new mapping uses home_node.uuid."""
+        new = parse_api_record(NETWORK_LIF_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, NetworkLIF)
+        # New mapping stores home_node uuid
+        assert new.home_node_uuid == "home-node-uuid-1"
+
+    def test_parity_old_stored_port_name_new_stores_uuid(
+        self, full_api_record: dict[str, Any]
+    ) -> None:
+        """Old parser used home_port.name; new mapping uses home_port.uuid."""
+        new = parse_api_record(NETWORK_LIF_MAPPING, full_api_record, "[test]")
+        assert isinstance(new, NetworkLIF)
+        # New mapping stores home_port uuid
+        assert new.home_port_uuid == "home-port-uuid-1"

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -402,17 +402,32 @@ class TestNetworkCollection:
             "/network/ip/interfaces?fields=*": {
                 "records": [
                     {
+                        "uuid": "lif-uuid-1",
                         "name": "data_lif1",
-                        "ip": {"address": "10.0.0.10", "netmask": "255.255.255.0"},
-                        "location": {
-                            "home_node": {"name": "node1"},
-                            "home_port": {"name": "e0d"},
-                            "node": {"name": "node1"},
-                            "port": {"name": "e0d"},
+                        "ip": {
+                            "address": "10.0.0.10",
+                            "netmask": "255.255.255.0",
+                            "family": "ipv4",
                         },
+                        "enabled": True,
                         "state": "up",
                         "scope": "svm",
-                        "svm": {"name": "svm1"},
+                        "vip": False,
+                        "svm": {"name": "svm1", "uuid": "svm-uuid-1"},
+                        "ipspace": {"uuid": "ipspace-uuid-1"},
+                        "service_policy": {"uuid": "sp-uuid-1"},
+                        "services": ["data_core", "data_nfs"],
+                        "location": {
+                            "auto_revert": True,
+                            "failover": "sfo-partner-only",
+                            "is_home": True,
+                            "home_node": {"name": "node1", "uuid": "node-uuid-1"},
+                            "home_port": {"name": "e0d", "uuid": "port-uuid-e0d"},
+                            "node": {"name": "node1", "uuid": "node-uuid-1"},
+                            "port": {"name": "e0d", "uuid": "port-uuid-e0d"},
+                        },
+                        "dns_zone": "example.com",
+                        "ddns_enabled": False,
                     }
                 ]
             },
@@ -482,7 +497,15 @@ class TestNetworkCollection:
         result = collector.collect_network()
 
         assert len(result.data_lifs) == 1
+        assert result.data_lifs[0].uuid == "lif-uuid-1"
         assert result.data_lifs[0].name == "data_lif1"
+        assert result.data_lifs[0].ip_address == "10.0.0.10"
+        assert result.data_lifs[0].netmask == "255.255.255.0"
+        assert result.data_lifs[0].scope == "svm"
+        assert result.data_lifs[0].svm_uuid == "svm-uuid-1"
+        assert result.data_lifs[0].home_node_uuid == "node-uuid-1"
+        assert result.data_lifs[0].home_port_uuid == "port-uuid-e0d"
+        assert result.data_lifs[0].services == ["data_core", "data_nfs"]
         assert len(result.broadcast_domains) == 1
         assert result.broadcast_domains[0].name == "Default"
         assert result.broadcast_domains[0].uuid == "bd-uuid-1"
@@ -1446,7 +1469,7 @@ class TestCollectAll:
 
         assert result.cluster_name == "test-cluster"
         assert result.cached_at is not None
-        assert result.cache_version == "1.0"
+        assert result.cache_version == "1.1"
 
 
 class TestCachedApiCallPagination:

--- a/tests/unit/cache/test_diff.py
+++ b/tests/unit/cache/test_diff.py
@@ -324,7 +324,7 @@ class TestComputeDiffModifiedEntities:
             cluster_name="test-cluster",
             network=NetworkInfo(
                 intercluster_lifs=[
-                    NetworkLIF(name="lif1", ip_address="10.0.0.1"),
+                    NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1"),
                 ],
             ),
         )
@@ -332,7 +332,7 @@ class TestComputeDiffModifiedEntities:
             cluster_name="test-cluster",
             network=NetworkInfo(
                 intercluster_lifs=[
-                    NetworkLIF(name="lif1", ip_address="10.0.0.2"),
+                    NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.2"),
                 ],
             ),
         )
@@ -1500,13 +1500,17 @@ class TestComputeDiffEdgeCases:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                intercluster_lifs=[NetworkLIF(name="lif1", ip_address="10.0.0.1")],
+                intercluster_lifs=[
+                    NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1")
+                ],
             ),
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                intercluster_lifs=[NetworkLIF(name="lif1", ip_address="10.0.0.1")],
+                intercluster_lifs=[
+                    NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1")
+                ],
             ),
         )
         changes = compute_diff(before, after)

--- a/tests/unit/cache/test_models.py
+++ b/tests/unit/cache/test_models.py
@@ -160,23 +160,48 @@ class TestNetworkLIF:
     def test_default_values(self) -> None:
         """Test default values."""
         lif = NetworkLIF()
+        assert lif.uuid == ""
         assert lif.name == ""
         assert lif.ip_address == ""
+        assert lif.netmask == ""
+        assert lif.ip_family == ""
+        assert lif.enabled is True
+        assert lif.state == ""
+        assert lif.scope == ""
+        assert lif.vip is False
+        assert lif.svm_uuid == ""
+        assert lif.ipspace_uuid == ""
+        assert lif.service_policy_uuid == ""
+        assert lif.services == []
+        assert lif.auto_revert is False
+        assert lif.failover == ""
+        assert lif.is_home is True
+        assert lif.home_node_uuid == ""
+        assert lif.home_port_uuid == ""
+        assert lif.current_node_uuid == ""
+        assert lif.current_port_uuid == ""
+        assert lif.dns_zone == ""
+        assert lif.ddns_enabled is False
+        assert lif.subnet_uuid == ""
+        assert lif.probe_port == 0
+        assert lif.rdma_protocols == []
 
     def test_with_values(self) -> None:
         """Test with LIF data."""
         lif = NetworkLIF(
+            uuid="lif-uuid-1",
             name="data_lif1",
             ip_address="10.0.0.10",
             netmask="255.255.255.0",
-            home_node="node1",
-            home_port="e0d",
-            role="data",
-            svm="svm1",
+            scope="svm",
+            svm_uuid="svm-uuid-1",
+            home_node_uuid="node-uuid-1",
+            home_port_uuid="port-uuid-1",
         )
         assert lif.name == "data_lif1"
         assert lif.ip_address == "10.0.0.10"
-        assert lif.role == "data"
+        assert lif.scope == "svm"
+        assert lif.svm_uuid == "svm-uuid-1"
 
 
 class TestBroadcastDomain:
@@ -1190,7 +1215,7 @@ class TestCachedClusterMetadata:
         """Test creating with minimal required fields."""
         metadata = CachedClusterMetadata(cluster_name="test-cluster")
         assert metadata.cluster_name == "test-cluster"
-        assert metadata.cache_version == "1.0"
+        assert metadata.cache_version == "1.1"
         assert metadata.cached_at is not None
 
     def test_cached_at_default(self) -> None:
@@ -1495,6 +1520,6 @@ class TestUuidIndex:
         node = NodeInfo(uuid="test-uuid")
         assert isinstance(node, HasUUID)
 
-        # Models without uuid field should not satisfy the protocol
-        lif = NetworkLIF(name="lif1")
-        assert not isinstance(lif, HasUUID)
+        # NetworkLIF now has uuid field and satisfies the protocol
+        lif = NetworkLIF(uuid="lif-uuid-1", name="lif1")
+        assert isinstance(lif, HasUUID)

--- a/tests/unit/cache/test_registry_integration.py
+++ b/tests/unit/cache/test_registry_integration.py
@@ -81,7 +81,7 @@ class TestMappingRegistration:
     """Tests that all mappings are registered via register_mapping()."""
 
     def test_registry_contains_all_mappings(self) -> None:
-        """All 11 type mappings should be registered."""
+        """All 13 type mappings should be registered."""
         expected_mappings = {
             "Aggregate",
             "BroadcastDomain",
@@ -91,6 +91,7 @@ class TestMappingRegistration:
             "DNS",
             "LicensePackage",
             "Mediator",
+            "NetworkLIF",
             "Node",
             "SnapMirror",
             "SVM",
@@ -101,8 +102,8 @@ class TestMappingRegistration:
         assert not missing, f"Mappings not registered: {missing}"
 
     def test_mapping_count(self) -> None:
-        """Registry should contain exactly 12 mappings."""
-        assert len(model_registry.mappings) == 12
+        """Registry should contain exactly 13 mappings."""
+        assert len(model_registry.mappings) == 13
 
     def test_mapping_lookup_by_name(self) -> None:
         """get_mapping() should return the correct TypeMapping for known names."""


### PR DESCRIPTION
## Description

Migrate NetworkLIF from hand-written parsing to the declarative field mapping framework. The model is expanded from 7 to 25 fields to capture the full API surface (UUID-only nested references for SVM, ipspace, service policy, subnet, and location nodes/ports). The collector now uses `parse_api_response()` with scope-based sorting, and the diff module switches to `uuid` as the key field.

## Related Issue

Addresses #211

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Created `NETWORK_LIF_MAPPING` in `src/pynetappfoundry/cache/network/ip/interfaces/mapping.py` with 25 API-only fields
- Rewrote `NetworkLIF` model from 7 to 25 fields in `model.py`
- Updated `__init__.py` chain (interfaces, ip, network) to export the mapping
- Added trigger import in `src/pynetappfoundry/cache/__init__.py`
- Replaced hand-written LIF parsing in `collector.py` with `parse_api_response()`
- Changed `diff.py` key_field from `name` to `uuid`
- Added `network_lif` to `INSPECT_TYPES` in the inspect CLI command
- Bumped `METADATA_SCHEMA_VERSION` from 1.0 to 1.1 in `_base.py`
- Updated ADR-0004 with issue #211 link
- Updated `docs/development/field-mapping.md` Migrated Types table with NetworkLIF entry
- Created `tests/unit/cache/mappings/test_network_lif.py` with mapping tests
- Updated `test_models.py`, `test_diff.py`, `test_collector.py`, and `test_registry_integration.py` for the new fields

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes (tests, lint, type-check, security, spell-check).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The model expansion from 7 to 25 fields captures the full ONTAP network interface API surface. Nested references (SVM, ipspace, service policy, subnet, location nodes/ports) are stored as UUIDs rather than names, aligning with the convention used by other migrated types. The key_field change from `name` to `uuid` in the diff module ensures unique identification since LIF names are not guaranteed unique across SVMs.
