### PR TITLE
feat: add on-demand fetching for realtime fields

### DIFF
--- a/docs/usage/ontap-access-patterns.md
+++ b/docs/usage/ontap-access-patterns.md
@@ -123,6 +123,50 @@ if isinstance(response, dict) and "job" in response:
         print(f"Job failed: {e.message} (code={e.error_code})")
 ```
 
+#### Realtime Fields
+
+Many ONTAP models define fields with `cache_strategy="realtime"` (metrics like IOPS, latency, space usage) that are excluded from cache storage because they change constantly. The `query.realtime` module provides on-demand access to these fields.
+
+```python
+from pynetappfoundry.query import (
+    fetch_realtime,
+    fetch_realtime_collection,
+    watch_realtime,
+    compare_realtime,
+)
+from pynetappfoundry.models.ontap.storage.volumes import OntapVolume
+
+# Fetch realtime metrics for a single volume
+metrics = fetch_realtime(OntapVolume, client, uuid="abc-123-def")
+print(f"IOPS read: {metrics['iops_read']}")
+
+# Fetch only specific realtime fields
+metrics = fetch_realtime(
+    OntapVolume, client, uuid="abc-123-def",
+    fields=["iops_read", "iops_write"],
+)
+
+# Fetch realtime metrics for multiple volumes (with filtering)
+all_metrics = fetch_realtime_collection(
+    OntapVolume, client, svm_name="vs1",
+)
+for m in all_metrics:
+    print(f"{m['name']}: read={m['iops_read']}, write={m['iops_write']}")
+
+# Poll metrics every 10 seconds (3 snapshots)
+for snapshot in watch_realtime(
+    OntapVolume, client, uuid="abc-123-def",
+    interval=10, count=3,
+):
+    print(f"[{snapshot['_timestamp']}] IOPS: {snapshot['iops_read']}")
+
+# Compare current metrics against a baseline
+baseline = fetch_realtime(OntapVolume, client, uuid="abc-123-def")
+# ... time passes ...
+diff = compare_realtime(OntapVolume, client, uuid="abc-123-def", baseline=baseline)
+print(f"IOPS read delta: {diff['iops_read']['delta']}")
+```
+
 ---
 
 ### 2. netapp_ontap SDK
@@ -368,6 +412,8 @@ Use this matrix to choose the right pattern:
 | Query ONTAP resources | `QuerySet` | Type-safe filtering, model attribute translation |
 | Create/update/delete resources | `Mutation` | Nested JSON from flat attrs, retry safety |
 | List volumes/aggregates | `QuerySet` | Fluent API, field projection, pagination |
+| Fetch live IOPS/latency metrics | `fetch_realtime` | On-demand realtime fields |
+| Poll metrics over time | `watch_realtime` | Generator-based polling |
 | Bulk data export | `QuerySet` | Handles pagination, typed results |
 | Generate a report | `netapp_ontap` SDK | Typed objects, well-documented |
 | Check license status | `netapp_ontap` SDK | LicensePackage resource available |

--- a/src/pynetappfoundry/query/__init__.py
+++ b/src/pynetappfoundry/query/__init__.py
@@ -8,6 +8,12 @@ from pynetappfoundry.query.exceptions import MultipleResultsError, NotFoundError
 from pynetappfoundry.query.job import JobError, JobTracker
 from pynetappfoundry.query.mutation import Mutation
 from pynetappfoundry.query.queryset import QuerySet
+from pynetappfoundry.query.realtime import (
+    compare_realtime,
+    fetch_realtime,
+    fetch_realtime_collection,
+    watch_realtime,
+)
 
 __all__ = [
     "JobError",
@@ -16,4 +22,8 @@ __all__ = [
     "Mutation",
     "NotFoundError",
     "QuerySet",
+    "compare_realtime",
+    "fetch_realtime",
+    "fetch_realtime_collection",
+    "watch_realtime",
 ]

--- a/src/pynetappfoundry/query/realtime.py
+++ b/src/pynetappfoundry/query/realtime.py
@@ -1,0 +1,308 @@
+"""On-demand fetching for realtime fields.
+
+Provides functions to fetch, poll, and compare fields with
+``cache_strategy="realtime"`` that are excluded from bulk cache collection.
+
+Functions:
+    fetch_realtime: Fetch current realtime metrics for a single resource.
+    fetch_realtime_collection: Fetch realtime metrics for multiple resources.
+    watch_realtime: Poll realtime metrics at intervals via generator.
+    compare_realtime: Compare current metrics against a baseline dict.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Generator
+from datetime import UTC, datetime
+from typing import Any
+
+from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.utils.dict_path import PathNotFoundError, get_nested_value
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_realtime(
+    model_class: type[Any],
+    fields: list[str] | None = None,
+) -> tuple[TypeMapping, tuple[FieldMapping, ...]]:
+    """Resolve TypeMapping and return filtered realtime fields.
+
+    Args:
+        model_class: Pydantic model class registered in the model registry.
+        fields: Optional list of ``cache_attr`` names to restrict to.
+
+    Returns:
+        Tuple of ``(mapping, realtime_fields)``.
+
+    Raises:
+        ValueError: If no TypeMapping is registered for the model class.
+    """
+    mapping = model_registry.get_mapping(model_class.__name__)
+    if mapping is None:
+        msg = (
+            f"No TypeMapping registered for '{model_class.__name__}'. "
+            f"Ensure the model's mapping module has been imported."
+        )
+        raise ValueError(msg)
+
+    rt_fields = mapping.realtime_fields()
+
+    if fields is not None:
+        field_set = set(fields)
+        rt_fields = tuple(f for f in rt_fields if f.cache_attr in field_set)
+
+    return mapping, rt_fields
+
+
+def _parse_realtime_record(
+    record: dict[str, Any],
+    realtime_fields: tuple[FieldMapping, ...],
+) -> dict[str, Any]:
+    """Extract realtime field values from an API response record.
+
+    For each field: uses ``transform(record)`` if set, else
+    ``get_nested_value(record, api_path)``, falling back to ``default``.
+
+    Args:
+        record: API response record dict.
+        realtime_fields: Tuple of realtime FieldMapping instances.
+
+    Returns:
+        Dict mapping ``cache_attr`` to extracted value.
+    """
+    result: dict[str, Any] = {}
+    for field in realtime_fields:
+        if field.transform is not None:
+            try:
+                result[field.cache_attr] = field.transform(record)
+            except Exception:
+                result[field.cache_attr] = field.default
+        elif field.api_path is not None:
+            try:
+                result[field.cache_attr] = get_nested_value(record, field.api_path)
+            except PathNotFoundError:
+                result[field.cache_attr] = field.default
+        else:
+            result[field.cache_attr] = field.default
+    return result
+
+
+def _realtime_api_fields(
+    realtime_fields: tuple[FieldMapping, ...],
+) -> list[str]:
+    """Deduplicate top-level API field names from realtime fields.
+
+    Takes the first segment (before ``.``) of each ``api_path``.
+
+    Args:
+        realtime_fields: Tuple of realtime FieldMapping instances.
+
+    Returns:
+        Sorted list of unique top-level API field names.
+    """
+    keys: set[str] = set()
+    for field in realtime_fields:
+        if field.api_path is not None:
+            first_segment = field.api_path.split(".")[0].split("[")[0]
+            keys.add(first_segment)
+    return sorted(keys)
+
+
+def _attr_to_api_path(
+    mapping: TypeMapping,
+    attr: str,
+) -> str:
+    """Translate a model attribute name to an API field path.
+
+    Iterates TypeMapping.fields looking for a FieldMapping whose
+    ``cache_attr`` matches *attr*.  Returns the corresponding
+    ``api_path`` if found, otherwise returns *attr* unchanged.
+
+    Args:
+        mapping: TypeMapping for the model.
+        attr: Model attribute name.
+
+    Returns:
+        API field path string.
+    """
+    for field in mapping.fields:
+        if field.cache_attr == attr and field.api_path is not None:
+            return field.api_path
+    return attr
+
+
+# ---------------------------------------------------------------------------
+# Public functions
+# ---------------------------------------------------------------------------
+
+
+def fetch_realtime(
+    model_class: type[Any],
+    client: Any,
+    uuid: str,
+    fields: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fetch current realtime metrics for a single resource by UUID.
+
+    Args:
+        model_class: Pydantic model class with registered TypeMapping.
+        client: API client with ``call_endpoint`` method.
+        uuid: Resource UUID.
+        fields: Optional list of ``cache_attr`` names to restrict to.
+
+    Returns:
+        Dict mapping ``cache_attr`` to current value.
+
+    Raises:
+        ValueError: If no TypeMapping is registered for the model class.
+    """
+    mapping, rt_fields = _resolve_realtime(model_class, fields)
+
+    if not rt_fields:
+        return {}
+
+    collection_path = mapping.collection_endpoint.split("?", 1)[0]
+    api_fields = _realtime_api_fields(rt_fields)
+    url = f"{collection_path}/{uuid}?fields={','.join(api_fields)}"
+
+    response = client.call_endpoint(url)
+    return _parse_realtime_record(response, rt_fields)
+
+
+def fetch_realtime_collection(
+    model_class: type[Any],
+    client: Any,
+    fields: list[str] | None = None,
+    **filters: Any,
+) -> list[dict[str, Any]]:
+    """Fetch realtime metrics for multiple resources with optional filtering.
+
+    Always includes ``uuid`` and ``name`` in the response for identification.
+
+    Args:
+        model_class: Pydantic model class with registered TypeMapping.
+        client: API client with ``get_all_records`` method.
+        fields: Optional list of ``cache_attr`` names to restrict to.
+        **filters: Filter kwargs using model attribute names.
+
+    Returns:
+        List of dicts, each with ``uuid``, ``name``, and realtime field values.
+
+    Raises:
+        ValueError: If no TypeMapping is registered for the model class.
+    """
+    mapping, rt_fields = _resolve_realtime(model_class, fields)
+
+    api_fields = _realtime_api_fields(rt_fields)
+    # Always include uuid and name for identification
+    for ident_field in ("uuid", "name"):
+        if ident_field not in api_fields:
+            api_fields.append(ident_field)
+    api_fields.sort()
+
+    collection_path = mapping.collection_endpoint.split("?", 1)[0]
+
+    # Build query params
+    params_parts = [f"fields={','.join(api_fields)}"]
+    for attr, value in filters.items():
+        api_path = _attr_to_api_path(mapping, attr)
+        params_parts.append(f"{api_path}={value}")
+
+    url = f"{collection_path}?{'&'.join(params_parts)}"
+
+    response = client.get_all_records(url)
+    records: list[dict[str, Any]] = []
+    raw_records = response.get("records", []) if isinstance(response, dict) else []
+
+    for raw in raw_records:
+        parsed = _parse_realtime_record(raw, rt_fields)
+        parsed["uuid"] = raw.get("uuid", "")
+        parsed["name"] = raw.get("name", "")
+        records.append(parsed)
+
+    return records
+
+
+def watch_realtime(
+    model_class: type[Any],
+    client: Any,
+    uuid: str,
+    fields: list[str] | None = None,
+    interval: float = 5,
+    count: int | None = None,
+) -> Generator[dict[str, Any], None, None]:
+    """Poll realtime metrics at intervals, yielding snapshots.
+
+    Generator that calls :func:`fetch_realtime` in a loop, adding a
+    ``_timestamp`` key (ISO format UTC) to each yielded dict.
+
+    Args:
+        model_class: Pydantic model class with registered TypeMapping.
+        client: API client with ``call_endpoint`` method.
+        uuid: Resource UUID.
+        fields: Optional list of ``cache_attr`` names to restrict to.
+        interval: Seconds between polls (default 5).
+        count: Stop after N iterations; ``None`` for infinite.
+
+    Yields:
+        Dict with realtime field values and ``_timestamp``.
+    """
+    iteration = 0
+    while True:
+        snapshot = fetch_realtime(model_class, client, uuid, fields)
+        snapshot["_timestamp"] = datetime.now(tz=UTC).isoformat()
+        yield snapshot
+
+        iteration += 1
+        if count is not None and iteration >= count:
+            return
+
+        time.sleep(interval)
+
+
+def compare_realtime(
+    model_class: type[Any],
+    client: Any,
+    uuid: str,
+    baseline: dict[str, Any],
+    fields: list[str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Compare current realtime metrics against a baseline dict.
+
+    For numeric values (int/float), includes ``baseline``, ``current``,
+    and ``delta`` (current - baseline).  For non-numeric values, includes
+    ``baseline`` and ``current`` only.  Fields in current but not in
+    baseline include ``current`` only.
+
+    Args:
+        model_class: Pydantic model class with registered TypeMapping.
+        client: API client with ``call_endpoint`` method.
+        uuid: Resource UUID.
+        baseline: Dict of ``cache_attr`` to baseline values.
+        fields: Optional list of ``cache_attr`` names to restrict to.
+
+    Returns:
+        Dict mapping ``cache_attr`` to comparison dict.
+    """
+    current = fetch_realtime(model_class, client, uuid, fields)
+
+    result: dict[str, dict[str, Any]] = {}
+    for attr, current_val in current.items():
+        if attr in baseline:
+            baseline_val = baseline[attr]
+            comparison: dict[str, Any] = {
+                "baseline": baseline_val,
+                "current": current_val,
+            }
+            if isinstance(current_val, (int, float)) and isinstance(baseline_val, (int, float)):
+                comparison["delta"] = current_val - baseline_val
+            result[attr] = comparison
+        else:
+            result[attr] = {"current": current_val}
+
+    return result

--- a/tests/unit/query/test_realtime.py
+++ b/tests/unit/query/test_realtime.py
@@ -1,0 +1,545 @@
+"""Tests for pynetappfoundry.query.realtime module."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from pynetappfoundry.cache._registry import model_registry
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+from pynetappfoundry.query.realtime import (
+    _attr_to_api_path,
+    _parse_realtime_record,
+    _realtime_api_fields,
+    _resolve_realtime,
+    compare_realtime,
+    fetch_realtime,
+    fetch_realtime_collection,
+    watch_realtime,
+)
+
+# ---------------------------------------------------------------------------
+# Test model and mapping fixtures
+# ---------------------------------------------------------------------------
+
+
+class FakeVolumeRT(BaseModel):
+    """Minimal model for realtime testing."""
+
+    name: str = ""
+    uuid: str = ""
+    svm_name: str = ""
+    iops_read: int = 0
+    iops_write: int = 0
+    latency_read: int = 0
+    status_text: str = ""
+
+
+def _custom_transform(record: dict[str, Any]) -> int:
+    """Test transform that sums two nested values."""
+    metric = record.get("metric", {})
+    return int(metric.get("iops", {}).get("read", 0)) + int(metric.get("iops", {}).get("write", 0))
+
+
+FAKE_FIELDS_RT = (
+    FieldMapping(cache_attr="name", api_path="name"),
+    FieldMapping(cache_attr="uuid", api_path="uuid"),
+    FieldMapping(cache_attr="svm_name", api_path="svm.name"),
+    FieldMapping(
+        cache_attr="iops_read",
+        api_path="metric.iops.read",
+        default=0,
+        cache_strategy="realtime",
+    ),
+    FieldMapping(
+        cache_attr="iops_write",
+        api_path="metric.iops.write",
+        default=0,
+        cache_strategy="realtime",
+    ),
+    FieldMapping(
+        cache_attr="latency_read",
+        api_path="statistics.latency_raw.read",
+        default=0,
+        cache_strategy="realtime",
+    ),
+    FieldMapping(
+        cache_attr="status_text",
+        api_path="status.message",
+        default="",
+        cache_strategy="realtime",
+    ),
+)
+
+FAKE_MAPPING_RT = TypeMapping(
+    name="FakeVolumeRT",
+    model_class=FakeVolumeRT,
+    api_endpoint="/storage/volumes?fields=*",
+    fields=FAKE_FIELDS_RT,
+    id_field="name",
+)
+
+
+class FakeNoRealtime(BaseModel):
+    """Model with no realtime fields."""
+
+    name: str = ""
+
+
+FAKE_MAPPING_NO_RT = TypeMapping(
+    name="FakeNoRealtime",
+    model_class=FakeNoRealtime,
+    api_endpoint="/storage/aggregates?fields=*",
+    fields=(FieldMapping(cache_attr="name", api_path="name"),),
+    id_field="name",
+)
+
+
+class FakeTransformModel(BaseModel):
+    """Model with a transform-based realtime field."""
+
+    name: str = ""
+    iops_total: int = 0
+
+
+FAKE_TRANSFORM_FIELDS = (
+    FieldMapping(cache_attr="name", api_path="name"),
+    FieldMapping(
+        cache_attr="iops_total",
+        api_path="metric.iops.total",
+        default=0,
+        cache_strategy="realtime",
+        transform=_custom_transform,
+    ),
+)
+
+FAKE_TRANSFORM_MAPPING = TypeMapping(
+    name="FakeTransformModel",
+    model_class=FakeTransformModel,
+    api_endpoint="/storage/volumes?fields=*",
+    fields=FAKE_TRANSFORM_FIELDS,
+    id_field="name",
+)
+
+
+@pytest.fixture(autouse=True)
+def _register_fake_mappings() -> Any:
+    """Register test mappings and clean up after test."""
+    model_registry.register_mapping("FakeVolumeRT", FAKE_MAPPING_RT)
+    model_registry.register_mapping("FakeNoRealtime", FAKE_MAPPING_NO_RT)
+    model_registry.register_mapping("FakeTransformModel", FAKE_TRANSFORM_MAPPING)
+    yield
+    model_registry._mappings.pop("FakeVolumeRT", None)
+    model_registry._mappings.pop("FakeNoRealtime", None)
+    model_registry._mappings.pop("FakeTransformModel", None)
+
+
+@pytest.fixture()
+def mock_client() -> MagicMock:
+    """Return a mocked API client."""
+    return MagicMock(spec=["call_endpoint", "get_all_records"])
+
+
+# ---------------------------------------------------------------------------
+# _resolve_realtime tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRealtime:
+    """Tests for _resolve_realtime."""
+
+    def test_resolve_returns_mapping_and_realtime_fields(self) -> None:
+        mapping, rt_fields = _resolve_realtime(FakeVolumeRT)
+        assert mapping is FAKE_MAPPING_RT
+        assert len(rt_fields) == 4
+        attrs = {f.cache_attr for f in rt_fields}
+        assert attrs == {"iops_read", "iops_write", "latency_read", "status_text"}
+
+    def test_resolve_filters_by_field_names(self) -> None:
+        _, rt_fields = _resolve_realtime(FakeVolumeRT, fields=["iops_read"])
+        assert len(rt_fields) == 1
+        assert rt_fields[0].cache_attr == "iops_read"
+
+    def test_resolve_unknown_model_raises(self) -> None:
+        class Unknown(BaseModel):
+            pass
+
+        with pytest.raises(ValueError, match="No TypeMapping registered for 'Unknown'"):
+            _resolve_realtime(Unknown)
+
+    def test_resolve_no_realtime_fields(self) -> None:
+        _, rt_fields = _resolve_realtime(FakeNoRealtime)
+        assert len(rt_fields) == 0
+
+
+# ---------------------------------------------------------------------------
+# _parse_realtime_record tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseRealtimeRecord:
+    """Tests for _parse_realtime_record."""
+
+    def test_parses_nested_values(self) -> None:
+        record = {
+            "metric": {"iops": {"read": 100, "write": 200}},
+            "statistics": {"latency_raw": {"read": 50}},
+            "status": {"message": "ok"},
+        }
+        _, rt_fields = _resolve_realtime(FakeVolumeRT)
+        result = _parse_realtime_record(record, rt_fields)
+        assert result["iops_read"] == 100
+        assert result["iops_write"] == 200
+        assert result["latency_read"] == 50
+        assert result["status_text"] == "ok"
+
+    def test_missing_values_use_defaults(self) -> None:
+        record: dict[str, Any] = {}
+        _, rt_fields = _resolve_realtime(FakeVolumeRT)
+        result = _parse_realtime_record(record, rt_fields)
+        assert result["iops_read"] == 0
+        assert result["iops_write"] == 0
+        assert result["latency_read"] == 0
+        assert result["status_text"] == ""
+
+    def test_transform_is_used(self) -> None:
+        record = {"metric": {"iops": {"read": 100, "write": 200}}}
+        _, rt_fields = _resolve_realtime(FakeTransformModel)
+        result = _parse_realtime_record(record, rt_fields)
+        assert result["iops_total"] == 300
+
+    def test_transform_failure_uses_default(self) -> None:
+        """When transform raises, fallback to default."""
+
+        def bad_transform(record: dict[str, Any]) -> int:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        field = FieldMapping(
+            cache_attr="bad",
+            api_path="x.y",
+            default=-1,
+            cache_strategy="realtime",
+            transform=bad_transform,
+        )
+        result = _parse_realtime_record({}, (field,))
+        assert result["bad"] == -1
+
+
+# ---------------------------------------------------------------------------
+# _realtime_api_fields tests
+# ---------------------------------------------------------------------------
+
+
+class TestRealtimeApiFields:
+    """Tests for _realtime_api_fields."""
+
+    def test_deduplicates_top_level_fields(self) -> None:
+        _, rt_fields = _resolve_realtime(FakeVolumeRT)
+        api_fields = _realtime_api_fields(rt_fields)
+        assert api_fields == ["metric", "statistics", "status"]
+
+    def test_empty_fields(self) -> None:
+        assert _realtime_api_fields(()) == []
+
+
+# ---------------------------------------------------------------------------
+# _attr_to_api_path tests
+# ---------------------------------------------------------------------------
+
+
+class TestAttrToApiPath:
+    """Tests for _attr_to_api_path."""
+
+    def test_translates_known_attr(self) -> None:
+        assert _attr_to_api_path(FAKE_MAPPING_RT, "svm_name") == "svm.name"
+
+    def test_returns_unknown_attr_unchanged(self) -> None:
+        assert _attr_to_api_path(FAKE_MAPPING_RT, "unknown_field") == "unknown_field"
+
+
+# ---------------------------------------------------------------------------
+# fetch_realtime tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRealtime:
+    """Tests for fetch_realtime."""
+
+    def test_calls_api_with_correct_url(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 10, "write": 20}},
+            "statistics": {"latency_raw": {"read": 5}},
+            "status": {"message": "ok"},
+        }
+        fetch_realtime(FakeVolumeRT, mock_client, "test-uuid")
+        url = mock_client.call_endpoint.call_args[0][0]
+        assert "/storage/volumes/test-uuid?" in url
+        assert "fields=" in url
+
+    def test_requests_correct_api_fields(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {}
+        fetch_realtime(FakeVolumeRT, mock_client, "test-uuid")
+        url = mock_client.call_endpoint.call_args[0][0]
+        assert "fields=metric,statistics,status" in url
+
+    def test_extracts_values_from_response(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 100, "write": 200}},
+            "statistics": {"latency_raw": {"read": 50}},
+            "status": {"message": "healthy"},
+        }
+        result = fetch_realtime(FakeVolumeRT, mock_client, "test-uuid")
+        assert result["iops_read"] == 100
+        assert result["iops_write"] == 200
+        assert result["latency_read"] == 50
+        assert result["status_text"] == "healthy"
+
+    def test_with_field_filter(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 42}},
+        }
+        result = fetch_realtime(FakeVolumeRT, mock_client, "test-uuid", fields=["iops_read"])
+        assert result == {"iops_read": 42}
+        url = mock_client.call_endpoint.call_args[0][0]
+        assert "fields=metric" in url
+
+    def test_unknown_model_raises(self, mock_client: MagicMock) -> None:
+        class NotRegistered(BaseModel):
+            pass
+
+        with pytest.raises(ValueError, match="No TypeMapping registered"):
+            fetch_realtime(NotRegistered, mock_client, "test-uuid")
+
+    def test_no_realtime_fields_returns_empty(self, mock_client: MagicMock) -> None:
+        result = fetch_realtime(FakeNoRealtime, mock_client, "test-uuid")
+        assert result == {}
+        mock_client.call_endpoint.assert_not_called()
+
+    def test_with_transform(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 150, "write": 250}},
+        }
+        result = fetch_realtime(FakeTransformModel, mock_client, "test-uuid")
+        assert result["iops_total"] == 400
+
+    def test_missing_values_use_defaults(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {}
+        result = fetch_realtime(FakeVolumeRT, mock_client, "test-uuid")
+        assert result["iops_read"] == 0
+        assert result["iops_write"] == 0
+        assert result["latency_read"] == 0
+        assert result["status_text"] == ""
+
+
+# ---------------------------------------------------------------------------
+# fetch_realtime_collection tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRealtimeCollection:
+    """Tests for fetch_realtime_collection."""
+
+    def test_fetches_multiple_records(self, mock_client: MagicMock) -> None:
+        mock_client.get_all_records.return_value = {
+            "records": [
+                {
+                    "uuid": "u1",
+                    "name": "vol1",
+                    "metric": {"iops": {"read": 10, "write": 20}},
+                    "statistics": {"latency_raw": {"read": 1}},
+                    "status": {"message": "ok"},
+                },
+                {
+                    "uuid": "u2",
+                    "name": "vol2",
+                    "metric": {"iops": {"read": 30, "write": 40}},
+                    "statistics": {"latency_raw": {"read": 2}},
+                    "status": {"message": "ok"},
+                },
+            ],
+        }
+        results = fetch_realtime_collection(FakeVolumeRT, mock_client)
+        assert len(results) == 2
+        assert results[0]["uuid"] == "u1"
+        assert results[0]["name"] == "vol1"
+        assert results[0]["iops_read"] == 10
+        assert results[1]["uuid"] == "u2"
+
+    def test_includes_uuid_and_name(self, mock_client: MagicMock) -> None:
+        mock_client.get_all_records.return_value = {
+            "records": [
+                {
+                    "uuid": "abc",
+                    "name": "test_vol",
+                    "metric": {"iops": {"read": 1, "write": 2}},
+                    "statistics": {"latency_raw": {"read": 0}},
+                    "status": {"message": ""},
+                },
+            ],
+        }
+        results = fetch_realtime_collection(FakeVolumeRT, mock_client)
+        assert results[0]["uuid"] == "abc"
+        assert results[0]["name"] == "test_vol"
+
+    def test_with_filters(self, mock_client: MagicMock) -> None:
+        mock_client.get_all_records.return_value = {"records": []}
+        fetch_realtime_collection(FakeVolumeRT, mock_client, svm_name="vs1")
+        url = mock_client.get_all_records.call_args[0][0]
+        assert "svm.name=vs1" in url
+
+    def test_uses_get_all_records(self, mock_client: MagicMock) -> None:
+        mock_client.get_all_records.return_value = {"records": []}
+        fetch_realtime_collection(FakeVolumeRT, mock_client)
+        mock_client.get_all_records.assert_called_once()
+
+    def test_empty_response(self, mock_client: MagicMock) -> None:
+        mock_client.get_all_records.return_value = {"records": []}
+        results = fetch_realtime_collection(FakeVolumeRT, mock_client)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# watch_realtime tests
+# ---------------------------------------------------------------------------
+
+
+class TestWatchRealtime:
+    """Tests for watch_realtime."""
+
+    @patch("pynetappfoundry.query.realtime.time.sleep")
+    def test_yields_snapshots(self, mock_sleep: MagicMock, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 10, "write": 20}},
+            "statistics": {"latency_raw": {"read": 5}},
+            "status": {"message": "ok"},
+        }
+        gen = watch_realtime(FakeVolumeRT, mock_client, "test-uuid", count=2)
+        snapshots = list(gen)
+        assert len(snapshots) == 2
+        assert snapshots[0]["iops_read"] == 10
+
+    @patch("pynetappfoundry.query.realtime.time.sleep")
+    def test_includes_timestamp(self, mock_sleep: MagicMock, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 1, "write": 2}},
+            "statistics": {"latency_raw": {"read": 0}},
+            "status": {"message": ""},
+        }
+        gen = watch_realtime(FakeVolumeRT, mock_client, "test-uuid", count=1)
+        snapshot = next(gen)
+        assert "_timestamp" in snapshot
+        # Should be ISO format string
+        assert "T" in snapshot["_timestamp"]
+
+    @patch("pynetappfoundry.query.realtime.time.sleep")
+    def test_respects_count(self, mock_sleep: MagicMock, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 1, "write": 2}},
+            "statistics": {"latency_raw": {"read": 0}},
+            "status": {"message": ""},
+        }
+        gen = watch_realtime(FakeVolumeRT, mock_client, "test-uuid", count=3)
+        snapshots = list(gen)
+        assert len(snapshots) == 3
+        # Sleep called between iterations (count-1 times)
+        assert mock_sleep.call_count == 2
+
+    @patch("pynetappfoundry.query.realtime.time.sleep")
+    def test_calls_fetch_realtime(self, mock_sleep: MagicMock, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 1, "write": 2}},
+            "statistics": {"latency_raw": {"read": 0}},
+            "status": {"message": ""},
+        }
+        gen = watch_realtime(FakeVolumeRT, mock_client, "test-uuid", count=1)
+        next(gen)
+        mock_client.call_endpoint.assert_called_once()
+        url = mock_client.call_endpoint.call_args[0][0]
+        assert "/storage/volumes/test-uuid?" in url
+
+    @patch("pynetappfoundry.query.realtime.time.sleep")
+    def test_custom_interval(self, mock_sleep: MagicMock, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 1, "write": 2}},
+            "statistics": {"latency_raw": {"read": 0}},
+            "status": {"message": ""},
+        }
+        gen = watch_realtime(FakeVolumeRT, mock_client, "test-uuid", interval=10, count=2)
+        list(gen)
+        mock_sleep.assert_called_with(10)
+
+
+# ---------------------------------------------------------------------------
+# compare_realtime tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompareRealtime:
+    """Tests for compare_realtime."""
+
+    def test_numeric_delta(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 150, "write": 250}},
+            "statistics": {"latency_raw": {"read": 30}},
+            "status": {"message": "ok"},
+        }
+        baseline = {"iops_read": 100, "iops_write": 200, "latency_read": 20}
+        result = compare_realtime(FakeVolumeRT, mock_client, "test-uuid", baseline)
+        assert result["iops_read"]["baseline"] == 100
+        assert result["iops_read"]["current"] == 150
+        assert result["iops_read"]["delta"] == 50
+        assert result["iops_write"]["delta"] == 50
+        assert result["latency_read"]["delta"] == 10
+
+    def test_non_numeric_no_delta(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 0, "write": 0}},
+            "statistics": {"latency_raw": {"read": 0}},
+            "status": {"message": "degraded"},
+        }
+        baseline = {"status_text": "healthy"}
+        result = compare_realtime(FakeVolumeRT, mock_client, "test-uuid", baseline)
+        assert result["status_text"]["baseline"] == "healthy"
+        assert result["status_text"]["current"] == "degraded"
+        assert "delta" not in result["status_text"]
+
+    def test_missing_baseline_field(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 50, "write": 60}},
+            "statistics": {"latency_raw": {"read": 10}},
+            "status": {"message": "ok"},
+        }
+        baseline: dict[str, Any] = {}  # No baseline values
+        result = compare_realtime(FakeVolumeRT, mock_client, "test-uuid", baseline)
+        assert result["iops_read"] == {"current": 50}
+        assert "baseline" not in result["iops_read"]
+
+    def test_calls_fetch_realtime(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 1, "write": 2}},
+            "statistics": {"latency_raw": {"read": 0}},
+            "status": {"message": ""},
+        }
+        compare_realtime(FakeVolumeRT, mock_client, "test-uuid", {})
+        mock_client.call_endpoint.assert_called_once()
+        url = mock_client.call_endpoint.call_args[0][0]
+        assert "/storage/volumes/test-uuid?" in url
+
+    def test_partial_baseline(self, mock_client: MagicMock) -> None:
+        """Baseline has some but not all fields."""
+        mock_client.call_endpoint.return_value = {
+            "metric": {"iops": {"read": 100, "write": 200}},
+            "statistics": {"latency_raw": {"read": 30}},
+            "status": {"message": "ok"},
+        }
+        baseline = {"iops_read": 50}
+        result = compare_realtime(FakeVolumeRT, mock_client, "test-uuid", baseline)
+        # Field in baseline: has baseline, current, delta
+        assert result["iops_read"]["delta"] == 50
+        # Field not in baseline: current only
+        assert result["iops_write"] == {"current": 200}
+        assert result["status_text"] == {"current": "ok"}


### PR DESCRIPTION
## Description

Add on-demand fetching for ONTAP model fields marked with `cache_strategy="realtime"` (metrics like IOPS, latency, space usage). These fields are excluded from cache storage because they change constantly; the new `query.realtime` module provides four functions to access them directly from the ONTAP API.

Addresses #410

## Related Issue

Addresses #410

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `src/pynetappfoundry/query/realtime.py` with four public functions:
  - `fetch_realtime` — fetch current realtime metrics for a single resource
  - `fetch_realtime_collection` — fetch realtime metrics across multiple resources
  - `watch_realtime` — generator-based polling at configurable intervals
  - `compare_realtime` — diff current metrics against a baseline snapshot
- Export the four functions from `query/__init__.py`
- Add usage examples to `docs/usage/ontap-access-patterns.md` (Realtime Fields section and decision matrix rows)
- Add 35 unit tests in `tests/unit/query/test_realtime.py`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (35 tests, all passing)
- [x] Manually tested the changes
- [x] mypy passes on `src/pynetappfoundry/query/`
- [x] ruff check passes on new files

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The `doit check` task has a pre-existing `type_check` failure in `tools/codegen/generators.py` (missing `tomli` stub) that is unrelated to this branch. All checks pass for the files changed in this PR.
