### PR TITLE
refactor: align cache field names and containers with ONTAP API endpoint hierarchy

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -50,7 +50,7 @@ class CachedClusterMetadata(BaseModel):
     cloud: list[CloudMetadata]       # Cloud provider info per node
     cluster: ClusterInfo             # Cluster identity
     nodes: list[NodeInfo]            # Node information
-    network: NetworkInfo             # LIFs, broadcast domains, DNS, subnets
+    network: NetworkInfo             # IP interfaces, broadcast domains, DNS, subnets
     storage: StorageInfo             # Aggregates, SVMs, volumes, LUNs, etc.
     licenses: LicenseInfo            # License information
     mediator: MediatorInfo           # ONTAP Mediator configuration
@@ -105,6 +105,7 @@ METADATA_SCHEMA_MIN_COMPATIBLE = "1.0"
 
 | Version | Changes |
 |---------|---------|
+| 2.0 | Rename cache fields to match ONTAP API endpoint hierarchy: `network.lifs` -> `network.ip_interfaces`, `network.broadcast_domains` -> `network.ethernet_broadcast_domains`, `network.subnets` -> `network.ip_subnets`, `protocols.export_policies` -> `protocols.nfs_export_policies` |
 | 1.0 | Initial schema with comprehensive model coverage |
 
 ## History Tracking
@@ -153,7 +154,7 @@ Changes are tracked as a list of change entries:
     "new": 24
   },
   {
-    "category": "network.lifs",
+    "category": "network.ip_interfaces",
     "type": "removed",
     "entity": "lif1"
   }
@@ -390,7 +391,7 @@ All models use `ConfigDict(extra="allow")` for forward compatibility with new AP
 | `IPSubnetInfo` | uuid, name, ipspace, broadcast_domain, subnet, gateway, ip_ranges | IP subnet |
 | `DNSInfo` | uuid, svm, scope, domains, servers, timeout, attempts | DNS configuration |
 
-**Container:** `NetworkInfo` holds `lifs`, `broadcast_domains`, `ipspaces`, `dns`, `subnets`.
+**Container:** `NetworkInfo` holds `ip_interfaces`, `ethernet_broadcast_domains`, `ipspaces`, `dns`, `ip_subnets`.
 
 ### Storage
 
@@ -421,7 +422,7 @@ All models use `ConfigDict(extra="allow")` for forward compatibility with new AP
 | `NFSServiceInfo` | svm, enabled, protocol_v3/v4/v41_enabled | NFS service config |
 | `S3BucketInfo` | uuid, name, svm, type, size, versioning_state | S3 bucket |
 
-**Container:** `ProtocolsInfo` holds `export_policies`, `cifs_shares`, `nfs_services`, `cifs_services`, `s3_buckets`.
+**Container:** `ProtocolsInfo` holds `nfs_export_policies`, `cifs_shares`, `nfs_services`, `cifs_services`, `s3_buckets`.
 
 ### Licensing & Mediator
 

--- a/src/pynetappfoundry/cache/_base.py
+++ b/src/pynetappfoundry/cache/_base.py
@@ -16,11 +16,11 @@ from pydantic import BaseModel, ConfigDict
 # Increment MINOR for backward-compatible changes (new optional fields).
 # Increment MAJOR for breaking changes (removed/renamed fields, type changes).
 # Format: "MAJOR.MINOR"
-METADATA_SCHEMA_VERSION = "1.1"
+METADATA_SCHEMA_VERSION = "2.0"
 
 # Minimum schema version that can be loaded without migration.
 # Snapshots older than this may fail to deserialize or have missing data.
