### PR TITLE
docs: extend ADR-0007 with cache field and container naming conventions

### DIFF
--- a/docs/decisions/0007-url-tree-model-registry.md
+++ b/docs/decisions/0007-url-tree-model-registry.md
@@ -16,6 +16,23 @@ Models live at `cache/<api-path>/model.py` and mappings at `cache/<api-path>/map
 - `cache/cluster/nodes/model.py` + `mapping.py` (maps to `/cluster/nodes`)
 - `cache/protocols/nfs/services/model.py` (maps to `/protocols/nfs/services`)
 
+### Cache Field and Container Naming
+
+The URL-tree convention extends beyond directory layout to cache field names and container groupings on `CachedClusterMetadata`. Every list field on a container model must use the API resource name from the endpoint path, and every container must correspond to a real ONTAP API top-level namespace.
+
+**Field naming rule:** Convert the API endpoint path to a dotted cache path by replacing `/` with `.` and `-` with `_`. The final segment becomes the field name on the parent container.
+
+| API Endpoint | Cache Path | Container Field |
+|---|---|---|
+| `/network/ip/interfaces` | `network.ip_interfaces` | `NetworkInfo.ip_interfaces` |
+| `/network/ethernet/broadcast-domains` | `network.ethernet_broadcast_domains` | `NetworkInfo.ethernet_broadcast_domains` |
+| `/storage/volumes` | `storage.volumes` | `StorageInfo.volumes` |
+| `/protocols/nfs/export-policies` | `protocols.nfs_export_policies` | `ProtocolsInfo.nfs_export_policies` |
+
+**Container rule:** Container models (`NetworkInfo`, `StorageInfo`, etc.) group fields that share the same API top-level namespace. A model must not hold fields from a different namespace (e.g., `/name-services/dns` must not live under `NetworkInfo`).
+
+**Model class naming rule:** Model class names should reflect the API resource. For example, `NetworkIpInterface` (not `NetworkLIF`), `NetworkEthernetBroadcastDomain` (not `BroadcastDomain`).
+
 ### Three-Layer Import Hierarchy
 
 Imports flow upward only (DAG guaranteed, no circular deps):
@@ -36,7 +53,7 @@ Imports flow upward only (DAG guaranteed, no circular deps):
 
 1. **Locality** - Adding a new ONTAP type requires touching only one directory (model + mapping + `__init__.py`), not 4+ scattered files (models.py, mappings/, `__init__.py` re-exports, collector imports).
 
-2. **Discoverability** - The directory tree mirrors ONTAP REST API paths, making it obvious where to find or add a model.
+2. **Discoverability** - The directory tree, cache field names, and container groupings all mirror ONTAP REST API paths, making it obvious where to find or add a model and how it maps to the API.
 
 3. **Automatic registration** - The `ModelRegistry` singleton enables tooling to discover all models and mappings without hardcoded lists, supporting future features like dynamic inspection and plugin systems.
 
@@ -47,6 +64,7 @@ Imports flow upward only (DAG guaranteed, no circular deps):
 ## Related Issues
 
 - Issue #257: refactor: deep URL-tree structure with automatic model and mapping discovery
+- Issue #295: refactor: align cache field names and containers with ONTAP API endpoint hierarchy
 
 ## Related Documentation
 


### PR DESCRIPTION
## Description

Extend ADR-0007 (URL-tree model registry) to codify that the URL-tree convention applies not just to directory layout but also to cache field names, container groupings, and model class names. Adds three explicit naming rules:

1. **Field naming rule** — cache field names derive from API endpoint paths (`/network/ip/interfaces` → `network.ip_interfaces`)
2. **Container rule** — container models group fields by API top-level namespace (no cross-namespace fields)
3. **Model class naming rule** — class names reflect API resource names (`NetworkIpInterface`, not `NetworkLIF`)

This establishes the documented rationale for the refactor in #295.

## Related Issue

Addresses #295

## Type of Change

- [x] Documentation update

## Changes Made

- Added "Cache Field and Container Naming" section to ADR-0007 with field naming, container, and class naming rules
- Updated rationale point #2 to reference field names and containers alongside directory tree
- Added issue #295 link to Related Issues

## Testing

- [x] All existing tests pass
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings