### PR TITLE
feat: per-model SQL table storage for cache layer

### DIFF
--- a/docs/decisions/0001-use-sqlite-for-cluster-metadata-caching.md
+++ b/docs/decisions/0001-use-sqlite-for-cluster-metadata-caching.md
@@ -26,6 +26,13 @@ Use **SQLite** as the storage backend for caching ONTAP cluster metadata that do
 - **Redis/external cache**: Overkill for local CLI tool, adds deployment complexity
 - **Automatic refresh with TTL**: Adds complexity, harder to reason about data freshness
 
+## Evolution
+
+The storage format evolved from a single JSON blob (schema v1) to per-model SQL
+tables (schema v2) in [ADR-0009](0009-sql-table-storage.md). The SQLite backend
+and manual refresh model remain unchanged; only the internal table structure
+changed to enable SQL-level queries and per-field indexing.
+
 ## Related Issues
 
 - Issue #32: feat: add cluster metadata cache for ONTAP clusters

--- a/docs/decisions/0009-sql-table-storage.md
+++ b/docs/decisions/0009-sql-table-storage.md
@@ -1,0 +1,72 @@
+# ADR-0009: Per-Model SQL Table Storage for Cache Layer
+
+## Status
+
+Accepted
+
+## Context
+
+The cluster metadata cache stored all data as a single JSON blob in the
+`cluster_metadata` table (`metadata_json TEXT` column). This prevented
+SQL-level queries, per-field updates, and granular storage.
+
+Since no production consumers depend on the v1 schema, this is a clean-slate
+rebuild of the storage layer.
+
+## Decision
+
+Replace the JSON blob with **per-model SQL tables** generated from Pydantic
+model field definitions:
+
+- **DDL generation** (`db_schema.py`): Walk `CachedClusterMetadata.model_fields`
+  to discover storable models. Map Python types to SQL column types. Generate
+  `CREATE TABLE` statements at import time via a `TABLE_REGISTRY`.
+- **Raw `sqlite3`**: No ORM. Parameterised queries only.
+- **`_row_id` PK**: Every table uses `_row_id INTEGER PRIMARY KEY AUTOINCREMENT`
+  to avoid collisions when UUID fields are empty (common for test fixtures and
+  new clusters).
+- **Container models** (e.g. `StorageInfo`, `NetworkInfo`) do **not** get their
+  own tables — their child list fields are stored directly.
+- **Sub-models stored as JSON**: Nested list/dict fields within a model (e.g.
+  `OntapNodeResponse.cluster_interfaces`) are serialised to JSON TEXT columns.
+  They lack independent identity and don't need separate tables.
+- **`_extra_json` column**: Every model table has this column to preserve
+  `extra="allow"` fields from newer ONTAP versions.
+- **`_uuid_index` table**: Cross-model UUID lookup, populated on `set()`.
+- **v1 → v2 migration**: Reads JSON blobs, decomposes into new tables, rebuilds
+  the envelope table without `metadata_json`.
+
+### Alternatives Considered
+
+- **SQLModel / SQLAlchemy**: Rejected. SQLModel is 0.0.x, 20-40x slower for
+  bulk inserts, and conflicts with Pydantic `extra="allow"` inheritance.
+- **Keep JSON blob + add indexed views**: Would not enable per-field updates
+  or eliminate full-blob serialization on every write.
+
+## Consequences
+
+### Positive
+
+- Enables SQL-level queries via `query_model()` with parameterised filters
+- `is_stale()` reads only the envelope row — no full metadata deserialisation
+- Per-field indexing possible (e.g. `CREATE INDEX ON ontapvolume (name)`)
+- `export_json()` / `import_json()` provide backward-compatible JSON I/O
+- `_extra_json` preserves forward compatibility with newer ONTAP versions
+
+### Negative
+
+- More complex `set()` / `get()` — decompose into ~29 tables on write,
+  reconstruct from ~29 tables on read
+- Column names must be quoted to handle SQLite reserved words (e.g. `"index"`)
+- Schema migrations needed when models add/remove fields
+
+## Related Issues
+
+- Issue #309: feat: per-model SQL table storage for cache layer
+- Issue #301: feat: field annotations, OpenAPI codegen, and SQL cache storage
+
+## Related Documentation
+
+- Cache module: `src/pynetappfoundry/cache/`
+- ADR-0001: [Use SQLite for cluster metadata caching](0001-use-sqlite-for-cluster-metadata-caching.md)
+- ADR-0003: [Base SQLiteDB class with version-based migrations](0003-use-base-sqlitedb-class-with-version-based-migrations.md)

--- a/src/pynetappfoundry/cache/db.py
+++ b/src/pynetappfoundry/cache/db.py
@@ -1,4 +1,10 @@
-"""SQLite database operations for cluster metadata cache."""
+"""SQLite database operations for cluster metadata cache.
+
+Schema v2 stores each Pydantic model in its own SQL table instead of a
+single JSON blob.  The public API (``get``/``set``/``clear``/etc.) is
+preserved so callers (collectors, query, inspect, diff, refresh) work
+unchanged.
+"""
 
 from __future__ import annotations
 
@@ -7,9 +13,20 @@ import re
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from pydantic import BaseModel
 
 from pynetappfoundry.cache._metadata import CachedClusterMetadata
+from pynetappfoundry.cache.db_schema import (
+    ENVELOPE_DDL,
+    UUID_INDEX_DDL,
+    _ensure_registry,
+    _is_json_column,
+    generate_cluster_name_index_ddl,
+    generate_table_ddl,
+    generate_uuid_column_index_ddl,
+)
 from pynetappfoundry.db.base import SQLiteDB
 
 if TYPE_CHECKING:
