### PR TITLE
refactor: flatten NetworkInfo LIF lists into single lifs list

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -153,7 +153,7 @@ Changes are tracked as a list of change entries:
     "new": 24
   },
   {
-    "category": "network.data_lifs",
+    "category": "network.lifs",
     "type": "removed",
     "entity": "lif1"
   }
@@ -385,12 +385,12 @@ All models use `ConfigDict(extra="allow")` for forward compatibility with new AP
 
 | Model | Key Fields | Description |
 |-------|------------|-------------|
-| `NetworkLIF` | name, ip_address, netmask, home_node, home_port, role, svm | Logical interface |
+| `NetworkLIF` | uuid, name, ip_address, netmask, ip_family, enabled, state, scope, vip, svm_uuid, ipspace_uuid, service_policy_uuid, services, auto_revert, failover, is_home, home_node_uuid, home_port_uuid, current_node_uuid, current_port_uuid, dns_zone, ddns_enabled, subnet_uuid, probe_port, rdma_protocols | Logical interface |
 | `BroadcastDomain` | uuid, name, ipspace, mtu, ports | Broadcast domain configuration |
 | `IPSubnetInfo` | uuid, name, ipspace, broadcast_domain, subnet, gateway, ip_ranges | IP subnet |
 | `DNSInfo` | uuid, svm, scope, domains, servers, timeout, attempts | DNS configuration |
 
-**Container:** `NetworkInfo` holds `intercluster_lifs`, `data_lifs`, `management_lifs`, `broadcast_domains`, `ipspaces`, `dns`, `subnets`.
+**Container:** `NetworkInfo` holds `lifs`, `broadcast_domains`, `ipspaces`, `dns`, `subnets`.
 
 ### Storage
 

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -964,18 +964,6 @@ class MetadataCollector:
                 self._log_missing_fields,
             ),
         )
