### PR TITLE
chore: add missing Pydantic v2 reserved words to codegen safe_attr_name

### DIFF
--- a/tests/unit/codegen/test_generators.py
+++ b/tests/unit/codegen/test_generators.py
@@ -10,6 +10,7 @@ from tools.codegen.generators import (
     _has_typed_sub_fields,
     _path_to_class_name,
     _path_to_module_parts,
+    _safe_attr_name,
     _schema_to_pascal,
     _select_leaf_fields,
     _singularize,
@@ -645,3 +646,24 @@ class TestGenerateMappingSubModel:
         ep = _make_endpoint_with_sub_model()
         code = generate_mapping(ep)
         compile(code, "mapping.py", "exec")
+
+
+# ---------------------------------------------------------------------------
+# _safe_attr_name
+# ---------------------------------------------------------------------------
+
+
+class TestSafeAttrName:
+    """Direct tests for _safe_attr_name."""
+
+    def test_python_keyword(self):
+        assert _safe_attr_name("class") == "class_"
+
+    def test_pydantic_reserved(self):
+        assert _safe_attr_name("model_config") == "model_config_"
+
+    def test_unreserved(self):
+        assert _safe_attr_name("name") == "name"
+
+    def test_compound_not_reserved(self):
+        assert _safe_attr_name("space_metadata") == "space_metadata"

--- a/tools/codegen/generators.py
+++ b/tools/codegen/generators.py
@@ -205,6 +205,18 @@ _PYTHON_KEYWORDS: frozenset[str] = frozenset(
         # Pydantic BaseModel reserved attributes
         "schema",
         "model",
+        # Pydantic v2 reserved attributes
+        "model_config",
+        "model_fields",
+        "model_computed_fields",
+        "model_extra",
+        "model_fields_set",
+        "model_post_init",
+        "model_validate",
+        "model_dump",
+        "model_json_schema",
+        "metadata",
+        "config",
     }
 )
 


### PR DESCRIPTION
## Description

Add missing Pydantic v2 reserved attributes to the `_PYTHON_KEYWORDS` frozenset in the codegen `_safe_attr_name` function. Without these, generated model fields that collide with Pydantic internals (e.g., `model_config`, `model_fields`, `metadata`) would silently shadow BaseModel attributes and cause runtime errors.

## Related Issue

Addresses #347

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added 10 Pydantic v2 reserved attributes (`model_config`, `model_fields`, `model_computed_fields`, `model_extra`, `model_fields_set`, `model_post_init`, `model_validate`, `model_dump`, `model_json_schema`, `metadata`, `config`) to `_PYTHON_KEYWORDS` in `tools/codegen/generators.py`
- Added `TestSafeAttrName` test class in `tests/unit/codegen/test_generators.py` covering Python keywords, Pydantic reserved words, unreserved names, and compound names

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (test, lint, type-check, security, spell-check)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