-METADATA_SCHEMA_MIN_COMPATIBLE = "1.0"
+METADATA_SCHEMA_MIN_COMPATIBLE = "2.0"
 
 
 def parse_schema_version(version: str) -> tuple[int, int]:

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -999,11 +999,11 @@ class MetadataCollector:
         subnets = self._parse_subnets_response(responses.get(endpoints[4]))
 
         return NetworkInfo(
-            lifs=all_lifs,
-            broadcast_domains=broadcast_domains,
+            ip_interfaces=all_lifs,
+            ethernet_broadcast_domains=broadcast_domains,
             ipspaces=ipspaces,
             dns=dns,
-            subnets=subnets,
+            ip_subnets=subnets,
         )
 
     # -------------------------------------------------------------------------
@@ -1753,7 +1753,7 @@ class MetadataCollector:
         s3_buckets = self._parse_s3_buckets_response(responses.get(endpoints[4]))
 
         return ProtocolsInfo(
-            export_policies=export_policies,
+            nfs_export_policies=export_policies,
             cifs_shares=cifs_shares,
             nfs_services=nfs_services,
             cifs_services=cifs_services,

--- a/src/pynetappfoundry/cache/diff.py
+++ b/src/pynetappfoundry/cache/diff.py
@@ -134,12 +134,12 @@ _ENTITY_CONFIGS: dict[str, EntityConfig] = {
         model_class=NodeInfo,
         display_field="name",
     ),
-    "network.broadcast_domains": EntityConfig(
+    "network.ethernet_broadcast_domains": EntityConfig(
         key_field="uuid",
         model_class=BroadcastDomain,
         display_field="name",
     ),
-    "network.subnets": EntityConfig(
+    "network.ip_subnets": EntityConfig(
         key_field="uuid",
         model_class=IPSubnetInfo,
         display_field="name",
@@ -225,7 +225,7 @@ _ENTITY_CONFIGS: dict[str, EntityConfig] = {
         model_class=CloudMetadata,
         display_field="node",
     ),
-    "network.lifs": EntityConfig(
+    "network.ip_interfaces": EntityConfig(
         key_field="uuid",
         model_class=NetworkLIF,
         display_field="name",
@@ -235,7 +235,7 @@ _ENTITY_CONFIGS: dict[str, EntityConfig] = {
         model_class=QtreeInfo,
         display_field="name",
     ),
-    "protocols.export_policies": EntityConfig(
+    "protocols.nfs_export_policies": EntityConfig(
         key_field="name",
         model_class=ExportPolicyInfo,
         display_field="name",

--- a/src/pynetappfoundry/cache/network/model.py
+++ b/src/pynetappfoundry/cache/network/model.py
@@ -16,11 +16,12 @@ from pynetappfoundry.cache.network.ip.subnets.model import IPSubnetInfo
 class NetworkInfo(CacheModel):
     """Network configuration information.
 
-    Contains LIFs, broadcast domains, IPspaces, DNS, and subnets.
+    Contains IP interfaces, ethernet broadcast domains, IPspaces, DNS,
+    and IP subnets.
     """
 
-    lifs: list[NetworkLIF] = Field(default_factory=list)
-    broadcast_domains: list[BroadcastDomain] = Field(default_factory=list)
+    ip_interfaces: list[NetworkLIF] = Field(default_factory=list)
+    ethernet_broadcast_domains: list[BroadcastDomain] = Field(default_factory=list)
     ipspaces: list[str] = Field(default_factory=list)
     dns: list[DNSInfo] = Field(default_factory=list)
-    subnets: list[IPSubnetInfo] = Field(default_factory=list)
+    ip_subnets: list[IPSubnetInfo] = Field(default_factory=list)

--- a/src/pynetappfoundry/cache/protocols/model.py
+++ b/src/pynetappfoundry/cache/protocols/model.py
@@ -17,11 +17,11 @@ from pynetappfoundry.cache.protocols.s3.buckets.model import S3BucketInfo
 class ProtocolsInfo(CacheModel):
     """Protocol configuration information.
 
-    Contains export policies, CIFS shares, NFS/CIFS services,
+    Contains NFS export policies, CIFS shares, NFS/CIFS services,
     S3 buckets, and protocol-related data.
     """
 
-    export_policies: list[ExportPolicyInfo] = Field(default_factory=list)
+    nfs_export_policies: list[ExportPolicyInfo] = Field(default_factory=list)
     cifs_shares: list[CIFSShareInfo] = Field(default_factory=list)
     nfs_services: list[NFSServiceInfo] = Field(default_factory=list)
     cifs_services: list[CIFSServiceInfo] = Field(default_factory=list)

--- a/src/pynetappfoundry/cli/commands/cache/inspect.py
+++ b/src/pynetappfoundry/cli/commands/cache/inspect.py
@@ -42,13 +42,13 @@ console = Console()
 # dot-path to the list of objects in CachedClusterMetadata.
 INSPECT_TYPES: dict[str, tuple[TypeMapping, str]] = {
     "aggregate": (AGGREGATE_MAPPING, "storage.aggregates"),
-    "broadcast_domain": (BROADCAST_DOMAIN_MAPPING, "network.broadcast_domains"),
+    "broadcast_domain": (BROADCAST_DOMAIN_MAPPING, "network.ethernet_broadcast_domains"),
     "cloud_metadata": (CLOUD_METADATA_MAPPING, "cloud"),
     "cluster_peer": (CLUSTER_PEER_MAPPING, "relationships.cluster_peers"),
     "license": (LICENSE_PACKAGE_MAPPING, "license_packages"),
     "node": (NODE_MAPPING, "nodes"),
     "svm": (SVM_MAPPING, "storage.svms"),
-    "network_lif": (NETWORK_LIF_MAPPING, "network.lifs"),
+    "network_lif": (NETWORK_LIF_MAPPING, "network.ip_interfaces"),
     "volume": (VOLUME_MAPPING, "storage.volumes"),
 }
 

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -496,32 +496,32 @@ class TestNetworkCollection:
         collector = MetadataCollector(api_client=api_client)
         result = collector.collect_network()
 
-        assert len(result.lifs) == 1
-        assert result.lifs[0].uuid == "lif-uuid-1"
-        assert result.lifs[0].name == "data_lif1"
-        assert result.lifs[0].ip_address == "10.0.0.10"
-        assert result.lifs[0].netmask == "255.255.255.0"
-        assert result.lifs[0].scope == "svm"
-        assert result.lifs[0].svm_uuid == "svm-uuid-1"
-        assert result.lifs[0].home_node_uuid == "node-uuid-1"
-        assert result.lifs[0].home_port_uuid == "port-uuid-e0d"
-        assert result.lifs[0].services == ["data_core", "data_nfs"]
-        assert len(result.broadcast_domains) == 1
-        assert result.broadcast_domains[0].name == "Default"
-        assert result.broadcast_domains[0].uuid == "bd-uuid-1"
-        assert result.broadcast_domains[0].ipspace_uuid == "ipspace-uuid-1"
-        assert result.broadcast_domains[0].mtu == 1500
-        assert result.broadcast_domains[0].port_uuids == ["port-uuid-1", "port-uuid-2"]
+        assert len(result.ip_interfaces) == 1
+        assert result.ip_interfaces[0].uuid == "lif-uuid-1"
+        assert result.ip_interfaces[0].name == "data_lif1"
+        assert result.ip_interfaces[0].ip_address == "10.0.0.10"
+        assert result.ip_interfaces[0].netmask == "255.255.255.0"
+        assert result.ip_interfaces[0].scope == "svm"
+        assert result.ip_interfaces[0].svm_uuid == "svm-uuid-1"
+        assert result.ip_interfaces[0].home_node_uuid == "node-uuid-1"
+        assert result.ip_interfaces[0].home_port_uuid == "port-uuid-e0d"
+        assert result.ip_interfaces[0].services == ["data_core", "data_nfs"]
+        assert len(result.ethernet_broadcast_domains) == 1
+        assert result.ethernet_broadcast_domains[0].name == "Default"
+        assert result.ethernet_broadcast_domains[0].uuid == "bd-uuid-1"
+        assert result.ethernet_broadcast_domains[0].ipspace_uuid == "ipspace-uuid-1"
+        assert result.ethernet_broadcast_domains[0].mtu == 1500
+        assert result.ethernet_broadcast_domains[0].port_uuids == ["port-uuid-1", "port-uuid-2"]
         assert "Default" in result.ipspaces
         assert len(result.dns) == 1
         assert result.dns[0].svm_uuid == "svm-uuid-1"
         assert result.dns[0].domains == ["example.com"]
         assert result.dns[0].servers == ["10.0.0.1", "10.0.0.2"]
-        assert len(result.subnets) == 1
-        assert result.subnets[0].name == "data-subnet"
-        assert result.subnets[0].subnet == "10.0.0.0/24"
-        assert result.subnets[0].gateway == "10.0.0.1"
-        assert result.subnets[0].ip_ranges == ["10.0.0.10-10.0.0.50"]
+        assert len(result.ip_subnets) == 1
+        assert result.ip_subnets[0].name == "data-subnet"
+        assert result.ip_subnets[0].subnet == "10.0.0.0/24"
+        assert result.ip_subnets[0].gateway == "10.0.0.1"
+        assert result.ip_subnets[0].ip_ranges == ["10.0.0.10-10.0.0.50"]
 
     def test_collect_network_no_clients(self) -> None:
         """Test network raises CollectionError when no API client."""
@@ -1331,10 +1331,10 @@ class TestProtocolsCollection:
         result = collector.collect_protocols()
 
         assert isinstance(result, ProtocolsInfo)
-        assert len(result.export_policies) == 2
+        assert len(result.nfs_export_policies) == 2
 
         # Check first policy
-        policy1 = result.export_policies[0]
+        policy1 = result.nfs_export_policies[0]
         assert policy1.id == 1
         assert policy1.name == "default"
         assert policy1.svm == "svm1"
@@ -1348,7 +1348,7 @@ class TestProtocolsCollection:
         assert policy1.rules[0].anonymous_user == "65534"
 
         # Check second policy with multiple rules
-        policy2 = result.export_policies[1]
+        policy2 = result.nfs_export_policies[1]
         assert policy2.name == "data_export"
         assert len(policy2.rules) == 2
         assert policy2.rules[0].clients == ["10.0.0.0/8", "172.16.0.0/12"]
@@ -1398,7 +1398,7 @@ class TestProtocolsCollection:
         result = collector.collect_protocols()
 
         assert isinstance(result, ProtocolsInfo)
-        assert result.export_policies == []
+        assert result.nfs_export_policies == []
         assert result.cifs_shares == []
         assert result.nfs_services == []
         assert result.cifs_services == []
@@ -1446,9 +1446,9 @@ class TestProtocolsCollection:
         collector = MetadataCollector(api_client=api_client)
         result = collector.collect_protocols()
 
-        assert len(result.export_policies) == 1
-        assert result.export_policies[0].name == "empty_policy"
-        assert result.export_policies[0].rules == []
+        assert len(result.nfs_export_policies) == 1
+        assert result.nfs_export_policies[0].name == "empty_policy"
+        assert result.nfs_export_policies[0].rules == []
 
 
 class TestCollectAll:
@@ -1469,7 +1469,7 @@ class TestCollectAll:
 
         assert result.cluster_name == "test-cluster"
         assert result.cached_at is not None
-        assert result.cache_version == "1.1"
+        assert result.cache_version == "2.0"
 
 
 class TestCachedApiCallPagination:

--- a/tests/unit/cache/test_diff.py
+++ b/tests/unit/cache/test_diff.py
@@ -323,7 +323,7 @@ class TestComputeDiffModifiedEntities:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                lifs=[
+                ip_interfaces=[
                     NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1"),
                 ],
             ),
@@ -331,14 +331,14 @@ class TestComputeDiffModifiedEntities:
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                lifs=[
+                ip_interfaces=[
                     NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.2"),
                 ],
             ),
         )
         changes = compute_diff(before, after)
 
-        lif_changes = [c for c in changes if c["category"] == "network.lifs"]
+        lif_changes = [c for c in changes if c["category"] == "network.ip_interfaces"]
         assert len(lif_changes) == 1
         assert lif_changes[0]["type"] == "modified"
         assert lif_changes[0]["field"] == "ip_address"
@@ -619,7 +619,7 @@ class TestComputeDiffAllCategories:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             protocols=ProtocolsInfo(
-                export_policies=[
+                nfs_export_policies=[
                     ExportPolicyInfo(name="default", id=1, svm="svm1"),
                 ],
             ),
@@ -627,14 +627,14 @@ class TestComputeDiffAllCategories:
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             protocols=ProtocolsInfo(
-                export_policies=[
+                nfs_export_policies=[
                     ExportPolicyInfo(name="default", id=1, svm="svm2"),
                 ],
             ),
         )
         changes = compute_diff(before, after)
 
-        policy_changes = [c for c in changes if c["category"] == "protocols.export_policies"]
+        policy_changes = [c for c in changes if c["category"] == "protocols.nfs_export_policies"]
         assert len(policy_changes) == 1
         assert policy_changes[0]["type"] == "modified"
         assert policy_changes[0]["field"] == "svm"
@@ -646,13 +646,13 @@ class TestComputeDiffAllCategories:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             protocols=ProtocolsInfo(
-                export_policies=[ExportPolicyInfo(name="default", id=1, svm="svm1")],
+                nfs_export_policies=[ExportPolicyInfo(name="default", id=1, svm="svm1")],
             ),
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             protocols=ProtocolsInfo(
-                export_policies=[
+                nfs_export_policies=[
                     ExportPolicyInfo(name="default", id=1, svm="svm1"),
                     ExportPolicyInfo(name="data_export", id=2, svm="svm1"),
                 ],
@@ -660,7 +660,7 @@ class TestComputeDiffAllCategories:
         )
         changes = compute_diff(before, after)
 
-        policy_changes = [c for c in changes if c["category"] == "protocols.export_policies"]
+        policy_changes = [c for c in changes if c["category"] == "protocols.nfs_export_policies"]
         assert len(policy_changes) == 1
         assert policy_changes[0]["type"] == "added"
         assert policy_changes[0]["entity"] == "data_export"
@@ -1145,7 +1145,7 @@ class TestComputeDiffAllCategories:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                subnets=[
+                ip_subnets=[
                     IPSubnetInfo(
                         uuid="sub-uuid-1",
                         name="data-subnet",
@@ -1158,7 +1158,7 @@ class TestComputeDiffAllCategories:
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                subnets=[
+                ip_subnets=[
                     IPSubnetInfo(
                         uuid="sub-uuid-1",
                         name="data-subnet",
@@ -1170,7 +1170,7 @@ class TestComputeDiffAllCategories:
         )
         changes = compute_diff(before, after)
 
-        subnet_changes = [c for c in changes if c["category"] == "network.subnets"]
+        subnet_changes = [c for c in changes if c["category"] == "network.ip_subnets"]
         assert len(subnet_changes) == 1
         assert subnet_changes[0]["type"] == "modified"
         assert subnet_changes[0]["field"] == "gateway"
@@ -1181,19 +1181,19 @@ class TestComputeDiffAllCategories:
         """Test IP subnet addition detection."""
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
-            network=NetworkInfo(subnets=[]),
+            network=NetworkInfo(ip_subnets=[]),
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                subnets=[
+                ip_subnets=[
                     IPSubnetInfo(uuid="sub-uuid-1", name="data-subnet", subnet="10.0.0.0/24"),
                 ],
             ),
         )
         changes = compute_diff(before, after)
 
-        subnet_changes = [c for c in changes if c["category"] == "network.subnets"]
+        subnet_changes = [c for c in changes if c["category"] == "network.ip_subnets"]
         assert len(subnet_changes) == 1
         assert subnet_changes[0]["type"] == "added"
         assert subnet_changes[0]["entity"] == "data-subnet"
@@ -1500,15 +1500,15 @@ class TestComputeDiffEdgeCases:
         before = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                lifs=[NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1")],
+                ip_interfaces=[NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1")],
             ),
         )
         after = CachedClusterMetadata(
             cluster_name="test-cluster",
             network=NetworkInfo(
-                lifs=[NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1")],
+                ip_interfaces=[NetworkLIF(uuid="lif-uuid-1", name="lif1", ip_address="10.0.0.1")],
             ),
         )
         changes = compute_diff(before, after)
-        lif_changes = [c for c in changes if c["category"] == "network.lifs"]
+        lif_changes = [c for c in changes if c["category"] == "network.ip_interfaces"]
         assert len(lif_changes) == 0

--- a/tests/unit/cache/test_history.py
+++ b/tests/unit/cache/test_history.py
@@ -551,12 +551,15 @@ class TestSchemaVersioning:
         """Test that very old versions are incompatible."""
         assert is_schema_compatible("0.1") is False
         assert is_schema_compatible("0.9") is False
+        assert is_schema_compatible("1.1") is False
+        assert is_schema_compatible("1.99") is False
 
     def test_is_schema_compatible_newer_version(self) -> None:
         """Test that newer versions are compatible (forward compatibility)."""
-        # Assuming current is 1.x, version 2.0 should be compatible
+        # Current is 2.0, version 2.1 and 3.0 should be compatible
         assert is_schema_compatible("2.0") is True
-        assert is_schema_compatible("1.99") is True
+        assert is_schema_compatible("2.1") is True
+        assert is_schema_compatible("3.0") is True
 
     def test_cached_metadata_has_version(self) -> None:
         """Test that CachedClusterMetadata includes cache_version."""

--- a/tests/unit/cache/test_models.py
+++ b/tests/unit/cache/test_models.py
@@ -233,20 +233,20 @@ class TestNetworkInfo:
     def test_default_values(self) -> None:
         """Test default values."""
         network = NetworkInfo()
-        assert network.lifs == []
+        assert network.ip_interfaces == []
         assert network.ipspaces == []
         assert network.dns == []
-        assert network.subnets == []
+        assert network.ip_subnets == []
 
-    def test_with_lifs(self) -> None:
-        """Test with LIF data."""
+    def test_with_ip_interfaces(self) -> None:
+        """Test with IP interface data."""
         lif = NetworkLIF(name="ic_lif1", ip_address="10.0.1.1")
         network = NetworkInfo(
-            lifs=[lif],
+            ip_interfaces=[lif],
             ipspaces=["Default", "Cluster"],
         )
-        assert len(network.lifs) == 1
-        assert network.lifs[0].name == "ic_lif1"
+        assert len(network.ip_interfaces) == 1
+        assert network.ip_interfaces[0].name == "ic_lif1"
 
 
 class TestAggregateInfo:
@@ -872,18 +872,18 @@ class TestProtocolsInfo:
     def test_default_values(self) -> None:
         """Test default values."""
         protocols = ProtocolsInfo()
-        assert protocols.export_policies == []
+        assert protocols.nfs_export_policies == []
         assert protocols.cifs_shares == []
         assert protocols.nfs_services == []
         assert protocols.cifs_services == []
         assert protocols.s3_buckets == []
 
-    def test_with_export_policies(self) -> None:
-        """Test with export policy data."""
+    def test_with_nfs_export_policies(self) -> None:
+        """Test with NFS export policy data."""
         policy = ExportPolicyInfo(name="default", svm="svm1")
-        protocols = ProtocolsInfo(export_policies=[policy])
-        assert len(protocols.export_policies) == 1
-        assert protocols.export_policies[0].name == "default"
+        protocols = ProtocolsInfo(nfs_export_policies=[policy])
+        assert len(protocols.nfs_export_policies) == 1
+        assert protocols.nfs_export_policies[0].name == "default"
 
     def test_with_cifs_shares(self) -> None:
         """Test with CIFS share data."""
@@ -1214,7 +1214,7 @@ class TestCachedClusterMetadata:
         """Test creating with minimal required fields."""
         metadata = CachedClusterMetadata(cluster_name="test-cluster")
         assert metadata.cluster_name == "test-cluster"
-        assert metadata.cache_version == "1.1"
+        assert metadata.cache_version == "2.0"
         assert metadata.cached_at is not None
 
     def test_cached_at_default(self) -> None:
@@ -1415,8 +1415,8 @@ class TestUuidIndex:
             cluster_name="test",
             nodes=[NodeInfo(uuid="uuid-01")],
             network=NetworkInfo(
-                broadcast_domains=[BroadcastDomain(uuid="uuid-02")],
-                subnets=[IPSubnetInfo(uuid="uuid-03")],
+                ethernet_broadcast_domains=[BroadcastDomain(uuid="uuid-02")],
+                ip_subnets=[IPSubnetInfo(uuid="uuid-03")],
                 dns=[DNSInfo(uuid="uuid-04")],
             ),
             storage=StorageInfo(
@@ -1468,7 +1468,7 @@ class TestUuidIndex:
             cloud=[CloudMetadata(instance_id="i-123", provider="AWS")],
             cluster=ClusterInfo(cluster_uuid="cluster-uuid-1"),
             protocols=ProtocolsInfo(
-                export_policies=[ExportPolicyInfo(id=1, name="default")],
+                nfs_export_policies=[ExportPolicyInfo(id=1, name="default")],
             ),
             storage=StorageInfo(
                 qtrees=[QtreeInfo(id=1, name="qt1")],

--- a/tests/unit/cli/commands/cache/test_schema.py
+++ b/tests/unit/cli/commands/cache/test_schema.py
@@ -75,7 +75,7 @@ class TestCacheSchemaCommand:
 
         assert result.exit_code == 0
         # Check deeply nested paths
-        assert "network.lifs[N].ip_address" in result.output
+        assert "network.ip_interfaces[N].ip_address" in result.output
         assert "storage.aggregates[N].name" in result.output
         assert "license_packages[N].name" in result.output
 


### PR DESCRIPTION
## Description

Rename cache field names and diff category paths on container models to follow the ONTAP API endpoint hierarchy convention established in ADR-0007. This is a breaking schema change (1.0 -> 2.0) because field names on serialized cache data have changed.

Addresses #295

## Related Issue

Addresses #295

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Rename `NetworkInfo.lifs` to `NetworkInfo.ip_interfaces` (matches `/network/ip/interfaces`)
- Rename `NetworkInfo.broadcast_domains` to `NetworkInfo.ethernet_broadcast_domains` (matches `/network/ethernet/broadcast-domains`)
- Rename `NetworkInfo.subnets` to `NetworkInfo.ip_subnets` (matches `/network/ip/subnets`)
- Rename `ProtocolsInfo.export_policies` to `ProtocolsInfo.nfs_export_policies` (matches `/protocols/nfs/export-policies`)
- Bump `METADATA_SCHEMA_VERSION` from 1.1 to 2.0 and `METADATA_SCHEMA_MIN_COMPATIBLE` from 1.0 to 2.0
- Update diff entity config keys to use new dotted cache paths
- Update collector to construct containers with new field names
- Update CLI inspect command cache paths
- Add schema version 2.0 entry to version history table in docs/reference/cache.md

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

All tests updated to use the new field names. `doit check` passes (tests, lint, type-check, security, spell-check).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This implements the cache field and container naming conventions documented in ADR-0007. The schema version bump to 2.0 (breaking) means existing cached data from schema 1.x will be treated as incompatible and re-collected on next refresh.
