### PR TITLE
chore: ignore CVE-2026-4539 (pygments) in pip-audit until fix available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,8 @@ jobs:
         run: uv pip install --upgrade pip
 
       - name: Run dependency audit
-        run: uv run pip-audit --skip-editable
+        # TODO: Remove --ignore-vuln once pygments releases a fix for CVE-2026-4539
+        run: uv run pip-audit --skip-editable --ignore-vuln CVE-2026-4539
 
       - name: Run tests with coverage
         run: uv run pytest --cov=pynetappfoundry --cov-report=xml:tmp/coverage.xml --cov-report=term -v

--- a/tools/doit/security.py
+++ b/tools/doit/security.py
@@ -9,7 +9,8 @@ def task_audit() -> dict[str, Any]:
     """Run security audit with pip-audit (requires security extras)."""
     return {
         "actions": [
-            "uv run pip-audit --skip-editable || "
+            # TODO: Remove --ignore-vuln once pygments releases a fix for CVE-2026-4539
+            "uv run pip-audit --skip-editable --ignore-vuln CVE-2026-4539 || "
             "echo 'pip-audit not installed. Run: uv sync --extra security'"
         ],
         "title": title_with_actions,


### PR DESCRIPTION
## Description

`pygments 2.19.2` has CVE-2026-4539 with no fix version available yet. This blocks all PRs because the `pip-audit` dependency audit step fails. Add `--ignore-vuln CVE-2026-4539` temporarily until a patched version is released.

Addresses #389

## Type of Change

- [x] Code refactoring

## Changes Made

- Added `--ignore-vuln CVE-2026-4539` to `pip-audit` in `.github/workflows/ci.yml`
- Added `--ignore-vuln CVE-2026-4539` to `pip-audit` in `tools/doit/security.py` (`doit audit`)
- Added TODO comments to remove the ignore once pygments is patched

## Testing

- [x] All existing tests pass
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
