### PR TITLE
fix: use relative paths in command-blocking.md

### DIFF
--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -64,8 +64,8 @@ EOF
 
 | File | Description |
 |------|-------------|
-| [`block-dangerous-commands.py`](https://github.com/endavis/pynetappfoundry/blob/main/tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude and Gemini) |
-| [`test_hook.py`](https://github.com/endavis/pynetappfoundry/blob/main/tools/hooks/ai/test_hook.py) | Test suite to verify hook behavior |
+| [`block-dangerous-commands.py`](../../../tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude and Gemini) |
+| [`test_hook.py`](../../../tools/hooks/ai/test_hook.py) | Test suite to verify hook behavior |
 
 ### Configuration
 
@@ -220,5 +220,5 @@ Then run the test suite to verify.
 ## Related
 
 - [AI Enforcement Principles](enforcement-principles.md) - Why and how we enforce rules in code
-- [AGENTS.md](https://github.com/endavis/pynetappfoundry/blob/main/AGENTS.md) - AI agent rules including "When Blocked Protocol"
+- [AGENTS.md](../../../AGENTS.md) - AI agent rules including "When Blocked Protocol"
 - [AI Agent Setup](../AI_SETUP.md) - Setting up AI coding assistants


### PR DESCRIPTION
## Description

Replaced 3 absolute GitHub URLs with relative paths in `docs/development/ai/command-blocking.md` to match the upstream pyproject-template. Absolute URLs break if the repo is forked or renamed.

Addresses #355

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Line 67: `block-dangerous-commands.py` link → relative path
- Line 68: `test_hook.py` link → relative path
- Line 223: `AGENTS.md` link → relative path

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
