### PR TITLE
fix: strip realtime fields from cache show output to hide meaningless defaults

### DIFF
--- a/src/pynetappfoundry/cache/db.py
+++ b/src/pynetappfoundry/cache/db.py
@@ -63,11 +63,11 @@ def _validate_cluster_name(cluster_name: str) -> None:
 
 
 @functools.cache
-def _realtime_attrs(model_class: type[BaseModel]) -> frozenset[str]:
+def realtime_attrs(model_class: type[BaseModel]) -> frozenset[str]:
     """Return cache_attr names of realtime fields for a model class.
 
     Uses deferred import of ``model_registry`` to avoid circular imports.
-    The ``lru_cache`` ensures each model class is resolved only once.
+    The ``functools.cache`` ensures each model class is resolved only once.
     """
     from pynetappfoundry.cache._registry import model_registry
 
@@ -75,6 +75,17 @@ def _realtime_attrs(model_class: type[BaseModel]) -> frozenset[str]:
     if mapping is None:
         return frozenset()
     return frozenset(f.cache_attr for f in mapping.realtime_fields())
+
+
+@functools.cache
+def all_realtime_attrs() -> frozenset[str]:
+    """Return all realtime cache_attr names across all registered models."""
+    from pynetappfoundry.cache._registry import model_registry
+
+    attrs: set[str] = set()
+    for mapping in model_registry.mappings.values():
+        attrs.update(f.cache_attr for f in mapping.realtime_fields())
+    return frozenset(attrs)
 
 
 def _model_to_row(
@@ -365,7 +376,7 @@ class ClusterMetadataDB(SQLiteDB):
         """Walk TABLE_REGISTRY and insert model data into per-model tables."""
         for path, spec in self._registry.items():
             data = _get_by_path(metadata, path)
-            rt = _realtime_attrs(spec.model_class)
+            rt = realtime_attrs(spec.model_class)
 
             if spec.is_list:
                 if not data:

--- a/src/pynetappfoundry/cli/commands/cache/show.py
+++ b/src/pynetappfoundry/cli/commands/cache/show.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 
@@ -11,6 +12,7 @@ from rich.panel import Panel
 from rich.tree import Tree
 
 from pynetappfoundry.cache import ClusterMetadataDB
+from pynetappfoundry.cache.db import all_realtime_attrs
 from pynetappfoundry.cli.utils import (
     format_value_markup,
     print_error,
@@ -21,6 +23,32 @@ from pynetappfoundry.core.config import Config
 
 logger = logging.getLogger(__name__)
 console = Console()
+
+
+def _strip_realtime_fields(data: dict[str, object], rt_attrs: frozenset[str]) -> dict[str, object]:
+    """Remove realtime fields from a nested model dump dict.
+
+    Args:
+        data: Dictionary from ``model_dump()``.
+        rt_attrs: Set of realtime attribute names to strip.
+
+    Returns:
+        New dictionary with realtime keys removed at every nesting level.
+    """
+    result: dict[str, object] = {}
+    for key, value in data.items():
+        if key in rt_attrs:
+            continue
+        if isinstance(value, dict):
+            result[key] = _strip_realtime_fields(value, rt_attrs)
+        elif isinstance(value, list):
+            result[key] = [
+                _strip_realtime_fields(item, rt_attrs) if isinstance(item, dict) else item
+                for item in value
+            ]
+        else:
+            result[key] = value
+    return result
 
 
 def _format_value(value: object) -> str:
@@ -156,12 +184,15 @@ def show(ctx: click.Context, cluster: str | None, section: str | None, output_js
         console.print("Use 'nf cache refresh {cluster}' to populate the cache.")
         ctx.exit(1)
 
+    rt = all_realtime_attrs()
+
     if output_json:
-        console.print(metadata.model_dump_json(indent=2))
+        data = _strip_realtime_fields(metadata.model_dump(mode="json"), rt)
+        console.print_json(json.dumps(data, indent=2))
         return
 
     # Build display tree
-    data = metadata.model_dump()
+    data = _strip_realtime_fields(metadata.model_dump(), rt)
 
     if section:
         section_lower = section.lower()

--- a/tests/unit/cache/test_db.py
+++ b/tests/unit/cache/test_db.py
@@ -15,8 +15,8 @@ from pynetappfoundry.cache import CachedClusterMetadata
 from pynetappfoundry.cache.db import (
     ClusterMetadataDB,
     _model_to_row,
-    _realtime_attrs,
     _validate_cluster_name,
+    realtime_attrs,
 )
 from pynetappfoundry.cache.ontap.cloud.metadata.model import CloudMetadata
 from pynetappfoundry.cache.ontap.cluster.model import ClusterInfo
@@ -756,17 +756,17 @@ class TestModelToRowExclude:
 
 
 class TestRealtimeAttrs:
-    """Tests for _realtime_attrs helper."""
+    """Tests for realtime_attrs helper."""
 
     def test_returns_realtime_cache_attrs_for_mapped_model(self) -> None:
-        """_realtime_attrs returns correct field names for models with realtime mappings."""
+        """realtime_attrs returns correct field names for models with realtime mappings."""
         # Import the mapping module to trigger register_mapping() calls
         from pynetappfoundry.cache.ontap.network.fc.ports.model import OntapFcPort
 
-        # Clear lru_cache to ensure fresh lookup
-        _realtime_attrs.cache_clear()
+        # Clear cache to ensure fresh lookup
+        realtime_attrs.cache_clear()
 
-        result = _realtime_attrs(OntapFcPort)
+        result = realtime_attrs(OntapFcPort)
 
         assert isinstance(result, frozenset)
         assert len(result) > 0
@@ -776,18 +776,18 @@ class TestRealtimeAttrs:
         assert "metric_iops_read" in result
 
     def test_returns_empty_frozenset_for_unmapped_model(self) -> None:
-        """_realtime_attrs returns empty frozenset for models without mappings."""
-        _realtime_attrs.cache_clear()
+        """realtime_attrs returns empty frozenset for models without mappings."""
+        realtime_attrs.cache_clear()
 
         # CachedClusterMetadata is a container model with no TypeMapping
-        result = _realtime_attrs(CachedClusterMetadata)
+        result = realtime_attrs(CachedClusterMetadata)
 
         assert isinstance(result, frozenset)
         assert len(result) == 0
 
     def test_returns_empty_frozenset_for_model_without_realtime_fields(self) -> None:
-        """_realtime_attrs returns empty frozenset when mapping has no realtime fields."""
-        _realtime_attrs.cache_clear()
+        """realtime_attrs returns empty frozenset when mapping has no realtime fields."""
+        realtime_attrs.cache_clear()
 
         # Create a mock mapping with no realtime fields
         mock_mapping = MagicMock()
@@ -798,20 +798,20 @@ class TestRealtimeAttrs:
 
         with patch("pynetappfoundry.cache._registry.model_registry") as mock_registry:
             mock_registry.get_mapping.return_value = mock_mapping
-            result = _realtime_attrs(_NoRealtime)
+            result = realtime_attrs(_NoRealtime)
 
         assert isinstance(result, frozenset)
         assert len(result) == 0
 
     def test_caches_result_per_model_class(self) -> None:
-        """_realtime_attrs caches results (lru_cache)."""
-        _realtime_attrs.cache_clear()
+        """realtime_attrs caches results (functools.cache)."""
+        realtime_attrs.cache_clear()
 
         # First call populates cache
-        result1 = _realtime_attrs(CachedClusterMetadata)
-        result2 = _realtime_attrs(CachedClusterMetadata)
+        result1 = realtime_attrs(CachedClusterMetadata)
+        result2 = realtime_attrs(CachedClusterMetadata)
 
         assert result1 is result2
         # Verify cache was used
-        info = _realtime_attrs.cache_info()
+        info = realtime_attrs.cache_info()
         assert info.hits >= 1

--- a/tests/unit/cli/commands/cache/test_show.py
+++ b/tests/unit/cli/commands/cache/test_show.py
@@ -10,7 +10,9 @@ import pytest
 from click.testing import CliRunner
 
 from pynetappfoundry.cache import CachedClusterMetadata
+from pynetappfoundry.cache.db import all_realtime_attrs
 from pynetappfoundry.cache.ontap.cloud.metadata.model import CloudMetadata
+from pynetappfoundry.cli.commands.cache.show import _strip_realtime_fields
 from pynetappfoundry.cli.main import nf
 
 
@@ -222,3 +224,98 @@ base_api_path = "/api"
         assert "Invalid cluster name" in result.output
         # Should NOT suggest cache query for names without dots/brackets
         assert "nf cache query" not in result.output
+
+
+class TestStripRealtimeFields:
+    """Tests for _strip_realtime_fields helper."""
+
+    def test_removes_known_realtime_keys(self) -> None:
+        """Realtime keys are stripped from a flat dict."""
+        rt = frozenset({"metric_a", "metric_b"})
+        data: dict[str, object] = {"name": "vol1", "metric_a": 100, "metric_b": 200, "size": 500}
+        result = _strip_realtime_fields(data, rt)
+
+        assert result == {"name": "vol1", "size": 500}
+
+    def test_preserves_non_realtime_keys(self) -> None:
+        """Non-realtime keys are preserved unchanged."""
+        rt = frozenset({"metric_a"})
+        data: dict[str, object] = {"name": "vol1", "size": 500}
+        result = _strip_realtime_fields(data, rt)
+
+        assert result == {"name": "vol1", "size": 500}
+
+    def test_handles_nested_dicts(self) -> None:
+        """Realtime keys are stripped recursively from nested dicts."""
+        rt = frozenset({"metric_a"})
+        data: dict[str, object] = {
+            "name": "cluster1",
+            "storage": {"name": "aggr1", "metric_a": 42, "capacity": 1024},
+        }
+        result = _strip_realtime_fields(data, rt)
+
+        assert result == {
+            "name": "cluster1",
+            "storage": {"name": "aggr1", "capacity": 1024},
+        }
+
+    def test_handles_lists_of_dicts(self) -> None:
+        """Realtime keys are stripped from dicts inside lists."""
+        rt = frozenset({"metric_a"})
+        data: dict[str, object] = {
+            "volumes": [
+                {"name": "vol1", "metric_a": 10},
+                {"name": "vol2", "metric_a": 20},
+            ],
+        }
+        result = _strip_realtime_fields(data, rt)
+
+        assert result == {
+            "volumes": [
+                {"name": "vol1"},
+                {"name": "vol2"},
+            ],
+        }
+
+    def test_handles_lists_of_scalars(self) -> None:
+        """Scalar lists are preserved unchanged."""
+        rt = frozenset({"metric_a"})
+        data: dict[str, object] = {"tags": ["a", "b", "c"]}
+        result = _strip_realtime_fields(data, rt)
+
+        assert result == {"tags": ["a", "b", "c"]}
+
+    def test_empty_rt_attrs_returns_same_structure(self) -> None:
+        """With no realtime attrs, the dict is returned unchanged."""
+        rt: frozenset[str] = frozenset()
+        data: dict[str, object] = {"name": "vol1", "size": 500}
+        result = _strip_realtime_fields(data, rt)
+
+        assert result == {"name": "vol1", "size": 500}
+
+    def test_empty_dict_returns_empty(self) -> None:
+        """An empty dict returns an empty dict."""
+        rt = frozenset({"metric_a"})
+        result = _strip_realtime_fields({}, rt)
+
+        assert result == {}
+
+
+class TestAllRealtimeAttrs:
+    """Tests for all_realtime_attrs function."""
+
+    def test_returns_non_empty_frozenset(self) -> None:
+        """all_realtime_attrs returns a non-empty frozenset of realtime field names."""
+        all_realtime_attrs.cache_clear()
+        result = all_realtime_attrs()
+
+        assert isinstance(result, frozenset)
+        assert len(result) > 0
+
+    def test_contains_known_realtime_field(self) -> None:
+        """all_realtime_attrs includes known realtime cache_attr names."""
+        all_realtime_attrs.cache_clear()
+        result = all_realtime_attrs()
+
+        # metric_duration is a realtime field on FC ports (and likely others)
+        assert "metric_duration" in result


### PR DESCRIPTION
## Description

Strip realtime fields from `nf cache show` output. Although PR #394 filters realtime fields from DB storage, `_row_to_model()` reconstructs the full Pydantic model with defaults for missing columns, so `model_dump()` includes them with meaningless values (0, "", empty).

Added `all_realtime_attrs()` that returns all realtime `cache_attr` names across all registered models, and a recursive `_strip_realtime_fields()` helper that removes those keys from the nested model dump dict before rendering.

Addresses #397

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **`src/pynetappfoundry/cache/db.py`** — renamed `_realtime_attrs` → `realtime_attrs` (public); added `all_realtime_attrs()` returning all realtime field names across all models
- **`src/pynetappfoundry/cli/commands/cache/show.py`** — added `_strip_realtime_fields()` recursive filter; applied to both JSON and tree output paths
- **`tests/unit/cache/test_db.py`** — updated imports to use renamed `realtime_attrs`
- **`tests/unit/cli/commands/cache/test_show.py`** — added 9 tests for stripping logic and `all_realtime_attrs()`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
