### PR TITLE
feat: generic derived field evaluation post-collection

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -23,6 +23,7 @@ from pynetappfoundry.cache._metadata import (
     CachedClusterMetadata,
     RelationshipsInfo,
 )
+from pynetappfoundry.cache._registry import model_registry
 from pynetappfoundry.cache.field_mapping import (
     parse_api_record,
     parse_api_response,
@@ -172,6 +173,13 @@ class MetadataCollector:
         CollectionPhase.PROTOCOLS: "Protocols",
     }
 
+    # Maps TypeMapping registry names to results dict keys for derived field evaluation.
+    # Only TypeMappings that have derived fields need to be listed here.
+    _MAPPING_RESULTS_KEYS: ClassVar[list[tuple[str, str]]] = [
+        ("Cluster", "cluster"),
+        ("OntapNodeResponse", "nodes"),
+    ]
+
     def __init__(
         self,
         api_client: ONTAPAPIClient | None = None,
@@ -283,6 +291,57 @@ class MetadataCollector:
         with self._cache_lock:
             self._api_cache.clear()
 
+    def _evaluate_derived_fields(self, results: dict[str, Any]) -> dict[str, Any]:
+        """Evaluate derived fields across all TypeMappings that declare them.
+
+        Iterates ``_MAPPING_RESULTS_KEYS``, looks up each TypeMapping from
+        the model registry, and for any that have ``derived_fields()``,
+        calls each field's ``post_collection(item, results)`` on every item
+        in the results dict.
+
+        Handles both singular results (e.g. ``ClusterInfo``) and list results
+        (e.g. ``list[OntapNodeResponse]``).
+
+        Args:
+            results: The full collection results dict keyed by phase name.
+
+        Returns:
+            Updated results dict with derived fields evaluated.
+        """
+        for mapping_name, results_key in self._MAPPING_RESULTS_KEYS:
+            if results_key not in results:
+                continue
+
+            mapping = model_registry.get_mapping(mapping_name)
+            if mapping is None:
+                continue
+
+            derived = mapping.derived_fields()
+            if not derived:
+                continue
+
+            result = results[results_key]
+            is_list = isinstance(result, list)
+            items = result if is_list else [result]
+
+            for field in derived:
+                if field.post_collection is None:
+                    continue
+                try:
+                    items = [field.post_collection(item, results) for item in items]
+                except Exception:
+                    logger.error(
+                        "%s DERIVED_FIELD_FAILURE: %s.%s - post_collection error",
+                        self._log_prefix,
+                        mapping_name,
+                        field.cache_attr,
+                    )
+                    raise
+
+            results[results_key] = items if is_list else items[0]
+
+        return results
+
     def collect_all(self, cluster_name: str) -> CachedClusterMetadata:
         """Collect all metadata categories for a cluster.
 
@@ -311,11 +370,9 @@ class MetadataCollector:
         total_elapsed = time.monotonic() - total_start
         logger.info("%s Completed metadata collection in %.2fs", self._log_prefix, total_elapsed)
 
-        # Enrich cluster info with is_ha (derived from node count)
+        # Evaluate derived fields (e.g. is_ha from node count)
+        results = self._evaluate_derived_fields(results)
         cluster_info: ClusterInfo = results["cluster"]
-        cluster_info = cluster_info.model_copy(
-            update={"is_ha": len(results["nodes"]) > 1},
-        )
 
         # Post-process Azure cloud metadata to fix instance links
         cloud_metadata = self._update_azure_cloud_links(

--- a/src/pynetappfoundry/cache/field_mapping.py
+++ b/src/pynetappfoundry/cache/field_mapping.py
@@ -45,7 +45,9 @@ class FieldMapping:
         requires_explicit_fetch: Whether this field requires explicit ``?fields=``
             in the API request (ONTAP expensive fields).
         post_collection: Optional callable to compute derived field values
-            after all records have been collected.
+            after all collection phases complete.  Signature:
+            ``(model_instance, results_dict) -> model_instance`` where
+            *results_dict* is the full cross-collection results dictionary.
     """
 
     cache_attr: str
@@ -56,7 +58,7 @@ class FieldMapping:
     cli_transform: Callable[[dict[str, Any]], Any] | None = None
     cache_strategy: Literal["cache", "realtime", "derived"] = "cache"
     requires_explicit_fetch: bool = False
-    post_collection: Callable[[Any], Any] | None = None
+    post_collection: Callable[[Any, dict[str, Any]], Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -378,11 +380,6 @@ def parse_api_response(
         record_id = record.get(mapping.id_field, record.get("uuid", "unknown"))
         log_missing_fn(record, expected, mapping.name, record_id)
         results.append(parse_api_record(mapping, record, log_prefix))
-
-    # Apply post_collection transforms for derived fields
-    for field in mapping.derived_fields():
-        if field.post_collection is not None:
-            results = [field.post_collection(item) for item in results]
 
     return results
 

--- a/src/pynetappfoundry/cache/ontap/cluster/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/mapping.py
@@ -2,16 +2,30 @@
 
 Defines CLUSTER_MAPPING which maps ONTAP REST API /cluster data to
 ClusterInfo cache model attributes.
-
-Note: ``is_ha`` is derived post-collection from node count and is
-intentionally excluded from the mapping.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 from pynetappfoundry.cache._registry import model_registry
 from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
 from pynetappfoundry.cache.ontap.cluster.model import ClusterInfo
+
+
+def compute_is_ha(cluster: ClusterInfo, results: dict[str, Any]) -> ClusterInfo:
+    """Derive ``is_ha`` from the collected node count.
+
+    Args:
+        cluster: The ClusterInfo instance to update.
+        results: Full collection results dict (needs ``"nodes"`` key).
+
+    Returns:
+        Updated ClusterInfo with ``is_ha`` set.
+    """
+    nodes = results.get("nodes", [])
+    return cluster.model_copy(update={"is_ha": len(nodes) > 1})
+
 
 CLUSTER_MAPPING = TypeMapping(
     name="Cluster",
@@ -112,6 +126,12 @@ CLUSTER_MAPPING = TypeMapping(
             cache_attr="auto_enable_analytics",
             api_path="auto_enable_analytics",
             default=False,
+        ),
+        FieldMapping(
+            cache_attr="is_ha",
+            cache_strategy="derived",
+            default=False,
+            post_collection=compute_is_ha,
         ),
     ),
 )

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -1,7 +1,18 @@
-"""Tests for collector endpoint usage — verifies mappings produce correct collection URLs."""
+"""Tests for collector endpoint usage and derived field evaluation."""
 
 from __future__ import annotations
 
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel
+
+from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache.collector import MetadataCollector
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.cache.ontap.cluster.mapping import compute_is_ha
+from pynetappfoundry.cache.ontap.cluster.model import ClusterInfo
 from pynetappfoundry.cache.ontap.protocols.nfs.export_policies.mapping import (
     ONTAPEXPORTPOLICY_MAPPING,
 )
@@ -56,3 +67,255 @@ class TestCollectorMappingEndpoints:
             f for f in ONTAPSNAPSHOTPOLICY_MAPPING.fields if f.cache_attr == "copies"
         )
         assert copies_field.requires_explicit_fetch is True
+
+
+# ---------------------------------------------------------------------------
+# _SampleModel for derived-field tests
+# ---------------------------------------------------------------------------
+
+
+class _DerivedModel(BaseModel):
+    """Minimal model for derived field tests."""
+
+    name: str = ""
+    computed: int = 0
+
+
+# ---------------------------------------------------------------------------
+# compute_is_ha tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeIsHa:
+    """Tests for the compute_is_ha derived field function."""
+
+    def test_is_ha_true_multi_node(self) -> None:
+        """2+ nodes sets is_ha=True."""
+        cluster = ClusterInfo(cluster_name="test")
+        results: dict[str, Any] = {"nodes": ["node1", "node2"]}
+        updated = compute_is_ha(cluster, results)
+        assert updated.is_ha is True
+
+    def test_is_ha_false_single_node(self) -> None:
+        """1 node sets is_ha=False."""
+        cluster = ClusterInfo(cluster_name="test")
+        results: dict[str, Any] = {"nodes": ["node1"]}
+        updated = compute_is_ha(cluster, results)
+        assert updated.is_ha is False
+
+    def test_is_ha_false_no_nodes(self) -> None:
+        """Empty nodes list sets is_ha=False."""
+        cluster = ClusterInfo(cluster_name="test")
+        results: dict[str, Any] = {"nodes": []}
+        updated = compute_is_ha(cluster, results)
+        assert updated.is_ha is False
+
+    def test_is_ha_false_missing_nodes_key(self) -> None:
+        """Missing 'nodes' key in results sets is_ha=False."""
+        cluster = ClusterInfo(cluster_name="test")
+        results: dict[str, Any] = {}
+        updated = compute_is_ha(cluster, results)
+        assert updated.is_ha is False
+
+    def test_preserves_other_fields(self) -> None:
+        """compute_is_ha preserves other ClusterInfo fields."""
+        cluster = ClusterInfo(cluster_name="prod", ontap_version="9.14.1")
+        results: dict[str, Any] = {"nodes": ["n1", "n2"]}
+        updated = compute_is_ha(cluster, results)
+        assert updated.cluster_name == "prod"
+        assert updated.ontap_version == "9.14.1"
+        assert updated.is_ha is True
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_derived_fields tests
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateDerivedFields:
+    """Tests for MetadataCollector._evaluate_derived_fields."""
+
+    @pytest.fixture
+    def collector(self) -> MetadataCollector:
+        """Collector with no clients (for unit testing derived evaluation)."""
+        return MetadataCollector(api_client=None, cli_client=None)
+
+    def test_derived_fields_evaluated_for_singular_result(
+        self, collector: MetadataCollector
+    ) -> None:
+        """Derived field is evaluated on a singular (non-list) result."""
+        call_log: list[str] = []
+
+        def post_fn(item: _DerivedModel, results: dict[str, Any]) -> _DerivedModel:
+            call_log.append(item.name)
+            return item.model_copy(update={"computed": 42})
+
+        mapping = TypeMapping(
+            name="TestSingular",
+            model_class=_DerivedModel,
+            api_endpoint="/t",
+            fields=(
+                FieldMapping(cache_attr="name", api_path="name"),
+                FieldMapping(
+                    cache_attr="computed",
+                    cache_strategy="derived",
+                    post_collection=post_fn,
+                ),
+            ),
+        )
+        model_registry.register_mapping("TestSingular", mapping)
+        try:
+            with patch.object(
+                MetadataCollector,
+                "_MAPPING_RESULTS_KEYS",
+                [("TestSingular", "test_singular")],
+            ):
+                results: dict[str, Any] = {
+                    "test_singular": _DerivedModel(name="item1"),
+                }
+                updated = collector._evaluate_derived_fields(results)
+                assert updated["test_singular"].computed == 42
+                assert call_log == ["item1"]
+        finally:
+            model_registry._mappings.pop("TestSingular", None)
+
+    def test_derived_fields_evaluated_for_list_results(self, collector: MetadataCollector) -> None:
+        """Derived field is evaluated on each item in a list result."""
+
+        def post_fn(item: _DerivedModel, results: dict[str, Any]) -> _DerivedModel:
+            return item.model_copy(update={"computed": len(results.get("other", []))})
+
+        mapping = TypeMapping(
+            name="TestList",
+            model_class=_DerivedModel,
+            api_endpoint="/t",
+            fields=(
+                FieldMapping(cache_attr="name", api_path="name"),
+                FieldMapping(
+                    cache_attr="computed",
+                    cache_strategy="derived",
+                    post_collection=post_fn,
+                ),
+            ),
+        )
+        model_registry.register_mapping("TestList", mapping)
+        try:
+            with patch.object(
+                MetadataCollector,
+                "_MAPPING_RESULTS_KEYS",
+                [("TestList", "test_list")],
+            ):
+                results: dict[str, Any] = {
+                    "test_list": [
+                        _DerivedModel(name="a"),
+                        _DerivedModel(name="b"),
+                    ],
+                    "other": [1, 2, 3],
+                }
+                updated = collector._evaluate_derived_fields(results)
+                assert len(updated["test_list"]) == 2
+                assert updated["test_list"][0].computed == 3
+                assert updated["test_list"][1].computed == 3
+        finally:
+            model_registry._mappings.pop("TestList", None)
+
+    def test_derived_fields_skips_missing_post_collection(
+        self, collector: MetadataCollector
+    ) -> None:
+        """Derived field with no post_collection callable is skipped."""
+        mapping = TypeMapping(
+            name="TestNoCallable",
+            model_class=_DerivedModel,
+            api_endpoint="/t",
+            fields=(
+                FieldMapping(cache_attr="name", api_path="name"),
+                FieldMapping(
+                    cache_attr="computed",
+                    cache_strategy="derived",
+                    # No post_collection set
+                ),
+            ),
+        )
+        model_registry.register_mapping("TestNoCallable", mapping)
+        try:
+            with patch.object(
+                MetadataCollector,
+                "_MAPPING_RESULTS_KEYS",
+                [("TestNoCallable", "test_no_callable")],
+            ):
+                original = _DerivedModel(name="x", computed=0)
+                results: dict[str, Any] = {"test_no_callable": original}
+                updated = collector._evaluate_derived_fields(results)
+                # Should be unchanged
+                assert updated["test_no_callable"].computed == 0
+        finally:
+            model_registry._mappings.pop("TestNoCallable", None)
+
+    def test_derived_field_error_propagates(self, collector: MetadataCollector) -> None:
+        """Bad post_collection callable raises and is logged."""
+
+        def bad_fn(item: _DerivedModel, results: dict[str, Any]) -> _DerivedModel:
+            raise ValueError("boom")
+
+        mapping = TypeMapping(
+            name="TestBad",
+            model_class=_DerivedModel,
+            api_endpoint="/t",
+            fields=(
+                FieldMapping(
+                    cache_attr="computed",
+                    cache_strategy="derived",
+                    post_collection=bad_fn,
+                ),
+            ),
+        )
+        model_registry.register_mapping("TestBad", mapping)
+        try:
+            with patch.object(
+                MetadataCollector,
+                "_MAPPING_RESULTS_KEYS",
+                [("TestBad", "test_bad")],
+            ):
+                results: dict[str, Any] = {"test_bad": _DerivedModel(name="x")}
+                with pytest.raises(ValueError, match="boom"):
+                    collector._evaluate_derived_fields(results)
+        finally:
+            model_registry._mappings.pop("TestBad", None)
+
+    def test_skips_missing_results_key(self, collector: MetadataCollector) -> None:
+        """Mapping whose results key is absent from results dict is skipped."""
+        results: dict[str, Any] = {"other_key": "something"}
+        # Should not raise even though _MAPPING_RESULTS_KEYS references keys not in results
+        updated = collector._evaluate_derived_fields(results)
+        assert updated == results
+
+    def test_skips_unregistered_mapping(self, collector: MetadataCollector) -> None:
+        """Mapping name not in registry is skipped."""
+        with patch.object(
+            MetadataCollector,
+            "_MAPPING_RESULTS_KEYS",
+            [("NonexistentMapping", "some_key")],
+        ):
+            results: dict[str, Any] = {"some_key": _DerivedModel(name="x")}
+            updated = collector._evaluate_derived_fields(results)
+            # Should be unchanged
+            assert updated["some_key"].name == "x"
+
+
+# ---------------------------------------------------------------------------
+# Cluster mapping is_ha integration test
+# ---------------------------------------------------------------------------
+
+
+class TestClusterMappingIsHa:
+    """Verify the is_ha derived field is declared on CLUSTER_MAPPING."""
+
+    def test_cluster_mapping_has_is_ha_derived_field(self) -> None:
+        """CLUSTER_MAPPING declares is_ha as a derived field."""
+        from pynetappfoundry.cache.ontap.cluster.mapping import CLUSTER_MAPPING
+
+        derived = CLUSTER_MAPPING.derived_fields()
+        assert len(derived) == 1
+        assert derived[0].cache_attr == "is_ha"
+        assert derived[0].cache_strategy == "derived"
+        assert derived[0].post_collection is compute_is_ha

--- a/tests/unit/cache/test_field_mapping.py
+++ b/tests/unit/cache/test_field_mapping.py
@@ -93,8 +93,8 @@ class TestFieldMappingNewFields:
         assert fm.requires_explicit_fetch is True
 
     def test_post_collection_callable(self) -> None:
-        """post_collection accepts a callable."""
-        fn = lambda x: x  # noqa: E731
+        """post_collection accepts a callable with (item, results) signature."""
+        fn = lambda x, r: x  # noqa: E731
         fm = FieldMapping(cache_attr="x", cache_strategy="derived", post_collection=fn)
         assert fm.post_collection is fn
 
@@ -284,7 +284,7 @@ class TestTypeMapping:
 
     def test_derived_fields(self) -> None:
         """derived_fields returns only cache_strategy='derived' fields."""
-        fn = lambda x: x  # noqa: E731
+        fn = lambda x, r: x  # noqa: E731
         tm = TypeMapping(
             name="T",
             model_class=_SampleModel,
@@ -1099,18 +1099,23 @@ class TestCacheStrategyFiltering:
 
 
 # ---------------------------------------------------------------------------
-# post_collection in parse_api_response tests
+# post_collection NOT in parse_api_response tests
 # ---------------------------------------------------------------------------
 
 
 class TestPostCollection:
-    """Tests for post_collection wiring in parse_api_response."""
+    """Tests verifying post_collection is NOT called in parse_api_response.
 
-    def test_post_collection_called_for_derived_fields(self) -> None:
-        """post_collection is called for derived fields after parsing."""
+    Derived field evaluation has been moved to the collector level
+    (``MetadataCollector._evaluate_derived_fields``) where cross-collection
+    context is available.
+    """
+
+    def test_post_collection_not_called_in_parse_api_response(self) -> None:
+        """post_collection is NOT called during parse_api_response."""
         call_log: list[str] = []
 
-        def post_fn(item: _SampleModel) -> _SampleModel:
+        def post_fn(item: _SampleModel, results: dict[str, Any]) -> _SampleModel:
             call_log.append(item.name)
             return item
 
@@ -1130,10 +1135,11 @@ class TestPostCollection:
         response = {"records": [{"name": "a"}, {"name": "b"}]}
         results = parse_api_response(tm, response, "[t]", MagicMock())
         assert len(results) == 2
-        assert call_log == ["a", "b"]
+        # post_collection should NOT have been called
+        assert call_log == []
 
-    def test_post_collection_not_called_when_none(self) -> None:
-        """Derived fields without post_collection are harmless."""
+    def test_derived_fields_without_post_collection_harmless(self) -> None:
+        """Derived fields without post_collection are harmless in parse_api_response."""
         tm = TypeMapping(
             name="T",
             model_class=_SampleModel,


### PR DESCRIPTION
## Description

Add a generic runtime step in the collector that evaluates derived fields after all collection phases complete, replacing the hardcoded `is_ha` enrichment with a declarative framework.

## Related Issue

Addresses #318

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Updated `post_collection` signature from `Callable[[Any], Any]` to `Callable[[Any, dict[str, Any]], Any]` for cross-collection access
- Removed `post_collection` loop from `parse_api_response()` (moved to collector level)
- Added `_MAPPING_RESULTS_KEYS` class variable and `_evaluate_derived_fields()` method to `MetadataCollector`
- Replaced hardcoded `is_ha` enrichment in `collect_all()` with generic derived field evaluation
- Added `compute_is_ha()` function and `is_ha` FieldMapping with `cache_strategy="derived"` to `CLUSTER_MAPPING`
- Updated and added comprehensive tests for both field_mapping and collector

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The `post_collection` signature change is technically breaking for any existing callables using the old `(item) -> item` signature, but no existing code was using it (the only derived field was `is_ha` which was hardcoded in the collector). The CLUSTER_MAPPING now declaratively owns the `is_ha` computation via `compute_is_ha`.