@@ -38,17 +55,120 @@ def _validate_cluster_name(cluster_name: str) -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# Row conversion helpers
+# ---------------------------------------------------------------------------
+
+
+def _model_to_row(
+    model_instance: BaseModel,
+    model_class: type[BaseModel],
+) -> dict[str, Any]:
+    """Convert a Pydantic model instance to a dict suitable for SQL INSERT.
+
+    Scalar fields are passed through.  ``list``/``dict``/sub-model fields
+    are serialised to JSON strings.  Any extra fields (from ``extra="allow"``)
+    are collected into the ``_extra_json`` column.
+    """
+    row: dict[str, Any] = {}
+    known_fields = set(model_class.model_fields)
+
+    for field_name, field_info in model_class.model_fields.items():
+        value = getattr(model_instance, field_name)
+        if _is_json_column(field_info.annotation):
+            # Serialize list/dict/sub-model to JSON
+            if isinstance(value, BaseModel):
+                row[field_name] = value.model_dump_json()
+            elif isinstance(value, list):
+                row[field_name] = json.dumps(
+                    [item.model_dump() if isinstance(item, BaseModel) else item for item in value]
+                )
+            elif isinstance(value, dict):
+                row[field_name] = json.dumps(value)
+            else:
+                row[field_name] = json.dumps(value)
+        elif isinstance(value, datetime):
+            row[field_name] = value.isoformat()
+        elif isinstance(value, bool):
+            row[field_name] = int(value)
+        else:
+            row[field_name] = value
+
+    # Collect extra fields
+    extra_data: dict[str, Any] = {}
+    for attr_name in model_instance.model_fields_set | set(model_instance.__pydantic_extra__ or {}):
+        if attr_name not in known_fields:
+            extra_data[attr_name] = getattr(model_instance, attr_name)
+
+    row["_extra_json"] = json.dumps(extra_data) if extra_data else None
+    return row
+
+
+def _row_to_model(
+    row: dict[str, Any],
+    model_class: type[BaseModel],
+) -> BaseModel:
+    """Convert a SQL row dict back to a Pydantic model instance.
+
+    Reverses ``_model_to_row``: JSON columns are parsed, booleans are
+    coerced from int, and extra fields from ``_extra_json`` are merged.
+    """
+    kwargs: dict[str, Any] = {}
+
+    for field_name, field_info in model_class.model_fields.items():
+        value = row.get(field_name)
+        if value is None:
+            continue
+        if _is_json_column(field_info.annotation):
+            kwargs[field_name] = json.loads(value) if isinstance(value, str) else value
+        else:
+            kwargs[field_name] = value
+
+    # Merge extra fields
+    extra_json = row.get("_extra_json")
+    if extra_json:
+        extra = json.loads(extra_json) if isinstance(extra_json, str) else extra_json
+        kwargs.update(extra)
+
+    return model_class.model_validate(kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Metadata path helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_by_path(obj: Any, path: str) -> Any:
+    """Traverse a dot-path on an object (e.g. ``"storage.volumes"``)."""
+    for part in path.split("."):
+        obj = getattr(obj, part)
+    return obj
+
+
+def _set_by_path(target: dict[str, Any], path: str, value: Any) -> None:
+    """Set a value in a nested dict via dot-path, creating intermediate dicts."""
+    parts = path.split(".")
+    for part in parts[:-1]:
+        target = target.setdefault(part, {})
+    target[parts[-1]] = value
+
+
+# ---------------------------------------------------------------------------
+# ClusterMetadataDB
+# ---------------------------------------------------------------------------
+
+
 class ClusterMetadataDB(SQLiteDB):
     """SQLite database for caching cluster metadata.
 
-    Stores serialized CachedClusterMetadata objects in a single table
-    with cluster_name as the primary key.
+    Schema v2 decomposes CachedClusterMetadata into per-model SQL tables.
+    The public ``get``/``set``/``clear`` API is preserved.
 
     Note: Change history is stored in a separate database (CacheHistoryDB)
     for data safety and isolation.
     """
 
-    SCHEMA_VERSION: ClassVar[int] = 1
+    SCHEMA_VERSION: ClassVar[int] = 2
     TABLE_NAME: ClassVar[str] = "cluster_metadata"
 
     def __init__(
@@ -77,6 +197,7 @@ class ClusterMetadataDB(SQLiteDB):
 
         self.conn = sqlite3.connect(self.db_path, detect_types=sqlite3.PARSE_DECLTYPES)
         self.conn.row_factory = sqlite3.Row
+        self._registry = _ensure_registry()
         self._migrate_old_schema_info()
         self._init_db()
 
@@ -86,19 +207,202 @@ class ClusterMetadataDB(SQLiteDB):
             "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_info'"
         )
         if cursor.fetchone() is not None:
-            # Old schema_info exists - drop it (we'll use _schema_version now)
             self.conn.execute("DROP TABLE schema_info")
 
+    # ------------------------------------------------------------------
+    # Schema creation (new DB)
+    # ------------------------------------------------------------------
+
     def _create_schema(self) -> None:
-        """Create the cluster_metadata table."""
-        self.conn.execute(f"""
-            CREATE TABLE {self.TABLE_NAME} (
-                cluster_name TEXT PRIMARY KEY,
-                cached_at TEXT NOT NULL,
-                cache_version TEXT NOT NULL,
-                metadata_json TEXT NOT NULL
+        """Create all tables for a fresh v2 database."""
+        # Envelope table
+        self.conn.execute(ENVELOPE_DDL)
+
+        # Per-model tables
+        for spec in self._registry.values():
+            ddl = generate_table_ddl(spec.table_name, spec.model_class)
+            self.conn.execute(ddl)
+            self.conn.execute(generate_cluster_name_index_ddl(spec.table_name))
+            if spec.has_uuid:
+                self.conn.execute(generate_uuid_column_index_ddl(spec.table_name))
+
+        # UUID index table
+        self.conn.execute(UUID_INDEX_DDL)
+
+    # ------------------------------------------------------------------
+    # Migration v1 → v2
+    # ------------------------------------------------------------------
+
+    def _upgrade_to_v2(self) -> None:
+        """Migrate from v1 (JSON blob) to v2 (per-model tables)."""
+        # 1. Read all v1 data
+        cursor = self.conn.execute(
+            "SELECT cluster_name, cached_at, cache_version, metadata_json FROM cluster_metadata"
+        )
+        v1_rows = [dict(row) for row in cursor.fetchall()]
+
+        # 2. Create new model tables + uuid index
+        for spec in self._registry.values():
+            ddl = generate_table_ddl(spec.table_name, spec.model_class)
+            self.conn.execute(ddl)
+            self.conn.execute(generate_cluster_name_index_ddl(spec.table_name))
+            if spec.has_uuid:
+                self.conn.execute(generate_uuid_column_index_ddl(spec.table_name))
+        self.conn.execute(UUID_INDEX_DDL)
+
+        # 3. Migrate each cluster's data
+        for v1_row in v1_rows:
+            cluster_name = v1_row["cluster_name"]
+            metadata = CachedClusterMetadata.model_validate(json.loads(v1_row["metadata_json"]))
+            self._insert_model_data(cluster_name, metadata)
+            self._populate_uuid_index(cluster_name, metadata)
+
+        # 4. Recreate envelope table without metadata_json
+        #    (SQLite doesn't support DROP COLUMN before 3.35)
+        self.conn.execute("ALTER TABLE cluster_metadata RENAME TO _old_cluster_metadata")
+        self.conn.execute(ENVELOPE_DDL)
+        self.conn.execute(
+            "INSERT INTO cluster_metadata (cluster_name, cached_at, cache_version) "
+            "SELECT cluster_name, cached_at, cache_version FROM _old_cluster_metadata"
+        )
+        self.conn.execute("DROP TABLE _old_cluster_metadata")
+
+    # ------------------------------------------------------------------
+    # Internal: decompose metadata into tables
+    # ------------------------------------------------------------------
+
+    def _insert_model_data(
+        self,
+        cluster_name: str,
+        metadata: CachedClusterMetadata,
+    ) -> None:
+        """Walk TABLE_REGISTRY and insert model data into per-model tables."""
+        for path, spec in self._registry.items():
+            data = _get_by_path(metadata, path)
+
+            if spec.is_list:
+                if not data:
+                    continue
+                rows = [_model_to_row(item, spec.model_class) for item in data]
+                for row in rows:
+                    row["cluster_name"] = cluster_name
+                self._bulk_insert(spec.table_name, rows)
+            else:
+                # Singleton
+                row = _model_to_row(data, spec.model_class)
+                row["cluster_name"] = cluster_name
+                self._bulk_insert(spec.table_name, [row])
+
+    def _bulk_insert(self, table_name: str, rows: list[dict[str, Any]]) -> None:
+        """Insert multiple rows into a table using executemany."""
+        if not rows:
+            return
+        columns = list(rows[0].keys())
+        placeholders = ", ".join("?" for _ in columns)
+        col_names = ", ".join(f'"{c}"' for c in columns)
+        sql = f"INSERT INTO {table_name} ({col_names}) VALUES ({placeholders})"
+        values = [tuple(row[c] for c in columns) for row in rows]
+        self.conn.executemany(sql, values)
+
+    def _populate_uuid_index(
+        self,
+        cluster_name: str,
+        metadata: CachedClusterMetadata,
+    ) -> None:
+        """Populate the _uuid_index table from a CachedClusterMetadata."""
+        rows: list[tuple[str, str, str]] = []
+        for path, spec in self._registry.items():
+            if not spec.has_uuid:
+                continue
+            data = _get_by_path(metadata, path)
+            items = data if spec.is_list else [data]
+            for item in items:
+                uuid_val = getattr(item, "uuid", "")
+                if uuid_val:
+                    rows.append((cluster_name, uuid_val, spec.table_name))
+        if rows:
+            self.conn.executemany(
+                "INSERT OR REPLACE INTO _uuid_index (cluster_name, uuid, table_name) "
+                "VALUES (?, ?, ?)",
+                rows,
             )
-        """)
+
+    # ------------------------------------------------------------------
+    # Internal: reconstruct metadata from tables
+    # ------------------------------------------------------------------
+
+    def _reconstruct_metadata(
+        self,
+        cluster_name: str,
+        envelope: dict[str, str],
+    ) -> CachedClusterMetadata:
+        """Read all model tables and rebuild a CachedClusterMetadata."""
+        root_kwargs: dict[str, Any] = {
+            "cluster_name": cluster_name,
+            "cached_at": envelope["cached_at"],
+            "cache_version": envelope["cache_version"],
+        }
+
+        for path, spec in self._registry.items():
+            cursor = self.conn.execute(
+                f"SELECT * FROM {spec.table_name} WHERE cluster_name = ?",
+                (cluster_name,),
+            )
+            rows = [dict(r) for r in cursor.fetchall()]
+
+            # Determine which columns to strip from the row before model construction.
+            # Always strip _row_id.  Strip cluster_name only if the model doesn't
+            # have its own cluster_name field (e.g. ClusterInfo keeps it).
+            model_has_cluster_name = "cluster_name" in spec.model_class.model_fields
+            strip_keys = {"_row_id"}
+            if not model_has_cluster_name:
+                strip_keys.add("cluster_name")
+
+            if spec.is_list:
+                models = [
+                    _row_to_model(
+                        {k: v for k, v in row.items() if k not in strip_keys},
+                        spec.model_class,
+                    )
+                    for row in rows
+                ]
+                _set_by_path(root_kwargs, path, models)
+            else:
+                if rows:
+                    row = rows[0]
+                    model = _row_to_model(
+                        {k: v for k, v in row.items() if k not in strip_keys},
+                        spec.model_class,
+                    )
+                    _set_by_path(root_kwargs, path, model)
+
+        return CachedClusterMetadata.model_validate(root_kwargs)
+
+    # ------------------------------------------------------------------
+    # Internal: delete model data for a cluster
+    # ------------------------------------------------------------------
+
+    def _delete_model_data(self, cluster_name: str) -> None:
+        """Delete all model rows for a cluster from every table."""
+        for spec in self._registry.values():
+            self.conn.execute(
+                f"DELETE FROM {spec.table_name} WHERE cluster_name = ?",
+                (cluster_name,),
+            )
+        self.conn.execute(
+            "DELETE FROM _uuid_index WHERE cluster_name = ?",
+            (cluster_name,),
+        )
+
+    def _delete_all_model_data(self) -> None:
+        """Delete all model rows from every table."""
+        for spec in self._registry.values():
+            self.conn.execute(f"DELETE FROM {spec.table_name}")
+        self.conn.execute("DELETE FROM _uuid_index")
+
+    # ------------------------------------------------------------------
+    # Public API — preserved interface
+    # ------------------------------------------------------------------
 
     def get(self, cluster_name: str) -> CachedClusterMetadata | None:
         """Retrieve cached metadata for a cluster.
@@ -114,17 +418,20 @@ class ClusterMetadataDB(SQLiteDB):
         """
         _validate_cluster_name(cluster_name)
         cursor = self.conn.execute(
-            f"SELECT metadata_json FROM {self.TABLE_NAME} WHERE cluster_name = ?",
+            "SELECT cluster_name, cached_at, cache_version "
+            "FROM cluster_metadata WHERE cluster_name = ?",
             (cluster_name,),
         )
         row = cursor.fetchone()
-        if row:
-            data = json.loads(row["metadata_json"])
-            return CachedClusterMetadata.model_validate(data)
-        return None
+        if row is None:
+            return None
+        return self._reconstruct_metadata(cluster_name, dict(row))
 
     def set(self, cluster_name: str, metadata: CachedClusterMetadata) -> None:
         """Store or update cached metadata for a cluster.
+
+        Decomposes the metadata into per-model tables within a single
+        transaction.
 
         Args:
             cluster_name: Name of the cluster.
@@ -134,21 +441,21 @@ class ClusterMetadataDB(SQLiteDB):
             ValueError: If cluster_name is invalid.
         """
         _validate_cluster_name(cluster_name)
-        metadata_json = metadata.model_dump_json()
         with self.conn:
+            # Upsert envelope
             self.conn.execute(
-                f"""
-                INSERT OR REPLACE INTO {self.TABLE_NAME}
-                (cluster_name, cached_at, cache_version, metadata_json)
-                VALUES (?, ?, ?, ?)
-            """,
+                "INSERT OR REPLACE INTO cluster_metadata "
+                "(cluster_name, cached_at, cache_version) VALUES (?, ?, ?)",
                 (
                     cluster_name,
                     metadata.cached_at.isoformat(),
                     metadata.cache_version,
-                    metadata_json,
                 ),
             )
+            # Delete old model rows then re-insert
+            self._delete_model_data(cluster_name)
+            self._insert_model_data(cluster_name, metadata)
+            self._populate_uuid_index(cluster_name, metadata)
 
     def clear(self, cluster_name: str | None = None) -> int:
         """Clear cached metadata.
@@ -158,7 +465,7 @@ class ClusterMetadataDB(SQLiteDB):
                          If None, clear all cached data.
 
         Returns:
-            Number of rows deleted.
+            Number of envelope rows deleted.
 
         Raises:
             ValueError: If cluster_name is provided but invalid.
@@ -166,16 +473,18 @@ class ClusterMetadataDB(SQLiteDB):
         with self.conn:
             if cluster_name:
                 _validate_cluster_name(cluster_name)
+                self._delete_model_data(cluster_name)
                 cursor = self.conn.execute(
-                    f"DELETE FROM {self.TABLE_NAME} WHERE cluster_name = ?",
+                    "DELETE FROM cluster_metadata WHERE cluster_name = ?",
                     (cluster_name,),
                 )
             else:
-                cursor = self.conn.execute(f"DELETE FROM {self.TABLE_NAME}")
+                self._delete_all_model_data()
+                cursor = self.conn.execute("DELETE FROM cluster_metadata")
             return cursor.rowcount
 
     def is_stale(self, cluster_name: str, ttl_days: int = 30) -> bool | None:
-        """Check if cached data is stale.
+        """Check if cached data is stale (optimized — envelope only).
 
         Args:
             cluster_name: Name of the cluster.
@@ -187,10 +496,25 @@ class ClusterMetadataDB(SQLiteDB):
         Raises:
             ValueError: If cluster_name is invalid.
         """
-        metadata = self.get(cluster_name)
-        if metadata is None:
+        _validate_cluster_name(cluster_name)
+        cursor = self.conn.execute(
+            "SELECT cached_at FROM cluster_metadata WHERE cluster_name = ?",
+            (cluster_name,),
+        )
+        row = cursor.fetchone()
+        if row is None:
             return None
-        return metadata.is_stale(ttl_days)
+
+        cached_at_str = row["cached_at"]
+        if cached_at_str.endswith("Z"):
+            cached_at_str = cached_at_str[:-1] + "+00:00"
+        if "+" not in cached_at_str and "-" not in cached_at_str[-6:]:
+            cached_at = datetime.fromisoformat(cached_at_str).replace(tzinfo=UTC)
+        else:
+            cached_at = datetime.fromisoformat(cached_at_str)
+
+        age = datetime.now(UTC) - cached_at
+        return age.days > ttl_days
 
     def list_clusters(self) -> list[dict[str, str]]:
         """List all cached clusters with cache info.
@@ -199,7 +523,7 @@ class ClusterMetadataDB(SQLiteDB):
             List of dicts with cluster_name, cached_at, cache_version.
         """
         cursor = self.conn.execute(
-            f"SELECT cluster_name, cached_at, cache_version FROM {self.TABLE_NAME}"
+            "SELECT cluster_name, cached_at, cache_version FROM cluster_metadata"
         )
         return [dict(row) for row in cursor.fetchall()]
 
@@ -216,11 +540,9 @@ class ClusterMetadataDB(SQLiteDB):
         result: list[dict[str, str | int | bool]] = []
         for cluster in clusters:
             cached_at_str = cluster["cached_at"]
-            # Handle both ISO format with and without timezone
             if cached_at_str.endswith("Z"):
                 cached_at_str = cached_at_str[:-1] + "+00:00"
             if "+" not in cached_at_str and "-" not in cached_at_str[-6:]:
-                # No timezone info, assume UTC
                 cached_at = datetime.fromisoformat(cached_at_str).replace(tzinfo=UTC)
             else:
                 cached_at = datetime.fromisoformat(cached_at_str)
@@ -235,3 +557,75 @@ class ClusterMetadataDB(SQLiteDB):
                 }
             )
         return result
