### PR TITLE
fix: emit api_path on transform-only FieldMappings for correct expensive field URL construction

### DIFF
--- a/src/pynetappfoundry/cache/field_mapping.py
+++ b/src/pynetappfoundry/cache/field_mapping.py
@@ -35,7 +35,10 @@ class FieldMapping:
         cli_field: Hyphenated CLI field name (e.g. ``"vserver"``).
         default: Default value when the field is missing.
         transform: Custom API extraction function receiving the full record dict.
-            Overrides ``api_path`` when set.
+            Overrides ``api_path`` for *extraction* when set.  ``api_path``
+            should still be provided alongside ``transform`` so that
+            :meth:`TypeMapping.explicit_fetch_api_fields` can derive the
+            correct top-level API field name.
         cli_transform: Custom CLI extraction function receiving the full record dict.
             Overrides ``cli_field`` when set.
         cache_strategy: How this field is collected and stored.
@@ -161,8 +164,9 @@ class TypeMapping:
 
         Considers only fields where ``requires_explicit_fetch=True`` AND
         ``cache_strategy="cache"``.  Extracts the first segment of
-        ``api_path`` (before ``.`` or ``[``); falls back to ``cache_attr``
-        for transform-only fields (no ``api_path``).
+        ``api_path`` (before ``.`` or ``[``).  Transform-only fields
+        without ``api_path`` are silently excluded because
+        ``cache_attr`` is not a valid API field name.
 
         Returns:
             Sorted list of unique top-level API field names.
@@ -176,8 +180,6 @@ class TypeMapping:
             if field.api_path is not None:
                 first_segment = field.api_path.split(".")[0].split("[")[0]
                 keys.add(first_segment)
-            else:
-                keys.add(field.cache_attr)
         return sorted(keys)
 
     def build_parameterized_url(self, parent_id: str) -> str:

--- a/src/pynetappfoundry/cache/ontap/application/applications/components/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/application/applications/components/mapping.py
@@ -92,21 +92,25 @@ ONTAPAPPLICATIONCOMPONENT_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="backing_storage_luns",
+            api_path="backing_storage.luns",
             transform=_transform_backing_storage_luns,
             default=[],
         ),
         FieldMapping(
             cache_attr="backing_storage_namespaces",
+            api_path="backing_storage.namespaces",
             transform=_transform_backing_storage_namespaces,
             default=[],
         ),
         FieldMapping(
             cache_attr="backing_storage_volumes",
+            api_path="backing_storage.volumes",
             transform=_transform_backing_storage_volumes,
             default=[],
         ),
         FieldMapping(
             cache_attr="cifs_access",
+            api_path="cifs_access",
             transform=_transform_cifs_access,
             default=[],
         ),
@@ -128,21 +132,25 @@ ONTAPAPPLICATIONCOMPONENT_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="nfs_access",
+            api_path="nfs_access",
             transform=_transform_nfs_access,
             default=[],
         ),
         FieldMapping(
             cache_attr="nvme_access",
+            api_path="nvme_access",
             transform=_transform_nvme_access,
             default=[],
         ),
         FieldMapping(
             cache_attr="protection_groups",
+            api_path="protection_groups",
             transform=_transform_protection_groups,
             default=[],
         ),
         FieldMapping(
             cache_attr="san_access",
+            api_path="san_access",
             transform=_transform_san_access,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/application/applications/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/application/applications/mapping.py
@@ -242,6 +242,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="rpo_components",
+            api_path="rpo.components",
             transform=_transform_rpo_components,
             default=[],
         ),
@@ -277,6 +278,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="statistics_components",
+            api_path="statistics.components",
             transform=_transform_statistics_components,
             default=[],
         ),
@@ -394,6 +396,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="mongo_db_on_san_new_igroups",
+            api_path="mongo_db_on_san.new_igroups",
             transform=_transform_mongo_db_on_san_new_igroups,
             default=[],
         ),
@@ -415,16 +418,19 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="mongo_db_on_san_secondary_igroups",
+            api_path="mongo_db_on_san.secondary_igroups",
             transform=_transform_mongo_db_on_san_secondary_igroups,
             default=[],
         ),
         FieldMapping(
             cache_attr="nas_application_components",
+            api_path="nas.application_components",
             transform=_transform_nas_application_components,
             default=[],
         ),
         FieldMapping(
             cache_attr="nas_cifs_access",
+            api_path="nas.cifs_access",
             transform=_transform_nas_cifs_access,
             default=[],
         ),
@@ -434,11 +440,13 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="nas_exclude_aggregates",
+            api_path="nas.exclude_aggregates",
             transform=_transform_nas_exclude_aggregates,
             default=[],
         ),
         FieldMapping(
             cache_attr="nas_nfs_access",
+            api_path="nas.nfs_access",
             transform=_transform_nas_nfs_access,
             default=[],
         ),
@@ -456,6 +464,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="nvme_components",
+            api_path="nvme.components",
             transform=_transform_nvme_components,
             default=[],
         ),
@@ -495,6 +504,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="oracle_on_nfs_nfs_access",
+            api_path="oracle_on_nfs.nfs_access",
             transform=_transform_oracle_on_nfs_nfs_access,
             default=[],
         ),
@@ -553,6 +563,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="oracle_on_san_new_igroups",
+            api_path="oracle_on_san.new_igroups",
             transform=_transform_oracle_on_san_new_igroups,
             default=[],
         ),
@@ -620,6 +631,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="oracle_rac_on_nfs_nfs_access",
+            api_path="oracle_rac_on_nfs.nfs_access",
             transform=_transform_oracle_rac_on_nfs_nfs_access,
             default=[],
         ),
@@ -688,6 +700,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="oracle_rac_on_san_db_sids",
+            api_path="oracle_rac_on_san.db_sids",
             transform=_transform_oracle_rac_on_san_db_sids,
             default=[],
         ),
@@ -702,6 +715,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="oracle_rac_on_san_new_igroups",
+            api_path="oracle_rac_on_san.new_igroups",
             transform=_transform_oracle_rac_on_san_new_igroups,
             default=[],
         ),
@@ -756,6 +770,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="s3_bucket_application_components",
+            api_path="s3_bucket.application_components",
             transform=_transform_s3_bucket_application_components,
             default=[],
         ),
@@ -765,16 +780,19 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="san_application_components",
+            api_path="san.application_components",
             transform=_transform_san_application_components,
             default=[],
         ),
         FieldMapping(
             cache_attr="san_exclude_aggregates",
+            api_path="san.exclude_aggregates",
             transform=_transform_san_exclude_aggregates,
             default=[],
         ),
         FieldMapping(
             cache_attr="san_new_igroups",
+            api_path="san.new_igroups",
             transform=_transform_san_new_igroups,
             default=[],
         ),
@@ -818,6 +836,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="sql_on_san_new_igroups",
+            api_path="sql_on_san.new_igroups",
             transform=_transform_sql_on_san_new_igroups,
             default=[],
         ),
@@ -915,6 +934,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="vdi_on_nas_nfs_access",
+            api_path="vdi_on_nas.nfs_access",
             transform=_transform_vdi_on_nas_nfs_access,
             default=[],
         ),
@@ -950,6 +970,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="vdi_on_san_new_igroups",
+            api_path="vdi_on_san.new_igroups",
             transform=_transform_vdi_on_san_new_igroups,
             default=[],
         ),
@@ -981,6 +1002,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="vsi_on_nas_nfs_access",
+            api_path="vsi_on_nas.nfs_access",
             transform=_transform_vsi_on_nas_nfs_access,
             default=[],
         ),
@@ -1016,6 +1038,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="vsi_on_san_new_igroups",
+            api_path="vsi_on_san.new_igroups",
             transform=_transform_vsi_on_san_new_igroups,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/application/applications/snapshots/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/application/applications/snapshots/mapping.py
@@ -39,6 +39,7 @@ ONTAPAPPLICATIONSNAPSHOT_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="components",
+            api_path="components",
             transform=_transform_components,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/application/consistency_groups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/application/consistency_groups/mapping.py
@@ -135,11 +135,13 @@ ONTAPCONSISTENCYGROUPRESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="consistency_groups",
+            api_path="consistency_groups",
             transform=_transform_consistency_groups,
             default=[],
         ),
         FieldMapping(
             cache_attr="luns",
+            api_path="luns",
             transform=_transform_luns,
             default=[],
         ),
@@ -236,6 +238,7 @@ ONTAPCONSISTENCYGROUPRESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="namespaces",
+            api_path="namespaces",
             transform=_transform_namespaces,
             default=[],
         ),
@@ -274,6 +277,7 @@ ONTAPCONSISTENCYGROUPRESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="replication_relationships",
+            api_path="replication_relationships",
             transform=_transform_replication_relationships,
             default=[],
         ),
@@ -410,6 +414,7 @@ ONTAPCONSISTENCYGROUPRESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="tiering_object_stores",
+            api_path="tiering.object_stores",
             transform=_transform_tiering_object_stores,
             default=[],
         ),
@@ -423,6 +428,7 @@ ONTAPCONSISTENCYGROUPRESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="volumes",
+            api_path="volumes",
             transform=_transform_volumes,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/application/consistency_groups/snapshots/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/application/consistency_groups/snapshots/mapping.py
@@ -108,21 +108,25 @@ ONTAPCONSISTENCYGROUPSNAPSHOTRESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="luns",
+            api_path="luns",
             transform=_transform_luns,
             default=[],
         ),
         FieldMapping(
             cache_attr="missing_luns",
+            api_path="missing_luns",
             transform=_transform_missing_luns,
             default=[],
         ),
         FieldMapping(
             cache_attr="missing_namespaces",
+            api_path="missing_namespaces",
             transform=_transform_missing_namespaces,
             default=[],
         ),
         FieldMapping(
             cache_attr="missing_volumes",
+            api_path="missing_volumes",
             transform=_transform_missing_volumes,
             default=[],
         ),
@@ -132,6 +136,7 @@ ONTAPCONSISTENCYGROUPSNAPSHOTRESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="namespaces",
+            api_path="namespaces",
             transform=_transform_namespaces,
             default=[],
         ),
@@ -151,6 +156,7 @@ ONTAPCONSISTENCYGROUPSNAPSHOTRESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="snapshot_volumes",
+            api_path="snapshot_volumes",
             transform=_transform_snapshot_volumes,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/application/templates/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/application/templates/mapping.py
@@ -266,6 +266,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="mongo_db_on_san_new_igroups",
+            api_path="mongo_db_on_san.new_igroups",
             transform=_transform_mongo_db_on_san_new_igroups,
             default=[],
         ),
@@ -287,16 +288,19 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="mongo_db_on_san_secondary_igroups",
+            api_path="mongo_db_on_san.secondary_igroups",
             transform=_transform_mongo_db_on_san_secondary_igroups,
             default=[],
         ),
         FieldMapping(
             cache_attr="nas_application_components",
+            api_path="nas.application_components",
             transform=_transform_nas_application_components,
             default=[],
         ),
         FieldMapping(
             cache_attr="nas_cifs_access",
+            api_path="nas.cifs_access",
             transform=_transform_nas_cifs_access,
             default=[],
         ),
@@ -306,11 +310,13 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="nas_exclude_aggregates",
+            api_path="nas.exclude_aggregates",
             transform=_transform_nas_exclude_aggregates,
             default=[],
         ),
         FieldMapping(
             cache_attr="nas_nfs_access",
+            api_path="nas.nfs_access",
             transform=_transform_nas_nfs_access,
             default=[],
         ),
@@ -328,6 +334,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="nvme_components",
+            api_path="nvme.components",
             transform=_transform_nvme_components,
             default=[],
         ),
@@ -367,6 +374,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="oracle_on_nfs_nfs_access",
+            api_path="oracle_on_nfs.nfs_access",
             transform=_transform_oracle_on_nfs_nfs_access,
             default=[],
         ),
@@ -425,6 +433,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="oracle_on_san_new_igroups",
+            api_path="oracle_on_san.new_igroups",
             transform=_transform_oracle_on_san_new_igroups,
             default=[],
         ),
@@ -492,6 +501,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="oracle_rac_on_nfs_nfs_access",
+            api_path="oracle_rac_on_nfs.nfs_access",
             transform=_transform_oracle_rac_on_nfs_nfs_access,
             default=[],
         ),
@@ -560,6 +570,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="oracle_rac_on_san_db_sids",
+            api_path="oracle_rac_on_san.db_sids",
             transform=_transform_oracle_rac_on_san_db_sids,
             default=[],
         ),
@@ -574,6 +585,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="oracle_rac_on_san_new_igroups",
+            api_path="oracle_rac_on_san.new_igroups",
             transform=_transform_oracle_rac_on_san_new_igroups,
             default=[],
         ),
@@ -632,6 +644,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="s3_bucket_application_components",
+            api_path="s3_bucket.application_components",
             transform=_transform_s3_bucket_application_components,
             default=[],
         ),
@@ -641,16 +654,19 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="san_application_components",
+            api_path="san.application_components",
             transform=_transform_san_application_components,
             default=[],
         ),
         FieldMapping(
             cache_attr="san_exclude_aggregates",
+            api_path="san.exclude_aggregates",
             transform=_transform_san_exclude_aggregates,
             default=[],
         ),
         FieldMapping(
             cache_attr="san_new_igroups",
+            api_path="san.new_igroups",
             transform=_transform_san_new_igroups,
             default=[],
         ),
@@ -694,6 +710,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="sql_on_san_new_igroups",
+            api_path="sql_on_san.new_igroups",
             transform=_transform_sql_on_san_new_igroups,
             default=[],
         ),
@@ -791,6 +808,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="vdi_on_nas_nfs_access",
+            api_path="vdi_on_nas.nfs_access",
             transform=_transform_vdi_on_nas_nfs_access,
             default=[],
         ),
@@ -826,6 +844,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="vdi_on_san_new_igroups",
+            api_path="vdi_on_san.new_igroups",
             transform=_transform_vdi_on_san_new_igroups,
             default=[],
         ),
@@ -857,6 +876,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="vsi_on_nas_nfs_access",
+            api_path="vsi_on_nas.nfs_access",
             transform=_transform_vsi_on_nas_nfs_access,
             default=[],
         ),
@@ -892,6 +912,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="vsi_on_san_new_igroups",
+            api_path="vsi_on_san.new_igroups",
             transform=_transform_vsi_on_san_new_igroups,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/chassis/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/chassis/mapping.py
@@ -37,6 +37,7 @@ ONTAPCHASSIS_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="frus",
+            api_path="frus",
             transform=_transform_frus,
             default=[],
         ),
@@ -46,11 +47,13 @@ ONTAPCHASSIS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="nodes",
+            api_path="nodes",
             transform=_transform_nodes,
             default=[],
         ),
         FieldMapping(
             cache_attr="shelves",
+            api_path="shelves",
             transform=_transform_shelves,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/counter/tables/rows/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/counter/tables/rows/mapping.py
@@ -47,6 +47,7 @@ ONTAPCOUNTERROW_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="counters",
+            api_path="counters",
             transform=_transform_counters,
             default=[],
         ),
@@ -56,6 +57,7 @@ ONTAPCOUNTERROW_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="properties",
+            api_path="properties",
             transform=_transform_properties,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/firmware/history/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/firmware/history/mapping.py
@@ -53,6 +53,7 @@ ONTAPFIRMWAREHISTORY_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="update_status",
+            api_path="update_status",
             transform=_transform_update_status,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/jobs/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/jobs/mapping.py
@@ -35,6 +35,7 @@ ONTAPJOB_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="error_arguments",
+            api_path="error.arguments",
             transform=_transform_error_arguments,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/licensing/capacity_pools/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/licensing/capacity_pools/mapping.py
@@ -29,6 +29,7 @@ ONTAPCAPACITYPOOLRESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="nodes",
+            api_path="nodes",
             transform=_transform_nodes,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/licensing/licenses/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/licensing/licenses/mapping.py
@@ -42,6 +42,7 @@ ONTAPLICENSEPACKAGERESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="licenses",
+            api_path="licenses",
             transform=_transform_licenses,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/metrocluster/diagnostics/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/metrocluster/diagnostics/mapping.py
@@ -61,6 +61,7 @@ ONTAPMETROCLUSTERDIAGNOSTICS_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="aggregate_details",
+            api_path="aggregate.details",
             transform=_transform_aggregate_details,
             default=[],
         ),
@@ -82,6 +83,7 @@ ONTAPMETROCLUSTERDIAGNOSTICS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="cluster_details",
+            api_path="cluster.details",
             transform=_transform_cluster_details,
             default=[],
         ),
@@ -119,6 +121,7 @@ ONTAPMETROCLUSTERDIAGNOSTICS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="connection_details",
+            api_path="connection.details",
             transform=_transform_connection_details,
             default=[],
         ),
@@ -156,6 +159,7 @@ ONTAPMETROCLUSTERDIAGNOSTICS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="node_details",
+            api_path="node.details",
             transform=_transform_node_details,
             default=[],
         ),
@@ -177,6 +181,7 @@ ONTAPMETROCLUSTERDIAGNOSTICS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="volume_details",
+            api_path="volume.details",
             transform=_transform_volume_details,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/metrocluster/dr_groups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/metrocluster/dr_groups/mapping.py
@@ -31,6 +31,7 @@ ONTAPMETROCLUSTERDRGROUP_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="dr_pairs",
+            api_path="dr_pairs",
             transform=_transform_dr_pairs,
             default=[],
         ),
@@ -41,6 +42,7 @@ ONTAPMETROCLUSTERDRGROUP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="mccip_ports",
+            api_path="mccip_ports",
             transform=_transform_mccip_ports,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/metrocluster/interconnects/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/metrocluster/interconnects/mapping.py
@@ -29,6 +29,7 @@ ONTAPMETROCLUSTERINTERCONNECT_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="interfaces",
+            api_path="interfaces",
             transform=_transform_interfaces,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/metrocluster/svms/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/metrocluster/svms/mapping.py
@@ -41,6 +41,7 @@ ONTAPMETROCLUSTERSVM_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="failed_reason_arguments",
+            api_path="failed_reason.arguments",
             transform=_transform_failed_reason_arguments,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/nodes/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/nodes/mapping.py
@@ -86,6 +86,7 @@ ONTAPNODERESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="cluster_interfaces",
+            api_path="cluster_interfaces",
             transform=_transform_cluster_interfaces,
             default=[],
         ),
@@ -134,11 +135,13 @@ ONTAPNODERESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="controller_flash_cache",
+            api_path="controller.flash_cache",
             transform=_transform_controller_flash_cache,
             default=[],
         ),
         FieldMapping(
             cache_attr="controller_frus",
+            api_path="controller.frus",
             transform=_transform_controller_frus,
             default=[],
         ),
@@ -200,6 +203,7 @@ ONTAPNODERESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="ha_giveback_status",
+            api_path="ha.giveback.status",
             transform=_transform_ha_giveback_status,
             default=[],
         ),
@@ -213,11 +217,13 @@ ONTAPNODERESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="ha_partners",
+            api_path="ha.partners",
             transform=_transform_ha_partners,
             default=[],
         ),
         FieldMapping(
             cache_attr="ha_ports",
+            api_path="ha.ports",
             transform=_transform_ha_ports,
             default=[],
         ),
@@ -290,6 +296,7 @@ ONTAPNODERESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="management_interfaces",
+            api_path="management_interfaces",
             transform=_transform_management_interfaces,
             default=[],
         ),
@@ -330,6 +337,7 @@ ONTAPNODERESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="metrocluster_ports",
+            api_path="metrocluster.ports",
             transform=_transform_metrocluster_ports,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/peers/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/peers/mapping.py
@@ -58,6 +58,7 @@ ONTAPCLUSTERPEER_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="initial_allowed_svms",
+            api_path="initial_allowed_svms",
             transform=_transform_initial_allowed_svms,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/cluster/software/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/software/mapping.py
@@ -39,6 +39,7 @@ ONTAPSOFTWAREREFERENCE_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="firmware_cluster_fw_progress",
+            api_path="firmware.cluster_fw_progress",
             transform=_transform_firmware_cluster_fw_progress,
             default=[],
         ),
@@ -156,6 +157,7 @@ ONTAPSOFTWAREREFERENCE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="software_images",
+            api_path="software_images",
             transform=_transform_software_images,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/name_services/dns/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/dns/mapping.py
@@ -84,6 +84,7 @@ ONTAPDNS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="status",
+            api_path="status",
             transform=_transform_status,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/name_services/nis/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/nis/mapping.py
@@ -25,6 +25,7 @@ ONTAPNISSERVICE_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="binding_details",
+            api_path="binding_details",
             transform=_transform_binding_details,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/name_services/unix_groups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/unix_groups/mapping.py
@@ -47,6 +47,7 @@ ONTAPUNIXGROUP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="users",
+            api_path="users",
             transform=_transform_users,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/name_services/unix_groups/users/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/unix_groups/users/mapping.py
@@ -31,6 +31,7 @@ ONTAPUNIXGROUPUSERS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="records",
+            api_path="records",
             transform=_transform_records,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/network/ethernet/broadcast_domains/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ethernet/broadcast_domains/mapping.py
@@ -42,6 +42,7 @@ ONTAPBROADCASTDOMAIN_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="ports",
+            api_path="ports",
             transform=_transform_ports,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/network/ethernet/ports/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ethernet/ports/mapping.py
@@ -60,6 +60,7 @@ ONTAPPORT_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="discovered_devices",
+            api_path="discovered_devices",
             transform=_transform_discovered_devices,
             default=[],
         ),
@@ -79,6 +80,7 @@ ONTAPPORT_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="lag_active_ports",
+            api_path="lag.active_ports",
             transform=_transform_lag_active_ports,
             default=[],
         ),
@@ -88,6 +90,7 @@ ONTAPPORT_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="lag_member_ports",
+            api_path="lag.member_ports",
             transform=_transform_lag_member_ports,
             default=[],
         ),
@@ -159,6 +162,7 @@ ONTAPPORT_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="reachable_broadcast_domains",
+            api_path="reachable_broadcast_domains",
             transform=_transform_reachable_broadcast_domains,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/network/fc/fabrics/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/fc/fabrics/mapping.py
@@ -35,6 +35,7 @@ ONTAPFABRIC_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="connections",
+            api_path="connections",
             transform=_transform_connections,
             default=[],
             requires_explicit_fetch=True,

--- a/src/pynetappfoundry/cache/ontap/network/fc/fabrics/switches/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/fc/fabrics/switches/mapping.py
@@ -53,6 +53,7 @@ ONTAPFCSWITCH_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="ports",
+            api_path="ports",
             transform=_transform_ports,
             default=[],
             requires_explicit_fetch=True,

--- a/src/pynetappfoundry/cache/ontap/network/fc/fabrics/zones/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/fc/fabrics/zones/mapping.py
@@ -44,6 +44,7 @@ ONTAPFCZONE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="members",
+            api_path="members",
             transform=_transform_members,
             default=[],
             requires_explicit_fetch=True,

--- a/src/pynetappfoundry/cache/ontap/network/fc/logins/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/fc/logins/mapping.py
@@ -22,6 +22,7 @@ ONTAPFCLOGIN_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="igroups",
+            api_path="igroups",
             transform=_transform_igroups,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/network/ip/routes/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ip/routes/mapping.py
@@ -41,6 +41,7 @@ ONTAPNETWORKROUTE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="interfaces",
+            api_path="interfaces",
             transform=_transform_interfaces,
             default=[],
             requires_explicit_fetch=True,

--- a/src/pynetappfoundry/cache/ontap/network/ip/subnets/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ip/subnets/mapping.py
@@ -36,6 +36,7 @@ ONTAPIPSUBNET_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="available_ip_ranges",
+            api_path="available_ip_ranges",
             transform=_transform_available_ip_ranges,
             default=[],
         ),
@@ -58,6 +59,7 @@ ONTAPIPSUBNET_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="ip_ranges",
+            api_path="ip_ranges",
             transform=_transform_ip_ranges,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/active_directory/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/active_directory/mapping.py
@@ -36,6 +36,7 @@ ONTAPACTIVEDIRECTORY_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="discovered_servers",
+            api_path="discovered_servers",
             transform=_transform_discovered_servers,
             default=[],
         ),
@@ -62,6 +63,7 @@ ONTAPACTIVEDIRECTORY_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="preferred_dcs",
+            api_path="preferred_dcs",
             transform=_transform_preferred_dcs,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/connections/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/connections/mapping.py
@@ -56,6 +56,7 @@ ONTAPCIFSCONNECTION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="sessions",
+            api_path="sessions",
             transform=_transform_sessions,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/domains/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/domains/mapping.py
@@ -59,6 +59,7 @@ ONTAPCIFSDOMAIN_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="discovered_servers",
+            api_path="discovered_servers",
             transform=_transform_discovered_servers,
             default=[],
         ),
@@ -104,6 +105,7 @@ ONTAPCIFSDOMAIN_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="preferred_dcs",
+            api_path="preferred_dcs",
             transform=_transform_preferred_dcs,
             default=[],
         ),
@@ -125,6 +127,7 @@ ONTAPCIFSDOMAIN_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="trust_relationships",
+            api_path="trust_relationships",
             transform=_transform_trust_relationships,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/group_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/group_policies/mapping.py
@@ -72,21 +72,25 @@ ONTAPPOLICIESANDRULESTOBEAPPLIED_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="to_be_applied_access_policies",
+            api_path="to_be_applied.access_policies",
             transform=_transform_to_be_applied_access_policies,
             default=[],
         ),
         FieldMapping(
             cache_attr="to_be_applied_access_rules",
+            api_path="to_be_applied.access_rules",
             transform=_transform_to_be_applied_access_rules,
             default=[],
         ),
         FieldMapping(
             cache_attr="to_be_applied_objects",
+            api_path="to_be_applied.objects",
             transform=_transform_to_be_applied_objects,
             default=[],
         ),
         FieldMapping(
             cache_attr="to_be_applied_restricted_groups",
+            api_path="to_be_applied.restricted_groups",
             transform=_transform_to_be_applied_restricted_groups,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/local_groups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/local_groups/mapping.py
@@ -29,6 +29,7 @@ ONTAPLOCALCIFSGROUP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="members",
+            api_path="members",
             transform=_transform_members,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/local_groups/members/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/local_groups/members/mapping.py
@@ -35,6 +35,7 @@ ONTAPLOCALCIFSGROUPMEMBERS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="records",
+            api_path="records",
             transform=_transform_records,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/local_users/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/local_users/mapping.py
@@ -38,6 +38,7 @@ ONTAPLOCALCIFSUSER_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="membership",
+            api_path="membership",
             transform=_transform_membership,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/netbios/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/netbios/mapping.py
@@ -75,6 +75,7 @@ ONTAPNETBIOS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="wins_servers",
+            api_path="wins_servers",
             transform=_transform_wins_servers,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/sessions/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/sessions/mapping.py
@@ -121,6 +121,7 @@ ONTAPCIFSSESSION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="volumes",
+            api_path="volumes",
             transform=_transform_volumes,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/shares/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/shares/mapping.py
@@ -30,6 +30,7 @@ ONTAPCIFSSHARE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="acls",
+            api_path="acls",
             transform=_transform_acls,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/policies/mapping.py
@@ -41,6 +41,7 @@ ONTAPFPOLICYPOLICY_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="events",
+            api_path="events",
             transform=_transform_events,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/mapping.py
@@ -43,6 +43,7 @@ ONTAPEXPORTPOLICY_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="clients",
+            api_path="clients",
             transform=_transform_clients,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/rules/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/rules/mapping.py
@@ -45,6 +45,7 @@ ONTAPEXPORTRULE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="clients",
+            api_path="clients",
             transform=_transform_clients,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/nvme/subsystems/hosts/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nvme/subsystems/hosts/mapping.py
@@ -65,6 +65,7 @@ ONTAPNVMESUBSYSTEMHOST_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="records",
+            api_path="records",
             transform=_transform_records,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/nvme/subsystems/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nvme/subsystems/mapping.py
@@ -40,6 +40,7 @@ ONTAPNVMESUBSYSTEM_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="hosts",
+            api_path="hosts",
             transform=_transform_hosts,
             default=[],
         ),
@@ -67,6 +68,7 @@ ONTAPNVMESUBSYSTEM_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="subsystem_maps",
+            api_path="subsystem_maps",
             transform=_transform_subsystem_maps,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/buckets/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/buckets/mapping.py
@@ -43,6 +43,7 @@ ONTAPS3BUCKET_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="aggregates",
+            api_path="aggregates",
             transform=_transform_aggregates,
             default=[],
         ),
@@ -70,6 +71,7 @@ ONTAPS3BUCKET_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="cors_rules",
+            api_path="cors.rules",
             transform=_transform_cors_rules,
             default=[],
         ),
@@ -80,6 +82,7 @@ ONTAPS3BUCKET_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="lifecycle_management_rules",
+            api_path="lifecycle_management.rules",
             transform=_transform_lifecycle_management_rules,
             default=[],
         ),
@@ -98,6 +101,7 @@ ONTAPS3BUCKET_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="policy_statements",
+            api_path="policy.statements",
             transform=_transform_policy_statements,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/services/buckets/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/services/buckets/mapping.py
@@ -45,6 +45,7 @@ ONTAPS3BUCKETSVM_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="aggregates",
+            api_path="aggregates",
             transform=_transform_aggregates,
             default=[],
         ),
@@ -67,6 +68,7 @@ ONTAPS3BUCKETSVM_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="cors_rules",
+            api_path="cors.rules",
             transform=_transform_cors_rules,
             default=[],
         ),
@@ -77,6 +79,7 @@ ONTAPS3BUCKETSVM_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="lifecycle_management_rules",
+            api_path="lifecycle_management.rules",
             transform=_transform_lifecycle_management_rules,
             default=[],
         ),
@@ -95,6 +98,7 @@ ONTAPS3BUCKETSVM_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="policy_statements",
+            api_path="policy.statements",
             transform=_transform_policy_statements,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/services/groups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/services/groups/mapping.py
@@ -46,6 +46,7 @@ ONTAPS3GROUP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="policies",
+            api_path="policies",
             transform=_transform_policies,
             default=[],
         ),
@@ -59,6 +60,7 @@ ONTAPS3GROUP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="users",
+            api_path="users",
             transform=_transform_users,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/services/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/services/mapping.py
@@ -31,6 +31,7 @@ ONTAPS3SERVICE_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="buckets",
+            api_path="buckets",
             transform=_transform_buckets,
             default=[],
         ),
@@ -262,6 +263,7 @@ ONTAPS3SERVICE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="users",
+            api_path="users",
             transform=_transform_users,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/services/policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/services/policies/mapping.py
@@ -40,6 +40,7 @@ ONTAPS3POLICY_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="statements",
+            api_path="statements",
             transform=_transform_statements,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/san/igroups/igroups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/igroups/igroups/mapping.py
@@ -35,6 +35,7 @@ ONTAPIGROUPNESTED_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="records",
+            api_path="records",
             transform=_transform_records,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/san/igroups/initiators/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/igroups/initiators/mapping.py
@@ -58,6 +58,7 @@ ONTAPIGROUPINITIATOR_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="connectivity_tracking_alerts",
+            api_path="connectivity_tracking.alerts",
             transform=_transform_connectivity_tracking_alerts,
             default=[],
             requires_explicit_fetch=True,
@@ -69,6 +70,7 @@ ONTAPIGROUPINITIATOR_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="connectivity_tracking_connections",
+            api_path="connectivity_tracking.connections",
             transform=_transform_connectivity_tracking_connections,
             default=[],
             requires_explicit_fetch=True,
@@ -92,11 +94,13 @@ ONTAPIGROUPINITIATOR_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="proximity_peer_svms",
+            api_path="proximity.peer_svms",
             transform=_transform_proximity_peer_svms,
             default=[],
         ),
         FieldMapping(
             cache_attr="records",
+            api_path="records",
             transform=_transform_records,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/san/igroups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/igroups/mapping.py
@@ -75,6 +75,7 @@ ONTAPIGROUP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="connectivity_tracking_alerts",
+            api_path="connectivity_tracking.alerts",
             transform=_transform_connectivity_tracking_alerts,
             default=[],
             requires_explicit_fetch=True,
@@ -86,6 +87,7 @@ ONTAPIGROUP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="connectivity_tracking_required_nodes",
+            api_path="connectivity_tracking.required_nodes",
             transform=_transform_connectivity_tracking_required_nodes,
             default=[],
             requires_explicit_fetch=True,
@@ -97,17 +99,20 @@ ONTAPIGROUP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="igroups",
+            api_path="igroups",
             transform=_transform_igroups,
             default=[],
             requires_explicit_fetch=True,
         ),
         FieldMapping(
             cache_attr="initiators",
+            api_path="initiators",
             transform=_transform_initiators,
             default=[],
         ),
         FieldMapping(
             cache_attr="lun_maps",
+            api_path="lun_maps",
             transform=_transform_lun_maps,
             default=[],
             requires_explicit_fetch=True,
@@ -122,6 +127,7 @@ ONTAPIGROUP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="parent_igroups",
+            api_path="parent_igroups",
             transform=_transform_parent_igroups,
             default=[],
             requires_explicit_fetch=True,
@@ -153,6 +159,7 @@ ONTAPIGROUP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="replication_error_summary_arguments",
+            api_path="replication.error.summary.arguments",
             transform=_transform_replication_error_summary_arguments,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/san/iscsi/credentials/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/iscsi/credentials/mapping.py
@@ -57,11 +57,13 @@ ONTAPISCSICREDENTIALS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="initiator_address_masks",
+            api_path="initiator_address.masks",
             transform=_transform_initiator_address_masks,
             default=[],
         ),
         FieldMapping(
             cache_attr="initiator_address_ranges",
+            api_path="initiator_address.ranges",
             transform=_transform_initiator_address_ranges,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/san/iscsi/sessions/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/iscsi/sessions/mapping.py
@@ -31,11 +31,13 @@ ONTAPISCSISESSION_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="connections",
+            api_path="connections",
             transform=_transform_connections,
             default=[],
         ),
         FieldMapping(
             cache_attr="igroups",
+            api_path="igroups",
             transform=_transform_igroups,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/san/lun_maps/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/lun_maps/mapping.py
@@ -77,6 +77,7 @@ ONTAPLUNMAP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="reporting_nodes",
+            api_path="reporting_nodes",
             transform=_transform_reporting_nodes,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/san/portsets/interfaces/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/portsets/interfaces/mapping.py
@@ -55,6 +55,7 @@ ONTAPPORTSETINTERFACE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="records",
+            api_path="records",
             transform=_transform_records,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/protocols/san/portsets/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/portsets/mapping.py
@@ -31,11 +31,13 @@ ONTAPPORTSET_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="igroups",
+            api_path="igroups",
             transform=_transform_igroups,
             default=[],
         ),
         FieldMapping(
             cache_attr="interfaces",
+            api_path="interfaces",
             transform=_transform_interfaces,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/security/accounts/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/accounts/mapping.py
@@ -25,6 +25,7 @@ ONTAPACCOUNT_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="applications",
+            api_path="applications",
             transform=_transform_applications,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/security/aws_kms/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/aws_kms/mapping.py
@@ -46,6 +46,7 @@ ONTAPAWSKMS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="ekmip_reachability",
+            api_path="ekmip_reachability",
             transform=_transform_ekmip_reachability,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/security/azure_key_vaults/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/azure_key_vaults/mapping.py
@@ -66,6 +66,7 @@ ONTAPAZUREKEYVAULT_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="ekmip_reachability",
+            api_path="ekmip_reachability",
             transform=_transform_ekmip_reachability,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/security/gcp_kms/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/gcp_kms/mapping.py
@@ -37,6 +37,7 @@ ONTAPGCPKMS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="ekmip_reachability",
+            api_path="ekmip_reachability",
             transform=_transform_ekmip_reachability,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/security/key_managers/key_servers/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/key_managers/key_servers/mapping.py
@@ -39,6 +39,7 @@ ONTAPKEYSERVER_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="connectivity_node_states",
+            api_path="connectivity.node_states",
             transform=_transform_connectivity_node_states,
             default=[],
         ),
@@ -53,6 +54,7 @@ ONTAPKEYSERVER_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="records",
+            api_path="records",
             transform=_transform_records,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/security/key_managers/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/key_managers/mapping.py
@@ -58,11 +58,13 @@ ONTAPSECURITYKEYMANAGER_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="external_server_ca_certificates",
+            api_path="external.server_ca_certificates",
             transform=_transform_external_server_ca_certificates,
             default=[],
         ),
         FieldMapping(
             cache_attr="external_servers",
+            api_path="external.servers",
             transform=_transform_external_servers,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/security/multi_admin_verify/rules/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/multi_admin_verify/rules/mapping.py
@@ -33,6 +33,7 @@ ONTAPMULTIADMINVERIFYRULE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="approval_groups",
+            api_path="approval_groups",
             transform=_transform_approval_groups,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/security/roles/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/roles/mapping.py
@@ -39,6 +39,7 @@ ONTAPROLE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="privileges",
+            api_path="privileges",
             transform=_transform_privileges,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/snapmirror/policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/snapmirror/policies/mapping.py
@@ -57,6 +57,7 @@ ONTAPSNAPMIRRORPOLICY_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="retention",
+            api_path="retention",
             transform=_transform_retention,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/snapmirror/relationships/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/snapmirror/relationships/mapping.py
@@ -78,6 +78,7 @@ ONTAPSNAPMIRRORRELATIONSHIP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="consistency_group_failover_error_arguments",
+            api_path="consistency_group_failover.error.arguments",
             transform=_transform_consistency_group_failover_error_arguments,
             default=[],
         ),
@@ -161,6 +162,7 @@ ONTAPSNAPMIRRORRELATIONSHIP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="destination_consistency_group_volumes",
+            api_path="destination.consistency_group_volumes",
             transform=_transform_destination_consistency_group_volumes,
             default=[],
         ),
@@ -275,6 +277,7 @@ ONTAPSNAPMIRRORRELATIONSHIP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="source_consistency_group_volumes",
+            api_path="source.consistency_group_volumes",
             transform=_transform_source_consistency_group_volumes,
             default=[],
         ),
@@ -304,6 +307,7 @@ ONTAPSNAPMIRRORRELATIONSHIP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="svmdr_volumes",
+            api_path="svmdr_volumes",
             transform=_transform_svmdr_volumes,
             default=[],
         ),
@@ -360,6 +364,7 @@ ONTAPSNAPMIRRORRELATIONSHIP_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="unhealthy_reason",
+            api_path="unhealthy_reason",
             transform=_transform_unhealthy_reason,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/snapmirror/relationships/transfers/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/snapmirror/relationships/transfers/mapping.py
@@ -62,6 +62,7 @@ ONTAPSNAPMIRRORTRANSFER_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="files",
+            api_path="files",
             transform=_transform_files,
             default=[],
         ),
@@ -92,6 +93,7 @@ ONTAPSNAPMIRRORTRANSFER_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="relationship_destination_consistency_group_volumes",
+            api_path="relationship.destination.consistency_group_volumes",
             transform=_transform_relationship_destination_consistency_group_volumes,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/aggregates/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/aggregates/mapping.py
@@ -88,6 +88,7 @@ ONTAPAGGREGATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="block_storage_hybrid_cache_simulated_raid_groups",
+            api_path="block_storage.hybrid_cache.simulated_raid_groups",
             transform=_transform_block_storage_hybrid_cache_simulated_raid_groups,
             default=[],
         ),
@@ -98,6 +99,7 @@ ONTAPAGGREGATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="block_storage_hybrid_cache_storage_pools",
+            api_path="block_storage.hybrid_cache.storage_pools",
             transform=_transform_block_storage_hybrid_cache_storage_pools,
             default=[],
         ),
@@ -117,6 +119,7 @@ ONTAPAGGREGATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="block_storage_plexes",
+            api_path="block_storage.plexes",
             transform=_transform_block_storage_plexes,
             default=[],
         ),
@@ -148,6 +151,7 @@ ONTAPAGGREGATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="block_storage_primary_simulated_raid_groups",
+            api_path="block_storage.primary.simulated_raid_groups",
             transform=_transform_block_storage_primary_simulated_raid_groups,
             default=[],
         ),
@@ -172,6 +176,7 @@ ONTAPAGGREGATE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="cloud_storage_stores",
+            api_path="cloud_storage.stores",
             transform=_transform_cloud_storage_stores,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/aggregates/plexes/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/aggregates/plexes/mapping.py
@@ -48,6 +48,7 @@ ONTAPPLEX_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="raid_groups",
+            api_path="raid_groups",
             transform=_transform_raid_groups,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/bridges/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/bridges/mapping.py
@@ -73,11 +73,13 @@ ONTAPSTORAGEBRIDGE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="errors",
+            api_path="errors",
             transform=_transform_errors,
             default=[],
         ),
         FieldMapping(
             cache_attr="fc_ports",
+            api_path="fc_ports",
             transform=_transform_fc_ports,
             default=[],
         ),
@@ -91,6 +93,7 @@ ONTAPSTORAGEBRIDGE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="last_reboot_reason_arguments",
+            api_path="last_reboot.reason.arguments",
             transform=_transform_last_reboot_reason_arguments,
             default=[],
         ),
@@ -125,16 +128,19 @@ ONTAPSTORAGEBRIDGE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="paths",
+            api_path="paths",
             transform=_transform_paths,
             default=[],
         ),
         FieldMapping(
             cache_attr="power_supply_units",
+            api_path="power_supply_units",
             transform=_transform_power_supply_units,
             default=[],
         ),
         FieldMapping(
             cache_attr="sas_ports",
+            api_path="sas_ports",
             transform=_transform_sas_ports,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/cluster/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/cluster/mapping.py
@@ -35,6 +35,7 @@ ONTAPCLUSTERSPACE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="block_storage_medias",
+            api_path="block_storage.medias",
             transform=_transform_block_storage_medias,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/disks/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/disks/mapping.py
@@ -43,6 +43,7 @@ ONTAPDISK_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="aggregates",
+            api_path="aggregates",
             transform=_transform_aggregates,
             default=[],
         ),
@@ -100,6 +101,7 @@ ONTAPDISK_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="error",
+            api_path="error",
             transform=_transform_error,
             default=[],
         ),
@@ -160,6 +162,7 @@ ONTAPDISK_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="outage_reason_arguments",
+            api_path="outage.reason.arguments",
             transform=_transform_outage_reason_arguments,
             default=[],
         ),
@@ -177,6 +180,7 @@ ONTAPDISK_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="paths",
+            api_path="paths",
             transform=_transform_paths,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/file/moves/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/file/moves/mapping.py
@@ -69,6 +69,7 @@ ONTAPFILEMOVE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="failure_arguments",
+            api_path="failure.arguments",
             transform=_transform_failure_arguments,
             default=[],
         ),
@@ -82,11 +83,13 @@ ONTAPFILEMOVE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="files_to_move_destinations",
+            api_path="files_to_move.destinations",
             transform=_transform_files_to_move_destinations,
             default=[],
         ),
         FieldMapping(
             cache_attr="files_to_move_sources",
+            api_path="files_to_move.sources",
             transform=_transform_files_to_move_sources,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/flexcache/flexcaches/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/flexcache/flexcaches/mapping.py
@@ -31,6 +31,7 @@ ONTAPFLEXCACHE_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="aggregates",
+            api_path="aggregates",
             transform=_transform_aggregates,
             default=[],
         ),
@@ -75,6 +76,7 @@ ONTAPFLEXCACHE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="origins",
+            api_path="origins",
             transform=_transform_origins,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/luns/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/luns/mapping.py
@@ -75,6 +75,7 @@ ONTAPLUN_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="attributes",
+            api_path="attributes",
             transform=_transform_attributes,
             default=[],
             requires_explicit_fetch=True,
@@ -119,6 +120,7 @@ ONTAPLUN_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="copy_destinations",
+            api_path="copy.destinations",
             transform=_transform_copy_destinations,
             default=[],
             requires_explicit_fetch=True,
@@ -152,6 +154,7 @@ ONTAPLUN_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="copy_source_progress_failure_arguments",
+            api_path="copy.source.progress.failure.arguments",
             transform=_transform_copy_source_progress_failure_arguments,
             default=[],
             requires_explicit_fetch=True,
@@ -228,6 +231,7 @@ ONTAPLUN_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="lun_maps",
+            api_path="lun_maps",
             transform=_transform_lun_maps,
             default=[],
             requires_explicit_fetch=True,
@@ -343,6 +347,7 @@ ONTAPLUN_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="movement_progress_failure_arguments",
+            api_path="movement.progress.failure.arguments",
             transform=_transform_movement_progress_failure_arguments,
             default=[],
             requires_explicit_fetch=True,
@@ -418,6 +423,7 @@ ONTAPLUN_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="provisioning_options_tiering_object_stores",
+            api_path="provisioning_options.tiering.object_stores",
             transform=_transform_provisioning_options_tiering_object_stores,
             default=[],
         ),
@@ -599,6 +605,7 @@ ONTAPLUN_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="vvol_bindings",
+            api_path="vvol.bindings",
             transform=_transform_vvol_bindings,
             default=[],
             requires_explicit_fetch=True,

--- a/src/pynetappfoundry/cache/ontap/storage/namespaces/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/namespaces/mapping.py
@@ -236,6 +236,7 @@ ONTAPNVMENAMESPACE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="provisioning_options_tiering_object_stores",
+            api_path="provisioning_options.tiering.object_stores",
             transform=_transform_provisioning_options_tiering_object_stores,
             default=[],
         ),
@@ -403,6 +404,7 @@ ONTAPNVMENAMESPACE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="subsystem_map_subsystem_hosts",
+            api_path="subsystem_map.subsystem.hosts",
             transform=_transform_subsystem_map_subsystem_hosts,
             default=[],
             requires_explicit_fetch=True,

--- a/src/pynetappfoundry/cache/ontap/storage/pools/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/pools/mapping.py
@@ -69,6 +69,7 @@ ONTAPSTORAGEPOOL_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="capacity_disks",
+            api_path="capacity.disks",
             transform=_transform_capacity_disks,
             default=[],
         ),
@@ -79,6 +80,7 @@ ONTAPSTORAGEPOOL_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="capacity_spare_allocation_units",
+            api_path="capacity.spare_allocation_units",
             transform=_transform_capacity_spare_allocation_units,
             default=[],
         ),
@@ -89,6 +91,7 @@ ONTAPSTORAGEPOOL_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="capacity_used_allocation_units",
+            api_path="capacity.used_allocation_units",
             transform=_transform_capacity_used_allocation_units,
             default=[],
         ),
@@ -103,6 +106,7 @@ ONTAPSTORAGEPOOL_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="health_unhealthy_reason_arguments",
+            api_path="health.unhealthy_reason.arguments",
             transform=_transform_health_unhealthy_reason_arguments,
             default=[],
         ),
@@ -120,6 +124,7 @@ ONTAPSTORAGEPOOL_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="nodes",
+            api_path="nodes",
             transform=_transform_nodes,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/quota/reports/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/quota/reports/mapping.py
@@ -109,6 +109,7 @@ ONTAPQUOTAREPORT_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="users",
+            api_path="users",
             transform=_transform_users,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/quota/rules/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/quota/rules/mapping.py
@@ -76,6 +76,7 @@ ONTAPQUOTARULE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="users",
+            api_path="users",
             transform=_transform_users,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/shelves/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/shelves/mapping.py
@@ -85,11 +85,13 @@ ONTAPSHELF_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="acps",
+            api_path="acps",
             transform=_transform_acps,
             default=[],
         ),
         FieldMapping(
             cache_attr="bays",
+            api_path="bays",
             transform=_transform_bays,
             default=[],
         ),
@@ -99,6 +101,7 @@ ONTAPSHELF_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="current_sensors",
+            api_path="current_sensors",
             transform=_transform_current_sensors,
             default=[],
         ),
@@ -109,21 +112,25 @@ ONTAPSHELF_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="drawers",
+            api_path="drawers",
             transform=_transform_drawers,
             default=[],
         ),
         FieldMapping(
             cache_attr="errors",
+            api_path="errors",
             transform=_transform_errors,
             default=[],
         ),
         FieldMapping(
             cache_attr="fans",
+            api_path="fans",
             transform=_transform_fans,
             default=[],
         ),
         FieldMapping(
             cache_attr="frus",
+            api_path="frus",
             transform=_transform_frus,
             default=[],
         ),
@@ -163,11 +170,13 @@ ONTAPSHELF_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="paths",
+            api_path="paths",
             transform=_transform_paths,
             default=[],
         ),
         FieldMapping(
             cache_attr="ports",
+            api_path="ports",
             transform=_transform_ports,
             default=[],
         ),
@@ -181,6 +190,7 @@ ONTAPSHELF_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="temperature_sensors",
+            api_path="temperature_sensors",
             transform=_transform_temperature_sensors,
             default=[],
         ),
@@ -210,6 +220,7 @@ ONTAPSHELF_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="voltage_sensors",
+            api_path="voltage_sensors",
             transform=_transform_voltage_sensors,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/snaplock/audit_logs/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snaplock/audit_logs/mapping.py
@@ -34,6 +34,7 @@ ONTAPSNAPLOCKLOG_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="log_files",
+            api_path="log_files",
             transform=_transform_log_files,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/snapshot_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snapshot_policies/mapping.py
@@ -29,6 +29,7 @@ ONTAPSNAPSHOTPOLICY_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="copies",
+            api_path="copies",
             transform=_transform_copies,
             default=[],
             requires_explicit_fetch=True,

--- a/src/pynetappfoundry/cache/ontap/storage/switches/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/switches/mapping.py
@@ -82,6 +82,7 @@ ONTAPSTORAGESWITCH_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="connections",
+            api_path="connections",
             transform=_transform_connections,
             default=[],
         ),
@@ -97,6 +98,7 @@ ONTAPSTORAGESWITCH_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="errors",
+            api_path="errors",
             transform=_transform_errors,
             default=[],
         ),
@@ -106,6 +108,7 @@ ONTAPSTORAGESWITCH_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="fans",
+            api_path="fans",
             transform=_transform_fans,
             default=[],
         ),
@@ -142,16 +145,19 @@ ONTAPSTORAGESWITCH_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="paths",
+            api_path="paths",
             transform=_transform_paths,
             default=[],
         ),
         FieldMapping(
             cache_attr="ports",
+            api_path="ports",
             transform=_transform_ports,
             default=[],
         ),
         FieldMapping(
             cache_attr="power_supply_units",
+            api_path="power_supply_units",
             transform=_transform_power_supply_units,
             default=[],
         ),
@@ -169,6 +175,7 @@ ONTAPSTORAGESWITCH_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="temperature_sensors",
+            api_path="temperature_sensors",
             transform=_transform_temperature_sensors,
             default=[],
         ),
@@ -178,6 +185,7 @@ ONTAPSTORAGESWITCH_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="vsans",
+            api_path="vsans",
             transform=_transform_vsans,
             default=[],
         ),
@@ -187,6 +195,7 @@ ONTAPSTORAGESWITCH_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="zones",
+            api_path="zones",
             transform=_transform_zones,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/tape_devices/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/tape_devices/mapping.py
@@ -39,6 +39,7 @@ ONTAPTAPEDEVICE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="aliases",
+            api_path="aliases",
             transform=_transform_aliases,
             default=[],
         ),
@@ -61,6 +62,7 @@ ONTAPTAPEDEVICE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="device_names",
+            api_path="device_names",
             transform=_transform_device_names,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/storage/volumes/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/volumes/mapping.py
@@ -104,6 +104,7 @@ ONTAPVOLUME_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="aggregates",
+            api_path="aggregates",
             transform=_transform_aggregates,
             default=[],
         ),
@@ -251,6 +252,7 @@ ONTAPVOLUME_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="anti_ransomware_attack_reports",
+            api_path="anti_ransomware.attack_reports",
             transform=_transform_anti_ransomware_attack_reports,
             default=[],
             requires_explicit_fetch=True,
@@ -344,6 +346,7 @@ ONTAPVOLUME_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="anti_ransomware_suspect_files",
+            api_path="anti_ransomware.suspect_files",
             transform=_transform_anti_ransomware_suspect_files,
             default=[],
             requires_explicit_fetch=True,
@@ -428,6 +431,7 @@ ONTAPVOLUME_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="anti_ransomware_workload_newly_observed_file_extensions",
+            api_path="anti_ransomware.workload.newly_observed_file_extensions",
             transform=_transform_anti_ransomware_workload_newly_observed_file_extensions,
             default=[],
             requires_explicit_fetch=True,
@@ -499,6 +503,7 @@ ONTAPVOLUME_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="anti_ransomware_workload_surge_usage_newly_observed_file_extensions",
+            api_path="anti_ransomware.workload.surge_usage.newly_observed_file_extensions",
             transform=_transform_anti_ransomware_workload_surge_usage_newly_observed_file_extensions,
             default=[],
             requires_explicit_fetch=True,
@@ -680,6 +685,7 @@ ONTAPVOLUME_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="constituents",
+            api_path="constituents",
             transform=_transform_constituents,
             default=[],
         ),
@@ -1646,6 +1652,7 @@ ONTAPVOLUME_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="rebalancing_notices",
+            api_path="rebalancing.notices",
             transform=_transform_rebalancing_notices,
             default=[],
             requires_explicit_fetch=True,

--- a/src/pynetappfoundry/cache/ontap/support/auto_update/updates/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/auto_update/updates/mapping.py
@@ -86,6 +86,7 @@ ONTAPAUTOUPDATESTATUS_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="status_arguments",
+            api_path="status.arguments",
             transform=_transform_status_arguments,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/support/configuration_backup/backups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/configuration_backup/backups/mapping.py
@@ -32,6 +32,7 @@ ONTAPCONFIGURATIONBACKUPFILE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="backup_nodes",
+            api_path="backup_nodes",
             transform=_transform_backup_nodes,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/support/ems/destinations/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/ems/destinations/mapping.py
@@ -51,6 +51,7 @@ ONTAPEMSDESTINATIONRESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="connectivity_errors",
+            api_path="connectivity.errors",
             transform=_transform_connectivity_errors,
             default=[],
         ),
@@ -64,6 +65,7 @@ ONTAPEMSDESTINATIONRESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="filters",
+            api_path="filters",
             transform=_transform_filters,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/support/ems/events/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/ems/events/mapping.py
@@ -50,6 +50,7 @@ ONTAPEMSEVENTRESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="parameters",
+            api_path="parameters",
             transform=_transform_parameters,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/support/ems/filters/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/ems/filters/mapping.py
@@ -47,6 +47,7 @@ ONTAPEMSFILTER_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="parameter_criteria",
+            api_path="parameter_criteria",
             transform=_transform_parameter_criteria,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/support/ems/filters/rules/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/ems/filters/rules/mapping.py
@@ -49,6 +49,7 @@ ONTAPEMSFILTERRULERESPONSE_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="parameter_criteria",
+            api_path="parameter_criteria",
             transform=_transform_parameter_criteria,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/svm/migrations/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/svm/migrations/mapping.py
@@ -86,16 +86,19 @@ ONTAPSVMMIGRATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="destination_volume_placement_aggregates",
+            api_path="destination.volume_placement.aggregates",
             transform=_transform_destination_volume_placement_aggregates,
             default=[],
         ),
         FieldMapping(
             cache_attr="destination_volume_placement_volume_aggregate_pairs",
+            api_path="destination.volume_placement.volume_aggregate_pairs",
             transform=_transform_destination_volume_placement_volume_aggregate_pairs,
             default=[],
         ),
         FieldMapping(
             cache_attr="ip_interface_placement_ip_interfaces",
+            api_path="ip_interface_placement.ip_interfaces",
             transform=_transform_ip_interface_placement_ip_interfaces,
             default=[],
         ),
@@ -109,6 +112,7 @@ ONTAPSVMMIGRATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="messages",
+            api_path="messages",
             transform=_transform_messages,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/svm/migrations/volumes/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/svm/migrations/volumes/mapping.py
@@ -27,6 +27,7 @@ ONTAPSVMMIGRATIONVOLUME_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="errors",
+            api_path="errors",
             transform=_transform_errors,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/svm/svms/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/svm/svms/mapping.py
@@ -43,6 +43,7 @@ ONTAPSVM_MAPPING = TypeMapping(
     fields=(
         FieldMapping(
             cache_attr="aggregates",
+            api_path="aggregates",
             transform=_transform_aggregates,
             default=[],
         ),
@@ -182,6 +183,7 @@ ONTAPSVM_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="fc_interfaces",
+            api_path="fc_interfaces",
             transform=_transform_fc_interfaces,
             default=[],
         ),
@@ -197,6 +199,7 @@ ONTAPSVM_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="ip_interfaces",
+            api_path="ip_interfaces",
             transform=_transform_ip_interfaces,
             default=[],
         ),
@@ -422,6 +425,7 @@ ONTAPSVM_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="routes",
+            api_path="routes",
             transform=_transform_routes,
             default=[],
         ),

--- a/src/pynetappfoundry/cache/ontap/svm/svms/top_metrics/users/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/svm/svms/top_metrics/users/mapping.py
@@ -83,6 +83,7 @@ ONTAPTOPMETRICSSVMUSER_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="volumes",
+            api_path="volumes",
             transform=_transform_volumes,
             default=[],
         ),

--- a/tests/unit/cache/test_field_mapping.py
+++ b/tests/unit/cache/test_field_mapping.py
@@ -846,8 +846,44 @@ class TestExplicitFetchApiFields:
         )
         assert tm.explicit_fetch_api_fields() == ["analytics"]
 
-    def test_transform_only_falls_back_to_cache_attr(self) -> None:
-        """Fields without api_path fall back to cache_attr."""
+    def test_transform_with_api_path_uses_api_path(self) -> None:
+        """Transform fields with api_path use api_path for derivation."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/t?fields=*",
+            fields=(
+                FieldMapping(
+                    cache_attr="copies",
+                    api_path="copies",
+                    transform=lambda r: r.get("copies", []),
+                    default=[],
+                    requires_explicit_fetch=True,
+                ),
+            ),
+        )
+        assert tm.explicit_fetch_api_fields() == ["copies"]
+
+    def test_transform_with_dotted_api_path(self) -> None:
+        """Transform fields with dotted api_path derive top-level segment."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/t?fields=*",
+            fields=(
+                FieldMapping(
+                    cache_attr="connectivity_tracking_alerts",
+                    api_path="connectivity_tracking.alerts",
+                    transform=lambda r: r.get("connectivity_tracking", {}).get("alerts", []),
+                    default=[],
+                    requires_explicit_fetch=True,
+                ),
+            ),
+        )
+        assert tm.explicit_fetch_api_fields() == ["connectivity_tracking"]
+
+    def test_transform_without_api_path_excluded(self) -> None:
+        """Transform-only fields without api_path are silently excluded."""
         tm = TypeMapping(
             name="T",
             model_class=_SampleModel,
@@ -861,7 +897,7 @@ class TestExplicitFetchApiFields:
                 ),
             ),
         )
-        assert tm.explicit_fetch_api_fields() == ["copies"]
+        assert tm.explicit_fetch_api_fields() == []
 
     def test_excludes_non_cache_strategy(self) -> None:
         """Fields with strategy != 'cache' are excluded."""
@@ -1067,7 +1103,7 @@ class TestBuildCollectionUrl:
         assert tm.build_collection_url() == "/cluster/nodes?order_by=name"
 
     def test_transform_only_fields(self) -> None:
-        """Transform-only fields use cache_attr as field name."""
+        """Transform fields with api_path use api_path for field name."""
         tm = TypeMapping(
             name="T",
             model_class=_SampleModel,
@@ -1076,6 +1112,7 @@ class TestBuildCollectionUrl:
                 FieldMapping(cache_attr="name", api_path="name"),
                 FieldMapping(
                     cache_attr="copies",
+                    api_path="copies",
                     transform=lambda r: r.get("copies", []),
                     default=[],
                     requires_explicit_fetch=True,

--- a/tests/unit/codegen/test_generators.py
+++ b/tests/unit/codegen/test_generators.py
@@ -637,6 +637,22 @@ class TestGenerateMappingSubModel:
         code = generate_mapping(ep)
         assert "transform=_transform_copies" in code
 
+    def test_sub_model_field_emits_api_path_and_transform(self):
+        ep = _make_endpoint_with_sub_model()
+        code = generate_mapping(ep)
+        assert 'api_path="copies"' in code
+        assert "transform=_transform_copies" in code
+        # Both must appear in the same FieldMapping block
+        lines = code.splitlines()
+        api_path_indices = [i for i, line in enumerate(lines) if 'api_path="copies"' in line]
+        transform_indices = [
+            i for i, line in enumerate(lines) if "transform=_transform_copies" in line
+        ]
+        assert api_path_indices, "api_path not found in mapping output"
+        assert transform_indices, "transform not found in mapping output"
+        # api_path line should come right before transform line
+        assert transform_indices[0] == api_path_indices[0] + 1
+
     def test_sub_model_imported(self):
         ep = _make_endpoint_with_sub_model()
         code = generate_mapping(ep)

--- a/tools/codegen/generators.py
+++ b/tools/codegen/generators.py
@@ -608,8 +608,10 @@ def generate_mapping(
         field_args = [f'        cache_attr="{attr}"']
 
         if field.api_path in sub_model_map:
-            # Sub-model field: use transform instead of api_path
+            # Sub-model field: keep api_path for field-name derivation,
+            # add transform for custom extraction logic
             func_name = f"_transform_{attr}"
+            field_args.append(f'        api_path="{field.api_path}"')
             field_args.append(f"        transform={func_name}")
         else:
             field_args.append(f'        api_path="{field.api_path}"')


### PR DESCRIPTION
## Description

`explicit_fetch_api_fields()` returned invalid API field names for transform-only
`FieldMapping` entries (sub-model fields like `svm.name`, `space.snapshot.used`).
The method fell back to `cache_attr` (e.g., `svm_name`) instead of using the
correct dotted API path (e.g., `svm.name`), producing URLs that ONTAP rejects.

Root cause: codegen emitted `transform` but omitted `api_path` on sub-model fields,
so `explicit_fetch_api_fields()` had no API path to use and fell back to the
snake_case cache attribute name.

## Related Issue

Addresses #387

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- **`tools/codegen/generators.py`** — codegen now emits `api_path` alongside `transform` for sub-model fields, so the dotted API path is always available
- **`src/pynetappfoundry/cache/field_mapping.py`** — removed the `cache_attr` fallback in `explicit_fetch_api_fields()`; the method now requires `api_path` to be set (as it should be for any API-sourced field); updated docstrings
- **98 generated mapping files under `src/pynetappfoundry/cache/ontap/`** — regenerated with correct `api_path` values on transform-only FieldMappings
- **`tests/unit/cache/test_field_mapping.py`** — updated and added tests for the fix
- **`tests/unit/codegen/test_generators.py`** — added test for codegen sub-model field generation

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

This fix is safe because `parse_api_record()` checks `transform` before `api_path` —
existing parsing behavior is unchanged. The only consumer of `api_path` on these
fields is `explicit_fetch_api_fields()`, which now returns correct dotted paths
instead of snake_case cache attribute names.
