### PR TITLE
fix: filter realtime fields from cache DB storage to prevent snapshot churn

### DIFF
--- a/src/pynetappfoundry/cache/db.py
+++ b/src/pynetappfoundry/cache/db.py
@@ -9,6 +9,7 @@ The public API (``get``/``set``/``clear``/etc.) is preserved so callers
 
 from __future__ import annotations
 
+import functools
 import json
 import re
 import sqlite3
@@ -61,20 +62,43 @@ def _validate_cluster_name(cluster_name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+@functools.cache
+def _realtime_attrs(model_class: type[BaseModel]) -> frozenset[str]:
+    """Return cache_attr names of realtime fields for a model class.
+
+    Uses deferred import of ``model_registry`` to avoid circular imports.
+    The ``lru_cache`` ensures each model class is resolved only once.
+    """
+    from pynetappfoundry.cache._registry import model_registry
+
+    mapping = model_registry.get_mapping(model_class.__name__)
+    if mapping is None:
+        return frozenset()
+    return frozenset(f.cache_attr for f in mapping.realtime_fields())
+
+
 def _model_to_row(
     model_instance: BaseModel,
     model_class: type[BaseModel],
+    exclude: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
     """Convert a Pydantic model instance to a dict suitable for SQL INSERT.
 
     Scalar fields are passed through.  ``list``/``dict``/sub-model fields
     are serialised to JSON strings.  Any extra fields (from ``extra="allow"``)
     are collected into the ``_extra_json`` column.
+
+    Args:
+        model_instance: The Pydantic model to convert.
+        model_class: The model's class (for field introspection).
+        exclude: Field names to skip (e.g. realtime fields).
     """
     row: dict[str, Any] = {}
     known_fields = set(model_class.model_fields)
 
     for field_name, field_info in model_class.model_fields.items():
+        if field_name in exclude:
+            continue
         value = getattr(model_instance, field_name)
         if _is_json_column(field_info.annotation):
             # Serialize list/dict/sub-model to JSON
@@ -341,17 +365,18 @@ class ClusterMetadataDB(SQLiteDB):
         """Walk TABLE_REGISTRY and insert model data into per-model tables."""
         for path, spec in self._registry.items():
             data = _get_by_path(metadata, path)
+            rt = _realtime_attrs(spec.model_class)
 
             if spec.is_list:
                 if not data:
                     continue
-                rows = [_model_to_row(item, spec.model_class) for item in data]
+                rows = [_model_to_row(item, spec.model_class, rt) for item in data]
                 for row in rows:
                     row["cluster_name"] = cluster_name
                 self._bulk_insert(spec.table_name, rows)
             else:
                 # Singleton
-                row = _model_to_row(data, spec.model_class)
+                row = _model_to_row(data, spec.model_class, rt)
                 row["cluster_name"] = cluster_name
                 self._bulk_insert(spec.table_name, [row])
 

--- a/tests/unit/cache/test_db.py
+++ b/tests/unit/cache/test_db.py
@@ -6,12 +6,18 @@ import json
 import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
 
 from pynetappfoundry.cache import CachedClusterMetadata
-from pynetappfoundry.cache.db import ClusterMetadataDB, _model_to_row, _validate_cluster_name
+from pynetappfoundry.cache.db import (
+    ClusterMetadataDB,
+    _model_to_row,
+    _realtime_attrs,
+    _validate_cluster_name,
+)
 from pynetappfoundry.cache.ontap.cloud.metadata.model import CloudMetadata
 from pynetappfoundry.cache.ontap.cluster.model import ClusterInfo
 from pynetappfoundry.cache.ontap.cluster.nodes.model import OntapNodeResponse
@@ -685,3 +691,127 @@ class TestClusterMetadataDBInitialization:
         # Attempting operations after close should fail
         with pytest.raises(sqlite3.ProgrammingError):
             db.list_clusters()
+
+
+class TestModelToRowExclude:
+    """Tests for _model_to_row exclude parameter."""
+
+    def test_excludes_fields_in_exclude_set(self) -> None:
+        """_model_to_row skips fields listed in the exclude frozenset."""
+
+        class _Sample(BaseModel):
+            name: str = ""
+            value: int = 0
+            metric: float = 0.0
+
+        instance = _Sample(name="test", value=42, metric=3.14)
+        row = _model_to_row(instance, _Sample, frozenset({"metric"}))
+
+        assert "name" in row
+        assert "value" in row
+        assert "metric" not in row
+
+    def test_includes_all_fields_when_exclude_empty(self) -> None:
+        """_model_to_row includes all fields when exclude is empty (backward compat)."""
+
+        class _Sample2(BaseModel):
+            name: str = ""
+            value: int = 0
+
+        instance = _Sample2(name="test", value=42)
+        row = _model_to_row(instance, _Sample2, frozenset())
+
+        assert "name" in row
+        assert "value" in row
+        assert row["name"] == "test"
+        assert row["value"] == 42
+
+    def test_includes_all_fields_when_exclude_not_provided(self) -> None:
+        """_model_to_row includes all fields when exclude defaults."""
+
+        class _Sample3(BaseModel):
+            name: str = ""
+            count: int = 0
+
+        instance = _Sample3(name="hello", count=7)
+        row = _model_to_row(instance, _Sample3)
+
+        assert "name" in row
+        assert "count" in row
+
+    def test_excludes_multiple_fields(self) -> None:
+        """_model_to_row can exclude multiple fields at once."""
+
+        class _Multi(BaseModel):
+            keep: str = ""
+            drop_a: int = 0
+            drop_b: float = 0.0
+
+        instance = _Multi(keep="yes", drop_a=1, drop_b=2.0)
+        row = _model_to_row(instance, _Multi, frozenset({"drop_a", "drop_b"}))
+
+        assert "keep" in row
+        assert "drop_a" not in row
+        assert "drop_b" not in row
+
+
+class TestRealtimeAttrs:
+    """Tests for _realtime_attrs helper."""
+
+    def test_returns_realtime_cache_attrs_for_mapped_model(self) -> None:
+        """_realtime_attrs returns correct field names for models with realtime mappings."""
+        # Import the mapping module to trigger register_mapping() calls
+        from pynetappfoundry.cache.ontap.network.fc.ports.model import OntapFcPort
+
+        # Clear lru_cache to ensure fresh lookup
+        _realtime_attrs.cache_clear()
+
+        result = _realtime_attrs(OntapFcPort)
+
+        assert isinstance(result, frozenset)
+        assert len(result) > 0
+        # These are known realtime fields from ports.toml
+        assert "metric_duration" in result
+        assert "metric_iops_total" in result
+        assert "metric_iops_read" in result
+
+    def test_returns_empty_frozenset_for_unmapped_model(self) -> None:
+        """_realtime_attrs returns empty frozenset for models without mappings."""
+        _realtime_attrs.cache_clear()
+
+        # CachedClusterMetadata is a container model with no TypeMapping
+        result = _realtime_attrs(CachedClusterMetadata)
+
+        assert isinstance(result, frozenset)
+        assert len(result) == 0
+
+    def test_returns_empty_frozenset_for_model_without_realtime_fields(self) -> None:
+        """_realtime_attrs returns empty frozenset when mapping has no realtime fields."""
+        _realtime_attrs.cache_clear()
+
+        # Create a mock mapping with no realtime fields
+        mock_mapping = MagicMock()
+        mock_mapping.realtime_fields.return_value = ()
+
+        class _NoRealtime(BaseModel):
+            name: str = ""
+
+        with patch("pynetappfoundry.cache._registry.model_registry") as mock_registry:
+            mock_registry.get_mapping.return_value = mock_mapping
+            result = _realtime_attrs(_NoRealtime)
+
+        assert isinstance(result, frozenset)
+        assert len(result) == 0
+
+    def test_caches_result_per_model_class(self) -> None:
+        """_realtime_attrs caches results (lru_cache)."""
+        _realtime_attrs.cache_clear()
+
+        # First call populates cache
+        result1 = _realtime_attrs(CachedClusterMetadata)
+        result2 = _realtime_attrs(CachedClusterMetadata)
+
+        assert result1 is result2
+        # Verify cache was used
+        info = _realtime_attrs.cache_info()
+        assert info.hits >= 1


### PR DESCRIPTION
## Description

Filter realtime fields (e.g. metrics, throughput, latency, IOPS) out of
`_model_to_row()` so they are never written to the cache DB. These fields
change on every poll and carry no useful snapshot value, causing unnecessary
churn in stored rows.

## Related Issue

Addresses #393

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `_realtime_attrs()` helper in `db.py` that queries the model registry
  for fields marked `realtime=True` and returns their `cache_attr` names as a
  `frozenset`. Result is cached via `functools.cache`.
- Extended `_model_to_row()` with an `exclude` parameter; fields in the set
  are skipped during row construction.
- Updated `_persist_models()` to compute the realtime set per model class and
  pass it to `_model_to_row()`.
- Added 8 new tests covering exclude behaviour and realtime attribute lookup.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

No documentation or ADR changes needed. This is an internal storage
optimisation; the public cache API is unchanged.
