### PR TITLE
fix: remove hardcoded collector endpoints and wire cache_strategy into parsing

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -1079,15 +1079,13 @@ class MetadataCollector:
             return StorageInfo()
 
         # Make all API calls in parallel using cached calls
-        # NOTE: snapshot-policies needs ?fields=*,copies which the generated
-        # mapping does not include, so we hardcode the endpoint.
         endpoints = [
             ONTAPAGGREGATE_MAPPING.api_endpoint,
             ONTAPSVM_MAPPING.api_endpoint,
             ONTAPCLOUDTARGET_MAPPING.api_endpoint,
             ONTAPVOLUME_MAPPING.api_endpoint,
             ONTAPQTREE_MAPPING.api_endpoint,
-            "/storage/snapshot-policies?fields=*,copies",
+            ONTAPSNAPSHOTPOLICY_MAPPING.api_endpoint,
             ONTAPSCHEDULE_MAPPING.api_endpoint,
             ONTAPLUN_MAPPING.api_endpoint,
             ONTAPIGROUP_MAPPING.api_endpoint,
@@ -1491,11 +1489,8 @@ class MetadataCollector:
             logger.debug("%s No API client available for protocols collection", self._log_prefix)
             return ProtocolsInfo()
 
-        # NOTE: export-policies generated mapping has a single-item endpoint
-        # with {id} which won't work for collection, so we hardcode the
-        # endpoint with ?fields=*,rules for the collection call.
         endpoints = [
-            "/protocols/nfs/export-policies?fields=*,rules",
+            ONTAPEXPORTPOLICY_MAPPING.api_endpoint,
             ONTAPCIFSSHARE_MAPPING.api_endpoint,
             ONTAPNFSSERVICE_MAPPING.api_endpoint,
             ONTAPCIFSSERVICE_MAPPING.api_endpoint,

--- a/src/pynetappfoundry/cache/field_mapping.py
+++ b/src/pynetappfoundry/cache/field_mapping.py
@@ -13,6 +13,7 @@ Example:
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -153,6 +154,21 @@ class TypeMapping:
         """
         return tuple(f for f in self.fields if f.cache_strategy == "derived")
 
+    @property
+    def collection_endpoint(self) -> str:
+        """Bulk-collection endpoint (strips ``{id}`` path placeholders).
+
+        For non-parameterized mappings, returns ``api_endpoint`` unchanged.
+        For ``/{id}`` mappings, strips the placeholder to produce a bulk
+        listing URL.
+
+        Returns:
+            Endpoint URL suitable for bulk collection.
+        """
+        parts = self.api_endpoint.split("?", 1)
+        path = re.sub(r"/\{[^}]+\}", "", parts[0])
+        return f"{path}?{parts[1]}" if len(parts) > 1 else path
+
 
 def _coerce_cli_value(value: str, default: Any) -> Any:
     """Coerce a CLI string value to match the default's type.
@@ -205,6 +221,8 @@ def parse_api_record(
     """
     kwargs: dict[str, Any] = {}
     for field in mapping.fields:
+        if field.cache_strategy != "cache":
+            continue  # realtime/derived fields not collected during bulk
         if field.transform is not None:
             try:
                 kwargs[field.cache_attr] = field.transform(record)
@@ -310,6 +328,12 @@ def parse_api_response(
         record_id = record.get(mapping.id_field, record.get("uuid", "unknown"))
         log_missing_fn(record, expected, mapping.name, record_id)
         results.append(parse_api_record(mapping, record, log_prefix))
+
+    # Apply post_collection transforms for derived fields
+    for field in mapping.derived_fields():
+        if field.post_collection is not None:
+            results = [field.post_collection(item) for item in results]
+
     return results
 
 

--- a/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/mapping.py
@@ -20,11 +20,8 @@ def _transform_clients(record: dict[str, Any]) -> list[OntapExportPolicyClient]:
 ONTAPEXPORTPOLICY_MAPPING = TypeMapping(
     name="OntapExportPolicy",
     model_class=OntapExportPolicy,
-    api_endpoint="/protocols/nfs/export-policies/{id}?fields=*",
+    api_endpoint="/protocols/nfs/export-policies?fields=*,rules",
     api_type="ontap",
-    records_path="rules",
-    parent_mapping="OntapProtocolsNfsExportPolicy",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="allow_device_creation",

--- a/src/pynetappfoundry/cache/ontap/storage/snapshot_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snapshot_policies/mapping.py
@@ -20,7 +20,7 @@ def _transform_copies(record: dict[str, Any]) -> list[OntapSnapshotPolicyCopy]:
 ONTAPSNAPSHOTPOLICY_MAPPING = TypeMapping(
     name="OntapSnapshotPolicy",
     model_class=OntapSnapshotPolicy,
-    api_endpoint="/storage/snapshot-policies?fields=*",
+    api_endpoint="/storage/snapshot-policies?fields=*,copies",
     api_type="ontap",
     fields=(
         FieldMapping(
@@ -31,6 +31,7 @@ ONTAPSNAPSHOTPOLICY_MAPPING = TypeMapping(
             cache_attr="copies",
             transform=_transform_copies,
             default=[],
+            requires_explicit_fetch=True,
         ),
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/storage/snapshot_policies/snapshot_policies.toml
+++ b/src/pynetappfoundry/cache/ontap/storage/snapshot_policies/snapshot_policies.toml
@@ -8,6 +8,7 @@ cache_strategy = "cache"
 
 [fields.copies]
 cache_strategy = "cache"
+requires_explicit_fetch = true
 
 [fields.enabled]
 cache_strategy = "cache"

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -1,0 +1,54 @@
+"""Tests for collector endpoint usage — verifies mappings are used instead of hardcoded strings."""
+
+from __future__ import annotations
+
+from pynetappfoundry.cache.ontap.protocols.nfs.export_policies.mapping import (
+    ONTAPEXPORTPOLICY_MAPPING,
+)
+from pynetappfoundry.cache.ontap.storage.snapshot_policies.mapping import (
+    ONTAPSNAPSHOTPOLICY_MAPPING,
+)
+
+
+class TestCollectorMappingEndpoints:
+    """Verify that collector-relevant mappings have correct endpoints."""
+
+    def test_snapshot_policies_includes_copies(self) -> None:
+        """Snapshot-policies mapping includes copies in api_endpoint."""
+        assert ",copies" in ONTAPSNAPSHOTPOLICY_MAPPING.api_endpoint
+
+    def test_snapshot_policies_endpoint(self) -> None:
+        """Snapshot-policies mapping has the expected full endpoint."""
+        assert (
+            ONTAPSNAPSHOTPOLICY_MAPPING.api_endpoint == "/storage/snapshot-policies?fields=*,copies"
+        )
+
+    def test_export_policies_bulk_endpoint(self) -> None:
+        """Export-policies mapping has a bulk collection endpoint (no {id})."""
+        assert "{" not in ONTAPEXPORTPOLICY_MAPPING.api_endpoint
+
+    def test_export_policies_includes_rules(self) -> None:
+        """Export-policies mapping includes rules in api_endpoint."""
+        assert ",rules" in ONTAPEXPORTPOLICY_MAPPING.api_endpoint
+
+    def test_export_policies_endpoint(self) -> None:
+        """Export-policies mapping has the expected full endpoint."""
+        assert (
+            ONTAPEXPORTPOLICY_MAPPING.api_endpoint
+            == "/protocols/nfs/export-policies?fields=*,rules"
+        )
+
+    def test_export_policies_records_path(self) -> None:
+        """Export-policies mapping uses standard records path."""
+        assert ONTAPEXPORTPOLICY_MAPPING.records_path == "records"
+
+    def test_export_policies_no_parent_mapping(self) -> None:
+        """Export-policies mapping has no parent_mapping for bulk collection."""
+        assert ONTAPEXPORTPOLICY_MAPPING.parent_mapping is None
+
+    def test_snapshot_policies_copies_requires_explicit_fetch(self) -> None:
+        """Snapshot-policies copies field has requires_explicit_fetch=True."""
+        copies_field = next(
+            f for f in ONTAPSNAPSHOTPOLICY_MAPPING.fields if f.cache_attr == "copies"
+        )
+        assert copies_field.requires_explicit_fetch is True

--- a/tests/unit/cache/test_field_mapping.py
+++ b/tests/unit/cache/test_field_mapping.py
@@ -739,3 +739,183 @@ class TestTransformFailureLogTag:
         tf_msgs = [r for r in caplog.records if "TRANSFORM_FAILURE" in r.message]
         assert len(tf_msgs) == 1
         assert tf_msgs[0].levelno == logging.ERROR
+
+
+# ---------------------------------------------------------------------------
+# collection_endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionEndpoint:
+    """Tests for TypeMapping.collection_endpoint property."""
+
+    def test_non_parameterized_returns_unchanged(self) -> None:
+        """Non-parameterized endpoint returns api_endpoint unchanged."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/storage/volumes?fields=*",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+        )
+        assert tm.collection_endpoint == "/storage/volumes?fields=*"
+
+    def test_strips_id_placeholder(self) -> None:
+        """Parameterized endpoint strips {id} placeholder."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/protocols/nfs/export-policies/{id}?fields=*",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+        )
+        assert tm.collection_endpoint == "/protocols/nfs/export-policies?fields=*"
+
+    def test_strips_named_placeholder(self) -> None:
+        """Parameterized endpoint strips named placeholders like {svm.uuid}."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/svm/svms/{svm.uuid}/top-metrics/files?fields=*",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+        )
+        assert tm.collection_endpoint == "/svm/svms/top-metrics/files?fields=*"
+
+    def test_preserves_query_params(self) -> None:
+        """Query parameters are preserved after stripping placeholder."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/storage/volumes/{uuid}?fields=*,statistics",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+        )
+        assert tm.collection_endpoint == "/storage/volumes?fields=*,statistics"
+
+    def test_no_query_string(self) -> None:
+        """Endpoint without query string works."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/storage/volumes/{uuid}",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+        )
+        assert tm.collection_endpoint == "/storage/volumes"
+
+
+# ---------------------------------------------------------------------------
+# cache_strategy filtering in parse_api_record tests
+# ---------------------------------------------------------------------------
+
+
+class TestCacheStrategyFiltering:
+    """Tests for cache_strategy filtering in parse_api_record."""
+
+    def test_skips_realtime_fields(self) -> None:
+        """Realtime fields are skipped and get model defaults."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/t",
+            fields=(
+                FieldMapping(cache_attr="name", api_path="name"),
+                FieldMapping(
+                    cache_attr="value",
+                    api_path="value",
+                    default=0,
+                    cache_strategy="realtime",
+                ),
+            ),
+        )
+        record = {"name": "test1", "value": 99}
+        result = parse_api_record(tm, record, "[test]")
+        assert result.name == "test1"
+        # value is realtime, should get model default (0), not 99
+        assert result.value == 0
+
+    def test_skips_derived_fields(self) -> None:
+        """Derived fields are skipped and get model defaults."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/t",
+            fields=(
+                FieldMapping(cache_attr="name", api_path="name"),
+                FieldMapping(
+                    cache_attr="value",
+                    api_path="value",
+                    default=0,
+                    cache_strategy="derived",
+                ),
+            ),
+        )
+        record = {"name": "test1", "value": 42}
+        result = parse_api_record(tm, record, "[test]")
+        assert result.name == "test1"
+        assert result.value == 0
+
+    def test_includes_cache_fields(self) -> None:
+        """Cache fields are extracted normally."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/t",
+            fields=(
+                FieldMapping(cache_attr="name", api_path="name", cache_strategy="cache"),
+                FieldMapping(
+                    cache_attr="value", api_path="value", default=0, cache_strategy="cache"
+                ),
+            ),
+        )
+        record = {"name": "test1", "value": 42}
+        result = parse_api_record(tm, record, "[test]")
+        assert result.name == "test1"
+        assert result.value == 42
+
+
+# ---------------------------------------------------------------------------
+# post_collection in parse_api_response tests
+# ---------------------------------------------------------------------------
+
+
+class TestPostCollection:
+    """Tests for post_collection wiring in parse_api_response."""
+
+    def test_post_collection_called_for_derived_fields(self) -> None:
+        """post_collection is called for derived fields after parsing."""
+        call_log: list[str] = []
+
+        def post_fn(item: _SampleModel) -> _SampleModel:
+            call_log.append(item.name)
+            return item
+
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/t",
+            fields=(
+                FieldMapping(cache_attr="name", api_path="name"),
+                FieldMapping(
+                    cache_attr="value",
+                    cache_strategy="derived",
+                    post_collection=post_fn,
+                ),
+            ),
+        )
+        response = {"records": [{"name": "a"}, {"name": "b"}]}
+        results = parse_api_response(tm, response, "[t]", MagicMock())
+        assert len(results) == 2
+        assert call_log == ["a", "b"]
+
+    def test_post_collection_not_called_when_none(self) -> None:
+        """Derived fields without post_collection are harmless."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/t",
+            fields=(
+                FieldMapping(cache_attr="name", api_path="name"),
+                FieldMapping(cache_attr="value", cache_strategy="derived"),
+            ),
+        )
+        response = {"records": [{"name": "a"}]}
+        # Should not raise
+        results = parse_api_response(tm, response, "[t]", MagicMock())
+        assert len(results) == 1


### PR DESCRIPTION
## Description

Remove hardcoded endpoint strings from the collector and wire `cache_strategy` filtering and `post_collection` into the parsing framework.

Addresses #312

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Replace hardcoded `/storage/snapshot-policies?fields=*,copies` with `ONTAPSNAPSHOTPOLICY_MAPPING.api_endpoint` (added `requires_explicit_fetch=true` on copies field so mapping includes `,copies`)
- Replace hardcoded `/protocols/nfs/export-policies?fields=*,rules` with `ONTAPEXPORTPOLICY_MAPPING.api_endpoint` (changed mapping to bulk collection endpoint, removed `parent_mapping`/`parent_id_field`)
- Add `collection_endpoint` property to `TypeMapping` that strips `{id}` placeholders for bulk collection URLs
- Wire `cache_strategy` filtering into `parse_api_record()` — realtime/derived fields are skipped during bulk collection
- Wire `post_collection` into `parse_api_response()` — derived field transforms called after all records parsed

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

New tests:
- `TestCollectionEndpoint` (5 tests): strips `{id}`, preserves query params, handles no query string
- `TestCacheStrategyFiltering` (3 tests): skips realtime/derived, includes cache fields
- `TestPostCollection` (2 tests): calls post_collection for derived, handles None
- `TestCollectorMappingEndpoints` (8 tests): verifies mapping endpoints match expected values

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings