### PR TITLE
feat: wire up SVM top-metrics users as parameterized endpoint integration

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -107,6 +107,10 @@ from pynetappfoundry.cache.ontap.svm.peers.mapping import ONTAPSVMPEER_MAPPING
 from pynetappfoundry.cache.ontap.svm.peers.model import OntapSvmPeer
 from pynetappfoundry.cache.ontap.svm.svms.mapping import ONTAPSVM_MAPPING
 from pynetappfoundry.cache.ontap.svm.svms.model import OntapSvm
+from pynetappfoundry.cache.ontap.svm.svms.top_metrics.users.mapping import (
+    ONTAPTOPMETRICSSVMUSER_MAPPING,
+)
+from pynetappfoundry.cache.ontap.svm.svms.top_metrics.users.model import OntapTopMetricsSvmUser
 from pynetappfoundry.utils.cloud import (
     build_cloud_instance_link,
     build_cloud_instance_sso_link,
@@ -439,6 +443,14 @@ class MetadataCollector:
         # Evaluate derived fields (e.g. is_ha from node count)
         results = self._evaluate_derived_fields(results)
         cluster_info: ClusterInfo = results["cluster"]
+
+        # Collect parameterized endpoints (requires parent objects from phases)
+        storage_info: StorageInfo = results["storage"]
+        svm_top_metrics_users = self._collect_svm_top_metrics_users(storage_info.svms)
+        storage_info = storage_info.model_copy(
+            update={"svm_top_metrics_users": svm_top_metrics_users}
+        )
+        results["storage"] = storage_info
 
         # Post-process Azure cloud metadata to fix instance links
         cloud_metadata = self._update_azure_cloud_links(
@@ -1571,6 +1583,26 @@ class MetadataCollector:
             snapmirror_destinations=snapmirror_destinations,
             cluster_peers=cluster_peers,
             svm_peers=svm_peers,
+        )
+
+    # -------------------------------------------------------------------------
+    # Parameterized Endpoint Collection
+    # -------------------------------------------------------------------------
+
+    def _collect_svm_top_metrics_users(self, svms: list[OntapSvm]) -> list[OntapTopMetricsSvmUser]:
+        """Collect top-metrics users per SVM using parameterized endpoint.
+
+        Args:
+            svms: List of collected SVM objects (parents).
+
+        Returns:
+            Aggregated list of OntapTopMetricsSvmUser across all SVMs.
+        """
+        if not self.api_client:
+            return []
+        return cast(
+            list[OntapTopMetricsSvmUser],
+            self._collect_parameterized(ONTAPTOPMETRICSSVMUSER_MAPPING, svms),
         )
 
     # -------------------------------------------------------------------------

--- a/src/pynetappfoundry/cache/ontap/storage/model.py
+++ b/src/pynetappfoundry/cache/ontap/storage/model.py
@@ -16,6 +16,7 @@ from pynetappfoundry.cache.ontap.storage.qtrees.model import OntapQtree
 from pynetappfoundry.cache.ontap.storage.snapshot_policies.model import OntapSnapshotPolicy
 from pynetappfoundry.cache.ontap.storage.volumes.model import OntapVolume
 from pynetappfoundry.cache.ontap.svm.svms.model import OntapSvm
+from pynetappfoundry.cache.ontap.svm.svms.top_metrics.users.model import OntapTopMetricsSvmUser
 
 
 class StorageInfo(CacheModel):
@@ -37,3 +38,4 @@ class StorageInfo(CacheModel):
     igroups: list[OntapIgroup] = Field(default_factory=list)
     qos_policies: list[OntapQosPolicy] = Field(default_factory=list)
     flexcaches: list[OntapFlexcache] = Field(default_factory=list)
+    svm_top_metrics_users: list[OntapTopMetricsSvmUser] = Field(default_factory=list)

--- a/tests/unit/cache/test_collector.py
+++ b/tests/unit/cache/test_collector.py
@@ -466,3 +466,49 @@ class TestCollectParameterized:
         )
         with pytest.raises(ValueError, match="parent_id_field must be set"):
             collector._collect_parameterized(mapping, [])
+
+
+# ---------------------------------------------------------------------------
+# _collect_svm_top_metrics_users integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCollectSvmTopMetricsUsers:
+    """Tests for MetadataCollector._collect_svm_top_metrics_users."""
+
+    @pytest.fixture
+    def collector(self) -> MetadataCollector:
+        """Collector with no clients (for unit testing)."""
+        return MetadataCollector(api_client=None, cli_client=None)
+
+    def test_returns_empty_without_api_client(self, collector: MetadataCollector) -> None:
+        """No API client → empty list without attempting collection."""
+        from pynetappfoundry.cache.ontap.svm.svms.model import OntapSvm
+
+        svms = [OntapSvm(name="svm1", uuid="uuid-1")]
+        result = collector._collect_svm_top_metrics_users(svms)
+        assert result == []
+
+    def test_delegates_to_collect_parameterized(self, collector: MetadataCollector) -> None:
+        """Delegates to _collect_parameterized with correct mapping and parents."""
+        from pynetappfoundry.cache.ontap.svm.svms.model import OntapSvm
+        from pynetappfoundry.cache.ontap.svm.svms.top_metrics.users.mapping import (
+            ONTAPTOPMETRICSSVMUSER_MAPPING,
+        )
+
+        svms = [OntapSvm(name="svm1", uuid="uuid-1")]
+        captured_args: list[tuple[Any, Any]] = []
+
+        def fake_collect_parameterized(mapping: Any, parents: Any) -> list[Any]:
+            captured_args.append((mapping, parents))
+            return []
+
+        collector.api_client = True  # type: ignore[assignment]
+        with patch.object(
+            collector, "_collect_parameterized", side_effect=fake_collect_parameterized
+        ):
+            collector._collect_svm_top_metrics_users(svms)
+
+        assert len(captured_args) == 1
+        assert captured_args[0][0] is ONTAPTOPMETRICSSVMUSER_MAPPING
+        assert captured_args[0][1] is svms


### PR DESCRIPTION
## Description

Wire up the first real usage of `_collect_parameterized()` (from PR #334) by collecting SVM top-metrics users using `OntapSvm` as parent objects. This demonstrates the parameterized endpoint pattern end-to-end.

## Related Issue

Addresses #321

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `svm_top_metrics_users` field to `StorageInfo` model
- Added `_collect_svm_top_metrics_users()` method to `MetadataCollector`
- Wired parameterized collection into `collect_all()` as a post-phase step using SVMs as parents
- Added 2 integration tests for the new method

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings