### PR TITLE
refactor: decouple diff engine _ENTITY_CONFIGS from hardcoded ONTAP models

### DIFF
--- a/src/pynetappfoundry/cache/diff.py
+++ b/src/pynetappfoundry/cache/diff.py
@@ -6,49 +6,36 @@ for change history tracking.
 Tracked fields are derived dynamically from each model's ``model_fields``,
 so new fields added to cache models are automatically tracked without
 manual updates to this module.
+
+Entity configurations are built dynamically by introspecting
+``CachedClusterMetadata`` model fields and looking up ``TypeMapping``
+entries in the model registry.  A small overrides dict handles
+models whose key/display fields don't follow the convention
+(``uuid`` if present, else ``name``).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, get_args, get_origin
 
 from pydantic import BaseModel
 
 from pynetappfoundry.cache._base import CacheModel
 from pynetappfoundry.cache.ontap.cloud.metadata.model import CloudMetadata
-from pynetappfoundry.cache.ontap.cloud.targets.model import OntapCloudTarget
 from pynetappfoundry.cache.ontap.cluster.licensing.licenses.model import (
     OntapLicensePackageResponse,
 )
 from pynetappfoundry.cache.ontap.cluster.model import ClusterInfo
-from pynetappfoundry.cache.ontap.cluster.nodes.model import OntapNodeResponse
-from pynetappfoundry.cache.ontap.cluster.peers.model import OntapClusterPeer
-from pynetappfoundry.cache.ontap.cluster.schedules.model import OntapSchedule
 from pynetappfoundry.cache.ontap.name_services.dns.model import OntapDns
-from pynetappfoundry.cache.ontap.network.ethernet.broadcast_domains.model import (
-    OntapBroadcastDomain,
-)
-from pynetappfoundry.cache.ontap.network.ip.interfaces.model import OntapIpInterface
-from pynetappfoundry.cache.ontap.network.ip.subnets.model import OntapIpSubnet
 from pynetappfoundry.cache.ontap.protocols.cifs.services.model import OntapCifsService
 from pynetappfoundry.cache.ontap.protocols.cifs.shares.model import OntapCifsShare
 from pynetappfoundry.cache.ontap.protocols.nfs.export_policies.model import OntapExportPolicy
 from pynetappfoundry.cache.ontap.protocols.nfs.services.model import OntapNfsService
-from pynetappfoundry.cache.ontap.protocols.s3.buckets.model import OntapS3Bucket
-from pynetappfoundry.cache.ontap.protocols.san.igroups.model import OntapIgroup
 from pynetappfoundry.cache.ontap.snapmirror.relationships.model import (
     OntapSnapmirrorRelationship,
 )
-from pynetappfoundry.cache.ontap.storage.aggregates.model import OntapAggregate
-from pynetappfoundry.cache.ontap.storage.flexcache.flexcaches.model import OntapFlexcache
-from pynetappfoundry.cache.ontap.storage.luns.model import OntapLun
-from pynetappfoundry.cache.ontap.storage.qos.policies.model import OntapQosPolicy
 from pynetappfoundry.cache.ontap.storage.qtrees.model import OntapQtree
-from pynetappfoundry.cache.ontap.storage.snapshot_policies.model import OntapSnapshotPolicy
-from pynetappfoundry.cache.ontap.storage.volumes.model import OntapVolume
-from pynetappfoundry.cache.ontap.svm.peers.model import OntapSvmPeer
-from pynetappfoundry.cache.ontap.svm.svms.model import OntapSvm
 
 if TYPE_CHECKING:
     from pynetappfoundry.cache._metadata import CachedClusterMetadata
@@ -131,144 +118,114 @@ def _get_display_name(entity: Any, display_field: str) -> str:
     return str(value)
 
 
-# Entity configurations: maps category path -> EntityConfig.
-# key_field is used for identity matching between snapshots.
-# display_field is the human-readable label shown in change output.
-# Tracked fields are derived automatically from model_class.model_fields.
-_ENTITY_CONFIGS: dict[str, EntityConfig] = {
-    # --- Models WITH uuid (use uuid as stable identity key) ---
-    "nodes": EntityConfig(
-        key_field="uuid",
-        model_class=OntapNodeResponse,
-        display_field="name",
-    ),
-    "network.ethernet_broadcast_domains": EntityConfig(
-        key_field="uuid",
-        model_class=OntapBroadcastDomain,
-        display_field="name",
-    ),
-    "network.ip_subnets": EntityConfig(
-        key_field="uuid",
-        model_class=OntapIpSubnet,
-        display_field="name",
-    ),
-    "network.dns": EntityConfig(
-        key_field="uuid",
-        model_class=OntapDns,
-        display_field="svm_uuid",
-    ),
-    "storage.aggregates": EntityConfig(
-        key_field="uuid",
-        model_class=OntapAggregate,
-        display_field="name",
-    ),
-    "storage.svms": EntityConfig(
-        key_field="uuid",
-        model_class=OntapSvm,
-        display_field="name",
-    ),
-    "storage.cloud_targets": EntityConfig(
-        key_field="uuid",
-        model_class=OntapCloudTarget,
-        display_field="name",
-    ),
-    "storage.volumes": EntityConfig(
-        key_field="uuid",
-        model_class=OntapVolume,
-        display_field="name",
-    ),
-    "storage.snapshot_policies": EntityConfig(
-        key_field="uuid",
-        model_class=OntapSnapshotPolicy,
-        display_field="name",
-    ),
-    "storage.schedules": EntityConfig(
-        key_field="uuid",
-        model_class=OntapSchedule,
-        display_field="name",
-    ),
-    "storage.luns": EntityConfig(
-        key_field="uuid",
-        model_class=OntapLun,
-        display_field="name",
-    ),
-    "storage.igroups": EntityConfig(
-        key_field="uuid",
-        model_class=OntapIgroup,
-        display_field="name",
-    ),
-    "storage.qos_policies": EntityConfig(
-        key_field="uuid",
-        model_class=OntapQosPolicy,
-        display_field="name",
-    ),
-    "storage.flexcaches": EntityConfig(
-        key_field="uuid",
-        model_class=OntapFlexcache,
-        display_field="name",
-    ),
-    "protocols.s3_buckets": EntityConfig(
-        key_field="uuid",
-        model_class=OntapS3Bucket,
-        display_field="name",
-    ),
-    "relationships.snapmirror_destinations": EntityConfig(
-        key_field="uuid",
-        model_class=OntapSnapmirrorRelationship,
-        display_field="{source_path}->{destination_path}",
-    ),
-    "relationships.cluster_peers": EntityConfig(
-        key_field="uuid",
-        model_class=OntapClusterPeer,
-        display_field="name",
-    ),
-    "relationships.svm_peers": EntityConfig(
-        key_field="uuid",
-        model_class=OntapSvmPeer,
-        display_field="name",
-    ),
-    # --- Models WITHOUT uuid (keep current key) ---
-    "cloud": EntityConfig(
-        key_field="node",
-        model_class=CloudMetadata,
-        display_field="node",
-    ),
-    "network.ip_interfaces": EntityConfig(
-        key_field="uuid",
-        model_class=OntapIpInterface,
-        display_field="name",
-    ),
-    "storage.qtrees": EntityConfig(
-        key_field="name",
-        model_class=OntapQtree,
-        display_field="name",
-    ),
-    "protocols.nfs_export_policies": EntityConfig(
-        key_field="index",
-        model_class=OntapExportPolicy,
-        display_field="index",
-    ),
-    "protocols.cifs_shares": EntityConfig(
-        key_field="name",
-        model_class=OntapCifsShare,
-        display_field="name",
-    ),
-    "protocols.nfs_services": EntityConfig(
-        key_field="svm_name",
-        model_class=OntapNfsService,
-        display_field="svm_name",
-    ),
-    "protocols.cifs_services": EntityConfig(
-        key_field="svm_name",
-        model_class=OntapCifsService,
-        display_field="svm_name",
-    ),
-    "license_packages": EntityConfig(
-        key_field="name",
-        model_class=OntapLicensePackageResponse,
-        display_field="name",
-    ),
+# ---------------------------------------------------------------------------
+# Dynamic entity config builder
+# ---------------------------------------------------------------------------
+
+# Overrides for models whose key/display fields don't follow the convention
+# (convention: key_field="uuid" if present else "name", display_field="name").
+# key: model class, value: (key_field, display_field)
+_DIFF_OVERRIDES: dict[type[CacheModel], tuple[str, str]] = {
+    CloudMetadata: ("node", "node"),
+    OntapDns: ("uuid", "svm_uuid"),
+    OntapQtree: ("name", "name"),
+    OntapExportPolicy: ("index", "index"),
+    OntapCifsShare: ("name", "name"),
+    OntapNfsService: ("svm_name", "svm_name"),
+    OntapCifsService: ("svm_name", "svm_name"),
+    OntapSnapmirrorRelationship: ("uuid", "{source_path}->{destination_path}"),
+    OntapLicensePackageResponse: ("name", "name"),
 }
+
+# Singleton fields on CachedClusterMetadata that are diffed separately
+# by _diff_cluster_info() and _diff_mediator_info().
+_SINGLETON_FIELDS = frozenset({"cluster", "mediator"})
+
+# Metadata-only fields on CachedClusterMetadata (not diffable entities).
+_METADATA_FIELDS = frozenset({"cluster_name", "cached_at", "cache_version"})
+
+
+def _build_entity_configs() -> dict[str, EntityConfig]:
+    """Build entity configs by introspecting CachedClusterMetadata.
+
+    Walks the model fields of ``CachedClusterMetadata`` recursively to
+    discover all ``list[CacheModel]`` fields and their category paths.
+    For each discovered model, looks up a matching ``TypeMapping`` in the
+    model registry to confirm it is a diffable entity, then applies
+    convention-based defaults or overrides for key/display fields.
+
+    Returns:
+        Mapping of category path to EntityConfig.
+    """
+    from pynetappfoundry.cache._metadata import CachedClusterMetadata
+    from pynetappfoundry.cache._registry import model_registry
+
+    # Build a set of model classes that have TypeMappings registered
+    mapped_classes: set[type[BaseModel]] = {
+        mapping.model_class for mapping in model_registry.mappings.values()
+    }
+
+    configs: dict[str, EntityConfig] = {}
+
+    def _walk(model_cls: type[BaseModel], prefix: str) -> None:
+        for field_name, field_info in model_cls.model_fields.items():
+            path = f"{prefix}.{field_name}" if prefix else field_name
+
+            # Skip metadata and singleton fields at the top level
+            if not prefix and field_name in (_METADATA_FIELDS | _SINGLETON_FIELDS):
+                continue
+
+            annotation = field_info.annotation
+            origin = get_origin(annotation)
+            args = get_args(annotation)
+
+            if origin is list and args:
+                inner = args[0]
+                if not (isinstance(inner, type) and issubclass(inner, CacheModel)):
+                    continue  # list[str] or other non-model list
+                if inner not in mapped_classes:
+                    continue  # no TypeMapping → not a diffable entity
+
+                # Determine key_field and display_field
+                if inner in _DIFF_OVERRIDES:
+                    key_field, display_field = _DIFF_OVERRIDES[inner]
+                elif "uuid" in inner.model_fields:
+                    key_field = "uuid"
+                    display_field = "name"
+                elif "name" in inner.model_fields:
+                    key_field = "name"
+                    display_field = "name"
+                else:
+                    continue  # no suitable identity key
+
+                configs[path] = EntityConfig(
+                    key_field=key_field,
+                    model_class=inner,
+                    display_field=display_field,
+                )
+
+            elif isinstance(annotation, type) and issubclass(annotation, BaseModel):
+                # Container model (e.g., StorageInfo, NetworkInfo) — recurse
+                _walk(annotation, path)
+
+    _walk(CachedClusterMetadata, "")
+    return configs
+
+
+# Lazy singleton — built on first access.
+_entity_configs: dict[str, EntityConfig] | None = None
+
+
+def _get_entity_configs() -> dict[str, EntityConfig]:
+    """Return the entity configs dict, building it on first access.
+
+    Returns:
+        Mapping of category path to EntityConfig.
+    """
+    global _entity_configs
+    if _entity_configs is None:
+        _entity_configs = _build_entity_configs()
+    return _entity_configs
 
 
 def compute_diff(
@@ -295,7 +252,7 @@ def compute_diff(
     # Handle initial capture (no before)
     if before is None:
         # Record all entities as "added"
-        for category, config in _ENTITY_CONFIGS.items():
+        for category, config in _get_entity_configs().items():
             entities = _get_entities(after, category)
             for entity in entities:
                 display = _get_display_name(entity, config.display_field)
@@ -312,7 +269,7 @@ def compute_diff(
         return changes
 
     # Compare each category
-    for category, config in _ENTITY_CONFIGS.items():
+    for category, config in _get_entity_configs().items():
         before_entities = _get_entities(before, category)
         after_entities = _get_entities(after, category)
         changes.extend(

--- a/tests/unit/cache/test_diff.py
+++ b/tests/unit/cache/test_diff.py
@@ -8,13 +8,14 @@ import pytest
 
 from pynetappfoundry.cache._metadata import CachedClusterMetadata
 from pynetappfoundry.cache.diff import (
-    _ENTITY_CONFIGS,
     EntityConfig,
+    _build_entity_configs,
     _diff_cluster_info,
     _diff_entity_list,
     _diff_mediator_info,
     _get_display_name,
     _get_entities,
+    _get_entity_configs,
     _get_tracked_fields,
     compute_diff,
     format_diff_summary,
@@ -236,7 +237,7 @@ class TestDiffEntityList:
 
     def test_entity_with_int_key_zero_added(self) -> None:
         """Entity with int key_field=0 detected as added."""
-        config = _ENTITY_CONFIGS["protocols.nfs_export_policies"]
+        config = _get_entity_configs()["protocols.nfs_export_policies"]
         before: list[Any] = []
         after = [OntapExportPolicy(index=0)]
         changes = _diff_entity_list("protocols.nfs_export_policies", before, after, config)
@@ -246,7 +247,7 @@ class TestDiffEntityList:
 
     def test_entity_with_int_key_zero_removed(self) -> None:
         """Entity with int key_field=0 detected as removed."""
-        config = _ENTITY_CONFIGS["protocols.nfs_export_policies"]
+        config = _get_entity_configs()["protocols.nfs_export_policies"]
         before = [OntapExportPolicy(index=0)]
         after: list[Any] = []
         changes = _diff_entity_list("protocols.nfs_export_policies", before, after, config)
@@ -256,7 +257,7 @@ class TestDiffEntityList:
 
     def test_entity_with_int_key_zero_modified(self) -> None:
         """Entity with int key_field=0 and changed field detected as modified."""
-        config = _ENTITY_CONFIGS["protocols.nfs_export_policies"]
+        config = _get_entity_configs()["protocols.nfs_export_policies"]
         before = [OntapExportPolicy(index=0, chown_mode="restricted")]
         after = [OntapExportPolicy(index=0, chown_mode="unrestricted")]
         changes = _diff_entity_list("protocols.nfs_export_policies", before, after, config)
@@ -466,18 +467,18 @@ class TestFormatDiffSummary:
 
 
 class TestEntityConfigsIntegrity:
-    """Verify _ENTITY_CONFIGS are correct."""
+    """Verify _get_entity_configs() are correct."""
 
     def test_all_category_paths_resolve(self) -> None:
-        """Every _ENTITY_CONFIGS key resolves on a default CachedClusterMetadata."""
+        """Every _get_entity_configs() key resolves on a default CachedClusterMetadata."""
         md = _make_metadata()
-        for category in _ENTITY_CONFIGS:
+        for category in _get_entity_configs():
             result = _get_entities(md, category)
             assert isinstance(result, list), f"{category} did not resolve to a list"
 
     def test_all_key_fields_exist_on_model(self) -> None:
         """Each config's key_field is in model_class.model_fields."""
-        for category, config in _ENTITY_CONFIGS.items():
+        for category, config in _get_entity_configs().items():
             assert config.key_field in config.model_class.model_fields, (
                 f"{category}: key_field '{config.key_field}' not in "
                 f"{config.model_class.__name__}.model_fields"
@@ -485,7 +486,7 @@ class TestEntityConfigsIntegrity:
 
     def test_all_display_fields_exist_or_are_templates(self) -> None:
         """Each config's display_field is a valid field name or contains '{'."""
-        for category, config in _ENTITY_CONFIGS.items():
+        for category, config in _get_entity_configs().items():
             if "{" in config.display_field:
                 continue  # Template — valid
             assert config.display_field in config.model_class.model_fields, (
@@ -495,4 +496,135 @@ class TestEntityConfigsIntegrity:
 
     def test_entity_config_count(self) -> None:
         """Currently 26 configs (catches accidental additions/removals)."""
-        assert len(_ENTITY_CONFIGS) == 26
+        assert len(_get_entity_configs()) == 26
+
+
+# ---------------------------------------------------------------------------
+# TestBuildEntityConfigs
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEntityConfigs:
+    """Verify _build_entity_configs() dynamic builder."""
+
+    def test_returns_correct_count(self) -> None:
+        """Builder discovers exactly 26 diffable entity categories."""
+        configs = _build_entity_configs()
+        assert len(configs) == 26
+
+    def test_matches_lazy_accessor(self) -> None:
+        """_build_entity_configs() and _get_entity_configs() return same data."""
+        built = _build_entity_configs()
+        cached = _get_entity_configs()
+        assert set(built.keys()) == set(cached.keys())
+        for key in built:
+            assert built[key].key_field == cached[key].key_field
+            assert built[key].model_class is cached[key].model_class
+            assert built[key].display_field == cached[key].display_field
+
+    def test_convention_uuid_model_gets_uuid_key(self) -> None:
+        """Models with uuid field and no override get key_field='uuid'."""
+        configs = _build_entity_configs()
+        # OntapAggregate has uuid, no override
+        config = configs["storage.aggregates"]
+        assert config.key_field == "uuid"
+        assert config.display_field == "name"
+
+    def test_convention_name_default_display(self) -> None:
+        """Convention defaults display_field to 'name'."""
+        configs = _build_entity_configs()
+        config = configs["nodes"]
+        assert config.display_field == "name"
+
+    def test_override_cloud_metadata(self) -> None:
+        """CloudMetadata override: key_field='node', display_field='node'."""
+        configs = _build_entity_configs()
+        config = configs["cloud"]
+        assert config.key_field == "node"
+        assert config.display_field == "node"
+
+    def test_override_dns(self) -> None:
+        """OntapDns override: display_field='svm_uuid'."""
+        configs = _build_entity_configs()
+        config = configs["network.dns"]
+        assert config.key_field == "uuid"
+        assert config.display_field == "svm_uuid"
+
+    def test_override_snapmirror_template(self) -> None:
+        """OntapSnapmirrorRelationship override uses format template."""
+        configs = _build_entity_configs()
+        config = configs["relationships.snapmirror_destinations"]
+        assert config.key_field == "uuid"
+        assert "{" in config.display_field
+
+    def test_override_export_policy(self) -> None:
+        """OntapExportPolicy override: key_field='index'."""
+        configs = _build_entity_configs()
+        config = configs["protocols.nfs_export_policies"]
+        assert config.key_field == "index"
+        assert config.display_field == "index"
+
+    def test_override_nfs_services(self) -> None:
+        """OntapNfsService override: key_field='svm_name'."""
+        configs = _build_entity_configs()
+        config = configs["protocols.nfs_services"]
+        assert config.key_field == "svm_name"
+        assert config.display_field == "svm_name"
+
+    def test_override_cifs_services(self) -> None:
+        """OntapCifsService override: key_field='svm_name'."""
+        configs = _build_entity_configs()
+        config = configs["protocols.cifs_services"]
+        assert config.key_field == "svm_name"
+        assert config.display_field == "svm_name"
+
+    def test_override_cifs_shares(self) -> None:
+        """OntapCifsShare override: key_field='name'."""
+        configs = _build_entity_configs()
+        config = configs["protocols.cifs_shares"]
+        assert config.key_field == "name"
+        assert config.display_field == "name"
+
+    def test_override_license_packages(self) -> None:
+        """OntapLicensePackageResponse override: key_field='name'."""
+        configs = _build_entity_configs()
+        config = configs["license_packages"]
+        assert config.key_field == "name"
+        assert config.display_field == "name"
+
+    def test_override_qtrees(self) -> None:
+        """OntapQtree override: key_field='name'."""
+        configs = _build_entity_configs()
+        config = configs["storage.qtrees"]
+        assert config.key_field == "name"
+        assert config.display_field == "name"
+
+    def test_singletons_excluded(self) -> None:
+        """Singleton fields (cluster, mediator) are not in configs."""
+        configs = _build_entity_configs()
+        assert "cluster" not in configs
+        assert "mediator" not in configs
+
+    def test_metadata_fields_excluded(self) -> None:
+        """Metadata fields (cluster_name, cached_at, cache_version) excluded."""
+        configs = _build_entity_configs()
+        assert "cluster_name" not in configs
+        assert "cached_at" not in configs
+        assert "cache_version" not in configs
+
+    def test_nested_categories_have_dotted_paths(self) -> None:
+        """Container fields produce dotted category paths."""
+        configs = _build_entity_configs()
+        nested = [k for k in configs if "." in k]
+        assert len(nested) > 0
+        assert "storage.aggregates" in configs
+        assert "network.ip_interfaces" in configs
+        assert "protocols.s3_buckets" in configs
+        assert "relationships.cluster_peers" in configs
+
+    def test_models_without_identity_key_excluded(self) -> None:
+        """Models with no uuid/name and no override are skipped."""
+        configs = _build_entity_configs()
+        # OntapTopMetricsSvmUser has a TypeMapping but no uuid/name field
+        categories_models = {cfg.model_class.__name__ for cfg in configs.values()}
+        assert "OntapTopMetricsSvmUser" not in categories_models


### PR DESCRIPTION
## Description

Replace the hardcoded `_ENTITY_CONFIGS` dictionary in `diff.py` with a dynamic builder that introspects `CachedClusterMetadata` model fields and the model registry at runtime. New cache models with a registered `TypeMapping` are now automatically discovered by the diff engine without manual dictionary maintenance.

Addresses #350

## Type of Change

- [x] Code refactoring

## Changes Made

- Remove the 26-entry `_ENTITY_CONFIGS` hardcoded dictionary and ~15 model imports that were only needed for it
- Add `_build_entity_configs()` that walks `CachedClusterMetadata` fields recursively, discovers `list[CacheModel]` annotations, and cross-references the model registry to find diffable entities
- Apply convention-based defaults (key=`uuid` if present else `name`, display=`name`) with explicit `_DIFF_OVERRIDES` for the 9 models that don't follow the convention
- Expose `_get_entity_configs()` lazy singleton so the config dict is built once on first access
- Add `_SINGLETON_FIELDS` and `_METADATA_FIELDS` frozen sets to exclude non-diffable top-level fields

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Added `TestBuildEntityConfigs` class with 17 new tests covering:
- Correct discovery count (26 entities)
- Consistency between `_build_entity_configs()` and `_get_entity_configs()`
- Convention-based defaults (uuid key, name display)
- All 9 override models verified individually
- Singleton and metadata field exclusion
- Dotted path generation for nested containers
- Models without identity keys are excluded

Updated existing tests to use `_get_entity_configs()` instead of the removed `_ENTITY_CONFIGS` dict.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This refactoring supports the multi-API generalization effort (ADR-0006, ADR-0007). When future API types (DII, AIQUM, etc.) add their own cache models under the URL-tree structure, the diff engine will automatically pick them up without any changes to `diff.py`.
