### PR TITLE
chore: remove unused _uuid_index SQL table from cache layer

### DIFF
--- a/docs/decisions/0009-sql-table-storage.md
+++ b/docs/decisions/0009-sql-table-storage.md
@@ -32,7 +32,10 @@ model field definitions:
   They lack independent identity and don't need separate tables.
 - **`_extra_json` column**: Every model table has this column to preserve
   `extra="allow"` fields from newer ONTAP versions.
-- **`_uuid_index` table**: Cross-model UUID lookup, populated on `set()`.
+- **`_uuid_index` table**: ~~Cross-model UUID lookup, populated on `set()`.~~
+  Removed in schema v3 — never queried in production. UUID resolution uses
+  the in-memory `CachedClusterMetadata.uuid_index` cached property
+  (see [ADR-0005](0005-uuid-index-for-cache-cross-references.md)).
 - **v1 → v2 migration**: Reads JSON blobs, decomposes into new tables, rebuilds
   the envelope table without `metadata_json`.
 

--- a/src/pynetappfoundry/cache/db.py
+++ b/src/pynetappfoundry/cache/db.py
@@ -1,9 +1,10 @@
 """SQLite database operations for cluster metadata cache.
 
-Schema v2 stores each Pydantic model in its own SQL table instead of a
-single JSON blob.  The public API (``get``/``set``/``clear``/etc.) is
-preserved so callers (collectors, query, inspect, diff, refresh) work
-unchanged.
+Schema v3 stores each Pydantic model in its own SQL table instead of a
+single JSON blob.  v3 removes the unused ``_uuid_index`` SQL table (UUID
+resolution uses the in-memory ``CachedClusterMetadata.uuid_index``).
+The public API (``get``/``set``/``clear``/etc.) is preserved so callers
+(collectors, query, inspect, diff, refresh) work unchanged.
 """
 
 from __future__ import annotations
@@ -20,7 +21,6 @@ from pydantic import BaseModel
 from pynetappfoundry.cache._metadata import CachedClusterMetadata
 from pynetappfoundry.cache.db_schema import (
     ENVELOPE_DDL,
-    UUID_INDEX_DDL,
     _ensure_registry,
     _is_json_column,
     generate_cluster_name_index_ddl,
@@ -164,14 +164,16 @@ def _set_by_path(target: dict[str, Any], path: str, value: Any) -> None:
 class ClusterMetadataDB(SQLiteDB):
     """SQLite database for caching cluster metadata.
 
-    Schema v2 decomposes CachedClusterMetadata into per-model SQL tables.
+    Schema v3 decomposes CachedClusterMetadata into per-model SQL tables.
+    The ``_uuid_index`` SQL table was removed in v3 (UUID resolution uses
+    the in-memory ``CachedClusterMetadata.uuid_index`` per ADR-0005).
     The public ``get``/``set``/``clear`` API is preserved.
 
     Note: Change history is stored in a separate database (CacheHistoryDB)
     for data safety and isolation.
     """
 
-    SCHEMA_VERSION: ClassVar[int] = 2
+    SCHEMA_VERSION: ClassVar[int] = 3
     TABLE_NAME: ClassVar[str] = "cluster_metadata"
 
     def __init__(
@@ -229,9 +231,6 @@ class ClusterMetadataDB(SQLiteDB):
             if spec.has_uuid:
                 self.conn.execute(generate_uuid_column_index_ddl(spec.table_name))
 
-        # UUID index table
-        self.conn.execute(UUID_INDEX_DDL)
-
     # ------------------------------------------------------------------
     # Migration v1 → v2
     # ------------------------------------------------------------------
@@ -251,14 +250,12 @@ class ClusterMetadataDB(SQLiteDB):
             self.conn.execute(generate_cluster_name_index_ddl(spec.table_name))
             if spec.has_uuid:
                 self.conn.execute(generate_uuid_column_index_ddl(spec.table_name))
-        self.conn.execute(UUID_INDEX_DDL)
 
         # 3. Migrate each cluster's data
         for v1_row in v1_rows:
             cluster_name = v1_row["cluster_name"]
             metadata = CachedClusterMetadata.model_validate(json.loads(v1_row["metadata_json"]))
             self._insert_model_data(cluster_name, metadata)
-            self._populate_uuid_index(cluster_name, metadata)
 
         # 4. Recreate envelope table without metadata_json
         #    (SQLite doesn't support DROP COLUMN before 3.35)
@@ -269,6 +266,14 @@ class ClusterMetadataDB(SQLiteDB):
             "SELECT cluster_name, cached_at, cache_version FROM _old_cluster_metadata"
         )
         self.conn.execute("DROP TABLE _old_cluster_metadata")
+
+    # ------------------------------------------------------------------
+    # Migration v2 → v3
+    # ------------------------------------------------------------------
+
+    def _upgrade_to_v3(self) -> None:
+        """Remove the unused _uuid_index table (never queried in production)."""
+        self.conn.execute("DROP TABLE IF EXISTS _uuid_index")
 
     # ------------------------------------------------------------------
     # Internal: decompose metadata into tables
@@ -306,29 +311,6 @@ class ClusterMetadataDB(SQLiteDB):
         sql = f"INSERT INTO {table_name} ({col_names}) VALUES ({placeholders})"
         values = [tuple(row[c] for c in columns) for row in rows]
         self.conn.executemany(sql, values)
-
-    def _populate_uuid_index(
-        self,
-        cluster_name: str,
-        metadata: CachedClusterMetadata,
-    ) -> None:
-        """Populate the _uuid_index table from a CachedClusterMetadata."""
-        rows: list[tuple[str, str, str]] = []
-        for path, spec in self._registry.items():
-            if not spec.has_uuid:
-                continue
-            data = _get_by_path(metadata, path)
-            items = data if spec.is_list else [data]
-            for item in items:
-                uuid_val = getattr(item, "uuid", "")
-                if uuid_val:
-                    rows.append((cluster_name, uuid_val, spec.table_name))
-        if rows:
-            self.conn.executemany(
-                "INSERT OR REPLACE INTO _uuid_index (cluster_name, uuid, table_name) "
-                "VALUES (?, ?, ?)",
-                rows,
-            )
 
     # ------------------------------------------------------------------
     # Internal: reconstruct metadata from tables
@@ -392,16 +374,11 @@ class ClusterMetadataDB(SQLiteDB):
                 f"DELETE FROM {spec.table_name} WHERE cluster_name = ?",
                 (cluster_name,),
             )
-        self.conn.execute(
-            "DELETE FROM _uuid_index WHERE cluster_name = ?",
-            (cluster_name,),
-        )
 
     def _delete_all_model_data(self) -> None:
         """Delete all model rows from every table."""
         for spec in self._registry.values():
             self.conn.execute(f"DELETE FROM {spec.table_name}")
-        self.conn.execute("DELETE FROM _uuid_index")
 
     # ------------------------------------------------------------------
     # Public API — preserved interface
@@ -458,7 +435,6 @@ class ClusterMetadataDB(SQLiteDB):
             # Delete old model rows then re-insert
             self._delete_model_data(cluster_name)
             self._insert_model_data(cluster_name, metadata)
-            self._populate_uuid_index(cluster_name, metadata)
 
     def clear(self, cluster_name: str | None = None) -> int:
         """Clear cached metadata.

--- a/src/pynetappfoundry/cache/db_schema.py
+++ b/src/pynetappfoundry/cache/db_schema.py
@@ -284,14 +284,6 @@ def generate_uuid_column_index_ddl(table_name: str) -> str:
 # Fixed table DDL
 # ---------------------------------------------------------------------------
 
-UUID_INDEX_DDL = """\
-CREATE TABLE _uuid_index (
-    cluster_name TEXT NOT NULL,
-    uuid TEXT NOT NULL,
-    table_name TEXT NOT NULL,
-    PRIMARY KEY (cluster_name, uuid)
-)"""
-
 ENVELOPE_DDL = """\
 CREATE TABLE cluster_metadata (
     cluster_name TEXT PRIMARY KEY,

--- a/tests/unit/cache/test_db.py
+++ b/tests/unit/cache/test_db.py
@@ -80,7 +80,6 @@ class TestClusterMetadataDB:
         tables = {row["name"] for row in cursor.fetchall()}
         assert "cluster_metadata" in tables
         assert "_schema_version" in tables
-        assert "_uuid_index" in tables
 
     def test_set_and_get(
         self, db: ClusterMetadataDB, sample_metadata: CachedClusterMetadata
@@ -356,48 +355,10 @@ class TestClusterMetadataDB:
         """export_json returns None for missing cluster."""
         assert db.export_json("nonexistent") is None
 
-    def test_uuid_index_populated(self, db: ClusterMetadataDB) -> None:
-        """_uuid_index table should have entries for models with non-empty uuids."""
-        meta = CachedClusterMetadata(
-            cluster_name="test-cluster",
-            nodes=[
-                OntapNodeResponse(
-                    name="node1",
-                    uuid="12345678-1234-1234-1234-123456789abc",
-                ),
-            ],
-        )
-        db.set("test-cluster", meta)
-
-        cursor = db.conn.execute(
-            "SELECT * FROM _uuid_index WHERE cluster_name = ?",
-            ("test-cluster",),
-        )
-        rows = [dict(r) for r in cursor.fetchall()]
-        assert len(rows) >= 1
-        uuids = {r["uuid"] for r in rows}
-        assert "12345678-1234-1234-1234-123456789abc" in uuids
-
-    def test_uuid_index_skips_empty(self, db: ClusterMetadataDB) -> None:
-        """_uuid_index should not include entries with empty uuid."""
-        meta = CachedClusterMetadata(
-            cluster_name="test-cluster",
-            nodes=[OntapNodeResponse(name="node1")],  # uuid defaults to ""
-        )
-        db.set("test-cluster", meta)
-
-        cursor = db.conn.execute(
-            "SELECT * FROM _uuid_index WHERE cluster_name = ?",
-            ("test-cluster",),
-        )
-        rows = cursor.fetchall()
-        # No entries because uuid is empty
-        assert len(rows) == 0
-
     def test_clear_removes_from_all_tables(
         self, db: ClusterMetadataDB, sample_metadata: CachedClusterMetadata
     ) -> None:
-        """clear() should remove rows from all model tables and uuid_index."""
+        """clear() should remove rows from all model tables."""
         db.set("test-cluster", sample_metadata)
         db.clear("test-cluster")
 
@@ -410,12 +371,6 @@ class TestClusterMetadataDB:
 
         cursor = db.conn.execute(
             "SELECT COUNT(*) FROM cloudmetadata WHERE cluster_name = ?",
-            ("test-cluster",),
-        )
-        assert cursor.fetchone()[0] == 0
-
-        cursor = db.conn.execute(
-            "SELECT COUNT(*) FROM _uuid_index WHERE cluster_name = ?",
             ("test-cluster",),
         )
         assert cursor.fetchone()[0] == 0
@@ -617,6 +572,93 @@ class TestClusterMetadataDBMigration:
         columns = {row[1] for row in cursor.fetchall()}
         assert "metadata_json" not in columns
         assert "cached_at" in columns
+
+        db.close()
+
+
+class TestClusterMetadataDBMigrationV3:
+    """Tests for v2 → v3 migration (drop _uuid_index table)."""
+
+    def test_migration_v2_to_v3(self, tmp_path: Path) -> None:
+        """Create a v2 database with _uuid_index data, open with v3 code, verify table is gone."""
+        db_path = tmp_path / "migrate_v3.db"
+
+        # Create a v2 database manually
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+
+        # Envelope table
+        conn.execute(
+            "CREATE TABLE cluster_metadata ("
+            "  cluster_name TEXT PRIMARY KEY,"
+            "  cached_at TEXT NOT NULL,"
+            "  cache_version TEXT NOT NULL"
+            ")"
+        )
+
+        # _uuid_index table (the one v3 removes)
+        conn.execute(
+            "CREATE TABLE _uuid_index ("
+            "  cluster_name TEXT NOT NULL,"
+            "  uuid TEXT NOT NULL,"
+            "  table_name TEXT NOT NULL,"
+            "  PRIMARY KEY (cluster_name, uuid)"
+            ")"
+        )
+        conn.execute(
+            "INSERT INTO _uuid_index (cluster_name, uuid, table_name) VALUES (?, ?, ?)",
+            ("test-cluster", "aaaa-bbbb-cccc", "ontapnoderesponse"),
+        )
+
+        # Schema version = 2
+        conn.execute("CREATE TABLE _schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO _schema_version (version) VALUES (2)")
+
+        # Insert envelope row
+        conn.execute(
+            "INSERT INTO cluster_metadata (cluster_name, cached_at, cache_version) "
+            "VALUES (?, ?, ?)",
+            ("test-cluster", "2025-01-01T00:00:00+00:00", "1.0.0"),
+        )
+
+        # Create per-model tables so the v3 DB can reconstruct metadata.
+        # We need at least the tables that CachedClusterMetadata expects.
+        # Open a temporary in-memory v3 DB to discover table DDL, then replay.
+        from pynetappfoundry.cache.db_schema import (
+            _ensure_registry,
+            generate_cluster_name_index_ddl,
+            generate_table_ddl,
+            generate_uuid_column_index_ddl,
+        )
+
+        registry = _ensure_registry()
+        for spec in registry.values():
+            ddl = generate_table_ddl(spec.table_name, spec.model_class)
+            conn.execute(ddl)
+            conn.execute(generate_cluster_name_index_ddl(spec.table_name))
+            if spec.has_uuid:
+                conn.execute(generate_uuid_column_index_ddl(spec.table_name))
+
+        conn.commit()
+        conn.close()
+
+        # Open with v3 code — should trigger migration
+        db = ClusterMetadataDB(db_path=db_path)
+
+        # Verify _uuid_index table is gone
+        cursor = db.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='_uuid_index'"
+        )
+        assert cursor.fetchone() is None
+
+        # Verify schema version is 3
+        cursor = db.conn.execute("SELECT version FROM _schema_version")
+        assert cursor.fetchone()[0] == 3
+
+        # Verify existing envelope data is intact
+        got = db.get("test-cluster")
+        assert got is not None
+        assert got.cluster_name == "test-cluster"
 
         db.close()
 


### PR DESCRIPTION
## Description

Remove the unused `_uuid_index` SQL table from the cache database layer and bump the schema to v3. The SQL-side UUID index was populated on every `set()` but never queried in production — UUID resolution has always used the in-memory `CachedClusterMetadata.uuid_index` cached property (ADR-0005).

Addresses #348

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Removed `UUID_INDEX_DDL` constant from `db_schema.py`
- Removed `_populate_uuid_index()` method and all `_uuid_index` table operations from `db.py`
- Bumped `SCHEMA_VERSION` from 2 to 3
- Added `_upgrade_to_v3()` migration that drops the `_uuid_index` table
- Updated ADR-0009 to document the removal and reference ADR-0005
- Updated tests: removed UUID index assertions, added v2-to-v3 migration test

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
