### PR TITLE
docs: update documentation for api-type namespace refactoring

### DIFF
--- a/docs/decisions/0007-url-tree-model-registry.md
+++ b/docs/decisions/0007-url-tree-model-registry.md
@@ -10,11 +10,13 @@ Restructure the `cache/` module from a monolithic `models.py` (793 lines, 30+ Py
 
 ### Directory Structure
 
-Models live at `cache/<api-path>/model.py` and mappings at `cache/<api-path>/mapping.py`, mirroring the ONTAP REST API URL hierarchy:
+Models live at `cache/<api-type>/<api-path>/model.py` and mappings at `cache/<api-type>/<api-path>/mapping.py`, namespaced by API type and mirroring the REST API URL hierarchy:
 
-- `cache/storage/volumes/model.py` + `mapping.py` (maps to `/storage/volumes`)
-- `cache/cluster/nodes/model.py` + `mapping.py` (maps to `/cluster/nodes`)
-- `cache/protocols/nfs/services/model.py` (maps to `/protocols/nfs/services`)
+- `cache/ontap/storage/volumes/model.py` + `mapping.py` (maps to `/storage/volumes`)
+- `cache/ontap/cluster/nodes/model.py` + `mapping.py` (maps to `/cluster/nodes`)
+- `cache/ontap/protocols/nfs/services/model.py` (maps to `/protocols/nfs/services`)
+
+The `<api-type>` namespace (`ontap/`, `aiqum/`, etc.) prevents path collisions when multiple APIs share endpoint paths like `/cluster`.
 
 ### Cache Field and Container Naming
 
@@ -57,7 +59,7 @@ Imports flow upward only (DAG guaranteed, no circular deps):
 
 3. **Automatic registration** - The `ModelRegistry` singleton enables tooling to discover all models and mappings without hardcoded lists, supporting future features like dynamic inspection and plugin systems.
 
-4. **Explicit imports** - Consumer code imports models from their URL-tree path (e.g., `from pynetappfoundry.cache.storage.volumes import VolumeInfo`), making the origin of each model immediately clear. Infrastructure (DB, collector, diff, registry) is imported from `pynetappfoundry.cache`.
+4. **Explicit imports** - Consumer code imports models from their URL-tree path (e.g., `from pynetappfoundry.cache.ontap.storage.volumes import VolumeInfo`), making the origin of each model immediately clear. Infrastructure (DB, collector, diff, registry) is imported from `pynetappfoundry.cache`.
 
 5. **Scalability** - The three-layer hierarchy prevents circular imports by construction. New models slot in at Layer 2 with no risk of breaking the import DAG.
 
@@ -65,6 +67,7 @@ Imports flow upward only (DAG guaranteed, no circular deps):
 
 - Issue #257: refactor: deep URL-tree structure with automatic model and mapping discovery
 - Issue #295: refactor: align cache field names and containers with ONTAP API endpoint hierarchy
+- Issue #314: refactor: namespace cache models under api-type directories
 
 ## Related Documentation
 

--- a/docs/development/field-mapping.md
+++ b/docs/development/field-mapping.md
@@ -56,6 +56,9 @@ Maps a single field across three domains: API response, CLI output, and cache mo
 | `default` | `Any` | Default value when the field is missing. Default: `""`. |
 | `transform` | `Callable \| None` | Custom API extraction function receiving the full record dict. Overrides `api_path`. |
 | `cli_transform` | `Callable \| None` | Custom CLI extraction function receiving the full record dict. Overrides `cli_field`. |
+| `cache_strategy` | `Literal["cache", "realtime", "derived"]` | How the field is collected and stored. Default: `"cache"`. See [Cache Model Architecture](cache-models.md#field-strategies). |
+| `requires_explicit_fetch` | `bool` | Whether this field requires explicit `?fields=` inclusion (ONTAP expensive fields). Default: `False`. |
+| `post_collection` | `Callable \| None` | Callable to compute derived field values after collection. Only used when `cache_strategy="derived"`. |
 
 ### TypeMapping
 
@@ -63,7 +66,7 @@ Defines a complete API object type mapping.
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `name` | `str` | Human-readable type name (e.g., `"Volume"`). |
+| `name` | `str` | Human-readable type name (e.g., `"OntapVolume"`). |
 | `model_class` | `type[BaseModel]` | Pydantic model class for the cache object. |
 | `api_endpoint` | `str` | REST API endpoint including query params. |
 | `cli_command` | `str` | CLI show command name. Default: `""` (empty, optional). |
@@ -71,11 +74,17 @@ Defines a complete API object type mapping.
 | `id_field` | `str` | Field used for log identification. Default: `"name"`. |
 | `records_path` | `str` | Dot-notation path to records list in the API response envelope. Default: `"records"`. Supports nested paths like `"_embedded.items"`. |
 | `api_type` | `str` | Tag identifying which API client/unit registry to use. Default: `"ontap"`. |
+| `parent_mapping` | `str \| None` | Name of the parent TypeMapping for parameterized endpoints. |
+| `parent_id_field` | `str \| None` | Field on the parent model providing the placeholder value. |
 
 Helper methods:
 
 - `api_expected_fields()` — derives top-level API keys from all `api_path` values (used for missing-field logging).
 - `cli_expected_fields()` — derives CLI field names from all `cli_field` values.
+- `explicit_fetch_fields()` — returns `cache_attr` names for fields with `requires_explicit_fetch=True`.
+- `cached_fields()` — returns fields with `cache_strategy="cache"`.
+- `realtime_fields()` — returns fields with `cache_strategy="realtime"`.
+- `derived_fields()` — returns fields with `cache_strategy="derived"`.
 
 ### Generic Parsers
 
@@ -102,7 +111,7 @@ Helper methods:
 
 ### Step 1: Create the mapping module
 
-Create `src/pynetappfoundry/cache/<api-path>/mapping.py` co-located with the model:
+Create `src/pynetappfoundry/cache/<api-type>/<api-path>/mapping.py` co-located with the model:
 
 ```python
 """<Type> type mapping definition."""
@@ -111,7 +120,7 @@ from __future__ import annotations
 
 from pynetappfoundry.cache._registry import model_registry
 from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
-from pynetappfoundry.cache.<api_path>.model import <TypeModel>
+from pynetappfoundry.cache.<api_type>.<api_path>.model import <TypeModel>
 
 <TYPE>_MAPPING = TypeMapping(
     name="<Type>",
@@ -166,11 +175,11 @@ The `cli_command` defaults to `""` (empty) since non-ONTAP APIs typically have n
 
 ### Step 2: Export from the package's `__init__.py`
 
-Add the import and `__all__` entry in `src/pynetappfoundry/cache/<api-path>/__init__.py`:
+Add the import and `__all__` entry in `src/pynetappfoundry/cache/<api-type>/<api-path>/__init__.py`:
 
 ```python
-from pynetappfoundry.cache.<api_path>.mapping import <TYPE>_MAPPING
-from pynetappfoundry.cache.<api_path>.model import <TypeModel>
+from pynetappfoundry.cache.<api_type>.<api_path>.mapping import <TYPE>_MAPPING
+from pynetappfoundry.cache.<api_type>.<api_path>.model import <TypeModel>
 
 __all__ = ["<TYPE>_MAPPING", "<TypeModel>"]
 ```
@@ -181,7 +190,7 @@ Replace hand-written parsing in the collector with the generic parsers:
 
 ```python
 from pynetappfoundry.cache.field_mapping import parse_api_response
-from pynetappfoundry.cache.<api_path>.mapping import <TYPE>_MAPPING
+from pynetappfoundry.cache.<api_type>.<api_path>.mapping import <TYPE>_MAPPING
 
 # API parsing
 items = parse_api_response(<TYPE>_MAPPING, response, log_prefix, log_missing_fn)
@@ -219,22 +228,18 @@ For CLI-only types, also test:
 - CLI record parsing (including coercion edge cases)
 - `cli_expected_fields()`
 
-## Migrated Types
+## Hand-Written Mappings
 
-| Type | Mapping | Model | Fields | Notes |
-|------|---------|-------|--------|-------|
-| Volume | `VOLUME_MAPPING` | `VolumeInfo` | 21 | API-only. Uses transform for aggregate list extraction. |
-| Aggregate | `AGGREGATE_MAPPING` | `AggregateInfo` | 28 | API-only. Deeply nested API paths (`block_storage.primary.*`). Explicit `?fields=*,is_spare_low,sidl_enabled`. |
-| Node | `NODE_MAPPING` | `NodeInfo` | 20 | API-only. Wildcard `[*]` syntax for list fields. `field_validator` for int→str coercion. |
-| ClusterPeer | `CLUSTER_PEER_MAPPING` | `ClusterPeer` | 7 | API-only. Uses transform for dict-vs-string fallback on `remote`, `authentication`, and `encryption`. |
-| Cluster | `CLUSTER_MAPPING` | `ClusterInfo` | 18 | API-only. Single-object endpoint (no `records` list), uses `parse_api_record()` directly. `is_ha` derived post-collection. |
-| CloudMetadata | `CLOUD_METADATA_MAPPING` | `CloudMetadata` | 19 | CLI-only (no API endpoint). Computed link fields built as post-processing in collector. |
-| BroadcastDomain | `BROADCAST_DOMAIN_MAPPING` | `BroadcastDomain` | 5 | API-only. Wildcard `[*]` syntax for `port_uuids`. Nested dot-path for `ipspace_uuid`. |
-| NetworkLIF | `NETWORK_LIF_MAPPING` | `NetworkLIF` | 25 | API-only. UUID-only nested refs for svm, ipspace, service_policy, subnet, and location nodes/ports. Scope-based sorting in collector. |
+Most mappings are now codegen-generated (e.g., `ONTAPVOLUME_MAPPING`, `ONTAPNODERESPONSE_MAPPING`). Two hand-written mappings remain for types that don't map to standard REST GET endpoints:
+
+| Type | Mapping | Model | Notes |
+|------|---------|-------|-------|
+| Cluster | `CLUSTER_MAPPING` | `ClusterInfo` | Hand-written. Single-object endpoint (no `records` list), uses `parse_api_record()` directly. `is_ha` derived post-collection. |
+| CloudMetadata | `CLOUD_METADATA_MAPPING` | `CloudMetadata` | Hand-written. CLI-only (no API endpoint). Computed link fields built as post-processing in collector. |
 
 ## Reference: Field Mapping Patterns
 
-The `VOLUME_MAPPING` in `src/pynetappfoundry/cache/mappings/volume.py` is the canonical example. It demonstrates all API field mapping patterns:
+The `VOLUME_MAPPING` in `src/pynetappfoundry/cache/ontap/storage/volumes/mapping.py` is the canonical example. It demonstrates all API field mapping patterns:
 
 ### Simple field (direct path)
 

--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -40,22 +40,22 @@ Both databases are SQLite files stored in the config directory:
 The `CachedClusterMetadata` Pydantic model defines the structure of cached data:
 
 ```python
-class CachedClusterMetadata(BaseModel):
+class CachedClusterMetadata(CacheModel, register=False):
     # Cache metadata
     cluster_name: str
     cached_at: datetime
     cache_version: str = "1.0"  # Schema version
 
     # Data categories
-    cloud: list[CloudMetadata]       # Cloud provider info per node
-    cluster: ClusterInfo             # Cluster identity
-    nodes: list[NodeInfo]            # Node information
-    network: NetworkInfo             # IP interfaces, broadcast domains, DNS, subnets
-    storage: StorageInfo             # Aggregates, SVMs, volumes, LUNs, etc.
-    licenses: LicenseInfo            # License information
-    mediator: MediatorInfo           # ONTAP Mediator configuration
-    relationships: RelationshipsInfo # SnapMirror, cluster/SVM peering
-    protocols: ProtocolsInfo         # Export policies, CIFS, NFS, S3
+    cloud: list[CloudMetadata]                          # Cloud provider info per node
+    cluster: ClusterInfo                                # Cluster identity
+    nodes: list[OntapNodeResponse]                      # Node information
+    network: NetworkInfo                                 # IP interfaces, broadcast domains, DNS, subnets
+    storage: StorageInfo                                 # Aggregates, SVMs, volumes, LUNs, etc.
+    license_packages: list[OntapLicensePackageResponse]  # License information
+    mediator: OntapMediatorResponse                      # ONTAP Mediator configuration
+    relationships: RelationshipsInfo                     # SnapMirror, cluster/SVM peering
+    protocols: ProtocolsInfo                             # Export policies, CIFS, NFS, S3
 ```
 
 ### UUID Cross-Reference Index
@@ -270,7 +270,7 @@ Update `METADATA_SCHEMA_VERSION` when modifying `CachedClusterMetadata`:
 
 When modifying the cache schema:
 
-1. **Update the model** in the appropriate `src/pynetappfoundry/cache/<api-path>/model.py` file
+1. **Update the model** in the appropriate `src/pynetappfoundry/cache/<api-type>/<api-path>/model.py` file
 
 2. **Update version constant**:
    ```python
@@ -378,18 +378,20 @@ All models use `ConfigDict(extra="allow")` for forward compatibility with new AP
 
 | Model | Key Fields | Description |
 |-------|------------|-------------|
-| `CloudMetadata` | node, instance_id, provider, region, instance_type | Cloud provider metadata per node |
-| `ClusterInfo` | cluster_name, cluster_uuid, ontap_version, version_generation, version_major, version_minor, contact, location, is_ha | Core cluster identity |
-| `NodeInfo` | uuid, name, serial_number, system_id, model, location, membership, version_full, storage_configuration, system_machine_type, controller_board, controller_memory_size, controller_cpu_count, vm_provider_type, ha_enabled, ha_auto_giveback, ha_partner_uuids, system_aggregate_uuid, cluster_interface_uuids, management_interface_uuids | Cluster node information |
+| `CloudMetadata` | node, instance_id, provider, region, instance_type | Cloud provider metadata per node (CLI-only) |
+| `ClusterInfo` | cluster_name, cluster_uuid, ontap_version, version_generation, version_major, version_minor, contact, location, is_ha, san_optimized | Core cluster identity |
+| `OntapNodeResponse` | uuid, name, serial_number, model, location, membership, version_full | Cluster node information (codegen-generated, ~118 fields) |
+| `OntapLicensePackageResponse` | name, scope, state | License package (codegen-generated) |
+| `OntapMediatorResponse` | ip_address, ca_certificate, dr_group_id | ONTAP Mediator configuration (codegen-generated) |
 
 ### Network
 
 | Model | Key Fields | Description |
 |-------|------------|-------------|
-| `NetworkLIF` | uuid, name, ip_address, netmask, ip_family, enabled, state, scope, vip, svm_uuid, ipspace_uuid, service_policy_uuid, services, auto_revert, failover, is_home, home_node_uuid, home_port_uuid, current_node_uuid, current_port_uuid, dns_zone, ddns_enabled, subnet_uuid, probe_port, rdma_protocols | Logical interface |
-| `BroadcastDomain` | uuid, name, ipspace, mtu, ports | Broadcast domain configuration |
-| `IPSubnetInfo` | uuid, name, ipspace, broadcast_domain, subnet, gateway, ip_ranges | IP subnet |
-| `DNSInfo` | uuid, svm, scope, domains, servers, timeout, attempts | DNS configuration |
+| `OntapIpInterface` | uuid, name, ip_address, netmask, enabled, state, scope | Logical interface (codegen-generated, ~49 fields) |
+| `OntapBroadcastDomain` | uuid, name, mtu | Broadcast domain configuration (codegen-generated) |
+| `OntapIpSubnet` | uuid, name, subnet, gateway | IP subnet (codegen-generated) |
+| `OntapDns` | uuid, domains, servers | DNS configuration (codegen-generated) |
 
 **Container:** `NetworkInfo` holds `ip_interfaces`, `ethernet_broadcast_domains`, `ipspaces`, `dns`, `ip_subnets`.
 
@@ -397,17 +399,17 @@ All models use `ConfigDict(extra="allow")` for forward compatibility with new AP
 
 | Model | Key Fields | Description |
 |-------|------------|-------------|
-| `AggregateInfo` | uuid, name, node, state, type, total_size, disk_count, disk_type, raid_type | Storage aggregate |
-| `SVMInfo` | uuid, name, state, subtype, root_volume, allowed_protocols, language | Storage VM |
-| `VolumeInfo` | uuid, name, svm, state, type, style, size, junction_path, export_policy, snapshot_policy | Volume |
-| `QtreeInfo` | id, name, svm, volume, path, security_style, export_policy | Qtree |
-| `CloudTargetInfo` | uuid, name, provider_type, server, container, owner, scope | Cloud object store target |
-| `FlexCacheInfo` | uuid, name, svm, path, size, origins, global_file_locking_enabled | FlexCache volume |
-| `SnapshotPolicyInfo` | uuid, name, svm, enabled, scope, schedules | Snapshot policy |
-| `ScheduleInfo` | uuid, name, type, scope, svm, cron, interval | Job schedule |
-| `LunInfo` | uuid, name, svm, volume, size, os_type, serial_number, enabled | LUN |
-| `IgroupInfo` | uuid, name, svm, protocol, os_type, initiators | Initiator group |
-| `QosPolicyInfo` | uuid, name, svm, scope, policy_class | QoS policy |
+| `OntapAggregate` | uuid, name, state | Storage aggregate (codegen-generated, ~128 fields) |
+| `OntapSvm` | uuid, name, state, subtype | Storage VM (codegen-generated, ~109 fields) |
+| `OntapVolume` | uuid, name, state, type, style, size | Volume (codegen-generated, ~512 fields) |
+| `OntapQtree` | uuid, name, security_style | Qtree (codegen-generated, ~52 fields) |
+| `OntapCloudTarget` | uuid, name, provider_type, server, container | Cloud object store target (codegen-generated) |
+| `OntapFlexcache` | uuid, name, size | FlexCache volume (codegen-generated) |
+| `OntapSnapshotPolicy` | uuid, name, enabled, scope | Snapshot policy (codegen-generated) |
+| `OntapSchedule` | uuid, name, type, scope | Job schedule (codegen-generated) |
+| `OntapLun` | uuid, name, size, os_type, serial_number, enabled | LUN (codegen-generated, ~105 fields) |
+| `OntapIgroup` | uuid, name, protocol, os_type | Initiator group (codegen-generated) |
+| `OntapQosPolicy` | uuid, name, scope | QoS policy (codegen-generated) |
 
 **Container:** `StorageInfo` holds `aggregates`, `svms`, `cloud_targets`, `volumes`, `qtrees`, `snapshot_policies`, `schedules`, `luns`, `igroups`, `qos_policies`, `flexcaches`.
 
@@ -415,32 +417,21 @@ All models use `ConfigDict(extra="allow")` for forward compatibility with new AP
 
 | Model | Key Fields | Description |
 |-------|------------|-------------|
-| `ExportPolicyInfo` | id, name, svm, rules | NFS export policy |
-| `ExportRuleInfo` | index, clients, protocols, ro_rule, rw_rule, superuser | Export rule |
-| `CIFSShareInfo` | name, path, svm, comment, oplocks, encryption | CIFS/SMB share |
-| `CIFSServiceInfo` | svm, name, enabled, ad_domain, netbios_aliases | CIFS service config |
-| `NFSServiceInfo` | svm, enabled, protocol_v3/v4/v41_enabled | NFS service config |
-| `S3BucketInfo` | uuid, name, svm, type, size, versioning_state | S3 bucket |
+| `OntapExportPolicy` | id, name | NFS export policy (codegen-generated) |
+| `OntapCifsShare` | name, path | CIFS/SMB share (codegen-generated) |
+| `OntapCifsService` | name, enabled | CIFS service config (codegen-generated, ~99 fields) |
+| `OntapNfsService` | enabled, state | NFS service config (codegen-generated, ~158 fields) |
+| `OntapS3Bucket` | uuid, name, type, size | S3 bucket (codegen-generated) |
 
 **Container:** `ProtocolsInfo` holds `nfs_export_policies`, `cifs_shares`, `nfs_services`, `cifs_services`, `s3_buckets`.
-
-### Licensing & Mediator
-
-| Model | Key Fields | Description |
-|-------|------------|-------------|
-| `LicenseFeature` | name, state, scope | Feature license |
-| `CapacityLicense` | name, licensed_capacity, used_capacity | Capacity license |
-| `MediatorInfo` | mediator_address, mediator_uuid, mediator_port | ONTAP Mediator configuration |
-
-**Container:** `LicenseInfo` holds `feature_licenses`, `capacity_licenses`.
 
 ### Relationships
 
 | Model | Key Fields | Description |
 |-------|------------|-------------|
-| `SnapMirrorRelationship` | uuid, source_path, destination_path, relationship_type, state | SnapMirror relationship |
-| `ClusterPeer` | uuid, name, remote_cluster_name, peer_addresses, authentication_state | Cluster peer |
-| `SVMPeerInfo` | uuid, name, svm, peer_svm, peer_cluster, state, applications | SVM peer |
+| `OntapSnapmirrorRelationship` | uuid, source_path, destination_path, state | SnapMirror relationship (codegen-generated, ~69 fields) |
+| `OntapClusterPeer` | uuid, name | Cluster peer (codegen-generated) |
+| `OntapSvmPeer` | uuid, name, state | SVM peer (codegen-generated) |
 
 **Container:** `RelationshipsInfo` holds `snapmirror_destinations`, `cluster_peers`, `svm_peers`.
 
@@ -478,16 +469,16 @@ from pynetappfoundry.cache import (
 )
 
 # Models (import from their URL-tree sub-package)
-from pynetappfoundry.cache.cloud.metadata import CloudMetadata
-from pynetappfoundry.cache.cluster import ClusterInfo
-from pynetappfoundry.cache.cluster.mediators import MediatorInfo
-from pynetappfoundry.cache.cluster.nodes import NodeInfo
-from pynetappfoundry.cache.cluster.peers import ClusterPeer
-from pynetappfoundry.cache.network import NetworkInfo
-from pynetappfoundry.cache.network.ip.interfaces import NetworkLIF
-from pynetappfoundry.cache.storage import StorageInfo
-from pynetappfoundry.cache.storage.aggregates import AggregateInfo
-from pynetappfoundry.cache.storage.volumes import VolumeInfo
+from pynetappfoundry.cache.ontap.cloud.metadata import CloudMetadata
+from pynetappfoundry.cache.ontap.cluster import ClusterInfo
+from pynetappfoundry.cache.ontap.cluster.mediators import MediatorInfo
+from pynetappfoundry.cache.ontap.cluster.nodes import NodeInfo
+from pynetappfoundry.cache.ontap.cluster.peers import ClusterPeer
+from pynetappfoundry.cache.ontap.network import NetworkInfo
+from pynetappfoundry.cache.ontap.network.ip.interfaces import NetworkLIF
+from pynetappfoundry.cache.ontap.storage import StorageInfo
+from pynetappfoundry.cache.ontap.storage.aggregates import AggregateInfo
+from pynetappfoundry.cache.ontap.storage.volumes import VolumeInfo
 # ... etc. — see URL-tree structure for all model paths
 ```
 
@@ -503,13 +494,7 @@ db.set("cluster1", metadata)
 metadata = db.get("cluster1")  # Returns CachedClusterMetadata or None
 
 # List all clusters
-clusters = db.list_clusters()  # Returns list of cluster names
-
-# Delete cluster
-db.delete("cluster1")
-
-# Always close when done
-db.close()
+clusters = db.list_clusters()  # Returns list of dicts with cluster info
 ```
 
 ### CacheHistoryDB


### PR DESCRIPTION
## Description

Updated documentation to reflect the api-type namespace refactoring from #314. Import paths now use `cache/ontap/...` namespace, model names reflect codegen-generated names (e.g., `OntapVolume`, `OntapNodeResponse`), and the migrated types table is replaced with a hand-written mappings section.

Addresses #314

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `docs/decisions/0007-url-tree-model-registry.md` — Updated paths to include `ontap/` namespace, added #314 issue link
- `docs/development/field-mapping.md` — Updated import paths, model names, added new FieldMapping/TypeMapping attributes, replaced migrated types table with hand-written mappings section
- `docs/reference/cache.md` — Updated model names to codegen-generated names, updated import paths, removed obsolete Licensing & Mediator section, simplified API examples

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
