### PR TITLE
docs: add ADR-0010 for ClusterEntry and namespace access pattern

### DIFF
--- a/docs/decisions/0010-clusterentry-and-namespace-access-pattern.md
+++ b/docs/decisions/0010-clusterentry-and-namespace-access-pattern.md
@@ -1,0 +1,65 @@
+# ADR-0010: ClusterEntry and namespace access pattern
+
+## Status
+
+Accepted
+
+## Context
+
+The previous cache integration approach used `_enrich_with_cache()` in `Config.__init__()` to eagerly open the SQLite cache database and merge cached metadata into every cluster's config dict. This had several problems:
+
+- **Startup latency**: The cache DB was opened and queried at Config init time, even when scripts never accessed cached data.
+- **Coupling**: Static TOML configuration and dynamic cache data were mixed into the same flat dict, making it unclear which keys came from config files vs. the cache.
+- **No namespace isolation**: All cached fields lived in the same dict, risking key collisions as more API types (OCCM, AIQUM, DII) were added.
+
+## Decision
+
+Replace `_enrich_with_cache()` with `ClusterEntry` — a `MutableMapping[str, Any]` wrapper that provides:
+
+1. **Dict-like backward compatibility** for TOML config keys (`__getitem__`, `get`, `keys`, `items`, etc.), so existing code that treats cluster data as a plain dict continues to work unchanged.
+2. **Lazy `@cached_property` namespace accessors** (`.ontap`, `.occm`, `.aiqum`, `.dii`) that open the cache database only on first access, fetch the relevant `CachedClusterMetadata`, close the DB, and cache the result.
+3. **Attribute fallback** via `__getattr__` delegating to the underlying config dict.
+
+Integration point: `Config._wrap_clusters()` replaces each raw cluster dict with a `ClusterEntry` instance after TOML parsing completes.
+
+## Rationale
+
+1. **Lazy loading** — The cache DB is never opened unless a namespace property is actually accessed, eliminating unnecessary startup latency.
+2. **Clean separation** — TOML config keys are accessed via dict interface; cached metadata is accessed via named properties. No mixing.
+3. **Namespace isolation** — Each API type gets its own `@cached_property`, preventing key collisions and making it explicit which API the data belongs to.
+4. **Extensibility** — Adding a new API type requires only a new `@cached_property` on `ClusterEntry`.
+5. **Backward compatible** — `MutableMapping` interface means existing dict-based code works without changes.
+
+### Alternatives Considered
+
+- **Keep eager loading (`_enrich_with_cache()`)**: Rejected — imposed startup latency, tightly coupled config and cache data, no namespace isolation.
+- **Merge all namespaces into a flat dict**: Rejected — collision risk between API types, no isolation, unclear data provenance.
+- **Separate cache accessor object (not dict-like)**: Rejected — would break existing code that treats cluster data as a dict.
+
+## Consequences
+
+### Positive
+
+- Faster startup for scripts that don't access cached data
+- Clean separation between static config (TOML) and dynamic cache (SQLite)
+- Extensible namespace pattern for future API types (OCCM, AIQUM, DII)
+- Full backward compatibility with existing dict-based access patterns
+
+### Negative
+
+- Two access patterns coexist: dict syntax for config keys, property syntax for cached namespaces
+- Developers must know that `.ontap` triggers a DB read on first access
+
+## Related Issues
+
+- Issue #320: feat: replace `_enrich_with_cache` with ClusterEntry lazy cache accessors
+- Issue #301: feat: field annotations, OpenAPI codegen, and SQL cache storage
+
+## Related Documentation
+
+- `ClusterEntry` implementation: `src/pynetappfoundry/core/cluster_entry.py`
+- Config integration: `src/pynetappfoundry/core/config.py` (`_wrap_clusters()`)
+- [ADR-0004: Declarative field mapping framework](0004-declarative-field-mapping-framework.md)
+- [ADR-0009: Per-model SQL table storage](0009-sql-table-storage.md)
+- [Cache reference](../reference/cache.md)
+- [Cache models development guide](../development/cache-models.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -72,3 +72,6 @@ Template-inherited ADRs (9XXX range) are maintained in [docs/template/decisions/
 | [0005](0005-uuid-index-for-cache-cross-references.md) | UUID index for cache cross-references | Accepted |
 | [0006](0006-generalize-field-mapping-for-multi-api.md) | Generalize field mapping framework for multi-API data collection | Accepted |
 | [0007](0007-url-tree-model-registry.md) | Deep URL-tree structure with automatic model and mapping discovery | Accepted |
+| [0008](0008-openapi-codegen-for-model-generation.md) | OpenAPI codegen for model and mapping generation | Accepted |
+| [0009](0009-sql-table-storage.md) | Per-Model SQL Table Storage for Cache Layer | Accepted |
+| [0010](0010-clusterentry-and-namespace-access-pattern.md) | ClusterEntry and namespace access pattern | Accepted |


### PR DESCRIPTION
## Description

Create ADR-0010 documenting the architectural decision to replace `_enrich_with_cache()` with `ClusterEntry` — a `MutableMapping` wrapper that provides dict-like backward compatibility for TOML config and lazy `@cached_property` namespace accessors (`.ontap`, `.occm`, `.aiqum`, `.dii`) that defer cache DB access until first use.

## Related Issue

Addresses #301

## Type of Change

- [x] Documentation update

## Changes Made

- Created `docs/decisions/0010-clusterentry-and-namespace-access-pattern.md` with full ADR covering context, decision, rationale, alternatives, and consequences
- Updated `docs/decisions/README.md` index table with ADR-0008, ADR-0009, and ADR-0010 entries (0008 and 0009 were previously missing)

## Testing

- [x] All existing tests pass
- [x] `doit check` passes (no code changes, documentation only)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings