### PR TITLE
feat: add write operations (POST/PATCH/DELETE) to ONTAP query layer

### DIFF
--- a/docs/usage/ontap-access-patterns.md
+++ b/docs/usage/ontap-access-patterns.md
@@ -19,13 +19,87 @@ pynetappfoundry provides three different ways to interact with ONTAP clusters. E
 
 | Pattern | Connection | Best For |
 |---------|------------|----------|
+| `QuerySet` + `Mutation` | HTTPS REST | Type-safe ONTAP queries and writes with model attribute translation |
 | `netapp_ontap` SDK | HTTPS REST | Structured data retrieval, reports, typed objects |
 | `ONTAPCLI` | SSH | Ad-hoc CLI commands, operations not in REST API |
 | `APIWrapper` | HTTPS REST | Custom queries, OpenAPI-based workflows, DII integration |
 
 ## Pattern Details
 
-### 1. netapp_ontap SDK (Recommended for Most Tasks)
+### 1. QuerySet + Mutation (Recommended for New Code)
+
+pynetappfoundry's native query and mutation layer uses the project's own Pydantic models (`OntapModel` subclasses) with declarative field mappings. `QuerySet` handles reads, `Mutation` handles writes.
+
+**When to Use:**
+
+- Querying ONTAP resources with type-safe filtering
+- Creating, updating, or deleting ONTAP resources
+- When you want model attribute names (e.g., `svm_name`) instead of raw API paths (`svm.name`)
+- Building automation that leverages the project's config-driven connections
+
+**Advantages:**
+
+- Fluent, chainable query API with field projection, ordering, and limits
+- Automatic translation between model attributes and API field paths
+- Write operations build nested JSON from flat kwargs
+- Retry safety — POST disables retry (non-idempotent), PATCH/DELETE use default retry
+- Type-safe Pydantic model instances as return values
+- Works with any registered `TypeMapping` (296 ONTAP resource types)
+
+**Limitations:**
+
+- Requires the model's `TypeMapping` to be registered (import its mapping module)
+- Async job tracking not yet built in (returns raw 202 responses)
+- Parameterized endpoints (child resources) not yet supported
+
+**Example Usage:**
+
+```python
+from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
+from pynetappfoundry.query import QuerySet, Mutation
+from pynetappfoundry.models.ontap.storage.volumes import OntapVolume
+
+# Setup client from config
+client = ONTAPAPIClient(cluster, config)
+
+# Query: list online volumes for an SVM
+vols = (QuerySet(OntapVolume, client)
+    .filter(svm_name="vs1", state="online")
+    .fields("name", "uuid", "size")
+    .order_by("name")
+    .limit(50)
+    .all())
+
+# Query: get a single volume
+vol = QuerySet(OntapVolume, client).get(uuid="abc-123-def")
+
+# Query: count matching resources
+count = QuerySet(OntapVolume, client).filter(state="online").count()
+
+# Query: iterate with wildcards
+for vol in QuerySet(OntapVolume, client).filter(name="*_backup"):
+    print(vol.name)
+
+# Create a volume
+result = Mutation(OntapVolume, client).create(
+    name="vol1",
+    svm_name="vs1",
+    size=1073741824,
+)
+
+# Update a volume
+result = Mutation(OntapVolume, client).update(
+    uuid="abc-123-def",
+    size=2147483648,
+)
+
+# Delete a volume
+Mutation(OntapVolume, client).delete(uuid="abc-123-def")
+```
+
+---
+
+### 2. netapp_ontap SDK
 
 NetApp's official Python SDK provides ORM-like objects for ONTAP resources. This is the **preferred pattern** for most operations.
 
@@ -265,14 +339,16 @@ Use this matrix to choose the right pattern:
 
 | Scenario | Recommended Pattern | Reason |
 |----------|---------------------|--------|
-| Generate a report | `netapp_ontap` SDK | Typed objects, pagination handling |
-| List volumes/aggregates | `netapp_ontap` SDK | Clean API, well-documented |
+| Query ONTAP resources | `QuerySet` | Type-safe filtering, model attribute translation |
+| Create/update/delete resources | `Mutation` | Nested JSON from flat attrs, retry safety |
+| List volumes/aggregates | `QuerySet` | Fluent API, field projection, pagination |
+| Bulk data export | `QuerySet` | Handles pagination, typed results |
+| Generate a report | `netapp_ontap` SDK | Typed objects, well-documented |
 | Check license status | `netapp_ontap` SDK | LicensePackage resource available |
 | Run CLI-only command | `ONTAPCLI` | No REST equivalent |
 | Debug cluster issue | `ONTAPCLI` | Full CLI access |
 | Query DII metrics | `APIWrapper` | DII uses different API |
 | Custom REST endpoint | `APIWrapper` | Flexible, schema-validated |
-| Bulk data export | `netapp_ontap` SDK | Handles pagination |
 | Interactive troubleshooting | `ONTAPCLI` | Familiar CLI interface |
 
 ## Configuration Flow

--- a/src/pynetappfoundry/query/__init__.py
+++ b/src/pynetappfoundry/query/__init__.py
@@ -5,6 +5,7 @@ ONTAP REST API using existing TypeMapping metadata.
 """
 
 from pynetappfoundry.query.exceptions import MultipleResultsError, NotFoundError
+from pynetappfoundry.query.mutation import Mutation
 from pynetappfoundry.query.queryset import QuerySet
 
-__all__ = ["MultipleResultsError", "NotFoundError", "QuerySet"]
+__all__ = ["MultipleResultsError", "Mutation", "NotFoundError", "QuerySet"]

--- a/src/pynetappfoundry/query/mutation.py
+++ b/src/pynetappfoundry/query/mutation.py
@@ -1,0 +1,200 @@
+"""Write operations (POST/PATCH/DELETE) for ONTAP models.
+
+Provides :class:`Mutation`, a high-level interface for creating, updating,
+and deleting ONTAP resources using existing
+:class:`~pynetappfoundry.cache.field_mapping.TypeMapping` metadata.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache.field_mapping import TypeMapping, parse_api_record
+from pynetappfoundry.clients.openapi import APIWrapper
+from pynetappfoundry.core.models import RetryConfig
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _set_nested(d: dict[str, Any], path: str, value: Any) -> None:
+    """Set a value in a nested dict using a dot-separated path.
+
+    Merges with existing keys so that sibling paths like ``svm.name``
+    and ``svm.uuid`` produce ``{"svm": {"name": ..., "uuid": ...}}``.
+
+    Args:
+        d: Target dictionary (modified in place).
+        path: Dot-separated key path (e.g. ``"svm.name"``).
+        value: Value to set at the leaf.
+    """
+    keys = path.split(".")
+    current = d
+    for key in keys[:-1]:
+        if key not in current:
+            current[key] = {}
+        current = current[key]
+    current[keys[-1]] = value
+
+
+class Mutation:
+    """Write interface for ONTAP models.
+
+    Translates model attribute names to nested API JSON and dispatches
+    POST, PATCH, and DELETE requests via the API client.
+
+    Example::
+
+        m = Mutation(OntapVolume, client)
+        vol = m.create(name="vol1", svm_name="vs1")
+        m.update("uuid-123", state="offline")
+        m.delete("uuid-123")
+    """
+
+    def __init__(
+        self,
+        model_class: type[T],
+        client: APIWrapper,
+    ) -> None:
+        self._model_class = model_class
+        self._client = client
+        self._mapping = self._resolve_mapping(model_class)
+
+    @staticmethod
+    def _resolve_mapping(model_class: type[T]) -> TypeMapping:
+        """Look up TypeMapping from the model registry.
+
+        Raises:
+            ValueError: If no mapping is registered for the model class.
+        """
+        mapping = model_registry.get_mapping(model_class.__name__)
+        if mapping is None:
+            msg = (
+                f"No TypeMapping registered for '{model_class.__name__}'. "
+                f"Ensure the model's mapping module has been imported."
+            )
+            raise ValueError(msg)
+        return mapping
+
+    def create(self, **kwargs: Any) -> Any:
+        """Create a new resource via POST.
+
+        Translates keyword arguments from model attribute names to nested
+        API JSON.  Disables retry (POST is non-idempotent).
+
+        Args:
+            **kwargs: Model attribute name/value pairs.
+
+        Returns:
+            Parsed model instance, or raw response for async jobs.
+        """
+        body = self._build_body(kwargs)
+        path = self._collection_path()
+        logger.debug("Mutation.create %s: POST %s body=%s", self._mapping.name, path, body)
+        response = self._client.call_endpoint(
+            path,
+            method="POST",
+            body=body,
+            retry_config=RetryConfig(enabled=False),
+        )
+        return self._parse_response(response)
+
+    def update(self, uuid: str, **kwargs: Any) -> Any:
+        """Update an existing resource via PATCH.
+
+        Args:
+            uuid: Resource UUID.
+            **kwargs: Model attribute name/value pairs to update.
+
+        Returns:
+            Parsed model instance, or raw response for async jobs.
+        """
+        body = self._build_body(kwargs)
+        path = f"{self._collection_path()}/{uuid}"
+        logger.debug("Mutation.update %s: PATCH %s body=%s", self._mapping.name, path, body)
+        response = self._client.call_endpoint(
+            path,
+            method="PATCH",
+            body=body,
+        )
+        return self._parse_response(response)
+
+    def delete(self, uuid: str, **kwargs: Any) -> Any:
+        """Delete a resource via DELETE.
+
+        Args:
+            uuid: Resource UUID.
+            **kwargs: Optional body parameters (e.g. force flags).
+
+        Returns:
+            Raw API response.
+        """
+        path = f"{self._collection_path()}/{uuid}"
+        body = self._build_body(kwargs) if kwargs else None
+        logger.debug("Mutation.delete %s: DELETE %s body=%s", self._mapping.name, path, body)
+        return self._client.call_endpoint(
+            path,
+            method="DELETE",
+            body=body,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _collection_path(self) -> str:
+        """Return the collection endpoint path without query parameters."""
+        return self._mapping.collection_endpoint.split("?", 1)[0]
+
+    def _attr_to_api_path(self, attr: str) -> str:
+        """Translate a model attribute name to an API field path.
+
+        Iterates TypeMapping.fields looking for a FieldMapping whose
+        ``cache_attr`` matches *attr*.  Returns the corresponding
+        ``api_path`` if found, otherwise returns *attr* unchanged
+        (allowing raw API field names).
+        """
+        for field in self._mapping.fields:
+            if field.cache_attr == attr and field.api_path is not None:
+                return field.api_path
+        return attr
+
+    def _build_body(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Translate flat model attrs to nested API JSON.
+
+        Each key is translated via ``_attr_to_api_path``, then the
+        dot-separated path is expanded into nested dicts.
+        """
+        body: dict[str, Any] = {}
+        for attr, value in kwargs.items():
+            api_path = self._attr_to_api_path(attr)
+            _set_nested(body, api_path, value)
+        return body
+
+    def _parse_response(self, response: Any) -> Any:
+        """Parse an API response into a model instance if possible.
+
+        Returns raw response for 202 async jobs (None/empty), or when
+        the response is not a dict containing record fields.
+        """
+        if not isinstance(response, dict):
+            return response
+
+        # Check if response looks like a record (has fields from the mapping)
+        mapping_api_paths = {
+            f.api_path.split(".")[0] for f in self._mapping.fields if f.api_path is not None
+        }
+        response_keys = set(response.keys())
+        if mapping_api_paths & response_keys:
+            return parse_api_record(
+                self._mapping,
+                response,
+                f"Mutation<{self._mapping.name}>",
+            )
+
+        return response

--- a/tests/unit/query/test_mutation.py
+++ b/tests/unit/query/test_mutation.py
@@ -1,0 +1,305 @@
+"""Tests for pynetappfoundry.query.mutation module."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.core.models import RetryConfig
+from pynetappfoundry.query.mutation import Mutation, _set_nested
+
+# ---------------------------------------------------------------------------
+# Test model and mapping fixtures
+# ---------------------------------------------------------------------------
+
+
+class FakeVolume(BaseModel):
+    """Minimal model for testing."""
+
+    name: str = ""
+    uuid: str = ""
+    svm_name: str = ""
+    svm_uuid: str = ""
+    state: str = ""
+
+
+FAKE_FIELDS = (
+    FieldMapping(cache_attr="name", api_path="name"),
+    FieldMapping(cache_attr="uuid", api_path="uuid"),
+    FieldMapping(cache_attr="svm_name", api_path="svm.name"),
+    FieldMapping(cache_attr="svm_uuid", api_path="svm.uuid"),
+    FieldMapping(cache_attr="state", api_path="state"),
+)
+
+FAKE_MAPPING = TypeMapping(
+    name="FakeVolumeMut",
+    model_class=FakeVolume,
+    api_endpoint="/storage/volumes?fields=*",
+    fields=FAKE_FIELDS,
+    id_field="name",
+)
+
+
+@pytest.fixture(autouse=True)
+def _register_fake_mapping() -> Any:
+    """Register FakeVolume mapping and clean up after test."""
+    model_registry.register_mapping("FakeVolume", FAKE_MAPPING)
+    yield
+    model_registry._mappings.pop("FakeVolume", None)
+
+
+@pytest.fixture()
+def mock_client() -> MagicMock:
+    """Return a mocked APIWrapper."""
+    return MagicMock(spec=["call_endpoint"])
+
+
+# ---------------------------------------------------------------------------
+# Constructor tests
+# ---------------------------------------------------------------------------
+
+
+class TestMutationInit:
+    """Tests for Mutation.__init__."""
+
+    def test_init_with_valid_mapping(self, mock_client: MagicMock) -> None:
+        m = Mutation(FakeVolume, mock_client)
+        assert m._mapping is FAKE_MAPPING
+        assert m._client is mock_client
+
+    def test_init_with_missing_mapping(self, mock_client: MagicMock) -> None:
+        class Unregistered(BaseModel):
+            pass
+
+        with pytest.raises(ValueError, match="No TypeMapping registered for 'Unregistered'"):
+            Mutation(Unregistered, mock_client)
+
+
+# ---------------------------------------------------------------------------
+# _set_nested tests
+# ---------------------------------------------------------------------------
+
+
+class TestSetNested:
+    """Tests for _set_nested helper."""
+
+    def test_simple_path(self) -> None:
+        d: dict[str, Any] = {}
+        _set_nested(d, "name", "vol1")
+        assert d == {"name": "vol1"}
+
+    def test_deep_path(self) -> None:
+        d: dict[str, Any] = {}
+        _set_nested(d, "svm.name", "vs1")
+        assert d == {"svm": {"name": "vs1"}}
+
+    def test_deeper_path(self) -> None:
+        d: dict[str, Any] = {}
+        _set_nested(d, "a.b.c", "val")
+        assert d == {"a": {"b": {"c": "val"}}}
+
+    def test_merges_siblings(self) -> None:
+        d: dict[str, Any] = {}
+        _set_nested(d, "svm.name", "vs1")
+        _set_nested(d, "svm.uuid", "abc")
+        assert d == {"svm": {"name": "vs1", "uuid": "abc"}}
+
+
+# ---------------------------------------------------------------------------
+# _build_body tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBody:
+    """Tests for Mutation._build_body."""
+
+    def test_translates_attrs(self, mock_client: MagicMock) -> None:
+        m = Mutation(FakeVolume, mock_client)
+        body = m._build_body({"svm_name": "vs1"})
+        assert body == {"svm": {"name": "vs1"}}
+
+    def test_passthrough_unknown(self, mock_client: MagicMock) -> None:
+        m = Mutation(FakeVolume, mock_client)
+        body = m._build_body({"unknown_field": "val"})
+        assert body == {"unknown_field": "val"}
+
+    def test_multiple_attrs_merge(self, mock_client: MagicMock) -> None:
+        m = Mutation(FakeVolume, mock_client)
+        body = m._build_body({"svm_name": "vs1", "svm_uuid": "abc", "name": "vol1"})
+        assert body == {"svm": {"name": "vs1", "uuid": "abc"}, "name": "vol1"}
+
+
+# ---------------------------------------------------------------------------
+# _collection_path tests
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionPath:
+    """Tests for Mutation._collection_path."""
+
+    def test_strips_query_params(self, mock_client: MagicMock) -> None:
+        m = Mutation(FakeVolume, mock_client)
+        assert m._collection_path() == "/storage/volumes"
+
+
+# ---------------------------------------------------------------------------
+# create tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreate:
+    """Tests for Mutation.create."""
+
+    def test_posts_to_collection_endpoint(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "name": "vol1",
+            "uuid": "abc",
+            "svm": {"name": "vs1", "uuid": "xyz"},
+            "state": "online",
+        }
+        m = Mutation(FakeVolume, mock_client)
+        m.create(name="vol1", svm_name="vs1")
+        mock_client.call_endpoint.assert_called_once()
+        call_args = mock_client.call_endpoint.call_args
+        assert call_args[0][0] == "/storage/volumes"
+        assert call_args[1]["method"] == "POST"
+
+    def test_translates_attrs_to_nested_json(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {}
+        m = Mutation(FakeVolume, mock_client)
+        m.create(name="vol1", svm_name="vs1")
+        call_args = mock_client.call_endpoint.call_args
+        assert call_args[1]["body"] == {"name": "vol1", "svm": {"name": "vs1"}}
+
+    def test_disables_retry(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {}
+        m = Mutation(FakeVolume, mock_client)
+        m.create(name="vol1")
+        call_args = mock_client.call_endpoint.call_args
+        retry_config = call_args[1]["retry_config"]
+        assert isinstance(retry_config, RetryConfig)
+        assert retry_config.enabled is False
+
+    def test_parses_response_to_model(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "name": "vol1",
+            "uuid": "abc",
+            "svm": {"name": "vs1", "uuid": "xyz"},
+            "state": "online",
+        }
+        m = Mutation(FakeVolume, mock_client)
+        result = m.create(name="vol1", svm_name="vs1")
+        assert isinstance(result, FakeVolume)
+        assert result.name == "vol1"
+        assert result.svm_name == "vs1"
+
+
+# ---------------------------------------------------------------------------
+# update tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdate:
+    """Tests for Mutation.update."""
+
+    def test_patches_with_uuid_in_url(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "name": "vol1",
+            "uuid": "abc-123",
+            "svm": {"name": "vs1", "uuid": "xyz"},
+            "state": "offline",
+        }
+        m = Mutation(FakeVolume, mock_client)
+        m.update("abc-123", state="offline")
+        call_args = mock_client.call_endpoint.call_args
+        assert call_args[0][0] == "/storage/volumes/abc-123"
+        assert call_args[1]["method"] == "PATCH"
+
+    def test_translates_attrs(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {}
+        m = Mutation(FakeVolume, mock_client)
+        m.update("abc-123", svm_name="vs2")
+        call_args = mock_client.call_endpoint.call_args
+        assert call_args[1]["body"] == {"svm": {"name": "vs2"}}
+
+    def test_uses_default_retry(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {}
+        m = Mutation(FakeVolume, mock_client)
+        m.update("abc-123", state="offline")
+        call_args = mock_client.call_endpoint.call_args
+        # No retry_config kwarg means default retry is used
+        assert "retry_config" not in call_args[1]
+
+
+# ---------------------------------------------------------------------------
+# delete tests
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    """Tests for Mutation.delete."""
+
+    def test_sends_delete_request(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = None
+        m = Mutation(FakeVolume, mock_client)
+        m.delete("abc-123")
+        call_args = mock_client.call_endpoint.call_args
+        assert call_args[0][0] == "/storage/volumes/abc-123"
+        assert call_args[1]["method"] == "DELETE"
+
+    def test_with_body_kwargs(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = None
+        m = Mutation(FakeVolume, mock_client)
+        m.delete("abc-123", force=True)
+        call_args = mock_client.call_endpoint.call_args
+        assert call_args[1]["body"] == {"force": True}
+
+    def test_returns_raw_response(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {"job": {"uuid": "job-123"}}
+        m = Mutation(FakeVolume, mock_client)
+        result = m.delete("abc-123")
+        assert result == {"job": {"uuid": "job-123"}}
+
+    def test_no_body_when_no_kwargs(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = None
+        m = Mutation(FakeVolume, mock_client)
+        m.delete("abc-123")
+        call_args = mock_client.call_endpoint.call_args
+        assert call_args[1]["body"] is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_response tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseResponse:
+    """Tests for Mutation._parse_response."""
+
+    def test_with_record(self, mock_client: MagicMock) -> None:
+        m = Mutation(FakeVolume, mock_client)
+        response = {
+            "name": "vol1",
+            "uuid": "abc",
+            "svm": {"name": "vs1", "uuid": "xyz"},
+            "state": "online",
+        }
+        result = m._parse_response(response)
+        assert isinstance(result, FakeVolume)
+        assert result.name == "vol1"
+
+    def test_none_response(self, mock_client: MagicMock) -> None:
+        m = Mutation(FakeVolume, mock_client)
+        result = m._parse_response(None)
+        assert result is None
+
+    def test_non_record_dict(self, mock_client: MagicMock) -> None:
+        m = Mutation(FakeVolume, mock_client)
+        response = {"job": {"uuid": "job-123"}}
+        result = m._parse_response(response)
+        assert result == {"job": {"uuid": "job-123"}}


### PR DESCRIPTION
## Description

Add the `Mutation` class to the query layer, providing a high-level interface for write operations (POST/PATCH/DELETE) against ONTAP resources. `Mutation` reuses existing `TypeMapping` metadata to translate flat model attribute names into nested API JSON, keeping the write path consistent with the read path established by `QuerySet`.

Addresses #406

## Related Issue

Addresses #406

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `src/pynetappfoundry/query/mutation.py` with `Mutation` class supporting `create()`, `update()`, and `delete()` operations
- Add `_set_nested()` helper to expand dot-separated API paths into nested dicts
- Export `Mutation` from `src/pynetappfoundry/query/__init__.py`
- Add 24 unit tests covering init, body translation, all three HTTP methods, response parsing, and edge cases

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (24 tests in `tests/unit/query/test_mutation.py`)
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The `type_check` failure in `doit check` is a pre-existing issue in `tools/codegen/generators.py` (missing `tomli` stub) and is unrelated to this PR. All checks pass for the changed files.