+
+    # ------------------------------------------------------------------
+    # New public methods
+    # ------------------------------------------------------------------
+
+    def query_model(
+        self,
+        cluster_name: str,
+        model_name: str,
+        **filters: Any,
+    ) -> list[BaseModel]:
+        """Query a specific model table with optional equality filters.
+
+        Args:
+            cluster_name: Name of the cluster.
+            model_name: The metadata_path key (e.g. ``"storage.volumes"``).
+            **filters: Field-name=value equality filters.
+
+        Returns:
+            List of deserialized model instances.
+
+        Raises:
+            ValueError: If cluster_name is invalid or model_name not found.
+        """
+        _validate_cluster_name(cluster_name)
+        spec = self._registry.get(model_name)
+        if spec is None:
+            raise ValueError(f"Unknown model name: {model_name!r}")
+
+        conditions = ['"cluster_name" = ?']
+        params: list[Any] = [cluster_name]
+        for col, val in filters.items():
+            if col not in spec.model_class.model_fields:
+                raise ValueError(f"Unknown field {col!r} on {spec.model_class.__name__}")
+            conditions.append(f'"{col}" = ?')
+            params.append(val)
+
+        sql = f"SELECT * FROM {spec.table_name} WHERE {' AND '.join(conditions)}"
+        cursor = self.conn.execute(sql, params)
+        rows = [dict(r) for r in cursor.fetchall()]
+
+        return [
+            _row_to_model(
+                {k: v for k, v in row.items() if k not in ("cluster_name", "_row_id")},
+                spec.model_class,
+            )
+            for row in rows
+        ]
+
+    def export_json(self, cluster_name: str) -> str | None:
+        """Export cluster metadata as a JSON string.
+
+        Args:
+            cluster_name: Name of the cluster.
+
+        Returns:
+            JSON string or None if cluster not found.
+        """
+        metadata = self.get(cluster_name)
+        if metadata is None:
+            return None
+        return metadata.model_dump_json()
+
+    def import_json(self, cluster_name: str, json_str: str) -> None:
+        """Import cluster metadata from a JSON string.
+
+        Args:
+            cluster_name: Name of the cluster.
+            json_str: JSON string of CachedClusterMetadata.
+        """
+        metadata = CachedClusterMetadata.model_validate_json(json_str)
+        self.set(cluster_name, metadata)

--- a/src/pynetappfoundry/cache/db_schema.py
+++ b/src/pynetappfoundry/cache/db_schema.py
@@ -1,0 +1,315 @@
+"""DDL generation for per-model SQL tables in the cluster metadata cache.
+
+Walks CachedClusterMetadata.model_fields to discover storable models
+and generates CREATE TABLE statements from their Pydantic field definitions.
+"""
+
+from __future__ import annotations
+
+import types
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Union, get_args, get_origin
+
+from pydantic import BaseModel
+
+from pynetappfoundry.cache._base import OntapUUID
+
+
+@dataclass(frozen=True)
+class TableSpec:
+    """Describes how a Pydantic model maps to a SQL table.
+
+    Attributes:
+        table_name: SQL table name (lowercased model class name).
+        model_class: The Pydantic model class.
+        metadata_path: Dot-path from CachedClusterMetadata root
+                       (e.g. ``"storage.volumes"``).
+        is_list: True for ``list[Model]`` fields, False for singletons.
+        has_uuid: True if the model has a ``uuid`` field.
+    """
+
+    table_name: str
+    model_class: type[BaseModel]
+    metadata_path: str
+    is_list: bool
+    has_uuid: bool
+
+
+# Fields on CachedClusterMetadata that are envelope/metadata, not data.
+_SKIP_FIELDS = frozenset({"cluster_name", "cached_at", "cache_version"})
+
+
+def _is_list_of_models(annotation: Any) -> type[BaseModel] | None:
+    """Return the item model class if annotation is ``list[SomeModel]``, else None."""
+    origin = get_origin(annotation)
+    if origin is list:
+        args = get_args(annotation)
+        if args and isinstance(args[0], type) and issubclass(args[0], BaseModel):
+            return args[0]
+    return None
+
+
+def _is_model_type(annotation: Any) -> type[BaseModel] | None:
+    """Return the model class if annotation is a BaseModel subclass, else None."""
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    return None
+
+
+def _has_list_model_fields(model_class: type[BaseModel]) -> bool:
+    """Check if a model has any list[BaseModel] fields (i.e., is a container)."""
+    for field_info in model_class.model_fields.values():
+        if _is_list_of_models(field_info.annotation) is not None:
+            return True
+    return False
+
+
+def build_table_registry() -> dict[str, TableSpec]:
+    """Walk CachedClusterMetadata fields and build a registry of table specs.
+
+    Returns:
+        Dict mapping ``metadata_path`` to ``TableSpec``.
+    """
+    # Deferred import to avoid circular references at module level.
+    from pynetappfoundry.cache._metadata import CachedClusterMetadata
+
+    registry: dict[str, TableSpec] = {}
+
+    for field_name, field_info in CachedClusterMetadata.model_fields.items():
+        if field_name in _SKIP_FIELDS:
+            continue
+
+        annotation = field_info.annotation
+
+        # Case 1: list[SomeModel] at top level (e.g. nodes, cloud, license_packages)
+        item_cls = _is_list_of_models(annotation)
+        if item_cls is not None:
+            _register_model(registry, field_name, item_cls, is_list=True)
+            continue
+
+        # Case 2: SomeModel singleton at top level (e.g. cluster, mediator)
+        model_cls = _is_model_type(annotation)
+        if model_cls is not None:
+            # If the model has list[BaseModel] sub-fields, it's a container.
+            if _has_list_model_fields(model_cls):
+                _walk_container(registry, field_name, model_cls)
+            else:
+                # Pure singleton (e.g. ClusterInfo, OntapMediatorResponse)
+                _register_model(registry, field_name, model_cls, is_list=False)
+
+    return registry
+
+
+def _register_model(
+    registry: dict[str, TableSpec],
+    metadata_path: str,
+    model_class: type[BaseModel],
+    *,
+    is_list: bool,
+) -> None:
+    """Add a TableSpec for a model to the registry."""
+    table_name = model_class.__name__.lower()
+    has_uuid = "uuid" in model_class.model_fields
+    registry[metadata_path] = TableSpec(
+        table_name=table_name,
+        model_class=model_class,
+        metadata_path=metadata_path,
+        is_list=is_list,
+        has_uuid=has_uuid,
+    )
+
+
+def _walk_container(
+    registry: dict[str, TableSpec],
+    prefix: str,
+    container_class: type[BaseModel],
+) -> None:
+    """Walk a container model's fields and register sub-models.
+
+    Also registers the container as a singleton if it has non-list scalar fields
+    beyond what its child lists cover (e.g. ``NetworkInfo.ipspaces``).
+    """
+    has_non_list_scalar = False
+
+    for field_name, field_info in container_class.model_fields.items():
+        annotation = field_info.annotation
+        path = f"{prefix}.{field_name}"
+
+        item_cls = _is_list_of_models(annotation)
+        if item_cls is not None:
+            _register_model(registry, path, item_cls, is_list=True)
+            continue
+
+        model_cls = _is_model_type(annotation)
+        if model_cls is not None:
+            if _has_list_model_fields(model_cls):
+                _walk_container(registry, path, model_cls)
+            else:
+                _register_model(registry, path, model_cls, is_list=False)
+            continue
+
+        # Scalar or list[str] etc. — part of the container itself
+        has_non_list_scalar = True
+
+    # If the container has scalar fields (like NetworkInfo.ipspaces: list[str]),
+    # register the container itself as a singleton so those fields are stored.
+    if has_non_list_scalar:
+        # Store the container model for its scalar-only fields.
+        _register_model(registry, prefix, container_class, is_list=False)
+
+
+# ---------------------------------------------------------------------------
+# Type mapping
+# ---------------------------------------------------------------------------
+
+
+def _unwrap_annotation(annotation: Any) -> Any:
+    """Unwrap Annotated, Optional, etc. to the core Python type."""
+    origin = get_origin(annotation)
+
+    # Annotated[str, ...] → str
+    if origin is not None and hasattr(annotation, "__metadata__"):
+        args = get_args(annotation)
+        return _unwrap_annotation(args[0]) if args else annotation
+
+    # Optional[X] → X  (Union[X, None])
+    if origin is Union or origin is types.UnionType:
+        args = tuple(a for a in get_args(annotation) if a is not type(None))
+        if len(args) == 1:
+            return _unwrap_annotation(args[0])
+
+    return annotation
+
+
+def _python_type_to_sql(annotation: Any) -> str:
+    """Map a Python/Pydantic type annotation to a SQL column type.
+
+    Returns:
+        SQL type string: TEXT, INTEGER, REAL, or TEXT (for JSON).
+    """
+    core = _unwrap_annotation(annotation)
+
+    if core is str or core is OntapUUID:
+        return "TEXT"
+    if core is int:
+        return "INTEGER"
+    if core is bool:
+        return "INTEGER"
+    if core is float:
+        return "REAL"
+    if core is datetime:
+        return "TEXT"
+
+    # list[...], dict[...], or any complex type → JSON as TEXT
+    origin = get_origin(core)
+    if origin is list or origin is dict:
+        return "TEXT"
+
+    # BaseModel sub-fields → JSON as TEXT
+    if isinstance(core, type) and issubclass(core, BaseModel):
+        return "TEXT"
+
+    # Fallback: TEXT
+    return "TEXT"
+
+
+def _is_json_column(annotation: Any) -> bool:
+    """Return True if the column stores JSON (list, dict, or BaseModel)."""
+    core = _unwrap_annotation(annotation)
+    origin = get_origin(core)
+    if origin is list or origin is dict:
+        return True
+    return isinstance(core, type) and issubclass(core, BaseModel)
+
+
+# ---------------------------------------------------------------------------
+# DDL generation
+# ---------------------------------------------------------------------------
+
+
+def generate_table_ddl(table_name: str, model_class: type[BaseModel]) -> str:
+    """Generate a CREATE TABLE statement for a Pydantic model.
+
+    Every table uses ``_row_id INTEGER PRIMARY KEY AUTOINCREMENT`` to avoid
+    collisions when UUID fields are empty.
+
+    Args:
+        table_name: SQL table name.
+        model_class: The Pydantic model to generate DDL from.
+
+    Returns:
+        Complete CREATE TABLE SQL string.
+    """
+    lines: list[str] = []
+    lines.append(f"CREATE TABLE {table_name} (")
+
+    # cluster_name column — skip if the model already defines one
+    model_has_cluster_name = "cluster_name" in model_class.model_fields
+    if not model_has_cluster_name:
+        lines.append("    cluster_name TEXT NOT NULL,")
+
+    # Always use _row_id as PK to avoid empty-uuid collisions
+    lines.append("    _row_id INTEGER PRIMARY KEY AUTOINCREMENT,")
+
+    # Model fields (quote names to avoid SQLite reserved word conflicts)
+    for field_name, field_info in model_class.model_fields.items():
+        sql_type = _python_type_to_sql(field_info.annotation)
+        quoted = f'"{field_name}"'
+        if field_name == "cluster_name":
+            lines.append(f"    {quoted} {sql_type} NOT NULL,")
+        else:
+            lines.append(f"    {quoted} {sql_type},")
+
+    # Extra JSON column for extra="allow" fields
+    lines.append("    _extra_json TEXT DEFAULT NULL")
+
+    ddl = "\n".join(lines) + "\n)"
+    return ddl
+
+
+def generate_cluster_name_index_ddl(table_name: str) -> str:
+    """Generate CREATE INDEX for cluster_name."""
+    return f'CREATE INDEX IF NOT EXISTS idx_{table_name}_cluster ON {table_name} ("cluster_name")'
+
+
+def generate_uuid_column_index_ddl(table_name: str) -> str:
+    """Generate CREATE INDEX for (cluster_name, uuid) on UUID-bearing tables."""
+    return (
+        f'CREATE INDEX IF NOT EXISTS idx_{table_name}_uuid ON {table_name} ("cluster_name", "uuid")'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixed table DDL
+# ---------------------------------------------------------------------------
+
+UUID_INDEX_DDL = """\
+CREATE TABLE _uuid_index (
+    cluster_name TEXT NOT NULL,
+    uuid TEXT NOT NULL,
+    table_name TEXT NOT NULL,
+    PRIMARY KEY (cluster_name, uuid)
+)"""
+
+ENVELOPE_DDL = """\
+CREATE TABLE cluster_metadata (
+    cluster_name TEXT PRIMARY KEY,
+    cached_at TEXT NOT NULL,
+    cache_version TEXT NOT NULL
+)"""
+
+
+# ---------------------------------------------------------------------------
+# Module-level registry (built once on first import)
+# ---------------------------------------------------------------------------
+
+TABLE_REGISTRY: dict[str, TableSpec] = {}
+
+
+def _ensure_registry() -> dict[str, TableSpec]:
+    """Lazily build and cache the table registry."""
+    global TABLE_REGISTRY
+    if not TABLE_REGISTRY:
+        TABLE_REGISTRY = build_table_registry()
+    return TABLE_REGISTRY

--- a/tests/unit/cache/test_db.py
+++ b/tests/unit/cache/test_db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -12,6 +13,7 @@ from pynetappfoundry.cache.cloud.metadata.model import CloudMetadata
 from pynetappfoundry.cache.cluster.model import ClusterInfo
 from pynetappfoundry.cache.cluster.nodes.model import OntapNodeResponse
 from pynetappfoundry.cache.db import ClusterMetadataDB, _validate_cluster_name
+from pynetappfoundry.cache.storage.volumes.model import OntapVolume
 
 
 class TestValidateClusterName:
@@ -77,6 +79,7 @@ class TestClusterMetadataDB:
         tables = {row["name"] for row in cursor.fetchall()}
         assert "cluster_metadata" in tables
         assert "_schema_version" in tables
+        assert "_uuid_index" in tables
 
     def test_set_and_get(
         self, db: ClusterMetadataDB, sample_metadata: CachedClusterMetadata
@@ -237,6 +240,356 @@ class TestClusterMetadataDB:
         with pytest.raises(ValueError, match="Invalid cluster name"):
             db.clear("123invalid")
 
+    # ------------------------------------------------------------------
+    # New v2 tests
+    # ------------------------------------------------------------------
+
+    def test_set_decomposes_to_tables(
+        self, db: ClusterMetadataDB, sample_metadata: CachedClusterMetadata
+    ) -> None:
+        """Verify rows exist in per-model tables after set()."""
+        db.set("test-cluster", sample_metadata)
+
+        # Check nodes table
+        cursor = db.conn.execute(
+            "SELECT * FROM ontapnoderesponse WHERE cluster_name = ?",
+            ("test-cluster",),
+        )
+        rows = cursor.fetchall()
+        assert len(rows) == 2
+
+        # Check cloud table
+        cursor = db.conn.execute(
+            "SELECT * FROM cloudmetadata WHERE cluster_name = ?",
+            ("test-cluster",),
+        )
+        rows = cursor.fetchall()
+        assert len(rows) == 1
+
+        # Check envelope table has no metadata_json
+        cursor = db.conn.execute(
+            "SELECT * FROM cluster_metadata WHERE cluster_name = ?",
+            ("test-cluster",),
+        )
+        row = dict(cursor.fetchone())
+        assert "metadata_json" not in row
+        assert "cached_at" in row
+        assert "cache_version" in row
+
+    def test_get_reconstructs_metadata(
+        self, db: ClusterMetadataDB, sample_metadata: CachedClusterMetadata
+    ) -> None:
+        """Round-trip set() → get() preserves all data."""
+        db.set("test-cluster", sample_metadata)
+        got = db.get("test-cluster")
+
+        assert got is not None
+        assert got.cluster_name == sample_metadata.cluster_name
+        assert got.cluster.ontap_version == sample_metadata.cluster.ontap_version
+        assert got.cluster.cluster_name == sample_metadata.cluster.cluster_name
+        assert len(got.nodes) == len(sample_metadata.nodes)
+        assert got.nodes[0].name == sample_metadata.nodes[0].name
+        assert got.nodes[1].serial_number == sample_metadata.nodes[1].serial_number
+        assert len(got.cloud) == len(sample_metadata.cloud)
+        assert got.cloud[0].provider == sample_metadata.cloud[0].provider
+
+    def test_query_model_basic(self, db: ClusterMetadataDB) -> None:
+        """query_model returns filtered results."""
+        meta = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            nodes=[
+                OntapNodeResponse(name="node1", serial_number="AAA"),
+                OntapNodeResponse(name="node2", serial_number="BBB"),
+            ],
+        )
+        db.set("test-cluster", meta)
+
+        results = db.query_model("test-cluster", "nodes", name="node1")
+        assert len(results) == 1
+        assert results[0].name == "node1"
+        assert results[0].serial_number == "AAA"
+
+    def test_query_model_no_filter(self, db: ClusterMetadataDB) -> None:
+        """query_model without filters returns all rows."""
+        meta = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            nodes=[
+                OntapNodeResponse(name="n1"),
+                OntapNodeResponse(name="n2"),
+                OntapNodeResponse(name="n3"),
+            ],
+        )
+        db.set("test-cluster", meta)
+
+        results = db.query_model("test-cluster", "nodes")
+        assert len(results) == 3
+
+    def test_query_model_unknown_model(self, db: ClusterMetadataDB) -> None:
+        """query_model raises for unknown model name."""
+        with pytest.raises(ValueError, match="Unknown model name"):
+            db.query_model("test-cluster", "nonexistent.path")
+
+    def test_query_model_unknown_field(self, db: ClusterMetadataDB) -> None:
+        """query_model raises for unknown filter field."""
+        with pytest.raises(ValueError, match="Unknown field"):
+            db.query_model("test-cluster", "nodes", bogus_field="x")
+
+    def test_export_import_round_trip(
+        self, db: ClusterMetadataDB, sample_metadata: CachedClusterMetadata
+    ) -> None:
+        """export_json → import_json preserves data."""
+        db.set("test-cluster", sample_metadata)
+        exported = db.export_json("test-cluster")
+        assert exported is not None
+
+        db.clear("test-cluster")
+        assert db.get("test-cluster") is None
+
+        db.import_json("test-cluster", exported)
+        got = db.get("test-cluster")
+        assert got is not None
+        assert got.cluster.ontap_version == "9.14.1"
+        assert len(got.nodes) == 2
+
+    def test_export_nonexistent(self, db: ClusterMetadataDB) -> None:
+        """export_json returns None for missing cluster."""
+        assert db.export_json("nonexistent") is None
+
+    def test_uuid_index_populated(self, db: ClusterMetadataDB) -> None:
+        """_uuid_index table should have entries for models with non-empty uuids."""
+        meta = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            nodes=[
+                OntapNodeResponse(
+                    name="node1",
+                    uuid="12345678-1234-1234-1234-123456789abc",
+                ),
+            ],
+        )
+        db.set("test-cluster", meta)
+
+        cursor = db.conn.execute(
+            "SELECT * FROM _uuid_index WHERE cluster_name = ?",
+            ("test-cluster",),
+        )
+        rows = [dict(r) for r in cursor.fetchall()]
+        assert len(rows) >= 1
+        uuids = {r["uuid"] for r in rows}
+        assert "12345678-1234-1234-1234-123456789abc" in uuids
+
+    def test_uuid_index_skips_empty(self, db: ClusterMetadataDB) -> None:
+        """_uuid_index should not include entries with empty uuid."""
+        meta = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            nodes=[OntapNodeResponse(name="node1")],  # uuid defaults to ""
+        )
+        db.set("test-cluster", meta)
+
+        cursor = db.conn.execute(
+            "SELECT * FROM _uuid_index WHERE cluster_name = ?",
+            ("test-cluster",),
+        )
+        rows = cursor.fetchall()
+        # No entries because uuid is empty
+        assert len(rows) == 0
+
+    def test_clear_removes_from_all_tables(
+        self, db: ClusterMetadataDB, sample_metadata: CachedClusterMetadata
+    ) -> None:
+        """clear() should remove rows from all model tables and uuid_index."""
+        db.set("test-cluster", sample_metadata)
+        db.clear("test-cluster")
+
+        # Check model tables are empty
+        cursor = db.conn.execute(
+            "SELECT COUNT(*) FROM ontapnoderesponse WHERE cluster_name = ?",
+            ("test-cluster",),
+        )
+        assert cursor.fetchone()[0] == 0
+
+        cursor = db.conn.execute(
+            "SELECT COUNT(*) FROM cloudmetadata WHERE cluster_name = ?",
+            ("test-cluster",),
+        )
+        assert cursor.fetchone()[0] == 0
+
+        cursor = db.conn.execute(
+            "SELECT COUNT(*) FROM _uuid_index WHERE cluster_name = ?",
+            ("test-cluster",),
+        )
+        assert cursor.fetchone()[0] == 0
+
+    def test_list_field_json_round_trip(self, db: ClusterMetadataDB) -> None:
+        """Sub-model list fields survive serialization round-trip."""
+        from pynetappfoundry.cache.cluster.nodes.model import (
+            OntapNodeResponseClusterInterface,
+        )
+
+        meta = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            nodes=[
+                OntapNodeResponse(
+                    name="node1",
+                    cluster_interfaces=[
+                        OntapNodeResponseClusterInterface(
+                            cluster_interfaces_name="e0a",
+                            cluster_interfaces_ip_address="10.0.0.1",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        db.set("test-cluster", meta)
+        got = db.get("test-cluster")
+
+        assert got is not None
+        assert len(got.nodes[0].cluster_interfaces) == 1
+        assert got.nodes[0].cluster_interfaces[0].cluster_interfaces_name == "e0a"
+        assert got.nodes[0].cluster_interfaces[0].cluster_interfaces_ip_address == "10.0.0.1"
+
+    def test_extra_fields_preserved(self, db: ClusterMetadataDB) -> None:
+        """Extra fields (extra='allow') round-trip via _extra_json."""
+        meta = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            cloud=[CloudMetadata(provider="AWS", **{"future_field": "hello"})],
+        )
+        db.set("test-cluster", meta)
+        got = db.get("test-cluster")
+
+        assert got is not None
+        assert got.cloud[0].future_field == "hello"  # type: ignore[attr-defined]
+
+    def test_set_updates_clears_old_model_data(self, db: ClusterMetadataDB) -> None:
+        """Updating a cluster replaces all model rows, not appends."""
+        meta1 = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            nodes=[
+                OntapNodeResponse(name="node1"),
+                OntapNodeResponse(name="node2"),
+            ],
+        )
+        db.set("test-cluster", meta1)
+
+        # Update with fewer nodes
+        meta2 = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            nodes=[OntapNodeResponse(name="node3")],
+        )
+        db.set("test-cluster", meta2)
+
+        got = db.get("test-cluster")
+        assert got is not None
+        assert len(got.nodes) == 1
+        assert got.nodes[0].name == "node3"
+
+    def test_multiple_clusters_isolated(self, db: ClusterMetadataDB) -> None:
+        """Data for different clusters is isolated."""
+        meta1 = CachedClusterMetadata(
+            cluster_name="cluster-a",
+            nodes=[OntapNodeResponse(name="nodeA")],
+        )
+        meta2 = CachedClusterMetadata(
+            cluster_name="cluster-b",
+            nodes=[OntapNodeResponse(name="nodeB1"), OntapNodeResponse(name="nodeB2")],
+        )
+        db.set("clusterA", meta1)
+        db.set("clusterB", meta2)
+
+        got_a = db.get("clusterA")
+        got_b = db.get("clusterB")
+        assert got_a is not None
+        assert got_b is not None
+        assert len(got_a.nodes) == 1
+        assert len(got_b.nodes) == 2
+        assert got_a.nodes[0].name == "nodeA"
+
+    def test_storage_volumes_round_trip(self, db: ClusterMetadataDB) -> None:
+        """Large models like OntapVolume serialize and deserialize correctly."""
+        from pynetappfoundry.cache.storage.model import StorageInfo
+
+        meta = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            storage=StorageInfo(
+                volumes=[
+                    OntapVolume(
+                        name="vol1",
+                        uuid="11111111-1111-1111-1111-111111111111",
+                        size=1073741824,
+                        state="online",
+                    ),
+                ],
+            ),
+        )
+        db.set("test-cluster", meta)
+        got = db.get("test-cluster")
+
+        assert got is not None
+        assert len(got.storage.volumes) == 1
+        assert got.storage.volumes[0].name == "vol1"
+        assert got.storage.volumes[0].uuid == "11111111-1111-1111-1111-111111111111"
+        assert got.storage.volumes[0].size == 1073741824
+
+
+class TestClusterMetadataDBMigration:
+    """Tests for v1 → v2 migration."""
+
+    def test_migration_v1_to_v2(self, tmp_path: Path) -> None:
+        """Create a v1 database, then open with v2 code and verify data."""
+        db_path = tmp_path / "migrate.db"
+
+        # Create v1 database manually
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE TABLE cluster_metadata ("
+            "  cluster_name TEXT PRIMARY KEY,"
+            "  cached_at TEXT NOT NULL,"
+            "  cache_version TEXT NOT NULL,"
+            "  metadata_json TEXT NOT NULL"
+            ")"
+        )
+        conn.execute("CREATE TABLE _schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO _schema_version (version) VALUES (1)")
+
+        # Insert a v1 row
+        meta = CachedClusterMetadata(
+            cluster_name="migrated-cluster",
+            cloud=[CloudMetadata(provider="GCP", region="us-central1")],
+            cluster=ClusterInfo(cluster_name="migrated-cluster", ontap_version="9.13.1"),
+            nodes=[OntapNodeResponse(name="mnode1", serial_number="M001")],
+        )
+        conn.execute(
+            "INSERT INTO cluster_metadata (cluster_name, cached_at, cache_version, metadata_json) "
+            "VALUES (?, ?, ?, ?)",
+            (
+                "migrated-cluster",
+                meta.cached_at.isoformat(),
+                meta.cache_version,
+                meta.model_dump_json(),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        # Open with v2 code — should trigger migration
+        db = ClusterMetadataDB(db_path=db_path)
+
+        # Verify data survived migration
+        got = db.get("migrated-cluster")
+        assert got is not None
+        assert got.cluster_name == "migrated-cluster"
+        assert got.cloud[0].provider == "GCP"
+        assert got.cluster.ontap_version == "9.13.1"
+        assert len(got.nodes) == 1
+        assert got.nodes[0].name == "mnode1"
+
+        # Verify envelope table no longer has metadata_json
+        cursor = db.conn.execute("PRAGMA table_info(cluster_metadata)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "metadata_json" not in columns
+        assert "cached_at" in columns
+
+        db.close()
+
 
 class TestClusterMetadataDBInitialization:
     """Tests for database initialization options."""
@@ -255,8 +608,6 @@ class TestClusterMetadataDBInitialization:
 
     def test_close(self, tmp_path: Path) -> None:
         """Test closing database connection."""
-        import sqlite3
-
         db_path = tmp_path / "close_test.db"
         db = ClusterMetadataDB(db_path=db_path)
         db.close()

--- a/tests/unit/cache/test_db_schema.py
+++ b/tests/unit/cache/test_db_schema.py
@@ -1,0 +1,221 @@
+"""Tests for cache database schema generation."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from pydantic import BaseModel, Field
+
+from pynetappfoundry.cache._base import OntapUUID
+from pynetappfoundry.cache.db_schema import (
+    TableSpec,
+    _python_type_to_sql,
+    build_table_registry,
+    generate_cluster_name_index_ddl,
+    generate_table_ddl,
+    generate_uuid_column_index_ddl,
+)
+
+
+class TestPythonTypeToSql:
+    """Tests for _python_type_to_sql type mapping."""
+
+    def test_str_maps_to_text(self) -> None:
+        assert _python_type_to_sql(str) == "TEXT"
+
+    def test_ontap_uuid_maps_to_text(self) -> None:
+        assert _python_type_to_sql(OntapUUID) == "TEXT"
+
+    def test_int_maps_to_integer(self) -> None:
+        assert _python_type_to_sql(int) == "INTEGER"
+
+    def test_bool_maps_to_integer(self) -> None:
+        assert _python_type_to_sql(bool) == "INTEGER"
+
+    def test_float_maps_to_real(self) -> None:
+        assert _python_type_to_sql(float) == "REAL"
+
+    def test_list_maps_to_text(self) -> None:
+        assert _python_type_to_sql(list[str]) == "TEXT"
+
+    def test_dict_maps_to_text(self) -> None:
+        assert _python_type_to_sql(dict[str, int]) == "TEXT"
+
+    def test_basemodel_maps_to_text(self) -> None:
+        class Nested(BaseModel):
+            x: int = 0
+
+        assert _python_type_to_sql(Nested) == "TEXT"
+
+    def test_datetime_maps_to_text(self) -> None:
+        from datetime import datetime
+
+        assert _python_type_to_sql(datetime) == "TEXT"
+
+
+class _SimpleModel(BaseModel):
+    """A model without uuid for DDL tests."""
+
+    name: str = ""
+    count: int = 0
+    active: bool = False
+
+
+class _UUIDModel(BaseModel):
+    """A model with uuid for DDL tests."""
+
+    uuid: str = ""
+    name: str = ""
+    tags: list[str] = Field(default_factory=list)
+
+
+class TestGenerateTableDdl:
+    """Tests for generate_table_ddl."""
+
+    def test_simple_model_has_row_id(self) -> None:
+        """Non-UUID model gets _row_id as PK."""
+        ddl = generate_table_ddl("simple", _SimpleModel)
+        assert "_row_id INTEGER PRIMARY KEY AUTOINCREMENT" in ddl
+        assert "cluster_name TEXT NOT NULL" in ddl
+
+    def test_uuid_model_has_row_id(self) -> None:
+        """UUID model also gets _row_id (not composite PK) to avoid empty-uuid collisions."""
+        ddl = generate_table_ddl("uuidmodel", _UUIDModel)
+        assert "_row_id INTEGER PRIMARY KEY AUTOINCREMENT" in ddl
+
+    def test_extra_json_column_present(self) -> None:
+        """Every table should have _extra_json column."""
+        ddl = generate_table_ddl("simple", _SimpleModel)
+        assert "_extra_json TEXT DEFAULT NULL" in ddl
+
+    def test_model_fields_present(self) -> None:
+        """All model fields should appear as columns."""
+        ddl = generate_table_ddl("simple", _SimpleModel)
+        assert '"name" TEXT' in ddl
+        assert '"count" INTEGER' in ddl
+        assert '"active" INTEGER' in ddl
+
+    def test_list_field_is_text(self) -> None:
+        """List fields should be TEXT (for JSON storage)."""
+        ddl = generate_table_ddl("uuidmodel", _UUIDModel)
+        assert '"tags" TEXT' in ddl
+
+    def test_ddl_is_valid_sql(self) -> None:
+        """Generated DDL should execute without error."""
+        conn = sqlite3.connect(":memory:")
+        ddl = generate_table_ddl("test_table", _SimpleModel)
+        conn.execute(ddl)
+        conn.close()
+
+    def test_model_with_cluster_name_field(self) -> None:
+        """Model that has its own cluster_name should not duplicate the column."""
+
+        class ModelWithClusterName(BaseModel):
+            cluster_name: str = ""
+            value: int = 0
+
+        ddl = generate_table_ddl("test_cn", ModelWithClusterName)
+        # Should have exactly one cluster_name column
+        assert ddl.count("cluster_name") == 1
+
+    def test_reserved_word_field_is_quoted(self) -> None:
+        """Fields with SQLite reserved names should be quoted."""
+
+        class ModelWithIndex(BaseModel):
+            index: int = 0
+            order: str = ""
+
+        ddl = generate_table_ddl("reserved", ModelWithIndex)
+        conn = sqlite3.connect(":memory:")
+        conn.execute(ddl)  # Should not raise
+        conn.close()
+
+
+class TestGenerateIndexDdl:
+    """Tests for index DDL generation."""
+
+    def test_cluster_name_index(self) -> None:
+        ddl = generate_cluster_name_index_ddl("mytable")
+        assert "CREATE INDEX" in ddl
+        assert "idx_mytable_cluster" in ddl
+        assert '"cluster_name"' in ddl
+
+    def test_uuid_column_index(self) -> None:
+        ddl = generate_uuid_column_index_ddl("mytable")
+        assert "CREATE INDEX" in ddl
+        assert "idx_mytable_uuid" in ddl
+        assert '"uuid"' in ddl
+
+
+class TestBuildTableRegistry:
+    """Tests for build_table_registry."""
+
+    def test_registry_is_nonempty(self) -> None:
+        registry = build_table_registry()
+        assert len(registry) > 0
+
+    def test_all_entries_are_table_specs(self) -> None:
+        registry = build_table_registry()
+        for spec in registry.values():
+            assert isinstance(spec, TableSpec)
+
+    def test_known_paths_present(self) -> None:
+        """Known top-level and nested paths should be in the registry."""
+        registry = build_table_registry()
+        expected_paths = [
+            "cloud",
+            "cluster",
+            "nodes",
+            "mediator",
+            "license_packages",
+            "storage.volumes",
+            "storage.aggregates",
+            "storage.svms",
+            "network.ip_interfaces",
+            "network.dns",
+            "protocols.nfs_export_policies",
+            "protocols.cifs_shares",
+            "relationships.snapmirror_destinations",
+            "relationships.cluster_peers",
+            "relationships.svm_peers",
+        ]
+        for path in expected_paths:
+            assert path in registry, f"Missing path: {path}"
+
+    def test_list_fields_marked_is_list(self) -> None:
+        registry = build_table_registry()
+        assert registry["nodes"].is_list is True
+        assert registry["storage.volumes"].is_list is True
+
+    def test_singleton_fields_marked_not_list(self) -> None:
+        registry = build_table_registry()
+        assert registry["cluster"].is_list is False
+        assert registry["mediator"].is_list is False
+
+    def test_uuid_fields_detected(self) -> None:
+        registry = build_table_registry()
+        # OntapNodeResponse has uuid field
+        assert registry["nodes"].has_uuid is True
+        # CloudMetadata does NOT have uuid field
+        assert registry["cloud"].has_uuid is False
+
+    def test_skip_metadata_fields(self) -> None:
+        """cluster_name, cached_at, cache_version should not be in registry."""
+        registry = build_table_registry()
+        assert "cluster_name" not in registry
+        assert "cached_at" not in registry
+        assert "cache_version" not in registry
+
+    def test_table_names_are_lowercase(self) -> None:
+        registry = build_table_registry()
+        for spec in registry.values():
+            assert spec.table_name == spec.table_name.lower()
+
+    def test_all_ddl_is_valid_sql(self) -> None:
+        """Every table in the registry should produce valid DDL."""
+        registry = build_table_registry()
+        conn = sqlite3.connect(":memory:")
+        for spec in registry.values():
+            ddl = generate_table_ddl(spec.table_name, spec.model_class)
+            conn.execute(ddl)
+        conn.close()


### PR DESCRIPTION
## Description

Replace JSON blob storage with per-model SQL tables. DDL is generated from Pydantic model field definitions via a TABLE_REGISTRY that walks CachedClusterMetadata fields. The public API (`get()`/`set()`/`clear()`) is preserved so all existing callers work unchanged.

## Related Issue

Addresses #309

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- **New `db_schema.py`**: `TableSpec` dataclass, `build_table_registry()` (29 tables), `_python_type_to_sql()` type mapping, `generate_table_ddl()`, `_uuid_index` and envelope table DDL
- **Rewritten `db.py`**: Schema v2 decomposes metadata into per-model tables on `set()`, reconstructs on `get()`. New `query_model()`, `export_json()`, `import_json()` methods. Optimized `is_stale()` reads envelope only. v1→v2 migration preserves existing data.
- **New `test_db_schema.py`**: 28 tests for DDL generation, type mapping, registry completeness, reserved word quoting
- **Rewritten `test_db.py`**: 39 tests (22 original preserved + 17 new) covering decomposition, reconstruction, query_model, export/import, uuid_index, migration, extra fields, sub-model JSON round-trip
- **New ADR-0009**: Documents per-model SQL table storage decision
- **Updated ADR-0001**: Evolution note linking to ADR-0009

### Key Design Decisions

- `_row_id INTEGER PRIMARY KEY AUTOINCREMENT` for all tables (avoids empty-uuid collisions)
- Column names double-quoted to handle SQLite reserved words (`"index"`, `"order"`)
- Container models (StorageInfo, NetworkInfo, etc.) don't get tables — child lists stored directly
- Sub-model lists stored as JSON TEXT in parent table
- `_extra_json` column on every table preserves `extra="allow"` fields

## Testing

- [x] All existing tests pass (22 original tests preserved and passing)
- [x] Added new tests for new functionality (28 schema + 17 db = 45 new tests)
- [x] Manually tested the changes (round-trip, migration, query_model, export/import)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The `OntapVolume` model (~600+ fields) round-trips correctly through the SQL storage layer. The v1→v2 migration is tested by creating a real v1 database and opening it with v2 code.