### PR TITLE
fix: codegen endpoint dedup, singularize exceptions, ApiType-prefixed naming, and typed sub-models

### DIFF
--- a/tests/unit/codegen/test_generators.py
+++ b/tests/unit/codegen/test_generators.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 from tools.codegen.adapters import ParsedEndpoint, ParsedField
 from tools.codegen.generators import (
+    _CLASS_NAME_OVERRIDES,
+    _SINGULAR_EXCEPTIONS,
     _field_to_cache_attr,
+    _has_typed_sub_fields,
     _path_to_class_name,
     _path_to_module_parts,
+    _schema_to_pascal,
     _select_leaf_fields,
     _singularize,
+    _sub_model_name,
     generate_init,
     generate_mapping,
     generate_model,
@@ -27,6 +32,7 @@ def _make_endpoint(
     expensive_patterns: list[str] | None = None,
     has_parent: bool = False,
     parent_path: str = "",
+    schema_name: str = "volume",
 ) -> ParsedEndpoint:
     if fields is None:
         fields = [
@@ -56,7 +62,7 @@ def _make_endpoint(
         ]
     return ParsedEndpoint(
         path=path,
-        schema_name="volume",
+        schema_name=schema_name,
         fields=fields,
         expensive_patterns=expensive_patterns or [],
         has_parent=has_parent,
@@ -87,17 +93,62 @@ class TestPathToModuleParts:
         assert _path_to_module_parts("/svm/svms/{svm.uuid}/web") == ["svm", "svms", "web"]
 
 
-class TestPathToClassName:
+class TestSchemaToPascal:
     def test_simple(self):
-        assert _path_to_class_name("/storage/volumes") == "StorageVolume"
+        assert _schema_to_pascal("volume") == "Volume"
 
-    def test_deep(self):
-        assert _path_to_class_name("/network/ip/interfaces") == "NetworkIpInterface"
+    def test_snake_case(self):
+        assert _schema_to_pascal("cloud_target") == "CloudTarget"
 
-    def test_hyphen(self):
-        assert _path_to_class_name("/network/ethernet/broadcast-domains") == (
-            "NetworkEthernetBroadcastDomain"
+    def test_multi_segment(self):
+        assert _schema_to_pascal("ip_interface") == "IpInterface"
+
+    def test_single_word(self):
+        assert _schema_to_pascal("svm") == "Svm"
+
+
+class TestPathToClassName:
+    def test_schema_name_with_api_prefix(self):
+        """When schema_name is provided, use {ApiType}{SchemaName}."""
+        assert _path_to_class_name("/storage/volumes", "volume", "ontap") == "OntapVolume"
+
+    def test_schema_name_snake_case(self):
+        assert _path_to_class_name("/cloud/targets", "cloud_target", "ontap") == "OntapCloudTarget"
+
+    def test_schema_name_different_api_type(self):
+        assert _path_to_class_name("/some/path", "node", "aiqum") == "AiqumNode"
+
+    def test_inline_fallback_simple(self):
+        """When schema_name is empty, fall back to URL-path-derived name with api prefix."""
+        assert _path_to_class_name("/cluster", "", "ontap") == "OntapCluster"
+
+    def test_inline_fallback_deep(self):
+        assert (
+            _path_to_class_name("/cluster/licensing/licenses", "", "ontap")
+            == "OntapClusterLicensingLicense"
         )
+
+    def test_inline_fallback_redundant_dedup(self):
+        """Inline fallback still deduplicates redundant segments."""
+        assert _path_to_class_name("/svm/svms", "", "ontap") == "OntapSvm"
+
+    def test_inline_fallback_hyphen(self):
+        assert (
+            _path_to_class_name("/network/ethernet/broadcast-domains", "", "ontap")
+            == "OntapNetworkEthernetBroadcastDomain"
+        )
+
+    def test_override_map_takes_precedence(self):
+        """_CLASS_NAME_OVERRIDES should override the algorithm."""
+        _CLASS_NAME_OVERRIDES["/test/override"] = "MyCustomName"
+        try:
+            assert _path_to_class_name("/test/override", "test", "ontap") == "MyCustomName"
+        finally:
+            del _CLASS_NAME_OVERRIDES["/test/override"]
+
+    def test_default_api_type(self):
+        """Default api_type is ontap."""
+        assert _path_to_class_name("/storage/volumes", "volume") == "OntapVolume"
 
 
 class TestSingularize:
@@ -115,6 +166,38 @@ class TestSingularize:
 
     def test_double_s(self):
         assert _singularize("access") == "access"
+
+    def test_exception_dns(self):
+        assert _singularize("dns") == "dns"
+
+    def test_exception_licenses(self):
+        assert _singularize("licenses") == "license"
+
+    def test_exception_chassis(self):
+        assert _singularize("chassis") == "chassis"
+
+    def test_exception_flexcaches(self):
+        assert _singularize("flexcaches") == "flexcache"
+
+    def test_exception_status(self):
+        assert _singularize("status") == "status"
+
+    def test_exception_alias(self):
+        assert _singularize("alias") == "alias"
+
+    def test_exception_bus(self):
+        assert _singularize("bus") == "bus"
+
+    def test_exception_nfs(self):
+        assert _singularize("nfs") == "nfs"
+
+    def test_exception_cifs(self):
+        assert _singularize("cifs") == "cifs"
+
+    def test_all_exceptions_covered(self):
+        """Every entry in _SINGULAR_EXCEPTIONS should produce the expected value."""
+        for plural, expected in _SINGULAR_EXCEPTIONS.items():
+            assert _singularize(plural) == expected, f"_singularize({plural!r}) != {expected!r}"
 
 
 class TestFieldToCacheAttr:
@@ -164,7 +247,7 @@ class TestGenerateModel:
     def test_basic_structure(self):
         ep = _make_endpoint()
         code = generate_model(ep)
-        assert "class StorageVolume(CacheModel):" in code
+        assert "class OntapVolume(CacheModel):" in code
         assert "from pynetappfoundry.cache._base import CacheModel" in code
 
     def test_uuid_import(self):
@@ -188,7 +271,6 @@ class TestGenerateModel:
         """Object container fields (svm) should not appear as model attrs."""
         ep = _make_endpoint()
         code = generate_model(ep)
-        # "svm: object" should not be in the model, only "svm_name: str"
         lines = code.split("\n")
         svm_lines = [line for line in lines if line.strip().startswith("svm:")]
         assert len(svm_lines) == 0
@@ -203,9 +285,9 @@ class TestGenerateMapping:
     def test_basic_structure(self):
         ep = _make_endpoint()
         code = generate_mapping(ep)
-        assert "STORAGEVOLUME_MAPPING = TypeMapping(" in code
-        assert 'name="StorageVolume"' in code
-        assert "model_class=StorageVolume" in code
+        assert "ONTAPVOLUME_MAPPING = TypeMapping(" in code
+        assert 'name="OntapVolume"' in code
+        assert "model_class=OntapVolume" in code
 
     def test_field_mappings(self):
         ep = _make_endpoint()
@@ -222,23 +304,41 @@ class TestGenerateMapping:
         code = generate_mapping(ep)
         assert "requires_explicit_fetch=True" in code
 
-    def test_parent_mapping(self):
+    def test_parent_mapping_with_schema_lookup(self):
         ep = _make_endpoint(
             path="/svm/svms/{svm.uuid}/web",
             has_parent=True,
             parent_path="/svm/svms",
+            schema_name="web",
             fields=[
                 ParsedField(name="enabled", api_path="enabled", python_type="bool", default=False)
             ],
         )
-        code = generate_mapping(ep)
-        assert 'parent_mapping="SvmSvm"' in code
+        # Provide schema_lookup so parent path resolves correctly
+        schema_lookup = {"/svm/svms": "svm"}
+        code = generate_mapping(ep, schema_lookup=schema_lookup)
+        assert 'parent_mapping="OntapSvm"' in code
         assert 'parent_id_field="uuid"' in code
+
+    def test_parent_mapping_inline_fallback(self):
+        """When parent has no schema_name in lookup, use URL-path fallback."""
+        ep = _make_endpoint(
+            path="/svm/svms/{svm.uuid}/web",
+            has_parent=True,
+            parent_path="/svm/svms",
+            schema_name="web",
+            fields=[
+                ParsedField(name="enabled", api_path="enabled", python_type="bool", default=False)
+            ],
+        )
+        # No schema_lookup — parent falls back to URL-path
+        code = generate_mapping(ep)
+        assert 'parent_mapping="OntapSvm"' in code
 
     def test_registry_call(self):
         ep = _make_endpoint()
         code = generate_mapping(ep)
-        assert 'model_registry.register_mapping("StorageVolume"' in code
+        assert 'model_registry.register_mapping("OntapVolume"' in code
 
 
 # ---------------------------------------------------------------------------
@@ -250,8 +350,8 @@ class TestGenerateInit:
     def test_exports_class(self):
         ep = _make_endpoint()
         code = generate_init(ep)
-        assert "from pynetappfoundry.cache.storage.volumes.model import StorageVolume" in code
-        assert '__all__ = ["StorageVolume"]' in code
+        assert "from pynetappfoundry.cache.storage.volumes.model import OntapVolume" in code
+        assert '__all__ = ["OntapVolume"]' in code
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +367,7 @@ class TestGenerateTomlOverlay:
         assert 'path = "/storage/volumes"' in toml
         assert "[fields.uuid]" in toml
         assert 'cache_strategy = "cache"' in toml
+        assert 'class_name = "OntapVolume"' in toml
 
     def test_expensive_field_marked(self):
         fields = [
@@ -333,6 +434,7 @@ class TestWriteEndpointFiles:
     def test_intermediate_init_files(self, tmp_path):
         ep = _make_endpoint(
             path="/network/ip/interfaces",
+            schema_name="ip_interface",
             fields=[
                 ParsedField(name="name", api_path="name"),
             ],
@@ -356,3 +458,171 @@ class TestWriteEndpointFiles:
 
         mapping_code = (tmp_path / "storage" / "volumes" / "mapping.py").read_text()
         compile(mapping_code, "mapping.py", "exec")
+
+    def test_schema_lookup_passed_to_mapping(self, tmp_path):
+        """Verify schema_lookup is used for parent resolution in generated mappings."""
+        ep = _make_endpoint(
+            path="/svm/svms/{svm.uuid}/web",
+            has_parent=True,
+            parent_path="/svm/svms",
+            schema_name="web",
+            fields=[
+                ParsedField(name="enabled", api_path="enabled", python_type="bool", default=False)
+            ],
+        )
+        schema_lookup = {"/svm/svms": "svm"}
+        write_endpoint_files(ep, tmp_path, schema_lookup=schema_lookup)
+
+        mapping_code = (tmp_path / "svm" / "svms" / "web" / "mapping.py").read_text()
+        assert 'parent_mapping="OntapSvm"' in mapping_code
+
+
+# ---------------------------------------------------------------------------
+# Sub-model helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSubModelName:
+    def test_basic(self):
+        f = ParsedField(name="copies", api_path="copies", is_list=True, is_object=True)
+        assert _sub_model_name("OntapSnapshotPolicy", f) == "OntapSnapshotPolicyCopy"
+
+    def test_underscored_field(self):
+        f = ParsedField(name="ip_ranges", api_path="ip_ranges", is_list=True, is_object=True)
+        assert _sub_model_name("OntapIpSubnet", f) == "OntapIpSubnetIpRange"
+
+
+class TestHasTypedSubFields:
+    def test_true_for_list_object_with_sub_fields(self):
+        f = ParsedField(
+            name="copies",
+            api_path="copies",
+            is_list=True,
+            is_object=True,
+            sub_fields=[
+                ParsedField(name="count", api_path="copies.count", python_type="int", default=0)
+            ],
+        )
+        assert _has_typed_sub_fields(f) is True
+
+    def test_false_for_list_without_sub_fields(self):
+        f = ParsedField(name="tags", api_path="tags", is_list=True, is_object=False)
+        assert _has_typed_sub_fields(f) is False
+
+    def test_false_for_empty_sub_fields(self):
+        f = ParsedField(name="copies", api_path="copies", is_list=True, is_object=True)
+        assert _has_typed_sub_fields(f) is False
+
+    def test_false_for_only_object_sub_fields(self):
+        """If all sub_fields are pure objects (no leaves), return False."""
+        f = ParsedField(
+            name="copies",
+            api_path="copies",
+            is_list=True,
+            is_object=True,
+            sub_fields=[
+                ParsedField(name="nested", api_path="copies.nested", is_object=True),
+            ],
+        )
+        assert _has_typed_sub_fields(f) is False
+
+
+# ---------------------------------------------------------------------------
+# Sub-model generation
+# ---------------------------------------------------------------------------
+
+
+def _make_endpoint_with_sub_model(
+    path: str = "/storage/snapshot-policies",
+) -> ParsedEndpoint:
+    """Build an endpoint with an array-of-objects field for sub-model testing."""
+    copy_sub_fields = [
+        ParsedField(name="count", api_path="copies.count", python_type="int", default=0),
+        ParsedField(
+            name="schedule",
+            api_path="copies.schedule",
+            python_type="object",
+            is_object=True,
+            sub_fields=[
+                ParsedField(name="name", api_path="copies.schedule.name", python_type="str"),
+            ],
+        ),
+        ParsedField(name="name", api_path="copies.schedule.name", python_type="str"),
+    ]
+    return ParsedEndpoint(
+        path=path,
+        schema_name="snapshot_policy",
+        fields=[
+            ParsedField(name="uuid", api_path="uuid", python_type="OntapUUID", is_uuid=True),
+            ParsedField(name="name", api_path="name", python_type="str"),
+            ParsedField(
+                name="copies",
+                api_path="copies",
+                python_type="list[dict[str, Any]]",
+                is_list=True,
+                is_object=True,
+                default=[],
+                sub_fields=copy_sub_fields,
+            ),
+        ],
+    )
+
+
+class TestGenerateModelSubModel:
+    def test_sub_model_class_generated(self):
+        ep = _make_endpoint_with_sub_model()
+        code = generate_model(ep)
+        assert "class OntapSnapshotPolicyCopy(CacheModel):" in code
+
+    def test_sub_model_before_parent(self):
+        ep = _make_endpoint_with_sub_model()
+        code = generate_model(ep)
+        sub_pos = code.index("class OntapSnapshotPolicyCopy")
+        parent_pos = code.index("class OntapSnapshotPolicy(CacheModel)")
+        assert sub_pos < parent_pos
+
+    def test_parent_field_typed_with_sub_model(self):
+        ep = _make_endpoint_with_sub_model()
+        code = generate_model(ep)
+        assert "copies: list[OntapSnapshotPolicyCopy]" in code
+
+    def test_no_any_import_when_all_sub_models_typed(self):
+        ep = _make_endpoint_with_sub_model()
+        code = generate_model(ep)
+        assert "from typing import Any" not in code
+
+    def test_sub_model_has_leaf_fields(self):
+        ep = _make_endpoint_with_sub_model()
+        code = generate_model(ep)
+        # The sub-model should have 'count' and 'name' (leaf fields from copies sub_fields)
+        # but not 'schedule' (which is a pure object container)
+        assert "    count: int = 0" in code
+        assert "    name: str" in code
+
+    def test_valid_python(self):
+        ep = _make_endpoint_with_sub_model()
+        code = generate_model(ep)
+        compile(code, "model.py", "exec")
+
+
+class TestGenerateMappingSubModel:
+    def test_transform_function_generated(self):
+        ep = _make_endpoint_with_sub_model()
+        code = generate_mapping(ep)
+        assert "def _transform_copies(record: dict[str, Any])" in code
+        assert "OntapSnapshotPolicyCopy(**item)" in code
+
+    def test_field_mapping_uses_transform(self):
+        ep = _make_endpoint_with_sub_model()
+        code = generate_mapping(ep)
+        assert "transform=_transform_copies" in code
+
+    def test_sub_model_imported(self):
+        ep = _make_endpoint_with_sub_model()
+        code = generate_mapping(ep)
+        assert "OntapSnapshotPolicyCopy" in code
+
+    def test_valid_python(self):
+        ep = _make_endpoint_with_sub_model()
+        code = generate_mapping(ep)
+        compile(code, "mapping.py", "exec")

--- a/tests/unit/codegen/test_openapi_codegen.py
+++ b/tests/unit/codegen/test_openapi_codegen.py
@@ -1,0 +1,76 @@
+"""Tests for openapi_codegen endpoint deduplication."""
+
+from __future__ import annotations
+
+from tools.codegen.adapters import ParsedEndpoint, ParsedField
+from tools.codegen.openapi_codegen import _deduplicate_endpoints
+
+
+def _make_ep(path: str, field_count: int) -> ParsedEndpoint:
+    """Build a minimal ParsedEndpoint with N scalar fields."""
+    fields = [
+        ParsedField(name=f"field_{i}", api_path=f"field_{i}", python_type="str")
+        for i in range(field_count)
+    ]
+    return ParsedEndpoint(path=path, schema_name="test", fields=fields)
+
+
+class TestDeduplicateEndpoints:
+    def test_no_duplicates_passthrough(self):
+        eps = [_make_ep("/storage/volumes", 10), _make_ep("/network/interfaces", 5)]
+        result = _deduplicate_endpoints(eps)
+        assert len(result) == 2
+
+    def test_keeps_richest_endpoint(self):
+        """When /storage/volumes (10 fields) and /storage/volumes/{uuid} (2 fields)
+        collide, keep the one with more fields."""
+        collection = _make_ep("/storage/volumes", 10)
+        instance = _make_ep("/storage/volumes/{uuid}", 2)
+        result = _deduplicate_endpoints([collection, instance])
+        assert len(result) == 1
+        assert result[0].path == "/storage/volumes"
+
+    def test_keeps_richest_reversed_order(self):
+        """Order shouldn't matter — richest endpoint wins."""
+        collection = _make_ep("/storage/volumes", 10)
+        instance = _make_ep("/storage/volumes/{uuid}", 2)
+        result = _deduplicate_endpoints([instance, collection])
+        assert len(result) == 1
+        assert result[0].path == "/storage/volumes"
+
+    def test_preserves_order_of_winners(self):
+        """Winner position in the output should match its first appearance in input."""
+        ep1 = _make_ep("/storage/volumes", 10)
+        ep2 = _make_ep("/network/interfaces", 5)
+        ep3 = _make_ep("/storage/volumes/{uuid}", 2)
+        result = _deduplicate_endpoints([ep1, ep2, ep3])
+        assert len(result) == 2
+        assert result[0].path == "/storage/volumes"
+        assert result[1].path == "/network/interfaces"
+
+    def test_empty_input(self):
+        assert _deduplicate_endpoints([]) == []
+
+    def test_single_endpoint(self):
+        ep = _make_ep("/storage/volumes", 5)
+        result = _deduplicate_endpoints([ep])
+        assert result == [ep]
+
+    def test_object_fields_excluded_from_leaf_count(self):
+        """Dedup uses _select_leaf_fields, so pure object containers don't inflate count."""
+        # 3 leaf fields + 1 object container = 3 effective leaves
+        fields_with_object = [
+            ParsedField(name="uuid", api_path="uuid"),
+            ParsedField(name="name", api_path="name"),
+            ParsedField(name="svm", api_path="svm", is_object=True),
+            ParsedField(name="svm_name", api_path="svm.name"),
+        ]
+        ep_with_obj = ParsedEndpoint(path="/storage/volumes", fields=fields_with_object)
+
+        # 4 plain leaf fields
+        ep_instance = _make_ep("/storage/volumes/{uuid}", 4)
+
+        result = _deduplicate_endpoints([ep_with_obj, ep_instance])
+        assert len(result) == 1
+        # Instance has 4 leaves vs collection's 3 leaves
+        assert result[0].path == "/storage/volumes/{uuid}"

--- a/tools/codegen/generators.py
+++ b/tools/codegen/generators.py
@@ -43,37 +43,109 @@ def _path_to_module_parts(api_path: str) -> list[str]:
     return result
 
 
-def _path_to_class_name(api_path: str) -> str:
-    """Convert an API path to a PascalCase class name.
+_CLASS_NAME_OVERRIDES: dict[str, str] = {}
+"""Manual overrides for class names keyed by API path.
 
-    ``"/storage/volumes"`` → ``"StorageVolume"``
-    ``"/network/ip/interfaces"`` → ``"NetworkIpInterface"``
+Use this as an escape hatch for names the algorithm can't handle.
+Example: ``{"/some/weird/path": "OntapBetterName"}``.
+"""
 
-    Uses singular form by stripping trailing ``s`` from the last segment.
+
+def _schema_to_pascal(name: str) -> str:
+    """Convert a snake_case schema name to PascalCase.
+
+    ``"cloud_target"`` → ``"CloudTarget"``
+    ``"ip_interface"`` → ``"IpInterface"``
+    ``"svm"`` → ``"Svm"``
+
+    Args:
+        name: Schema name (typically snake_case).
+
+    Returns:
+        PascalCase string.
+    """
+    return "".join(w.capitalize() for w in name.split("_"))
+
+
+def _path_to_class_name(
+    api_path: str,
+    schema_name: str = "",
+    api_type: str = "ontap",
+) -> str:
+    """Derive a PascalCase class name for an API endpoint.
+
+    Uses ``{ApiType}{SchemaName}`` when a schema ``$ref`` name is
+    available.  Falls back to ``{ApiType}{UrlPathDerived}`` for inline
+    schemas (with redundant-segment deduplication).
+
+    Examples (with ``api_type="ontap"``):
+
+    * ``schema_name="volume"`` → ``"OntapVolume"``
+    * ``schema_name="svm"`` → ``"OntapSvm"``
+    * ``schema_name="cloud_target"`` → ``"OntapCloudTarget"``
+    * ``schema_name=""`` (inline), path ``"/cluster"`` → ``"OntapCluster"``
+    * ``schema_name=""`` (inline), path ``"/cluster/licensing/licenses"``
+      → ``"OntapClusterLicensingLicense"``
 
     Args:
         api_path: API endpoint path.
+        schema_name: Schema ``$ref`` name (e.g. ``"volume"``).
+            Empty string for inline schemas.
+        api_type: API type prefix (e.g. ``"ontap"``, ``"aiqum"``).
 
     Returns:
         PascalCase class name string.
     """
+    if api_path in _CLASS_NAME_OVERRIDES:
+        return _CLASS_NAME_OVERRIDES[api_path]
+
+    prefix = api_type.capitalize()
+
+    if schema_name:
+        return f"{prefix}{_schema_to_pascal(schema_name)}"
+
+    # Fallback: derive from the URL path
     parts = _path_to_module_parts(api_path)
-    words = []
+    if parts:
+        parts[-1] = _singularize(parts[-1])
+
+    # Remove redundant segments
+    deduped: list[str] = []
     for i, part in enumerate(parts):
-        # Singularize only the last segment
-        if i == len(parts) - 1:
-            part = _singularize(part)
-        # Convert underscores to PascalCase
+        if part in parts[i + 1 :]:
+            continue
+        deduped.append(part)
+
+    words = []
+    for part in deduped:
         for word in part.split("_"):
             words.append(word.capitalize())
-    return "".join(words)
+    return f"{prefix}{''.join(words)}"
+
+
+_SINGULAR_EXCEPTIONS: dict[str, str] = {
+    "dns": "dns",
+    "licenses": "license",
+    "chassis": "chassis",
+    "flexcaches": "flexcache",
+    "status": "status",
+    "alias": "alias",
+    "bus": "bus",
+    "metrocluster": "metrocluster",
+    "nfs": "nfs",
+    "cifs": "cifs",
+    "s3": "s3",
+    "iscsi": "iscsi",
+    "nvme": "nvme",
+    "fpolicy": "fpolicy",
+}
 
 
 def _singularize(name: str) -> str:
-    """Naive singularization of a plural resource name.
+    """Singularize a plural resource name.
 
-    Handles common patterns: ``policies`` → ``policy``,
-    ``interfaces`` → ``interface``, ``volumes`` → ``volume``.
+    Checks an exception dictionary first, then applies common English
+    pluralization rules.
 
     Args:
         name: Plural resource name.
@@ -81,6 +153,8 @@ def _singularize(name: str) -> str:
     Returns:
         Singular form.
     """
+    if name in _SINGULAR_EXCEPTIONS:
+        return _SINGULAR_EXCEPTIONS[name]
     if name.endswith("ies"):
         return name[:-3] + "y"
     if name.endswith("ses") or name.endswith("xes") or name.endswith("zes"):
@@ -106,17 +180,51 @@ def _field_to_cache_attr(field: ParsedField) -> str:
     return field.api_path.replace(".", "_").replace("-", "_")
 
 
-def _python_type_annotation(field: ParsedField) -> str:
+def _sub_model_name(parent_class: str, field: ParsedField) -> str:
+    """Build a sub-model class name for an array-of-objects field.
+
+    Convention: ``{ParentClassName}{FieldNameSingularized}``.
+
+    ``StorageSnapshotPolicy`` + ``copies`` → ``StorageSnapshotPolicyCopy``
+
+    Args:
+        parent_class: Parent model class name.
+        field: The array-of-objects field.
+
+    Returns:
+        Sub-model class name.
+    """
+    singular = _singularize(field.name)
+    # PascalCase the singular field name
+    pascal = "".join(w.capitalize() for w in singular.split("_"))
+    return f"{parent_class}{pascal}"
+
+
+def _has_typed_sub_fields(field: ParsedField) -> bool:
+    """Check if a field should get a typed sub-model.
+
+    True when the field is an array of objects with at least one
+    non-object sub-field (i.e. actual leaf data to model).
+    """
+    if not (field.is_list and field.is_object and field.sub_fields):
+        return False
+    return any(not (sf.is_object and not sf.is_list) for sf in field.sub_fields)
+
+
+def _python_type_annotation(field: ParsedField, sub_model_map: dict[str, str] | None = None) -> str:
     """Get the Python type annotation string for a field.
 
     Args:
         field: Parsed field.
+        sub_model_map: Optional mapping from field api_path to sub-model class name.
 
     Returns:
         Type annotation string.
     """
     if field.is_uuid:
         return "OntapUUID"
+    if sub_model_map and field.api_path in sub_model_map:
+        return f"list[{sub_model_map[field.api_path]}]"
     if field.is_list:
         return field.python_type
     return field.python_type
@@ -168,6 +276,8 @@ def generate_model(endpoint: ParsedEndpoint, api_type: str = "ontap") -> str:
     """Generate a Pydantic model class for an endpoint.
 
     Produces a flat ``CacheModel`` subclass following ADR-0007 naming.
+    Array-of-objects fields with sub-fields get typed sub-model classes
+    defined before the parent class.
 
     Args:
         endpoint: Parsed endpoint with fields.
@@ -176,13 +286,31 @@ def generate_model(endpoint: ParsedEndpoint, api_type: str = "ontap") -> str:
     Returns:
         Python source code for the model module.
     """
-    class_name = _path_to_class_name(endpoint.path)
+    class_name = _path_to_class_name(endpoint.path, endpoint.schema_name, api_type)
     doc = f"{class_name} — {endpoint.path}."
     leaves = _select_leaf_fields(endpoint.fields)
 
+    # Identify fields that get typed sub-models
+    sub_model_map: dict[str, str] = {}  # field api_path -> sub-model class name
+    sub_model_fields: list[tuple[str, ParsedField]] = []  # (sub_class_name, field)
+    for field in leaves:
+        if _has_typed_sub_fields(field):
+            sub_cls = _sub_model_name(class_name, field)
+            sub_model_map[field.api_path] = sub_cls
+            sub_model_fields.append((sub_cls, field))
+
     needs_field_import = any(f.is_list for f in leaves)
-    needs_any_import = any(f.is_list and f.is_object for f in leaves)
+    # Only need Any import if there are list-of-object fields WITHOUT sub-models
+    needs_any_import = any(
+        f.is_list and f.is_object and f.api_path not in sub_model_map for f in leaves
+    )
     needs_uuid_import = any(f.is_uuid for f in leaves)
+
+    # Check sub-model fields for UUID needs
+    for _sub_cls, sf in sub_model_fields:
+        sub_leaves = _select_leaf_fields(sf.sub_fields)
+        if any(ssf.is_uuid for ssf in sub_leaves):
+            needs_uuid_import = True
 
     lines = [
         f'"""{doc}"""',
@@ -197,9 +325,6 @@ def generate_model(endpoint: ParsedEndpoint, api_type: str = "ontap") -> str:
         lines.append("")
 
     pydantic_imports = ["Field"] if needs_field_import else []
-    if not pydantic_imports:
-        # No pydantic imports needed beyond CacheModel
-        pass
 
     base_imports = ["CacheModel"]
     if needs_uuid_import:
@@ -211,6 +336,24 @@ def generate_model(endpoint: ParsedEndpoint, api_type: str = "ontap") -> str:
 
     lines.append(f"from pynetappfoundry.cache._base import {', '.join(sorted(base_imports))}")
     lines.append("")
+
+    # Generate sub-model classes before the parent
+    for sub_cls, field in sub_model_fields:
+        lines.append("")
+        lines.append(f"class {sub_cls}(CacheModel):")
+        lines.append(f'    """{sub_cls} sub-model for {field.name}."""')
+        lines.append("")
+        sub_leaves = _select_leaf_fields(field.sub_fields)
+        if not sub_leaves:
+            lines.append("    pass")
+        else:
+            for sf in sub_leaves:
+                attr = sf.name.replace("-", "_")
+                type_ann = _python_type_annotation(sf)
+                default_repr = _python_default_repr(sf)
+                lines.append(f"    {attr}: {type_ann} = {default_repr}")
+        lines.append("")
+
     lines.append("")
     lines.append(f"class {class_name}(CacheModel):")
     lines.append(f'    """{class_name} information."""')
@@ -221,7 +364,7 @@ def generate_model(endpoint: ParsedEndpoint, api_type: str = "ontap") -> str:
     else:
         for field in leaves:
             attr = _field_to_cache_attr(field)
-            type_ann = _python_type_annotation(field)
+            type_ann = _python_type_annotation(field, sub_model_map)
             default_repr = _python_default_repr(field)
             lines.append(f"    {attr}: {type_ann} = {default_repr}")
 
@@ -232,42 +375,80 @@ def generate_model(endpoint: ParsedEndpoint, api_type: str = "ontap") -> str:
 def generate_mapping(
     endpoint: ParsedEndpoint,
     api_type: str = "ontap",
+    schema_lookup: dict[str, str] | None = None,
 ) -> str:
     """Generate a TypeMapping/FieldMapping module for an endpoint.
 
     Produces a ``mapping.py`` file with the mapping constant and
-    registry registration call.
+    registry registration call.  Array-of-objects fields with typed
+    sub-models get transform functions that construct sub-model instances.
 
     Args:
         endpoint: Parsed endpoint with fields.
         api_type: API type tag.
+        schema_lookup: Optional mapping of API path → schema name for
+            resolving parent class names.
 
     Returns:
         Python source code for the mapping module.
     """
-    class_name = _path_to_class_name(endpoint.path)
+    class_name = _path_to_class_name(endpoint.path, endpoint.schema_name, api_type)
     module_parts = _path_to_module_parts(endpoint.path)
     mapping_name = f"{class_name.upper()}_MAPPING"
     leaves = _select_leaf_fields(endpoint.fields)
 
+    # Identify sub-model fields
+    sub_model_map: dict[str, str] = {}
+    for field in leaves:
+        if _has_typed_sub_fields(field):
+            sub_model_map[field.api_path] = _sub_model_name(class_name, field)
+
     # Build the import path for the model
     model_import = f"pynetappfoundry.cache.{'.'.join(module_parts)}.model"
+
+    # Build model imports (parent class + any sub-model classes)
+    model_classes = [class_name, *sorted(sub_model_map.values())]
 
     lines = [
         f'"""{class_name} type mapping — {endpoint.path}."""',
         "",
         "from __future__ import annotations",
         "",
-        "from pynetappfoundry.cache._registry import model_registry",
-        "from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping",
-        f"from {model_import} import {class_name}",
-        "",
-        "",
-        f"{mapping_name} = TypeMapping(",
-        f'    name="{class_name}",',
-        f"    model_class={class_name},",
-        f'    api_endpoint="{endpoint.path}?fields=*',
     ]
+
+    if sub_model_map:
+        lines.append("from typing import Any")
+        lines.append("")
+
+    lines.extend(
+        [
+            "from pynetappfoundry.cache._registry import model_registry",
+            "from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping",
+            f"from {model_import} import {', '.join(model_classes)}",
+        ]
+    )
+
+    # Generate transform functions for sub-model fields
+    if sub_model_map:
+        for field in leaves:
+            if field.api_path not in sub_model_map:
+                continue
+            sub_cls = sub_model_map[field.api_path]
+            func_name = f"_transform_{_field_to_cache_attr(field)}"
+            lines.append("")
+            lines.append("")
+            lines.append(f"def {func_name}(record: dict[str, Any]) -> list[{sub_cls}]:")
+            lines.append(f'    """Transform {field.api_path} dicts into {sub_cls} instances."""')
+            lines.append(
+                f'    return [{sub_cls}(**item) for item in record.get("{field.api_path}", [])]'
+            )
+
+    lines.append("")
+    lines.append("")
+    lines.append(f"{mapping_name} = TypeMapping(")
+    lines.append(f'    name="{class_name}",')
+    lines.append(f"    model_class={class_name},")
+    lines.append(f'    api_endpoint="{endpoint.path}?fields=*')
 
     # Add expensive fields to the endpoint query
     expensive = [f for f in leaves if f.requires_explicit_fetch]
@@ -285,7 +466,8 @@ def generate_mapping(
 
     if endpoint.has_parent:
         # Derive parent mapping name from parent path
-        parent_class = _path_to_class_name(endpoint.parent_path)
+        parent_schema = (schema_lookup or {}).get(endpoint.parent_path, "")
+        parent_class = _path_to_class_name(endpoint.parent_path, parent_schema, api_type)
         lines.append(f'    parent_mapping="{parent_class}",')
         lines.append('    parent_id_field="uuid",')
 
@@ -296,7 +478,13 @@ def generate_mapping(
         default_repr = _python_default_repr(field)
 
         field_args = [f'        cache_attr="{attr}"']
-        field_args.append(f'        api_path="{field.api_path}"')
+
+        if field.api_path in sub_model_map:
+            # Sub-model field: use transform instead of api_path
+            func_name = f"_transform_{attr}"
+            field_args.append(f"        transform={func_name}")
+        else:
+            field_args.append(f'        api_path="{field.api_path}"')
 
         if field.default != "":
             field_args.append(f"        default={default_repr}")
@@ -318,16 +506,17 @@ def generate_mapping(
     return "\n".join(lines)
 
 
-def generate_init(endpoint: ParsedEndpoint) -> str:
+def generate_init(endpoint: ParsedEndpoint, api_type: str = "ontap") -> str:
     """Generate an ``__init__.py`` for an endpoint's package.
 
     Args:
         endpoint: Parsed endpoint.
+        api_type: API type prefix for class naming.
 
     Returns:
         Python source code for ``__init__.py``.
     """
-    class_name = _path_to_class_name(endpoint.path)
+    class_name = _path_to_class_name(endpoint.path, endpoint.schema_name, api_type)
     module_parts = _path_to_module_parts(endpoint.path)
 
     lines = [
@@ -344,6 +533,7 @@ def generate_init(endpoint: ParsedEndpoint) -> str:
 def generate_toml_overlay(
     endpoint: ParsedEndpoint,
     existing_path: Path | None = None,
+    api_type: str = "ontap",
 ) -> str:
     """Generate or update a TOML overlay for an endpoint.
 
@@ -354,11 +544,12 @@ def generate_toml_overlay(
     Args:
         endpoint: Parsed endpoint with fields.
         existing_path: Path to existing overlay file, or None.
+        api_type: API type prefix for class naming.
 
     Returns:
         TOML content as a string.
     """
-    class_name = _path_to_class_name(endpoint.path)
+    class_name = _path_to_class_name(endpoint.path, endpoint.schema_name, api_type)
     leaves = _select_leaf_fields(endpoint.fields)
 
     # Load existing overlay if present
@@ -403,6 +594,7 @@ def write_endpoint_files(
     output_dir: Path,
     api_type: str = "ontap",
     overlay_dir: Path | None = None,
+    schema_lookup: dict[str, str] | None = None,
 ) -> list[Path]:
     """Write all generated files for an endpoint.
 
@@ -416,6 +608,8 @@ def write_endpoint_files(
         api_type: API type tag.
         overlay_dir: Directory for TOML overlay files.  If None, overlays
             are written next to the model files.
+        schema_lookup: Mapping of API path → schema name for resolving
+            parent class names in mappings.
 
     Returns:
         List of paths to all files written.
@@ -438,12 +632,12 @@ def write_endpoint_files(
 
     # mapping.py
     mapping_path = pkg_dir / "mapping.py"
-    mapping_path.write_text(generate_mapping(endpoint, api_type))
+    mapping_path.write_text(generate_mapping(endpoint, api_type, schema_lookup))
     written.append(mapping_path)
 
     # __init__.py for the leaf package
     init_path = pkg_dir / "__init__.py"
-    init_path.write_text(generate_init(endpoint))
+    init_path.write_text(generate_init(endpoint, api_type))
     written.append(init_path)
 
     # TOML overlay
@@ -451,7 +645,7 @@ def write_endpoint_files(
     toml_dir.mkdir(parents=True, exist_ok=True)
     toml_path = toml_dir / f"{module_parts[-1]}.toml"
     existing = toml_path if toml_path.exists() else None
-    toml_path.write_text(generate_toml_overlay(endpoint, existing))
+    toml_path.write_text(generate_toml_overlay(endpoint, existing, api_type))
     written.append(toml_path)
 
     return written

--- a/tools/codegen/openapi_codegen.py
+++ b/tools/codegen/openapi_codegen.py
@@ -17,8 +17,48 @@ import argparse
 import sys
 from pathlib import Path
 
-from tools.codegen.adapters import parse_openapi_spec
-from tools.codegen.generators import write_endpoint_files
+from tools.codegen.adapters import ParsedEndpoint, parse_openapi_spec
+from tools.codegen.generators import (
+    _path_to_class_name,
+    _path_to_module_parts,
+    _select_leaf_fields,
+    write_endpoint_files,
+)
+
+
+def _deduplicate_endpoints(endpoints: list[ParsedEndpoint]) -> list[ParsedEndpoint]:
+    """Deduplicate endpoints that resolve to the same module path.
+
+    When ``/storage/volumes`` and ``/storage/volumes/{uuid}`` both map to
+    module path ``["storage", "volumes"]``, keep the endpoint with the
+    most leaf fields (the richer schema).
+
+    Args:
+        endpoints: List of parsed endpoints.
+
+    Returns:
+        Deduplicated list, preserving original order for the winners.
+    """
+    groups: dict[tuple[str, ...], list[ParsedEndpoint]] = {}
+    for ep in endpoints:
+        key = tuple(_path_to_module_parts(ep.path))
+        groups.setdefault(key, []).append(ep)
+
+    seen: set[tuple[str, ...]] = set()
+    result: list[ParsedEndpoint] = []
+    for ep in endpoints:
+        key = tuple(_path_to_module_parts(ep.path))
+        if key in seen:
+            continue
+        seen.add(key)
+        candidates = groups[key]
+        if len(candidates) == 1:
+            result.append(candidates[0])
+        else:
+            # Pick the endpoint with the most leaf fields
+            best = max(candidates, key=lambda e: len(_select_leaf_fields(e.fields)))
+            result.append(best)
+    return result
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -97,15 +137,24 @@ def run(
         endpoints = [e for e in endpoints if e.path in endpoint_filter]
         print(f"Filtered to {len(endpoints)} endpoints.")
 
+    # Deduplicate endpoints that resolve to the same module path.
+    # e.g. /storage/volumes and /storage/volumes/{uuid} both map to
+    # storage/volumes — keep the one with the most leaf fields.
+    endpoints = _deduplicate_endpoints(endpoints)
+
     if not endpoints:
         print("No endpoints to generate.", file=sys.stderr)
         return []
+
+    # Build schema lookup for parent path resolution in mappings
+    schema_lookup: dict[str, str] = {ep.path: ep.schema_name for ep in endpoints}
 
     all_written: list[Path] = []
 
     for ep in endpoints:
         if dry_run:
-            print(f"  [dry-run] {ep.path} -> {len(ep.fields)} fields")
+            class_name = _path_to_class_name(ep.path, ep.schema_name, api_type)
+            print(f"  [dry-run] {ep.path} -> {class_name} ({len(ep.fields)} fields)")
             continue
 
         written = write_endpoint_files(
@@ -113,6 +162,7 @@ def run(
             output,
             api_type,
             overlay_dir,
+            schema_lookup,
         )
         all_written.extend(written)
         field_count = len([f for f in ep.fields if not f.is_object or f.is_list])


### PR DESCRIPTION
## Description

Fix four codegen bugs that prevent correct generation for the full ONTAP spec (486 GET endpoints), and rework the class naming convention to use `{ApiType}{SchemaName}` from the OpenAPI `$ref` (e.g. `OntapVolume`, `OntapSvm`).

## Related Issue

Addresses #305
Addresses #301

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **Endpoint deduplication**: `_deduplicate_endpoints()` groups endpoints by resolved module path and keeps the one with the most leaf fields (fixes `/storage/volumes` vs `/storage/volumes/{uuid}` collision)
- **Singularize exceptions**: Added `_SINGULAR_EXCEPTIONS` dict (14 entries) for words that break naive singularization (`dns`, `licenses`, `chassis`, `flexcaches`, `status`, etc.)
- **ApiType-prefixed naming**: Reworked `_path_to_class_name()` to use `{ApiType}{SchemaName}` from the OpenAPI `$ref` when available (e.g. `OntapVolume`, `OntapSvm`, `OntapCloudTarget`), with URL-path fallback + redundant-segment dedup for inline schemas. Added `_CLASS_NAME_OVERRIDES` as extension point.
- **Typed sub-models**: Array-of-objects fields (e.g. snapshot policy `copies`, export policy `rules`) now generate typed sub-model classes instead of `list[dict[str, Any]]`, with transform functions in mappings
- **Schema lookup**: `run()` builds path→schema_name lookup, passed through `write_endpoint_files` → `generate_mapping` for consistent parent class name resolution

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

New test coverage:
- `test_openapi_codegen.py` — 7 tests for endpoint deduplication
- `test_generators.py` — 40+ new tests covering singularize exceptions, schema-based naming, inline fallback, override map, sub-model helpers, sub-model generation in models and mappings, schema_lookup propagation

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings