### PR TITLE
fix: handle int-typed key/display fields in diff engine

### DIFF
--- a/src/pynetappfoundry/cache/diff.py
+++ b/src/pynetappfoundry/cache/diff.py
@@ -125,8 +125,10 @@ def _get_display_name(entity: Any, display_field: str) -> str:
             return display_field.format(**fmt_dict)
         except (KeyError, AttributeError):
             return str(entity)
-    value = getattr(entity, display_field, "") or ""
-    return value or str(entity)
+    value = getattr(entity, display_field, None)
+    if value is None or value == "":
+        return str(entity)
+    return str(value)
 
 
 # Entity configurations: maps category path -> EntityConfig.
@@ -378,14 +380,14 @@ def _diff_entity_list(
     # Build lookup maps by key
     before_map: dict[str, Any] = {}
     for entity in before_list:
-        key = getattr(entity, key_field, "") or ""
-        if key:
+        key = getattr(entity, key_field, None)
+        if key is not None:
             before_map[key] = entity
 
     after_map: dict[str, Any] = {}
     for entity in after_list:
-        key = getattr(entity, key_field, "") or ""
-        if key:
+        key = getattr(entity, key_field, None)
+        if key is not None:
             after_map[key] = entity
 
     # Find removed entities

--- a/tests/unit/cache/test_diff.py
+++ b/tests/unit/cache/test_diff.py
@@ -22,6 +22,7 @@ from pynetappfoundry.cache.diff import (
 from pynetappfoundry.cache.ontap.cluster.mediators.model import OntapMediatorResponse
 from pynetappfoundry.cache.ontap.cluster.model import ClusterInfo
 from pynetappfoundry.cache.ontap.cluster.nodes.model import OntapNodeResponse
+from pynetappfoundry.cache.ontap.protocols.nfs.export_policies.model import OntapExportPolicy
 from pynetappfoundry.cache.ontap.snapmirror.relationships.model import (
     OntapSnapmirrorRelationship,
 )
@@ -153,6 +154,12 @@ class TestGetDisplayName:
         result = _get_display_name(sm, "{source_path}->{destination_path}")
         assert result == "svm1:vol1->svm2:vol2"
 
+    def test_int_display_field_zero(self) -> None:
+        """Int display_field with value 0 returns '0', not model repr."""
+        policy = OntapExportPolicy(index=0)
+        result = _get_display_name(policy, "index")
+        assert result == "0"
+
     def test_missing_attribute_fallback(self) -> None:
         """Falls back to str(entity) when attribute is empty."""
         node = _node(UUID1, "")
@@ -226,6 +233,38 @@ class TestDiffEntityList:
         changes = _diff_entity_list("nodes", before, after, node_config)
         types = {c["type"] for c in changes}
         assert types == {"added", "removed", "modified"}
+
+    def test_entity_with_int_key_zero_added(self) -> None:
+        """Entity with int key_field=0 detected as added."""
+        config = _ENTITY_CONFIGS["protocols.nfs_export_policies"]
+        before: list[Any] = []
+        after = [OntapExportPolicy(index=0)]
+        changes = _diff_entity_list("protocols.nfs_export_policies", before, after, config)
+        assert len(changes) == 1
+        assert changes[0]["type"] == "added"
+        assert changes[0]["entity"] == "0"
+
+    def test_entity_with_int_key_zero_removed(self) -> None:
+        """Entity with int key_field=0 detected as removed."""
+        config = _ENTITY_CONFIGS["protocols.nfs_export_policies"]
+        before = [OntapExportPolicy(index=0)]
+        after: list[Any] = []
+        changes = _diff_entity_list("protocols.nfs_export_policies", before, after, config)
+        assert len(changes) == 1
+        assert changes[0]["type"] == "removed"
+        assert changes[0]["entity"] == "0"
+
+    def test_entity_with_int_key_zero_modified(self) -> None:
+        """Entity with int key_field=0 and changed field detected as modified."""
+        config = _ENTITY_CONFIGS["protocols.nfs_export_policies"]
+        before = [OntapExportPolicy(index=0, chown_mode="restricted")]
+        after = [OntapExportPolicy(index=0, chown_mode="unrestricted")]
+        changes = _diff_entity_list("protocols.nfs_export_policies", before, after, config)
+        mod_changes = [c for c in changes if c["type"] == "modified"]
+        assert len(mod_changes) == 1
+        assert mod_changes[0]["field"] == "chown_mode"
+        assert mod_changes[0]["old"] == "restricted"
+        assert mod_changes[0]["new"] == "unrestricted"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Replace `or ""` truthiness patterns with explicit `None` checks in `_get_display_name` and `_diff_entity_list` so falsy int values like `0` are no longer silently dropped from diffs.

PR #322 changed `protocols.nfs_export_policies` to use `key_field="index"` and `display_field="index"` (an `int` field). This exposed three bugs where `or ""` truthiness checks fail for falsy int values like `0`: entities with `index=0` were dropped from diffs entirely, and their display names fell back to full model repr.

## Related Issue

Addresses #325

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `_get_display_name`: replaced `getattr(..., "") or ""` with explicit `None`/empty-string check so int value `0` returns `"0"` instead of `str(entity)`
- `_diff_entity_list` before_map: replaced `or ""` + `if key:` with `if key is not None` so entities with `key=0` are included
- `_diff_entity_list` after_map: same fix for the after map
- Added 4 tests covering int-typed key/display fields with value `0` (added, removed, modified, display name)

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (tests, lint, type-check, security, spell)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings