### PR TITLE
feat: add parameterized endpoint support via parent_mapping iteration

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -12,12 +12,14 @@ import logging
 import re
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, cast
+
+from pydantic import BaseModel
 
 from pynetappfoundry.cache._metadata import (
     CachedClusterMetadata,
@@ -25,6 +27,7 @@ from pynetappfoundry.cache._metadata import (
 )
 from pynetappfoundry.cache._registry import model_registry
 from pynetappfoundry.cache.field_mapping import (
+    TypeMapping,
     parse_api_record,
     parse_api_response,
     parse_cli_records,
@@ -290,6 +293,69 @@ class MetadataCollector:
         """Clear the API response cache."""
         with self._cache_lock:
             self._api_cache.clear()
+
+    def _collect_parameterized(
+        self,
+        mapping: TypeMapping,
+        parent_objects: Sequence[BaseModel],
+    ) -> list[BaseModel]:
+        """Fetch child records from a parameterized endpoint by iterating parents.
+
+        For each parent object, substitutes the parent's identifier into the
+        URL placeholder, fetches child records, and aggregates them.
+
+        Args:
+            mapping: Child TypeMapping (must have parent_mapping and parent_id_field set).
+            parent_objects: List of already-collected parent model instances.
+
+        Returns:
+            Aggregated list of child model instances across all parents.
+
+        Raises:
+            ValueError: If mapping.parent_mapping or mapping.parent_id_field is not set.
+        """
+        if not mapping.parent_mapping:
+            raise ValueError(
+                f"{mapping.name}: parent_mapping must be set for parameterized collection"
+            )
+        if not mapping.parent_id_field:
+            raise ValueError(
+                f"{mapping.name}: parent_id_field must be set for parameterized collection"
+            )
+
+        aggregated: list[BaseModel] = []
+        for parent in parent_objects:
+            parent_id = getattr(parent, mapping.parent_id_field, None)
+            if not parent_id:
+                parent_name = getattr(parent, "name", repr(parent))
+                logger.warning(
+                    "%s SKIP_PARENT: %s - parent %s has no '%s'",
+                    self._log_prefix,
+                    mapping.name,
+                    parent_name,
+                    mapping.parent_id_field,
+                )
+                continue
+
+            url = mapping.build_parameterized_url(str(parent_id))
+            try:
+                response = self._cached_api_call(url)
+                children = parse_api_response(
+                    mapping, response, self._log_prefix, self._log_missing_fields
+                )
+                aggregated.extend(children)
+            except Exception as e:
+                parent_name = getattr(parent, "name", repr(parent))
+                logger.warning(
+                    "%s CHILD_FETCH_FAILED: %s for parent %s - %s: %s",
+                    self._log_prefix,
+                    mapping.name,
+                    parent_name,
+                    type(e).__name__,
+                    e,
+                )
+
+        return aggregated
 
     def _evaluate_derived_fields(self, results: dict[str, Any]) -> dict[str, Any]:
         """Evaluate derived fields across all TypeMappings that declare them.

--- a/src/pynetappfoundry/cache/field_mapping.py
+++ b/src/pynetappfoundry/cache/field_mapping.py
@@ -180,6 +180,34 @@ class TypeMapping:
                 keys.add(field.cache_attr)
         return sorted(keys)
 
+    def build_parameterized_url(self, parent_id: str) -> str:
+        """Build a parameterized endpoint URL by substituting the placeholder.
+
+        Replaces the first ``{...}`` path placeholder with *parent_id*,
+        then appends explicit-fetch fields the same way
+        :meth:`build_collection_url` does.
+
+        Args:
+            parent_id: The parent object's identifier value.
+
+        Returns:
+            Fully resolved endpoint URL.
+        """
+        parts = self.api_endpoint.split("?", 1)
+        path = re.sub(r"\{[^}]+\}", parent_id, parts[0], count=1)
+
+        if len(parts) == 1:
+            return path
+
+        query = parts[1]
+        if not query.startswith("fields=*"):
+            return f"{path}?{query}"
+
+        expensive = self.explicit_fetch_api_fields()
+        if expensive:
+            return f"{path}?fields=*,{','.join(expensive)}"
+        return f"{path}?fields=*"
+
     def build_collection_url(self) -> str:
         """Build the collection URL with dynamically appended expensive fields.
 

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import patch
 
@@ -319,3 +320,149 @@ class TestClusterMappingIsHa:
         assert derived[0].cache_attr == "is_ha"
         assert derived[0].cache_strategy == "derived"
         assert derived[0].post_collection is compute_is_ha
+
+
+# ---------------------------------------------------------------------------
+# _collect_parameterized tests
+# ---------------------------------------------------------------------------
+
+
+class _ParentModel(BaseModel):
+    """Parent model with uuid for parameterized tests."""
+
+    name: str = ""
+    uuid: str = ""
+
+
+class _ChildModel(BaseModel):
+    """Child model for parameterized tests."""
+
+    name: str = ""
+    parent_uuid: str = ""
+
+
+_CHILD_MAPPING = TypeMapping(
+    name="Child",
+    model_class=_ChildModel,
+    api_endpoint="/parents/{parent.uuid}/children?fields=*",
+    fields=(
+        FieldMapping(cache_attr="name", api_path="name"),
+        FieldMapping(cache_attr="parent_uuid", api_path="parent.uuid", default=""),
+    ),
+    parent_mapping="Parent",
+    parent_id_field="uuid",
+)
+
+
+class TestCollectParameterized:
+    """Tests for MetadataCollector._collect_parameterized."""
+
+    @pytest.fixture
+    def collector(self) -> MetadataCollector:
+        """Collector with no clients (for unit testing)."""
+        return MetadataCollector(api_client=None, cli_client=None)
+
+    def test_iterates_parents_aggregates_results(self, collector: MetadataCollector) -> None:
+        """2 parents each returning 2 children → 4 total."""
+        parents = [
+            _ParentModel(name="p1", uuid="uuid-1"),
+            _ParentModel(name="p2", uuid="uuid-2"),
+        ]
+        responses = {
+            "/parents/uuid-1/children?fields=*": {
+                "records": [
+                    {"name": "c1", "parent": {"uuid": "uuid-1"}},
+                    {"name": "c2", "parent": {"uuid": "uuid-1"}},
+                ],
+            },
+            "/parents/uuid-2/children?fields=*": {
+                "records": [
+                    {"name": "c3", "parent": {"uuid": "uuid-2"}},
+                    {"name": "c4", "parent": {"uuid": "uuid-2"}},
+                ],
+            },
+        }
+
+        with patch.object(
+            collector, "_cached_api_call", side_effect=lambda url, **kw: responses[url]
+        ):
+            result = collector._collect_parameterized(_CHILD_MAPPING, parents)
+        assert len(result) == 4
+        names = [r.name for r in result]  # type: ignore[attr-defined]
+        assert names == ["c1", "c2", "c3", "c4"]
+
+    def test_empty_parent_list_returns_empty(self, collector: MetadataCollector) -> None:
+        """No parents → empty list."""
+        result = collector._collect_parameterized(_CHILD_MAPPING, [])
+        assert result == []
+
+    def test_parent_missing_id_field_skipped(
+        self, collector: MetadataCollector, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Parent without the id attr → logged warning, skipped."""
+        # _ParentModel has uuid="" by default (empty → falsy → skip)
+        parents = [_ParentModel(name="no-uuid")]
+
+        with caplog.at_level(logging.WARNING):
+            result = collector._collect_parameterized(_CHILD_MAPPING, parents)
+        assert result == []
+        assert any("SKIP_PARENT" in r.message for r in caplog.records)
+
+    def test_parent_empty_id_skipped(
+        self, collector: MetadataCollector, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Parent with empty string id → skipped."""
+        parents = [_ParentModel(name="empty-uuid", uuid="")]
+
+        with caplog.at_level(logging.WARNING):
+            result = collector._collect_parameterized(_CHILD_MAPPING, parents)
+        assert result == []
+        assert any("SKIP_PARENT" in r.message for r in caplog.records)
+
+    def test_failed_child_fetch_continues(
+        self, collector: MetadataCollector, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """API error on one parent → warns, continues, returns partial results."""
+        parents = [
+            _ParentModel(name="p1", uuid="uuid-1"),
+            _ParentModel(name="p2", uuid="uuid-2"),
+        ]
+
+        def side_effect(url: str, **kw: Any) -> dict[str, Any]:
+            if "uuid-1" in url:
+                raise ConnectionError("timeout")
+            return {"records": [{"name": "c1", "parent": {"uuid": "uuid-2"}}]}
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch.object(collector, "_cached_api_call", side_effect=side_effect),
+        ):
+            result = collector._collect_parameterized(_CHILD_MAPPING, parents)
+        assert len(result) == 1
+        assert any("CHILD_FETCH_FAILED" in r.message for r in caplog.records)
+
+    def test_raises_if_no_parent_mapping(self, collector: MetadataCollector) -> None:
+        """parent_mapping=None → ValueError."""
+        mapping = TypeMapping(
+            name="Bad",
+            model_class=_ChildModel,
+            api_endpoint="/bad",
+            fields=(),
+            parent_mapping=None,
+            parent_id_field="uuid",
+        )
+        with pytest.raises(ValueError, match="parent_mapping must be set"):
+            collector._collect_parameterized(mapping, [])
+
+    def test_raises_if_no_parent_id_field(self, collector: MetadataCollector) -> None:
+        """parent_id_field=None → ValueError."""
+        mapping = TypeMapping(
+            name="Bad",
+            model_class=_ChildModel,
+            api_endpoint="/bad",
+            fields=(),
+            parent_mapping="Parent",
+            parent_id_field=None,
+        )
+        with pytest.raises(ValueError, match="parent_id_field must be set"):
+            collector._collect_parameterized(mapping, [])

--- a/tests/unit/cache/test_field_mapping.py
+++ b/tests/unit/cache/test_field_mapping.py
@@ -920,6 +920,83 @@ class TestExplicitFetchApiFields:
 # ---------------------------------------------------------------------------
 
 
+class TestBuildParameterizedUrl:
+    """Tests for TypeMapping.build_parameterized_url."""
+
+    def test_substitutes_named_placeholder(self) -> None:
+        """Named placeholder like {svm.uuid} is replaced with parent_id."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/svm/svms/{svm.uuid}/top-metrics/users?fields=*",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+        )
+        url = tm.build_parameterized_url("abc-123")
+        assert url == "/svm/svms/abc-123/top-metrics/users?fields=*"
+
+    def test_substitutes_bare_placeholder(self) -> None:
+        """Bare placeholder like {uuid} is replaced with parent_id."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/storage/volumes/{uuid}/snapshots?fields=*",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+        )
+        url = tm.build_parameterized_url("vol-uuid-456")
+        assert url == "/storage/volumes/vol-uuid-456/snapshots?fields=*"
+
+    def test_appends_explicit_fetch_fields(self) -> None:
+        """Expensive fields are appended after substitution."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/svm/svms/{svm.uuid}/metrics?fields=*",
+            fields=(
+                FieldMapping(cache_attr="name", api_path="name"),
+                FieldMapping(
+                    cache_attr="throughput",
+                    api_path="throughput.total",
+                    requires_explicit_fetch=True,
+                ),
+            ),
+        )
+        url = tm.build_parameterized_url("svm-uuid")
+        assert url == "/svm/svms/svm-uuid/metrics?fields=*,throughput"
+
+    def test_no_placeholder_returns_unchanged(self) -> None:
+        """URL without {placeholder} passes through unchanged."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/storage/volumes?fields=*",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+        )
+        url = tm.build_parameterized_url("some-id")
+        assert url == "/storage/volumes?fields=*"
+
+    def test_only_first_placeholder_replaced(self) -> None:
+        """Multi-placeholder URL: only the first placeholder is replaced."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/a/{parent.uuid}/b/{child.uuid}?fields=*",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+        )
+        url = tm.build_parameterized_url("parent-id")
+        assert url == "/a/parent-id/b/{child.uuid}?fields=*"
+
+    def test_preserves_non_fields_star_query_params(self) -> None:
+        """Query params that don't start with fields=* are preserved."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/svm/svms/{svm.uuid}/data?order_by=name",
+            fields=(FieldMapping(cache_attr="name", api_path="name"),),
+        )
+        url = tm.build_parameterized_url("svm-id")
+        assert url == "/svm/svms/svm-id/data?order_by=name"
+
+
 class TestBuildCollectionUrl:
     """Tests for TypeMapping.build_collection_url."""
 


### PR DESCRIPTION
## Description

Add `build_parameterized_url()` to `TypeMapping` and `_collect_parameterized()` to `MetadataCollector`, enabling child endpoint collection by iterating parent objects and substituting URL placeholders with parent IDs.

## Related Issue

Addresses #321

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `TypeMapping.build_parameterized_url(parent_id)` — substitutes the first `{...}` placeholder with `parent_id` and appends explicit-fetch fields
- Added `MetadataCollector._collect_parameterized(mapping, parent_objects)` — iterates parents, builds parameterized URLs, fetches child records, aggregates results with graceful error handling
- Added `TestBuildParameterizedUrl` (6 tests) in `test_field_mapping.py`
- Added `TestCollectParameterized` (7 tests) in `test_collector.py`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings