### PR TITLE
feat: rewrite reports locks command with QuerySet

### DIFF
--- a/src/pynetappfoundry/cli/commands/reports/locks.py
+++ b/src/pynetappfoundry/cli/commands/reports/locks.py
@@ -8,9 +8,14 @@ from typing import Any
 import click
 from openpyxl import Workbook
 
+import pynetappfoundry.cache.ontap.protocols.locks.mapping  # noqa: F401 - register TypeMapping
 from pynetappfoundry.cli.decorators import with_config
 from pynetappfoundry.cli.utils import print_debug, print_error, print_info, print_success
+from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
 from pynetappfoundry.core.config import Config
+from pynetappfoundry.core.models import ClusterConfig
+from pynetappfoundry.models.ontap.protocols.locks import OntapClientLock
+from pynetappfoundry.query import QuerySet
 
 
 @click.command()
@@ -54,58 +59,48 @@ def _gather_lock_data(
     wb: Workbook,
 ) -> None:
     """Gather lock data from a single cluster."""
-    from netapp_ontap import HostConnection
-    from netapp_ontap.resources import ClientLock
-
-    user, password = config.get_user("clusters", name)
-
     try:
-        with HostConnection(
-            details["ip"],
-            username=user,
-            password=password,
-            verify=False,
-        ):
-            ws = wb.create_sheet(name)
-            ws.append(["Volume", "Protocol", "Type", "Path", "Lock", "State", "IP Address"])
+        cluster_config = ClusterConfig(**details)
+        client = ONTAPAPIClient(cluster=cluster_config, config=config)
 
-            locks_data: list[dict[str, Any]] = []
-            for lock in ClientLock.get_collection(fields="*"):
-                locks_data.append(lock.to_dict())
+        locks_data: list[OntapClientLock] = QuerySet(OntapClientLock, client).all()
 
-            print_debug(f"Locks found: {len(locks_data)}")
+        ws = wb.create_sheet(name)
+        ws.append(["Volume", "Protocol", "Type", "Path", "Lock", "State", "IP Address"])
 
-            for item in locks_data:
-                try:
-                    lock_type = item.get("type", "unknown")
-                    if lock_type == "share_level":
-                        ws.append(
-                            [
-                                item.get("volume", {}).get("name", "Unknown"),
-                                item.get("protocol", "Unknown"),
-                                lock_type,
-                                item.get("path", "Unknown"),
-                                str(item.get("share_lock", "")),
-                                item.get("state", "Unknown"),
-                                item.get("client_address", "Unknown"),
-                            ]
-                        )
-                    elif lock_type == "op_lock":
-                        ws.append(
-                            [
-                                item.get("volume", {}).get("name", "Unknown"),
-                                item.get("protocol", "Unknown"),
-                                lock_type,
-                                item.get("path", "Unknown"),
-                                str(item.get("oplock_level", "")),
-                                item.get("state", "Unknown"),
-                                item.get("client_address", "Unknown"),
-                            ]
-                        )
-                    else:
-                        print_debug(f"Unknown lock type: {lock_type}")
-                except Exception as e:
-                    print_error(f"Lock error: {e}")
+        print_debug(f"Locks found: {len(locks_data)}")
+
+        for lock in locks_data:
+            try:
+                lock_type = lock.type_
+                if lock_type == "share_level":
+                    ws.append(
+                        [
+                            lock.volume_name or "Unknown",
+                            lock.protocol or "Unknown",
+                            lock_type,
+                            lock.path or "Unknown",
+                            lock.share_lock_mode,
+                            lock.state or "Unknown",
+                            lock.client_address or "Unknown",
+                        ]
+                    )
+                elif lock_type == "op_lock":
+                    ws.append(
+                        [
+                            lock.volume_name or "Unknown",
+                            lock.protocol or "Unknown",
+                            lock_type,
+                            lock.path or "Unknown",
+                            lock.oplock_level,
+                            lock.state or "Unknown",
+                            lock.client_address or "Unknown",
+                        ]
+                    )
+                else:
+                    print_debug(f"Unknown lock type: {lock_type}")
+            except Exception as e:
+                print_error(f"Lock error: {e}")
 
     except Exception as e:
         print_error(f"Could not gather lock data for {name}: {e}")

--- a/tests/unit/cli/commands/reports/test_locks.py
+++ b/tests/unit/cli/commands/reports/test_locks.py
@@ -1,0 +1,198 @@
+"""Tests for reports locks command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from openpyxl import Workbook
+
+from pynetappfoundry.cli.commands.reports.locks import _gather_lock_data
+from pynetappfoundry.models.ontap.protocols.locks.model import OntapClientLock
+
+
+def _make_lock(
+    *,
+    volume_name: str = "vol1",
+    protocol: str = "cifs",
+    type_: str = "share_level",
+    path: str = "/data/file.txt",
+    share_lock_mode: str = "read",
+    oplock_level: str = "",
+    state: str = "granted",
+    client_address: str = "192.168.1.10",
+) -> OntapClientLock:
+    """Create an OntapClientLock with common defaults."""
+    return OntapClientLock(
+        volume_name=volume_name,
+        protocol=protocol,
+        type_=type_,
+        path=path,
+        share_lock_mode=share_lock_mode,
+        oplock_level=oplock_level,
+        state=state,
+        client_address=client_address,
+    )
+
+
+@pytest.fixture
+def mock_config() -> MagicMock:
+    """Create a mock Config object."""
+    config = MagicMock()
+    config.get_user.return_value = ("admin", "password123")
+    config.output_dir = Path("/tmp/test_output")
+    config.get_ontap_api_settings.return_value = MagicMock(
+        base_api_path="/api",
+        timeout=30.0,
+    )
+    config.get_schema_location.return_value = Path("/tmp/schema")
+    return config
+
+
+@pytest.fixture
+def sample_details() -> dict[str, Any]:
+    """Sample cluster connection details."""
+    return {"ip": "10.0.0.1", "bu": "Platform", "env": "Prod"}
+
+
+class TestGatherLockData:
+    """Tests for _gather_lock_data."""
+
+    @patch("pynetappfoundry.cli.commands.reports.locks.QuerySet")
+    @patch("pynetappfoundry.cli.commands.reports.locks.ONTAPAPIClient")
+    def test_creates_sheet(
+        self,
+        mock_client_cls: MagicMock,
+        mock_qs_cls: MagicMock,
+        mock_config: MagicMock,
+        sample_details: dict[str, Any],
+    ) -> None:
+        """Test that a sheet is created for the cluster."""
+        lock = _make_lock()
+        mock_qs_cls.return_value.all.return_value = [lock]
+
+        wb = Workbook()
+        default = wb.active
+        if default:
+            wb.remove(default)
+
+        _gather_lock_data("cluster1", sample_details, mock_config, wb)
+
+        assert "cluster1" in wb.sheetnames
+        ws = wb["cluster1"]
+        # Header row
+        assert ws.cell(row=1, column=1).value == "Volume"
+        assert ws.cell(row=1, column=7).value == "IP Address"
+        # Data row
+        assert ws.cell(row=2, column=1).value == "vol1"
+
+    @patch("pynetappfoundry.cli.commands.reports.locks.QuerySet")
+    @patch("pynetappfoundry.cli.commands.reports.locks.ONTAPAPIClient")
+    def test_share_level_lock_row(
+        self,
+        mock_client_cls: MagicMock,
+        mock_qs_cls: MagicMock,
+        mock_config: MagicMock,
+        sample_details: dict[str, Any],
+    ) -> None:
+        """Test that share_level lock row has correct columns."""
+        lock = _make_lock(
+            type_="share_level",
+            share_lock_mode="read_write",
+        )
+        mock_qs_cls.return_value.all.return_value = [lock]
+
+        wb = Workbook()
+        default = wb.active
+        if default:
+            wb.remove(default)
+
+        _gather_lock_data("cluster1", sample_details, mock_config, wb)
+
+        ws = wb["cluster1"]
+        # Row 2 is data (row 1 is header)
+        assert ws.cell(row=2, column=1).value == "vol1"
+        assert ws.cell(row=2, column=2).value == "cifs"
+        assert ws.cell(row=2, column=3).value == "share_level"
+        assert ws.cell(row=2, column=4).value == "/data/file.txt"
+        assert ws.cell(row=2, column=5).value == "read_write"
+        assert ws.cell(row=2, column=6).value == "granted"
+        assert ws.cell(row=2, column=7).value == "192.168.1.10"
+
+    @patch("pynetappfoundry.cli.commands.reports.locks.QuerySet")
+    @patch("pynetappfoundry.cli.commands.reports.locks.ONTAPAPIClient")
+    def test_op_lock_row(
+        self,
+        mock_client_cls: MagicMock,
+        mock_qs_cls: MagicMock,
+        mock_config: MagicMock,
+        sample_details: dict[str, Any],
+    ) -> None:
+        """Test that op_lock row has correct columns."""
+        lock = _make_lock(
+            type_="op_lock",
+            share_lock_mode="",
+            oplock_level="batch",
+        )
+        mock_qs_cls.return_value.all.return_value = [lock]
+
+        wb = Workbook()
+        default = wb.active
+        if default:
+            wb.remove(default)
+
+        _gather_lock_data("cluster1", sample_details, mock_config, wb)
+
+        ws = wb["cluster1"]
+        assert ws.cell(row=2, column=3).value == "op_lock"
+        assert ws.cell(row=2, column=5).value == "batch"
+
+    @patch("pynetappfoundry.cli.commands.reports.locks.print_error")
+    @patch("pynetappfoundry.cli.commands.reports.locks.ONTAPAPIClient")
+    def test_error_handling_creates_error_sheet(
+        self,
+        mock_client_cls: MagicMock,
+        mock_print_error: MagicMock,
+        mock_config: MagicMock,
+        sample_details: dict[str, Any],
+    ) -> None:
+        """Test that connection failure creates an error sheet."""
+        mock_client_cls.side_effect = Exception("Connection refused")
+
+        wb = Workbook()
+        default = wb.active
+        if default:
+            wb.remove(default)
+
+        _gather_lock_data("cluster1", sample_details, mock_config, wb)
+
+        assert "cluster1" in wb.sheetnames
+        ws = wb["cluster1"]
+        assert ws.cell(row=1, column=1).value == "Error"
+        assert "Connection refused" in ws.cell(row=1, column=2).value
+        mock_print_error.assert_called_once()
+
+    @patch("pynetappfoundry.cli.commands.reports.locks.QuerySet")
+    @patch("pynetappfoundry.cli.commands.reports.locks.ONTAPAPIClient")
+    def test_empty_locks_creates_header_only(
+        self,
+        mock_client_cls: MagicMock,
+        mock_qs_cls: MagicMock,
+        mock_config: MagicMock,
+        sample_details: dict[str, Any],
+    ) -> None:
+        """Test that no locks creates a sheet with header only."""
+        mock_qs_cls.return_value.all.return_value = []
+
+        wb = Workbook()
+        default = wb.active
+        if default:
+            wb.remove(default)
+
+        _gather_lock_data("cluster1", sample_details, mock_config, wb)
+
+        ws = wb["cluster1"]
+        assert ws.cell(row=1, column=1).value == "Volume"
+        assert ws.cell(row=2, column=1).value is None


### PR DESCRIPTION
## Description

Replace `netapp_ontap` SDK (`HostConnection` + `ClientLock.get_collection()`) with `QuerySet(OntapClientLock, client)` in the reports locks command. Access lock fields via model attributes instead of raw dict access.

Addresses #424

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Replaced `netapp_ontap.HostConnection` + `ClientLock.get_collection()` with `ONTAPAPIClient` + `QuerySet(OntapClientLock, client)`
- Replaced raw dict access (`item.get("volume", {}).get("name")`) with model attributes (`lock.volume_name`, `lock.type_`, etc.)
- Added 5 unit tests covering sheet creation, lock type handling, error handling, and empty results

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (5 tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