-        intercluster_lifs: list[NetworkLIF] = []
-        data_lifs: list[NetworkLIF] = []
-        management_lifs: list[NetworkLIF] = []
-
-        for lif in all_lifs:
-            if lif.scope == "cluster":
-                intercluster_lifs.append(lif)
-            elif lif.scope == "svm":
-                data_lifs.append(lif)
-            else:
-                management_lifs.append(lif)
-
         # Process broadcast domains response
         broadcast_domains = cast(
             list[BroadcastDomain],
@@ -1011,9 +999,7 @@ class MetadataCollector:
         subnets = self._parse_subnets_response(responses.get(endpoints[4]))
 
         return NetworkInfo(
-            intercluster_lifs=intercluster_lifs,
-            data_lifs=data_lifs,
-            management_lifs=management_lifs,
+            lifs=all_lifs,
             broadcast_domains=broadcast_domains,
             ipspaces=ipspaces,
             dns=dns,

--- a/src/pynetappfoundry/cache/diff.py
+++ b/src/pynetappfoundry/cache/diff.py
@@ -225,17 +225,7 @@ _ENTITY_CONFIGS: dict[str, EntityConfig] = {
         model_class=CloudMetadata,
         display_field="node",
     ),
-    "network.intercluster_lifs": EntityConfig(
-        key_field="uuid",
-        model_class=NetworkLIF,
-        display_field="name",
-    ),
-    "network.data_lifs": EntityConfig(
-        key_field="uuid",
-        model_class=NetworkLIF,
-        display_field="name",
-    ),
-    "network.management_lifs": EntityConfig(
+    "network.lifs": EntityConfig(
         key_field="uuid",
         model_class=NetworkLIF,
         display_field="name",

--- a/src/pynetappfoundry/cache/network/model.py
+++ b/src/pynetappfoundry/cache/network/model.py
@@ -19,9 +19,7 @@ class NetworkInfo(CacheModel):
     Contains LIFs, broadcast domains, IPspaces, DNS, and subnets.
     """
 
-    intercluster_lifs: list[NetworkLIF] = Field(default_factory=list)
-    data_lifs: list[NetworkLIF] = Field(default_factory=list)
-    management_lifs: list[NetworkLIF] = Field(default_factory=list)
+    lifs: list[NetworkLIF] = Field(default_factory=list)
     broadcast_domains: list[BroadcastDomain] = Field(default_factory=list)
     ipspaces: list[str] = Field(default_factory=list)
     dns: list[DNSInfo] = Field(default_factory=list)

--- a/src/pynetappfoundry/cli/commands/cache/inspect.py
+++ b/src/pynetappfoundry/cli/commands/cache/inspect.py
@@ -48,7 +48,7 @@ INSPECT_TYPES: dict[str, tuple[TypeMapping, str]] = {
     "license": (LICENSE_PACKAGE_MAPPING, "license_packages"),
     "node": (NODE_MAPPING, "nodes"),
     "svm": (SVM_MAPPING, "storage.svms"),
-    "network_lif": (NETWORK_LIF_MAPPING, "network.data_lifs"),
+    "network_lif": (NETWORK_LIF_MAPPING, "network.lifs"),
     "volume": (VOLUME_MAPPING, "storage.volumes"),
 }
 

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -496,16 +496,16 @@ class TestNetworkCollection:
         collector = MetadataCollector(api_client=api_client)
         result = collector.collect_network()
 
-        assert len(result.data_lifs) == 1
-        assert result.data_lifs[0].uuid == "lif-uuid-1"
-        assert result.data_lifs[0].name == "data_lif1"
-        assert result.data_lifs[0].ip_address == "10.0.0.10"
-        assert result.data_lifs[0].netmask == "255.255.255.0"
-        assert result.data_lifs[0].scope == "svm"
-        assert result.data_lifs[0].svm_uuid == "svm-uuid-1"
-        assert result.data_lifs[0].home_node_uuid == "node-uuid-1"
-        assert result.data_lifs[0].home_port_uuid == "port-uuid-e0d"
-        assert result.data_lifs[0].services == ["data_core", "data_nfs"]
+        assert len(result.lifs) == 1
+        assert result.lifs[0].uuid == "lif-uuid-1"
+        assert result.lifs[0].name == "data_lif1"
+        assert result.lifs[0].ip_address == "10.0.0.10"
+        assert result.lifs[0].netmask == "255.255.255.0"
+        assert result.lifs[0].scope == "svm"
+        assert result.lifs[0].svm_uuid == "svm-uuid-1"
+        assert result.lifs[0].home_node_uuid == "node-uuid-1"
+        assert result.lifs[0].home_port_uuid == "port-uuid-e0d"
+        assert result.lifs[0].services == ["data_core", "data_nfs"]
         assert len(result.broadcast_domains) == 1
         assert result.broadcast_domains[0].name == "Default"
         assert result.broadcast_domains[0].uuid == "bd-uuid-1"

--- a/tests/unit/cache/test_diff.py
+++ b/tests/unit/cache/test_diff.py
@@ -323,7 +323,7 @@ class TestComputeDiffModifiedEntities:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                intercluster_lifs=[
+                lifs=[
                     NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1"),
                 ],
             ),
@@ -331,14 +331,14 @@ class TestComputeDiffModifiedEntities:
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                intercluster_lifs=[
+                lifs=[
                     NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.2"),
                 ],
             ),
         )
         changes = compute_diff(before, after)
 
-        lif_changes = [c for c in changes if c["category"] == "network.intercluster_lifs"]
+        lif_changes = [c for c in changes if c["category"] == "network.lifs"]
         assert len(lif_changes) == 1
         assert lif_changes[0]["type"] == "modified"
         assert lif_changes[0]["field"] == "ip_address"
@@ -1500,19 +1500,15 @@ class TestComputeDiffEdgeCases:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                intercluster_lifs=[
-                    NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1")
-                ],
+                lifs=[NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1")],
             ),
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                intercluster_lifs=[
-                    NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1")
-                ],
+                lifs=[NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1")],
             ),
         )
         changes = compute_diff(before, after)
-        lif_changes = [c for c in changes if c["category"] == "network.intercluster_lifs"]
+        lif_changes = [c for c in changes if c["category"] == "network.lifs"]
         assert len(lif_changes) == 0

--- a/tests/unit/cache/test_models.py
+++ b/tests/unit/cache/test_models.py
@@ -233,8 +233,7 @@ class TestNetworkInfo:
     def test_default_values(self) -> None:
         """Test default values."""
         network = NetworkInfo()
-        assert network.intercluster_lifs == []
-        assert network.data_lifs == []
+        assert network.lifs == []
         assert network.ipspaces == []
         assert network.dns == []
         assert network.subnets == []
@@ -243,11 +242,11 @@ class TestNetworkInfo:
         """Test with LIF data."""
         lif = NetworkLIF(name="ic_lif1", ip_address="10.0.1.1")
         network = NetworkInfo(
-            intercluster_lifs=[lif],
+            lifs=[lif],
             ipspaces=["Default", "Cluster"],
         )
-        assert len(network.intercluster_lifs) == 1
-        assert network.intercluster_lifs[0].name == "ic_lif1"
+        assert len(network.lifs) == 1
+        assert network.lifs[0].name == "ic_lif1"
 
 
 class TestAggregateInfo:

--- a/tests/unit/cli/commands/cache/test_schema.py
+++ b/tests/unit/cli/commands/cache/test_schema.py
@@ -75,7 +75,7 @@ class TestCacheSchemaCommand:
 
         assert result.exit_code == 0
         # Check deeply nested paths
-        assert "network.intercluster_lifs[N].ip_address" in result.output
+        assert "network.lifs[N].ip_address" in result.output
         assert "storage.aggregates[N].name" in result.output
         assert "license_packages[N].name" in result.output
 


### PR DESCRIPTION
## Description

Replace the three scope-based LIF lists (`intercluster_lifs`, `data_lifs`, `management_lifs`) on `NetworkInfo` with a single flat `lifs` list. The cache layer now mirrors the flat list returned by the ONTAP `/network/ip/interfaces` endpoint. Consumers can filter by the existing `scope` field on each `NetworkLIF`.

## Related Issue

Addresses #293

## Type of Change

- [x] Code refactoring

## Changes Made

- **Model** (`cache/network/model.py`): Replaced three LIF fields with single `lifs: list[NetworkLIF]`
- **Collector** (`cache/collector.py`): Removed scope-based sorting loop; passes `all_lifs` directly
- **Diff config** (`cache/diff.py`): Replaced three `EntityConfig` entries with single `network.lifs`
- **Inspect command** (`cli/commands/cache/inspect.py`): Updated cache path to `network.lifs`
- **Documentation** (`docs/reference/cache.md`): Updated example, field list, and container description
- **Tests**: Updated all four test files to use `lifs` instead of split lists

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes
- [x] `doit check` passes (test, lint, type-check, security, spell-check)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings