### PR TITLE
chore: fix broken parent_mapping and parent_id_field values across TypeMappings

### DIFF
--- a/src/pynetappfoundry/cache/ontap/cluster/counter/tables/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/counter/tables/mapping.py
@@ -12,8 +12,8 @@ ONTAPCOUNTERTABLE_MAPPING = TypeMapping(
     api_endpoint="/cluster/counter/tables/{name}?fields=*",
     api_type="ontap",
     records_path="counter_schemas",
-    parent_mapping="OntapClusterCounterTable",
-    parent_id_field="uuid",
+    parent_mapping=None,
+    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="denominator_name",

--- a/src/pynetappfoundry/cache/ontap/cluster/counter/tables/rows/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/counter/tables/rows/mapping.py
@@ -28,8 +28,8 @@ ONTAPCOUNTERROW_MAPPING = TypeMapping(
     model_class=OntapCounterRow,
     api_endpoint="/cluster/counter/tables/{counter_table.name}/rows?fields=*",
     api_type="ontap",
-    parent_mapping="OntapClusterCounterTable",
-    parent_id_field="uuid",
+    parent_mapping="OntapCounterTable",
+    parent_id_field="name",
     fields=(
         FieldMapping(
             cache_attr="aggregation_complete",

--- a/src/pynetappfoundry/cache/ontap/name_services/netgroup_files/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/netgroup_files/mapping.py
@@ -11,7 +11,7 @@ ONTAPNETGROUPFILE_MAPPING = TypeMapping(
     model_class=OntapNetgroupFile,
     api_endpoint="/name-services/netgroup-files/{svm.uuid}?fields=*",
     api_type="ontap",
-    parent_mapping="OntapNameServicesNetgroupFile",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/name_services/unix_groups/users/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/unix_groups/users/mapping.py
@@ -23,7 +23,7 @@ ONTAPUNIXGROUPUSERS_MAPPING = TypeMapping(
     api_endpoint="/name-services/unix-groups/{svm.uuid}/{unix_group.name}/users?fields=*",
     api_type="ontap",
     parent_mapping="OntapUnixGroup",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="name",

--- a/src/pynetappfoundry/cache/ontap/network/fc/fabrics/switches/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/fc/fabrics/switches/mapping.py
@@ -23,7 +23,7 @@ ONTAPFCSWITCH_MAPPING = TypeMapping(
     api_endpoint="/network/fc/fabrics/{fabric.name}/switches?fields=*",
     api_type="ontap",
     parent_mapping="OntapFabric",
-    parent_id_field="uuid",
+    parent_id_field="name",
     fields=(
         FieldMapping(
             cache_attr="cache_age",

--- a/src/pynetappfoundry/cache/ontap/network/fc/fabrics/zones/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/fc/fabrics/zones/mapping.py
@@ -23,7 +23,7 @@ ONTAPFCZONE_MAPPING = TypeMapping(
     api_endpoint="/network/fc/fabrics/{fabric.name}/zones?fields=*",
     api_type="ontap",
     parent_mapping="OntapFabric",
-    parent_id_field="uuid",
+    parent_id_field="name",
     fields=(
         FieldMapping(
             cache_attr="cache_age",

--- a/src/pynetappfoundry/cache/ontap/protocols/active_directory/preferred_domain_controllers/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/active_directory/preferred_domain_controllers/mapping.py
@@ -15,7 +15,7 @@ ONTAPACTIVEDIRECTORYPREFERREDDC_MAPPING = TypeMapping(
     api_endpoint="/protocols/active-directory/{svm.uuid}/preferred-domain-controllers?fields=*",
     api_type="ontap",
     parent_mapping="OntapActiveDirectory",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="fqdn",

--- a/src/pynetappfoundry/cache/ontap/protocols/audit/object_store/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/audit/object_store/mapping.py
@@ -12,7 +12,7 @@ ONTAPS3AUDIT_MAPPING = TypeMapping(
     api_endpoint="/protocols/audit/{svm.uuid}/object-store?fields=*",
     api_type="ontap",
     parent_mapping="OntapAudit",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/domains/preferred_domain_controllers/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/domains/preferred_domain_controllers/mapping.py
@@ -14,7 +14,7 @@ ONTAPCIFSDOMAINPREFERREDDC_MAPPING = TypeMapping(
     api_endpoint="/protocols/cifs/domains/{svm.uuid}/preferred-domain-controllers?fields=*",
     api_type="ontap",
     parent_mapping="OntapCifsDomain",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="fqdn",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/group_policies/central_access_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/group_policies/central_access_policies/mapping.py
@@ -15,7 +15,7 @@ ONTAPGROUPPOLICYOBJECTCENTRALACCESSPOLICY_MAPPING = TypeMapping(
     api_endpoint="/protocols/cifs/group-policies/{svm.uuid}/central-access-policies?fields=*",
     api_type="ontap",
     parent_mapping="OntapPoliciesAndRulesToBeApplied",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="create_time",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/group_policies/central_access_rules/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/group_policies/central_access_rules/mapping.py
@@ -14,7 +14,7 @@ ONTAPGROUPPOLICYOBJECTCENTRALACCESSRULE_MAPPING = TypeMapping(
     api_endpoint="/protocols/cifs/group-policies/{svm.uuid}/central-access-rules?fields=*",
     api_type="ontap",
     parent_mapping="OntapPoliciesAndRulesToBeApplied",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="create_time",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/group_policies/objects/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/group_policies/objects/mapping.py
@@ -14,7 +14,7 @@ ONTAPGROUPPOLICYOBJECT_MAPPING = TypeMapping(
     api_endpoint="/protocols/cifs/group-policies/{svm.uuid}/objects?fields=*",
     api_type="ontap",
     parent_mapping="OntapPoliciesAndRulesToBeApplied",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="central_access_policy_settings",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/group_policies/restricted_groups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/group_policies/restricted_groups/mapping.py
@@ -14,7 +14,7 @@ ONTAPGROUPPOLICYOBJECTRESTRICTEDGROUP_MAPPING = TypeMapping(
     api_endpoint="/protocols/cifs/group-policies/{svm.uuid}/restricted-groups?fields=*",
     api_type="ontap",
     parent_mapping="OntapPoliciesAndRulesToBeApplied",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="group_name",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/local_groups/members/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/local_groups/members/mapping.py
@@ -23,7 +23,7 @@ ONTAPLOCALCIFSGROUPMEMBERS_MAPPING = TypeMapping(
     api_endpoint="/protocols/cifs/local-groups/{svm.uuid}/{local_cifs_group.sid}/members?fields=*",
     api_type="ontap",
     parent_mapping="OntapLocalCifsGroup",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="local_cifs_group_sid",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/services/metrics/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/services/metrics/mapping.py
@@ -14,7 +14,7 @@ ONTAPPERFORMANCECIFSMETRICRESPONSE_MAPPING = TypeMapping(
     api_endpoint="/protocols/cifs/services/{svm.uuid}/metrics?fields=*",
     api_type="ontap",
     parent_mapping="OntapCifsService",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="duration",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/shares/acls/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/shares/acls/mapping.py
@@ -12,7 +12,7 @@ ONTAPCIFSSHAREACL_MAPPING = TypeMapping(
     api_endpoint="/protocols/cifs/shares/{svm.uuid}/{share}/acls?fields=*",
     api_type="ontap",
     parent_mapping="OntapCifsShare",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="permission",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/users_and_groups/bulk_import/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/users_and_groups/bulk_import/mapping.py
@@ -13,7 +13,7 @@ ONTAPLOCALCIFSUSERSANDGROUPSIMPORT_MAPPING = TypeMapping(
     model_class=OntapLocalCifsUsersAndGroupsImport,
     api_endpoint="/protocols/cifs/users-and-groups/bulk-import/{svm.uuid}?fields=*",
     api_type="ontap",
-    parent_mapping="OntapProtocolsCifsUsersAndGroupsBulkImport",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/file_security/permissions/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/file_security/permissions/mapping.py
@@ -14,7 +14,7 @@ ONTAPFILEDIRECTORYSECURITY_MAPPING = TypeMapping(
     api_endpoint="/protocols/file-security/permissions/{svm.uuid}/{path}?fields=*",
     api_type="ontap",
     records_path="acls",
-    parent_mapping="OntapProtocolsFileSecurityPermission",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/connections/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/connections/mapping.py
@@ -11,7 +11,7 @@ ONTAPFPOLICYCONNECTION_MAPPING = TypeMapping(
     model_class=OntapFpolicyConnection,
     api_endpoint="/protocols/fpolicy/{svm.uuid}/connections?fields=*",
     api_type="ontap",
-    parent_mapping="OntapProtocolsFpolicy",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/engines/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/engines/mapping.py
@@ -11,7 +11,7 @@ ONTAPFPOLICYENGINE_MAPPING = TypeMapping(
     model_class=OntapFpolicyEngine,
     api_endpoint="/protocols/fpolicy/{svm.uuid}/engines?fields=*",
     api_type="ontap",
-    parent_mapping="OntapProtocolsFpolicy",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/events/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/events/mapping.py
@@ -11,7 +11,7 @@ ONTAPFPOLICYEVENT_MAPPING = TypeMapping(
     model_class=OntapFpolicyEvent,
     api_endpoint="/protocols/fpolicy/{svm.uuid}/events?fields=*",
     api_type="ontap",
-    parent_mapping="OntapProtocolsFpolicy",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/mapping.py
@@ -12,7 +12,7 @@ ONTAPFPOLICY_MAPPING = TypeMapping(
     api_endpoint="/protocols/fpolicy/{svm.uuid}?fields=*",
     api_type="ontap",
     records_path="engines",
-    parent_mapping="OntapProtocolsFpolicy",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/persistent_stores/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/persistent_stores/mapping.py
@@ -13,7 +13,7 @@ ONTAPFPOLICYPERSISTENTSTORE_MAPPING = TypeMapping(
     model_class=OntapFpolicyPersistentStore,
     api_endpoint="/protocols/fpolicy/{svm.uuid}/persistent-stores?fields=*",
     api_type="ontap",
-    parent_mapping="OntapProtocolsFpolicy",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/policies/mapping.py
@@ -22,7 +22,7 @@ ONTAPFPOLICYPOLICY_MAPPING = TypeMapping(
     model_class=OntapFpolicyPolicy,
     api_endpoint="/protocols/fpolicy/{svm.uuid}/policies?fields=*",
     api_type="ontap",
-    parent_mapping="OntapProtocolsFpolicy",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/ndmp/svms/passwords/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/ndmp/svms/passwords/mapping.py
@@ -12,7 +12,7 @@ ONTAPNDMPPASSWORD_MAPPING = TypeMapping(
     api_endpoint="/protocols/ndmp/svms/{svm.uuid}/passwords/{user}?fields=*",
     api_type="ontap",
     parent_mapping="OntapNdmpSvm",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="password",

--- a/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/rules/clients/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/rules/clients/mapping.py
@@ -13,8 +13,8 @@ ONTAPEXPORTCLIENT_MAPPING = TypeMapping(
     model_class=OntapExportClient,
     api_endpoint="/protocols/nfs/export-policies/{policy.id}/rules/{index}/clients?fields=*",
     api_type="ontap",
-    parent_mapping="OntapProtocolsNfsExportPolicy",
-    parent_id_field="uuid",
+    parent_mapping=None,
+    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="index",

--- a/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/rules/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/rules/mapping.py
@@ -22,8 +22,8 @@ ONTAPEXPORTRULE_MAPPING = TypeMapping(
     model_class=OntapExportRule,
     api_endpoint="/protocols/nfs/export-policies/{policy.id}/rules?fields=*",
     api_type="ontap",
-    parent_mapping="OntapProtocolsNfsExportPolicy",
-    parent_id_field="uuid",
+    parent_mapping=None,
+    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="allow_device_creation",

--- a/src/pynetappfoundry/cache/ontap/protocols/nfs/services/metrics/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nfs/services/metrics/mapping.py
@@ -14,7 +14,7 @@ ONTAPPERFORMANCESVMNFSRESPONSE_MAPPING = TypeMapping(
     api_endpoint="/protocols/nfs/services/{svm.uuid}/metrics?fields=*",
     api_type="ontap",
     parent_mapping="OntapNfsService",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="v3_duration",

--- a/src/pynetappfoundry/cache/ontap/protocols/nvme/services/metrics/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nvme/services/metrics/mapping.py
@@ -14,7 +14,7 @@ ONTAPPERFORMANCENVMEMETRICRESPONSE_MAPPING = TypeMapping(
     api_endpoint="/protocols/nvme/services/{svm.uuid}/metrics?fields=*",
     api_type="ontap",
     parent_mapping="OntapNvmeService",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="duration",

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/services/buckets/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/services/buckets/mapping.py
@@ -41,7 +41,7 @@ ONTAPS3BUCKETSVM_MAPPING = TypeMapping(
     api_endpoint="/protocols/s3/services/{svm.uuid}/buckets?fields=*",
     api_type="ontap",
     parent_mapping="OntapS3Service",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="aggregates",

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/services/buckets/rules/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/services/buckets/rules/mapping.py
@@ -14,7 +14,7 @@ ONTAPS3BUCKETLIFECYCLERULE_MAPPING = TypeMapping(
     api_endpoint="/protocols/s3/services/{svm.uuid}/buckets/{s3_bucket.uuid}/rules?fields=*",
     api_type="ontap",
     parent_mapping="OntapS3Service",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="abort_incomplete_multipart_upload_after_initiation_days",

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/services/buckets/snapshots/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/services/buckets/snapshots/mapping.py
@@ -14,7 +14,7 @@ ONTAPS3BUCKETSNAPSHOT_MAPPING = TypeMapping(
     api_endpoint="/protocols/s3/services/{svm.uuid}/buckets/{s3_bucket.uuid}/snapshots?fields=*",
     api_type="ontap",
     parent_mapping="OntapS3Service",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="bucket_uuid",

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/services/groups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/services/groups/mapping.py
@@ -29,7 +29,7 @@ ONTAPS3GROUP_MAPPING = TypeMapping(
     api_endpoint="/protocols/s3/services/{svm.uuid}/groups?fields=*",
     api_type="ontap",
     parent_mapping="OntapS3Service",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="comment",

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/services/metrics/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/services/metrics/mapping.py
@@ -14,7 +14,7 @@ ONTAPPERFORMANCES3METRICRESPONSE_MAPPING = TypeMapping(
     api_endpoint="/protocols/s3/services/{svm.uuid}/metrics?fields=*",
     api_type="ontap",
     parent_mapping="OntapS3Service",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="duration",

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/services/policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/services/policies/mapping.py
@@ -23,7 +23,7 @@ ONTAPS3POLICY_MAPPING = TypeMapping(
     api_endpoint="/protocols/s3/services/{svm.uuid}/policies?fields=*",
     api_type="ontap",
     parent_mapping="OntapS3Service",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="comment",

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/services/users/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/services/users/mapping.py
@@ -12,7 +12,7 @@ ONTAPS3USER_MAPPING = TypeMapping(
     api_endpoint="/protocols/s3/services/{svm.uuid}/users?fields=*",
     api_type="ontap",
     parent_mapping="OntapS3Service",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="access_key",

--- a/src/pynetappfoundry/cache/ontap/protocols/san/fcp/services/metrics/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/fcp/services/metrics/mapping.py
@@ -14,7 +14,7 @@ ONTAPPERFORMANCEFCPMETRICRESPONSE_MAPPING = TypeMapping(
     api_endpoint="/protocols/san/fcp/services/{svm.uuid}/metrics?fields=*",
     api_type="ontap",
     parent_mapping="OntapFcpService",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="duration",

--- a/src/pynetappfoundry/cache/ontap/protocols/san/iscsi/services/metrics/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/iscsi/services/metrics/mapping.py
@@ -14,7 +14,7 @@ ONTAPPERFORMANCEISCSIMETRICRESPONSE_MAPPING = TypeMapping(
     api_endpoint="/protocols/san/iscsi/services/{svm.uuid}/metrics?fields=*",
     api_type="ontap",
     parent_mapping="OntapIscsiService",
-    parent_id_field="uuid",
+    parent_id_field="svm_uuid",
     fields=(
         FieldMapping(
             cache_attr="duration",

--- a/src/pynetappfoundry/cache/ontap/protocols/san/lun_maps/reporting_nodes/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/lun_maps/reporting_nodes/mapping.py
@@ -14,7 +14,7 @@ ONTAPLUNMAPREPORTINGNODE_MAPPING = TypeMapping(
     api_endpoint="/protocols/san/lun-maps/{lun.uuid}/{igroup.uuid}/reporting-nodes?fields=*",
     api_type="ontap",
     parent_mapping="OntapLunMap",
-    parent_id_field="uuid",
+    parent_id_field="lun_uuid",
     fields=(
         FieldMapping(
             cache_attr="igroup_uuid",

--- a/src/pynetappfoundry/cache/ontap/protocols/vscan/events/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/vscan/events/mapping.py
@@ -11,7 +11,7 @@ ONTAPVSCANEVENT_MAPPING = TypeMapping(
     model_class=OntapVscanEvent,
     api_endpoint="/protocols/vscan/{svm.uuid}/events?fields=*",
     api_type="ontap",
-    parent_mapping="OntapProtocolsVscan",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/vscan/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/vscan/mapping.py
@@ -12,7 +12,7 @@ ONTAPVSCAN_MAPPING = TypeMapping(
     api_endpoint="/protocols/vscan/{svm.uuid}?fields=*",
     api_type="ontap",
     records_path="on_access_policies",
-    parent_mapping="OntapProtocolsVscan",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/vscan/on_access_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/vscan/on_access_policies/mapping.py
@@ -11,7 +11,7 @@ ONTAPVSCANONACCESS_MAPPING = TypeMapping(
     model_class=OntapVscanOnAccess,
     api_endpoint="/protocols/vscan/{svm.uuid}/on-access-policies?fields=*",
     api_type="ontap",
-    parent_mapping="OntapProtocolsVscan",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/vscan/on_demand_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/vscan/on_demand_policies/mapping.py
@@ -11,7 +11,7 @@ ONTAPVSCANONDEMAND_MAPPING = TypeMapping(
     model_class=OntapVscanOnDemand,
     api_endpoint="/protocols/vscan/{svm.uuid}/on-demand-policies?fields=*",
     api_type="ontap",
-    parent_mapping="OntapProtocolsVscan",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/vscan/scanner_pools/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/vscan/scanner_pools/mapping.py
@@ -11,7 +11,7 @@ ONTAPVSCANSCANNERPOOL_MAPPING = TypeMapping(
     model_class=OntapVscanScannerPool,
     api_endpoint="/protocols/vscan/{svm.uuid}/scanner-pools?fields=*",
     api_type="ontap",
-    parent_mapping="OntapProtocolsVscan",
+    parent_mapping="OntapSvm",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/resource_tags/resources/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/resource_tags/resources/mapping.py
@@ -12,7 +12,7 @@ ONTAPRESOURCETAGRESOURCE_MAPPING = TypeMapping(
     api_endpoint="/resource-tags/{resource_tag.value}/resources?fields=*",
     api_type="ontap",
     parent_mapping="OntapResourceTag",
-    parent_id_field="uuid",
+    parent_id_field="value",
     fields=(
         FieldMapping(
             cache_attr="href",

--- a/src/pynetappfoundry/cache/ontap/security/roles/privileges/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/roles/privileges/mapping.py
@@ -12,7 +12,7 @@ ONTAPROLEPRIVILEGE_MAPPING = TypeMapping(
     api_endpoint="/security/roles/{owner.uuid}/{name}/privileges?fields=*",
     api_type="ontap",
     parent_mapping="OntapRole",
-    parent_id_field="uuid",
+    parent_id_field="owner_uuid",
     fields=(
         FieldMapping(
             cache_attr="access",

--- a/src/pynetappfoundry/cache/ontap/storage/flexcache/origins/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/flexcache/origins/mapping.py
@@ -12,8 +12,8 @@ ONTAPFLEXCACHEORIGIN_MAPPING = TypeMapping(
     api_endpoint="/storage/flexcache/origins/{uuid}?fields=*",
     api_type="ontap",
     records_path="flexcaches",
-    parent_mapping="OntapStorageFlexcacheOrigin",
-    parent_id_field="uuid",
+    parent_mapping=None,
+    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="cluster_name",

--- a/src/pynetappfoundry/cache/ontap/storage/qtrees/metrics/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/qtrees/metrics/mapping.py
@@ -14,7 +14,7 @@ ONTAPPERFORMANCEQTREEMETRICRESPONSE_MAPPING = TypeMapping(
     api_endpoint="/storage/qtrees/{volume.uuid}/{qtree.id}/metrics?fields=*",
     api_type="ontap",
     parent_mapping="OntapQtree",
-    parent_id_field="uuid",
+    parent_id_field="id",
     fields=(
         FieldMapping(
             cache_attr="duration",

--- a/src/pynetappfoundry/cache/ontap/storage/snaplock/file/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snaplock/file/mapping.py
@@ -11,7 +11,7 @@ ONTAPSNAPLOCKFILERETENTION_MAPPING = TypeMapping(
     model_class=OntapSnaplockFileRetention,
     api_endpoint="/storage/snaplock/file/{volume.uuid}/{path}?fields=*",
     api_type="ontap",
-    parent_mapping="OntapStorageSnaplockFile",
+    parent_mapping="OntapVolume",
     parent_id_field="uuid",
     fields=(
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/storage/snaplock/file_fingerprints/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snaplock/file_fingerprints/mapping.py
@@ -13,8 +13,8 @@ ONTAPSNAPLOCKFILEFINGERPRINT_MAPPING = TypeMapping(
     model_class=OntapSnaplockFileFingerprint,
     api_endpoint="/storage/snaplock/file-fingerprints/{id}?fields=*",
     api_type="ontap",
-    parent_mapping="OntapStorageSnaplockFileFingerprint",
-    parent_id_field="uuid",
+    parent_mapping=None,
+    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="algorithm",

--- a/src/pynetappfoundry/cache/ontap/storage/snaplock/litigations/files/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snaplock/litigations/files/mapping.py
@@ -13,8 +13,8 @@ ONTAPSNAPLOCKLITIGATIONFILERESPONSE_MAPPING = TypeMapping(
     model_class=OntapSnaplockLitigationFileResponse,
     api_endpoint="/storage/snaplock/litigations/{litigation.id}/files?fields=*",
     api_type="ontap",
-    parent_mapping="OntapStorageSnaplockLitigation",
-    parent_id_field="uuid",
+    parent_mapping="OntapSnaplockLitigation",
+    parent_id_field="id",
     fields=(
         FieldMapping(
             cache_attr="file",

--- a/src/pynetappfoundry/cache/ontap/storage/snaplock/litigations/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snaplock/litigations/mapping.py
@@ -12,8 +12,8 @@ ONTAPSNAPLOCKLITIGATION_MAPPING = TypeMapping(
     api_endpoint="/storage/snaplock/litigations/{id}?fields=*",
     api_type="ontap",
     records_path="operations",
-    parent_mapping="OntapStorageSnaplockLitigation",
-    parent_id_field="uuid",
+    parent_mapping=None,
+    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="id",

--- a/src/pynetappfoundry/cache/ontap/storage/snaplock/litigations/operations/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snaplock/litigations/operations/mapping.py
@@ -13,8 +13,8 @@ ONTAPSNAPLOCKLEGALHOLDOPERATION_MAPPING = TypeMapping(
     model_class=OntapSnaplockLegalHoldOperation,
     api_endpoint="/storage/snaplock/litigations/{litigation.id}/operations/{id}?fields=*",
     api_type="ontap",
-    parent_mapping="OntapStorageSnaplockLitigation",
-    parent_id_field="uuid",
+    parent_mapping="OntapSnaplockLitigation",
+    parent_id_field="id",
     fields=(
         FieldMapping(
             cache_attr="id",

--- a/src/pynetappfoundry/cache/ontap/support/ems/filters/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/ems/filters/mapping.py
@@ -25,8 +25,8 @@ ONTAPEMSFILTER_MAPPING = TypeMapping(
     api_endpoint="/support/ems/filters/{name}?fields=*",
     api_type="ontap",
     records_path="rules",
-    parent_mapping="OntapSupportEmsFilter",
-    parent_id_field="uuid",
+    parent_mapping=None,
+    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="index",

--- a/src/pynetappfoundry/cache/ontap/support/ems/filters/rules/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/ems/filters/rules/mapping.py
@@ -27,8 +27,8 @@ ONTAPEMSFILTERRULERESPONSE_MAPPING = TypeMapping(
     model_class=OntapEmsFilterRuleResponse,
     api_endpoint="/support/ems/filters/{name}/rules?fields=*",
     api_type="ontap",
-    parent_mapping="OntapSupportEmsFilter",
-    parent_id_field="uuid",
+    parent_mapping=None,
+    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="index",

--- a/tests/unit/cache/test_mapping_parent_validation.py
+++ b/tests/unit/cache/test_mapping_parent_validation.py
@@ -1,0 +1,96 @@
+"""Regression tests for TypeMapping parent_mapping and parent_id_field validity.
+
+Ensures that every TypeMapping with a parent_mapping value references a
+registered mapping name, and that every parent_id_field value corresponds
+to an actual field on the parent model class.
+
+See: https://github.com/endavis/pynetappfoundry/issues/335
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import pytest
+
+from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache.field_mapping import TypeMapping
+
+
+def _import_all_mapping_modules() -> None:
+    """Import every ``mapping`` module under ``pynetappfoundry.cache.ontap``.
+
+    This triggers ``model_registry.register_mapping()`` calls in each
+    module, ensuring the registry is fully populated before tests run.
+    """
+    import pynetappfoundry.cache.ontap as root
+
+    for _, modname, _ in pkgutil.walk_packages(
+        root.__path__,
+        prefix=root.__name__ + ".",
+    ):
+        if modname.endswith(".mapping"):
+            importlib.import_module(modname)
+
+
+# Populate the registry once at module level.
+_import_all_mapping_modules()
+
+
+def _mappings_with_parent() -> list[tuple[str, TypeMapping]]:
+    """Return all registered mappings that declare a parent_mapping."""
+    return [
+        (name, mapping)
+        for name, mapping in model_registry.mappings.items()
+        if mapping.parent_mapping is not None
+    ]
+
+
+class TestParentMappingResolution:
+    """Every parent_mapping value must resolve to a registered mapping name."""
+
+    @pytest.mark.parametrize(
+        ("name", "mapping"),
+        _mappings_with_parent(),
+        ids=[name for name, _ in _mappings_with_parent()],
+    )
+    def test_parent_mapping_resolves(self, name: str, mapping: TypeMapping) -> None:
+        parent = model_registry.get_mapping(mapping.parent_mapping)  # type: ignore[arg-type]
+        assert parent is not None, (
+            f"Mapping {name!r} references parent_mapping={mapping.parent_mapping!r} "
+            f"which is not registered in model_registry"
+        )
+
+
+class TestParentIdFieldExists:
+    """Every parent_id_field must exist on the parent model class."""
+
+    @pytest.mark.parametrize(
+        ("name", "mapping"),
+        _mappings_with_parent(),
+        ids=[name for name, _ in _mappings_with_parent()],
+    )
+    def test_parent_id_field_exists_on_parent_model(self, name: str, mapping: TypeMapping) -> None:
+        if mapping.parent_id_field is None:
+            pytest.skip("No parent_id_field set")
+
+        parent = model_registry.get_mapping(mapping.parent_mapping)  # type: ignore[arg-type]
+        assert parent is not None, (
+            f"Cannot validate parent_id_field: parent_mapping={mapping.parent_mapping!r} not found"
+        )
+
+        parent_model = parent.model_class
+        # Check Pydantic model_fields (preferred) or fallback to hasattr
+        if hasattr(parent_model, "model_fields"):
+            field_names = set(parent_model.model_fields.keys())
+            assert mapping.parent_id_field in field_names, (
+                f"Mapping {name!r} declares parent_id_field={mapping.parent_id_field!r} "
+                f"but parent model {parent_model.__name__} has fields: "
+                f"{sorted(field_names)}"
+            )
+        else:
+            assert hasattr(parent_model, mapping.parent_id_field), (
+                f"Mapping {name!r} declares parent_id_field={mapping.parent_id_field!r} "
+                f"but parent model {parent_model.__name__} has no such attribute"
+            )


### PR DESCRIPTION
## Description

Fix incorrect `parent_mapping` and `parent_id_field` values across 55 TypeMapping
declarations. The codegen tool was emitting self-referential parent_mapping values
(pointing to the type's own mapping name instead of the actual parent) and setting
non-None parent fields on root-level endpoints that have no parent.

Addresses #335

## Related Issue

Addresses #335

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Corrected `parent_mapping` values that self-referenced the type's own mapping name to point to the actual parent type (e.g., `OntapSvm`, `OntapVolume`) or `None` for root endpoints
- Set `parent_id_field` to `None` on mappings where `parent_mapping` is `None` (root-level endpoints with no parent)
- Fixed multi-level hierarchies (e.g., export policy rules/clients, snaplock litigations/files) to reference the correct immediate parent
- Added `tests/unit/cache/test_mapping_parent_validation.py` with programmatic validation that all TypeMapping declarations have consistent parent_mapping/parent_id_field values

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

New test file validates:
- `parent_mapping` is either `None` or a known mapping name
- `parent_id_field` is `None` when `parent_mapping` is `None`
- `parent_id_field` is not `None` when `parent_mapping` is set
- No self-referential `parent_mapping` values

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This is an internal metadata correctness fix. No user-facing behavior changes; the
parameterized endpoint iteration feature (PR #334, #336) depends on correct
`parent_mapping` values to resolve URL placeholders at collection time.
