### PR TITLE
feat: add TOML overlay loader for cache field strategies

### DIFF
--- a/src/pynetappfoundry/cache/__init__.py
+++ b/src/pynetappfoundry/cache/__init__.py
@@ -46,7 +46,15 @@ import pynetappfoundry.cache.ontap.storage.snapshot_policies
 import pynetappfoundry.cache.ontap.storage.volumes
 import pynetappfoundry.cache.ontap.svm.peers
 import pynetappfoundry.cache.ontap.svm.svms  # noqa: F401
-from pynetappfoundry.cache._base import (
+from pynetappfoundry.cache._registry import model_registry as _reg
+
+# Apply package-default TOML overlay field strategies
+from pynetappfoundry.cache.overlay_loader import load_overlays as _load_overlays
+
+_load_overlays(_reg)
+del _load_overlays, _reg
+
+from pynetappfoundry.cache._base import (  # noqa: E402
     METADATA_SCHEMA_MIN_COMPATIBLE,
     METADATA_SCHEMA_VERSION,
     CacheModel,
@@ -58,27 +66,27 @@ from pynetappfoundry.cache._base import (
 
 # Layer 3: Container models (importing _metadata triggers the full
 # model registration chain via transitive leaf-model imports)
-from pynetappfoundry.cache._metadata import (
+from pynetappfoundry.cache._metadata import (  # noqa: E402
     CachedClusterMetadata,
     RelationshipsInfo,
 )
 
 # Layer 1: Registry
-from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache._registry import model_registry  # noqa: E402
 
 # Infrastructure (collector, db, diff, etc.)
-from pynetappfoundry.cache.collector import (
+from pynetappfoundry.cache.collector import (  # noqa: E402
     CollectionError,
     CollectionPhase,
     MetadataCollector,
     ProgressCallback,
     ProgressInfo,
 )
-from pynetappfoundry.cache.db import ClusterMetadataDB
-from pynetappfoundry.cache.diff import ChangeEntry, compute_diff, format_diff_summary
-from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
-from pynetappfoundry.cache.history_db import CacheHistoryDB
-from pynetappfoundry.cache.ontap.cluster.mediators.model import OntapMediatorResponse
+from pynetappfoundry.cache.db import ClusterMetadataDB  # noqa: E402
+from pynetappfoundry.cache.diff import ChangeEntry, compute_diff, format_diff_summary  # noqa: E402
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping  # noqa: E402
+from pynetappfoundry.cache.history_db import CacheHistoryDB  # noqa: E402
+from pynetappfoundry.cache.ontap.cluster.mediators.model import OntapMediatorResponse  # noqa: E402
 
 __all__ = [
     "METADATA_SCHEMA_MIN_COMPATIBLE",

--- a/src/pynetappfoundry/cache/overlay_loader.py
+++ b/src/pynetappfoundry/cache/overlay_loader.py
@@ -1,0 +1,188 @@
+"""TOML overlay loader for cache field strategies.
+
+Reads package-default TOML overlay files that define per-field
+``cache_strategy`` and ``requires_explicit_fetch`` values, optionally
+merges user overrides, and applies the merged configuration to
+registered ``TypeMapping`` instances in the model registry.
+"""
+
+from __future__ import annotations
+
+import logging
+import tomllib
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from pynetappfoundry.cache._registry import ModelRegistry
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+
+logger = logging.getLogger(__name__)
+
+_PACKAGE_OVERLAY_ROOT = Path(__file__).parent / "ontap"
+
+
+def discover_toml_overlays(root: Path) -> dict[str, Path]:
+    """Recursively discover TOML overlay files and map class names to paths.
+
+    Each TOML file is expected to contain an ``[endpoint]`` table with a
+    ``class_name`` key.  Files missing this key are silently skipped.
+
+    Args:
+        root: Directory to search recursively for ``*.toml`` files.
+
+    Returns:
+        Mapping of ``class_name`` to the ``Path`` of its overlay file.
+    """
+    result: dict[str, Path] = {}
+    if not root.is_dir():
+        return result
+
+    for toml_path in sorted(root.rglob("*.toml")):
+        try:
+            with toml_path.open("rb") as fh:
+                data = tomllib.load(fh)
+        except tomllib.TOMLDecodeError:
+            logger.warning("Skipping malformed TOML: %s", toml_path)
+            continue
+
+        endpoint = data.get("endpoint")
+        if not isinstance(endpoint, dict):
+            continue
+        class_name = endpoint.get("class_name")
+        if not class_name:
+            continue
+
+        if class_name in result:
+            logger.warning(
+                "Duplicate class_name %r: %s shadows %s",
+                class_name,
+                toml_path,
+                result[class_name],
+            )
+        result[class_name] = toml_path
+
+    return result
+
+
+def load_overlay(path: Path) -> dict[str, Any]:
+    """Load and return the contents of a TOML overlay file.
+
+    Args:
+        path: Path to the TOML file.
+
+    Returns:
+        Parsed TOML data as a dict.
+
+    Raises:
+        FileNotFoundError: If *path* does not exist.
+        tomllib.TOMLDecodeError: If the file is malformed.
+    """
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def merge_overlays(
+    package: dict[str, Any],
+    user: dict[str, Any] | None,
+) -> dict[str, dict[str, Any]]:
+    """Merge package-default and user-override field configurations.
+
+    Extracts the ``fields`` table from each overlay dict.  User fields
+    completely replace the package default at field-level granularity
+    (i.e. the entire sub-dict for a field name is replaced, not merged
+    key-by-key within a field).
+
+    Args:
+        package: Parsed package-default overlay.
+        user: Parsed user-override overlay, or ``None``.
+
+    Returns:
+        Merged ``{field_name: {config_key: value, ...}}`` dict.
+    """
+    merged = dict(package.get("fields", {}))
+    if user is not None:
+        merged.update(user.get("fields", {}))
+    return merged
+
+
+def apply_overlay_to_mapping(
+    mapping: TypeMapping,
+    fields_config: dict[str, dict[str, Any]],
+) -> TypeMapping:
+    """Apply overlay field configuration to a ``TypeMapping``.
+
+    For each field in the mapping whose ``cache_attr`` appears in
+    *fields_config*, creates a new ``FieldMapping`` with updated
+    ``cache_strategy`` and/or ``requires_explicit_fetch`` values.
+
+    Args:
+        mapping: The original (frozen) type mapping.
+        fields_config: ``{field_name: {"cache_strategy": ..., ...}}`` dict.
+
+    Returns:
+        New ``TypeMapping`` with updated field definitions.
+    """
+    new_fields: list[FieldMapping] = []
+    for field in mapping.fields:
+        config = fields_config.get(field.cache_attr)
+        if config is None:
+            new_fields.append(field)
+            continue
+
+        replacements: dict[str, Any] = {}
+        if "cache_strategy" in config:
+            replacements["cache_strategy"] = config["cache_strategy"]
+        if "requires_explicit_fetch" in config:
+            replacements["requires_explicit_fetch"] = config["requires_explicit_fetch"]
+
+        if replacements:
+            new_fields.append(replace(field, **replacements))
+        else:
+            new_fields.append(field)
+
+    return replace(mapping, fields=tuple(new_fields))
+
+
+def load_overlays(
+    registry: ModelRegistry,
+    user_overlay_dir: Path | None = None,
+) -> int:
+    """Load TOML overlays and apply field strategies to registry mappings.
+
+    Discovers package-default overlays under the built-in ``ontap/``
+    tree, optionally discovers user overrides, merges them, and updates
+    each matching ``TypeMapping`` in *registry*.
+
+    Args:
+        registry: The model registry containing type mappings.
+        user_overlay_dir: Optional directory with user-override TOML files
+            that mirror the package tree structure.
+
+    Returns:
+        Number of mappings updated.
+    """
+    package_overlays = discover_toml_overlays(_PACKAGE_OVERLAY_ROOT)
+
+    user_overlays: dict[str, Path] = {}
+    if user_overlay_dir is not None:
+        user_overlays = discover_toml_overlays(user_overlay_dir)
+
+    updated = 0
+    for class_name, pkg_path in package_overlays.items():
+        mapping = registry.get_mapping(class_name)
+        if mapping is None:
+            continue
+
+        pkg_data = load_overlay(pkg_path)
+
+        user_data: dict[str, Any] | None = None
+        if class_name in user_overlays:
+            user_data = load_overlay(user_overlays[class_name])
+
+        fields_config = merge_overlays(pkg_data, user_data)
+        new_mapping = apply_overlay_to_mapping(mapping, fields_config)
+        registry.register_mapping(class_name, new_mapping)
+        updated += 1
+
+    return updated

--- a/tests/unit/cache/test_overlay_loader.py
+++ b/tests/unit/cache/test_overlay_loader.py
@@ -1,0 +1,341 @@
+"""Tests for cache.overlay_loader module."""
+
+from __future__ import annotations
+
+import tomllib
+
+import pytest
+from pydantic import BaseModel
+
+from pynetappfoundry.cache._registry import ModelRegistry
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.cache.overlay_loader import (
+    apply_overlay_to_mapping,
+    discover_toml_overlays,
+    load_overlay,
+    load_overlays,
+    merge_overlays,
+)
+
+
+class _DummyModel(BaseModel):
+    name: str = ""
+    size: int = 0
+    state: str = ""
+
+
+def _make_mapping(
+    *,
+    name: str = "DummyModel",
+    fields: tuple[FieldMapping, ...] | None = None,
+) -> TypeMapping:
+    if fields is None:
+        fields = (
+            FieldMapping(cache_attr="name", api_path="name"),
+            FieldMapping(cache_attr="size", api_path="size"),
+            FieldMapping(
+                cache_attr="state",
+                api_path="state",
+                cache_strategy="cache",
+                requires_explicit_fetch=True,
+            ),
+        )
+    return TypeMapping(
+        name=name,
+        model_class=_DummyModel,
+        api_endpoint="/test",
+        fields=fields,
+    )
+
+
+def _write_toml(path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+class TestDiscoverTomlOverlays:
+    """Tests for discover_toml_overlays."""
+
+    def test_discovers_overlays_in_tree(self, tmp_path):
+        _write_toml(
+            tmp_path / "storage" / "volumes" / "volumes.toml",
+            '[endpoint]\nclass_name = "OntapVolume"\n\n[fields.name]\ncache_strategy = "cache"\n',
+        )
+        _write_toml(
+            tmp_path / "cluster" / "nodes" / "nodes.toml",
+            '[endpoint]\nclass_name = "OntapNodeResponse"\n\n'
+            '[fields.state]\ncache_strategy = "realtime"\n',
+        )
+        result = discover_toml_overlays(tmp_path)
+        assert result == {
+            "OntapVolume": tmp_path / "storage" / "volumes" / "volumes.toml",
+            "OntapNodeResponse": tmp_path / "cluster" / "nodes" / "nodes.toml",
+        }
+
+    def test_skips_toml_without_class_name(self, tmp_path):
+        _write_toml(
+            tmp_path / "no_endpoint.toml",
+            '[fields.name]\ncache_strategy = "cache"\n',
+        )
+        _write_toml(
+            tmp_path / "empty_endpoint.toml",
+            '[endpoint]\npath = "/test"\n',
+        )
+        result = discover_toml_overlays(tmp_path)
+        assert result == {}
+
+    def test_returns_empty_for_empty_dir(self, tmp_path):
+        result = discover_toml_overlays(tmp_path)
+        assert result == {}
+
+    def test_returns_empty_for_nonexistent_dir(self, tmp_path):
+        result = discover_toml_overlays(tmp_path / "nonexistent")
+        assert result == {}
+
+    def test_warns_on_duplicate_class_name(self, tmp_path, caplog):
+        _write_toml(
+            tmp_path / "a" / "first.toml",
+            '[endpoint]\nclass_name = "Dup"\n\n[fields.x]\ncache_strategy = "cache"\n',
+        )
+        _write_toml(
+            tmp_path / "b" / "second.toml",
+            '[endpoint]\nclass_name = "Dup"\n\n[fields.x]\ncache_strategy = "realtime"\n',
+        )
+        with caplog.at_level("WARNING"):
+            result = discover_toml_overlays(tmp_path)
+        assert "Dup" in result
+        assert "Duplicate class_name" in caplog.text
+
+    def test_skips_malformed_toml(self, tmp_path, caplog):
+        bad = tmp_path / "bad.toml"
+        bad.write_text("this is not valid toml {{{}}")
+        with caplog.at_level("WARNING"):
+            result = discover_toml_overlays(tmp_path)
+        assert result == {}
+        assert "malformed TOML" in caplog.text
+
+
+class TestLoadOverlay:
+    """Tests for load_overlay."""
+
+    def test_loads_valid_toml(self, tmp_path):
+        p = tmp_path / "test.toml"
+        p.write_text('[endpoint]\nclass_name = "Foo"\n\n[fields.bar]\ncache_strategy = "cache"\n')
+        data = load_overlay(p)
+        assert data["endpoint"]["class_name"] == "Foo"
+        assert data["fields"]["bar"]["cache_strategy"] == "cache"
+
+    def test_raises_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_overlay(tmp_path / "missing.toml")
+
+    def test_raises_toml_decode_error(self, tmp_path):
+        p = tmp_path / "bad.toml"
+        p.write_text("not valid toml {{{")
+        with pytest.raises(tomllib.TOMLDecodeError):
+            load_overlay(p)
+
+
+class TestMergeOverlays:
+    """Tests for merge_overlays."""
+
+    def test_package_only(self):
+        pkg = {
+            "fields": {"name": {"cache_strategy": "cache"}, "size": {"cache_strategy": "realtime"}}
+        }
+        result = merge_overlays(pkg, None)
+        assert result == {
+            "name": {"cache_strategy": "cache"},
+            "size": {"cache_strategy": "realtime"},
+        }
+
+    def test_user_replaces_field(self):
+        pkg = {"fields": {"name": {"cache_strategy": "cache"}, "size": {"cache_strategy": "cache"}}}
+        user = {"fields": {"name": {"cache_strategy": "realtime", "requires_explicit_fetch": True}}}
+        result = merge_overlays(pkg, user)
+        assert result["name"] == {"cache_strategy": "realtime", "requires_explicit_fetch": True}
+        assert result["size"] == {"cache_strategy": "cache"}
+
+    def test_fields_not_in_user_inherit_package(self):
+        pkg = {"fields": {"a": {"cache_strategy": "cache"}, "b": {"cache_strategy": "derived"}}}
+        user = {"fields": {"a": {"cache_strategy": "realtime"}}}
+        result = merge_overlays(pkg, user)
+        assert result["b"] == {"cache_strategy": "derived"}
+
+    def test_none_user_overlay(self):
+        pkg = {"fields": {"x": {"cache_strategy": "cache"}}}
+        result = merge_overlays(pkg, None)
+        assert result == {"x": {"cache_strategy": "cache"}}
+
+    def test_empty_package_fields(self):
+        result = merge_overlays({}, None)
+        assert result == {}
+
+
+class TestApplyOverlayToMapping:
+    """Tests for apply_overlay_to_mapping."""
+
+    def test_updates_cache_strategy(self):
+        mapping = _make_mapping()
+        config = {"name": {"cache_strategy": "realtime"}}
+        result = apply_overlay_to_mapping(mapping, config)
+        name_field = next(f for f in result.fields if f.cache_attr == "name")
+        assert name_field.cache_strategy == "realtime"
+
+    def test_updates_requires_explicit_fetch(self):
+        mapping = _make_mapping()
+        config = {"size": {"requires_explicit_fetch": True}}
+        result = apply_overlay_to_mapping(mapping, config)
+        size_field = next(f for f in result.fields if f.cache_attr == "size")
+        assert size_field.requires_explicit_fetch is True
+
+    def test_unmatched_fields_unchanged(self):
+        mapping = _make_mapping()
+        config = {"name": {"cache_strategy": "realtime"}}
+        result = apply_overlay_to_mapping(mapping, config)
+        size_field = next(f for f in result.fields if f.cache_attr == "size")
+        assert size_field.cache_strategy == "cache"
+        assert size_field.requires_explicit_fetch is False
+
+    def test_extra_overlay_fields_ignored(self):
+        mapping = _make_mapping()
+        config = {"nonexistent_field": {"cache_strategy": "realtime"}}
+        result = apply_overlay_to_mapping(mapping, config)
+        assert len(result.fields) == len(mapping.fields)
+
+    def test_original_not_mutated(self):
+        mapping = _make_mapping()
+        original_fields = mapping.fields
+        config = {"name": {"cache_strategy": "realtime"}}
+        apply_overlay_to_mapping(mapping, config)
+        assert mapping.fields is original_fields
+        name_field = next(f for f in mapping.fields if f.cache_attr == "name")
+        assert name_field.cache_strategy == "cache"
+
+    def test_empty_config_returns_equivalent_mapping(self):
+        mapping = _make_mapping()
+        result = apply_overlay_to_mapping(mapping, {})
+        assert result.fields == mapping.fields
+
+
+class TestLoadOverlays:
+    """Integration tests for load_overlays."""
+
+    def test_applies_package_defaults(self, tmp_path):
+        registry = ModelRegistry()
+        mapping = _make_mapping()
+        registry.register_mapping("DummyModel", mapping)
+
+        _write_toml(
+            tmp_path / "test.toml",
+            '[endpoint]\nclass_name = "DummyModel"\n\n[fields.name]\ncache_strategy = "realtime"\n',
+        )
+
+        import pynetappfoundry.cache.overlay_loader as loader
+
+        original_root = loader._PACKAGE_OVERLAY_ROOT
+        try:
+            loader._PACKAGE_OVERLAY_ROOT = tmp_path
+            count = load_overlays(registry)
+        finally:
+            loader._PACKAGE_OVERLAY_ROOT = original_root
+
+        assert count == 1
+        updated = registry.get_mapping("DummyModel")
+        assert updated is not None
+        name_field = next(f for f in updated.fields if f.cache_attr == "name")
+        assert name_field.cache_strategy == "realtime"
+
+    def test_user_override_wins(self, tmp_path):
+        registry = ModelRegistry()
+        mapping = _make_mapping()
+        registry.register_mapping("DummyModel", mapping)
+
+        pkg_dir = tmp_path / "pkg"
+        user_dir = tmp_path / "user"
+
+        _write_toml(
+            pkg_dir / "test.toml",
+            '[endpoint]\nclass_name = "DummyModel"\n\n[fields.name]\ncache_strategy = "cache"\n',
+        )
+        _write_toml(
+            user_dir / "test.toml",
+            '[endpoint]\nclass_name = "DummyModel"\n\n[fields.name]\ncache_strategy = "realtime"\n',
+        )
+
+        import pynetappfoundry.cache.overlay_loader as loader
+
+        original_root = loader._PACKAGE_OVERLAY_ROOT
+        try:
+            loader._PACKAGE_OVERLAY_ROOT = pkg_dir
+            count = load_overlays(registry, user_overlay_dir=user_dir)
+        finally:
+            loader._PACKAGE_OVERLAY_ROOT = original_root
+
+        assert count == 1
+        updated = registry.get_mapping("DummyModel")
+        assert updated is not None
+        name_field = next(f for f in updated.fields if f.cache_attr == "name")
+        assert name_field.cache_strategy == "realtime"
+
+    def test_missing_overlay_keeps_original(self, tmp_path):
+        registry = ModelRegistry()
+        mapping = _make_mapping()
+        registry.register_mapping("DummyModel", mapping)
+
+        import pynetappfoundry.cache.overlay_loader as loader
+
+        original_root = loader._PACKAGE_OVERLAY_ROOT
+        try:
+            loader._PACKAGE_OVERLAY_ROOT = tmp_path  # empty dir
+            count = load_overlays(registry)
+        finally:
+            loader._PACKAGE_OVERLAY_ROOT = original_root
+
+        assert count == 0
+        assert registry.get_mapping("DummyModel") is mapping
+
+    def test_returns_correct_count(self, tmp_path):
+        registry = ModelRegistry()
+        for name in ("Alpha", "Beta", "Gamma"):
+            m = _make_mapping(name=name)
+            registry.register_mapping(name, m)
+
+        for name in ("Alpha", "Beta"):
+            _write_toml(
+                tmp_path / f"{name.lower()}.toml",
+                f'[endpoint]\nclass_name = "{name}"\n\n'
+                f'[fields.name]\ncache_strategy = "realtime"\n',
+            )
+
+        import pynetappfoundry.cache.overlay_loader as loader
+
+        original_root = loader._PACKAGE_OVERLAY_ROOT
+        try:
+            loader._PACKAGE_OVERLAY_ROOT = tmp_path
+            count = load_overlays(registry)
+        finally:
+            loader._PACKAGE_OVERLAY_ROOT = original_root
+
+        assert count == 2
+
+    def test_nonexistent_user_dir_no_error(self, tmp_path):
+        registry = ModelRegistry()
+        mapping = _make_mapping()
+        registry.register_mapping("DummyModel", mapping)
+
+        _write_toml(
+            tmp_path / "test.toml",
+            '[endpoint]\nclass_name = "DummyModel"\n\n[fields.name]\ncache_strategy = "cache"\n',
+        )
+
+        import pynetappfoundry.cache.overlay_loader as loader
+
+        original_root = loader._PACKAGE_OVERLAY_ROOT
+        try:
+            loader._PACKAGE_OVERLAY_ROOT = tmp_path
+            count = load_overlays(registry, user_overlay_dir=tmp_path / "nonexistent")
+        finally:
+            loader._PACKAGE_OVERLAY_ROOT = original_root
+
+        assert count == 1


### PR DESCRIPTION
## Description

Add runtime TOML overlay loader that reads package-default overlay files defining per-field `cache_strategy` and `requires_explicit_fetch` values, optionally merges user overrides, and applies the merged configuration to registered `TypeMapping` instances in the model registry.

## Related Issue

Addresses #316

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- New module `src/pynetappfoundry/cache/overlay_loader.py` with functions: `discover_toml_overlays`, `load_overlay`, `merge_overlays`, `apply_overlay_to_mapping`, `load_overlays`
- Updated `src/pynetappfoundry/cache/__init__.py` to apply package-default TOML overlays at import time after all mapping registrations
- New test file `tests/unit/cache/test_overlay_loader.py` with 25 tests across 5 test classes

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (25 tests)
- [x] `doit check` passes (tests, lint, type-check, security, spelling)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

User-override integration point (calling `load_overlays(registry, user_overlay_dir=config.config_dir / "overlays")` at CLI startup) is designed but not wired up — requires access to `Config` at app startup, which is a separate concern.