### PR TITLE
fix: scope _ensure_init_files to api_type namespace directory

### DIFF
--- a/tests/unit/codegen/test_generators.py
+++ b/tests/unit/codegen/test_generators.py
@@ -425,10 +425,10 @@ class TestWriteEndpointFiles:
         ep = _make_endpoint()
         written = write_endpoint_files(ep, tmp_path)
 
-        assert (tmp_path / "storage" / "volumes" / "model.py").exists()
-        assert (tmp_path / "storage" / "volumes" / "mapping.py").exists()
-        assert (tmp_path / "storage" / "volumes" / "__init__.py").exists()
-        assert (tmp_path / "storage" / "volumes" / "volumes.toml").exists()
+        assert (tmp_path / "ontap" / "storage" / "volumes" / "model.py").exists()
+        assert (tmp_path / "ontap" / "storage" / "volumes" / "mapping.py").exists()
+        assert (tmp_path / "ontap" / "storage" / "volumes" / "__init__.py").exists()
+        assert (tmp_path / "ontap" / "storage" / "volumes" / "volumes.toml").exists()
         assert len(written) == 4
 
     def test_intermediate_init_files(self, tmp_path):
@@ -441,14 +441,14 @@ class TestWriteEndpointFiles:
         )
         write_endpoint_files(ep, tmp_path)
 
-        assert (tmp_path / "network" / "__init__.py").exists()
-        assert (tmp_path / "network" / "ip" / "__init__.py").exists()
+        assert (tmp_path / "ontap" / "network" / "__init__.py").exists()
+        assert (tmp_path / "ontap" / "network" / "ip" / "__init__.py").exists()
 
     def test_generated_model_is_valid_python(self, tmp_path):
         ep = _make_endpoint()
         write_endpoint_files(ep, tmp_path)
 
-        model_code = (tmp_path / "storage" / "volumes" / "model.py").read_text()
+        model_code = (tmp_path / "ontap" / "storage" / "volumes" / "model.py").read_text()
         # Should compile without syntax errors
         compile(model_code, "model.py", "exec")
 
@@ -456,7 +456,7 @@ class TestWriteEndpointFiles:
         ep = _make_endpoint()
         write_endpoint_files(ep, tmp_path)
 
-        mapping_code = (tmp_path / "storage" / "volumes" / "mapping.py").read_text()
+        mapping_code = (tmp_path / "ontap" / "storage" / "volumes" / "mapping.py").read_text()
         compile(mapping_code, "mapping.py", "exec")
 
     def test_schema_lookup_passed_to_mapping(self, tmp_path):
@@ -473,8 +473,27 @@ class TestWriteEndpointFiles:
         schema_lookup = {"/svm/svms": "svm"}
         write_endpoint_files(ep, tmp_path, schema_lookup=schema_lookup)
 
-        mapping_code = (tmp_path / "svm" / "svms" / "web" / "mapping.py").read_text()
+        mapping_code = (tmp_path / "ontap" / "svm" / "svms" / "web" / "mapping.py").read_text()
         assert 'parent_mapping="OntapSvm"' in mapping_code
+
+    def test_no_orphan_dirs_under_output_dir(self, tmp_path):
+        """Only the api_type subdirectory should exist directly under output_dir."""
+        ep = _make_endpoint()
+        write_endpoint_files(ep, tmp_path)
+
+        subdirs = [p.name for p in tmp_path.iterdir() if p.is_dir()]
+        assert subdirs == ["ontap"]
+
+    def test_custom_api_type(self, tmp_path):
+        """Files should land under the custom api_type subdirectory."""
+        ep = _make_endpoint()
+        write_endpoint_files(ep, tmp_path, api_type="aiqum")
+
+        assert (tmp_path / "aiqum" / "storage" / "volumes" / "model.py").exists()
+        assert (tmp_path / "aiqum" / "storage" / "volumes" / "mapping.py").exists()
+        assert (tmp_path / "aiqum" / "storage" / "volumes" / "__init__.py").exists()
+        # No ontap directory should exist
+        assert not (tmp_path / "ontap").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/codegen/generators.py
+++ b/tools/codegen/generators.py
@@ -735,7 +735,7 @@ def write_endpoint_files(
         List of paths to all files written.
     """
     module_parts = _path_to_module_parts(endpoint.path)
-    pkg_dir = output_dir
+    pkg_dir = output_dir / api_type
     for part in module_parts:
         pkg_dir = pkg_dir / part
 
@@ -743,7 +743,7 @@ def write_endpoint_files(
     written: list[Path] = []
 
     # Also ensure intermediate __init__.py files exist
-    _ensure_init_files(output_dir, module_parts)
+    _ensure_init_files(output_dir / api_type, module_parts)
 
     # model.py
     model_path = pkg_dir / "model.py"


### PR DESCRIPTION
## Description

Fix `_ensure_init_files` in `tools/codegen/generators.py` to scope `__init__.py` creation within the `api_type` namespace directory. Previously, the function received `output_dir` without the `api_type` prefix, causing orphan `__init__.py` files to be created one level above the intended namespace.

Addresses #349

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `write_endpoint_files`: prepend `api_type` to `pkg_dir` before iterating `module_parts`, so the package directory is rooted under `output_dir / api_type`
- `write_endpoint_files`: pass `output_dir / api_type` (instead of bare `output_dir`) to `_ensure_init_files` so intermediate `__init__.py` files are created inside the api_type namespace
- Updated 5 existing tests to reflect the corrected path structure
- Added 2 new tests verifying `__init__.py` files are created only within the api_type namespace

## Testing

- [x] All existing tests pass
- [x] Added new tests for the fix
- [x] `doit check` passes (format, lint, type-check, security, spell-check, tests)
