### PR TITLE
feat: rewrite licenses check with QuerySet and styled HTML email

### DIFF
--- a/src/pynetappfoundry/cli/commands/licenses/check.py
+++ b/src/pynetappfoundry/cli/commands/licenses/check.py
@@ -6,12 +6,19 @@ from datetime import UTC, datetime
 from typing import Any
 
 import click
-from netapp_ontap import HostConnection
-from netapp_ontap.resources import LicensePackage, Node
 
+import pynetappfoundry.cache.ontap.cluster.licensing.licenses.mapping
+import pynetappfoundry.cache.ontap.cluster.nodes.mapping  # noqa: F401 - register TypeMapping
 from pynetappfoundry.cli.decorators import with_config
 from pynetappfoundry.cli.utils import print_error, print_info, print_warning
+from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
 from pynetappfoundry.core.config import Config
+from pynetappfoundry.core.models import ClusterConfig
+from pynetappfoundry.models.ontap.cluster.licensing.licenses import (
+    OntapLicensePackageResponse,
+)
+from pynetappfoundry.models.ontap.cluster.nodes import OntapNodeResponse
+from pynetappfoundry.query import QuerySet
 from pynetappfoundry.utils.email import send_email
 
 
@@ -24,6 +31,7 @@ from pynetappfoundry.utils.email import send_email
 )
 @click.option(
     "--send-email/--no-send-email",
+    "send_email_flag",
     default=True,
     help="Send email notification (default: True).",
 )
@@ -53,6 +61,8 @@ def check(
             _send_license_email(config, license_issues)
     else:
         print_info("No licensing issues found.")
+        if send_email_flag:
+            _send_no_issues_email(config)
 
 
 def _check_cluster_licenses(
@@ -65,90 +75,90 @@ def _check_cluster_licenses(
     days_to_check = 30
     current_time = datetime.now(UTC)
 
-    user, password = config.get_user("clusters", name)
     try:
-        with HostConnection(
-            details["ip"],
-            username=user,
-            password=password,
-            verify=False,
-        ):
-            licenses_data: list[dict[str, Any]] = []
-            for license_pkg in LicensePackage.get_collection(fields="*"):
-                licenses_data.append(license_pkg.to_dict())
+        cluster_config = ClusterConfig(**details)
+        client = ONTAPAPIClient(cluster=cluster_config, config=config)
 
-            nodes_data: dict[str, dict[str, Any]] = {}
-            for node in Node.get_collection(fields="*"):
-                nodes_data[node["name"]] = node.to_dict()
-                nodes_data[node["name"]]["has_license"] = False
+        packages: list[OntapLicensePackageResponse] = QuerySet(
+            OntapLicensePackageResponse, client
+        ).all()
 
-            if not licenses_data:
+        nodes_response: list[OntapNodeResponse] = QuerySet(OntapNodeResponse, client).all()
+
+        nodes_data: dict[str, dict[str, Any]] = {}
+        for node in nodes_response:
+            nodes_data[node.name] = {
+                "serial_number": node.serial_number,
+                "has_license": False,
+            }
+
+        if not packages:
+            issues.append(
+                {
+                    "cluster": name,
+                    "owner": "",
+                    "error": "Could not get licenses",
+                    "days_checked": -1,
+                    "serial_number": -1,
+                    "expires": -1,
+                    "license_type": -1,
+                }
+            )
+            return issues
+
+        for pkg in packages:
+            for lic in pkg.licenses:
+                serial_number = lic.serial_number
+                license_type = "ONTAP BYOL"
+                days_check = days_to_check
+
+                # Determine license type and check period
+                if serial_number.startswith("9092"):
+                    days_check = 13
+                    license_type = "ONTAP Cloud Capacity"
+                elif serial_number.startswith("2265"):
+                    days_check = 13
+                    license_type = "Data Tiering"
+                elif serial_number.startswith("3200"):
+                    license_type = "ONTAP Select"
+
+                owner = lic.owner or "none"
+                if owner in nodes_data:
+                    nodes_data[owner]["has_license"] = True
+                    nodes_data[owner]["license_type"] = license_type
+
+                if lic.expiry_time and owner != "none":
+                    expiry_time = datetime.fromisoformat(lic.expiry_time)
+                    delta = expiry_time - current_time
+                    days_difference = delta.days
+
+                    if days_difference < days_check:
+                        issues.append(
+                            {
+                                "cluster": name,
+                                "owner": owner,
+                                "error": "Expiring license",
+                                "days_checked": days_difference,
+                                "serial_number": serial_number,
+                                "expires": expiry_time,
+                                "license_type": license_type,
+                            }
+                        )
+
+        # Check for nodes without licenses
+        for node_name, node_data in nodes_data.items():
+            if not node_data.get("has_license", False):
                 issues.append(
                     {
                         "cluster": name,
-                        "owner": "",
-                        "error": "Could not get licenses",
+                        "node": node_name,
+                        "error": "No License",
                         "days_checked": -1,
-                        "serial_number": -1,
+                        "serial_number": node_data.get("serial_number", "Unknown"),
                         "expires": -1,
-                        "license_type": -1,
+                        "license_type": "None",
                     }
                 )
-                return issues
-
-            for lic in licenses_data:
-                for item in lic.get("licenses", []):
-                    serial_number = item.get("serial_number", "")
-                    license_type = "ONTAP BYOL"
-                    days_check = days_to_check
-
-                    # Determine license type and check period
-                    if serial_number.startswith("9092"):
-                        days_check = 13
-                        license_type = "ONTAP Cloud Capacity"
-                    elif serial_number.startswith("2265"):
-                        days_check = 13
-                        license_type = "Data Tiering"
-                    elif serial_number.startswith("3200"):
-                        license_type = "ONTAP Select"
-
-                    owner = item.get("owner", "none")
-                    if owner in nodes_data:
-                        nodes_data[owner]["has_license"] = True
-                        nodes_data[owner]["license_type"] = license_type
-
-                    if "expiry_time" in item and owner != "none":
-                        expiry_time = datetime.fromisoformat(item["expiry_time"])
-                        delta = expiry_time - current_time
-                        days_difference = delta.days
-
-                        if days_difference < days_check:
-                            issues.append(
-                                {
-                                    "cluster": name,
-                                    "owner": owner,
-                                    "error": "Expiring license",
-                                    "days_checked": days_difference,
-                                    "serial_number": serial_number,
-                                    "expires": expiry_time,
-                                    "license_type": license_type,
-                                }
-                            )
-
-            # Check for nodes without licenses
-            for node_name, node_data in nodes_data.items():
-                if not node_data.get("has_license", False):
-                    issues.append(
-                        {
-                            "cluster": name,
-                            "node": node_name,
-                            "error": "No License",
-                            "days_checked": -1,
-                            "serial_number": node_data.get("serial_number", "Unknown"),
-                            "expires": -1,
-                            "license_type": "None",
-                        }
-                    )
 
     except Exception as e:
         print_error(f"Could not retrieve licenses for {name}: {e}")
@@ -176,6 +186,69 @@ def _print_issue(issue: dict[str, Any]) -> None:
         )
 
 
+def _build_styled_html(issues: list[dict[str, Any]]) -> str:
+    """Build styled HTML email body for license issues.
+
+    Args:
+        issues: List of license issue dicts.
+
+    Returns:
+        Styled HTML string.
+    """
+    html_parts: list[str] = [
+        "<html>",
+        "<head>",
+        "    <style>",
+        "    .red-white {",
+        "        background-color: red;",
+        "        color: white;",
+        "        padding: 5px;",
+        "        font-weight: bold;",
+        "    }",
+        "    .yellow-black {",
+        "        background-color: yellow;",
+        "        color: black;",
+        "        padding: 5px;",
+        "        font-weight: bold;",
+        "    }",
+        "    </style>",
+        "</head>",
+        "<body>",
+        "    <p>The following licenses should be checked</p>",
+    ]
+
+    for issue in issues:
+        cluster = issue.get("cluster", "Unknown")
+        owner = issue.get("owner", "Unknown")
+        serial = issue.get("serial_number", "Unknown")
+        license_type = issue.get("license_type", "Unknown")
+        days = issue.get("days_checked", "Unknown")
+        expires = issue.get("expires", "Unknown")
+
+        if isinstance(expires, datetime):
+            expires_str = expires.strftime("%Y-%m-%d")
+        else:
+            expires_str = str(expires)
+
+        if isinstance(days, (int, float)) and days < 0:
+            abs_days = abs(days)
+            html_parts.append(
+                f"    <p class='red-white'>"
+                f"{cluster} - {owner} - {serial} - {license_type} "
+                f"has expired {abs_days} days ago on {expires_str}!</p>"
+            )
+        else:
+            html_parts.append(
+                f"    <p class='yellow-black'>"
+                f"{cluster} - {owner} - {serial} - {license_type} "
+                f"expires in {days} days on {expires_str}.</p>"
+            )
+
+    html_parts.extend(["</body>", "</html>"])
+
+    return "\n".join(html_parts)
+
+
 def _send_license_email(
     config: Config,
     issues: list[dict[str, Any]],
@@ -187,23 +260,32 @@ def _send_license_email(
         print_warning("Email settings not configured, skipping notification")
         return
 
-    html_body = ["<html><body>"]
-    html_body.append("<p>The following licenses should be checked:</p>")
-    for issue in issues:
-        days = issue.get("days_checked", "Unknown")
-        html_body.append(f"<p>{issue['cluster']} - {issue.get('error', 'Unknown error')}")
-        if days != "Unknown":
-            html_body.append(f" - {days} days</p>")
-        else:
-            html_body.append("</p>")
-    html_body.append("</body></html>")
+    html_body = _build_styled_html(issues)
 
     send_email(
         config,
         subject=f"{datetime.now().date()} : Licensing issues found",
-        body="\n".join(html_body),
+        body=html_body,
         body_type="html",
         mailfrom=licensing_settings.mailfrom,
         mailto=licensing_settings.mailto,
         high_priority=True,
+    )
+
+
+def _send_no_issues_email(config: Config) -> None:
+    """Send email when no licensing issues are found."""
+    licensing_settings = config.get_licensing_settings()
+
+    if not licensing_settings:
+        print_warning("Email settings not configured, skipping notification")
+        return
+
+    send_email(
+        config,
+        subject=f"{datetime.now().date()} : No licensing issues found",
+        body="No licensing issues",
+        body_type="html",
+        mailfrom=licensing_settings.mailfrom,
+        mailto=licensing_settings.mailto,
     )

--- a/tests/unit/cli/commands/licenses/test_check.py
+++ b/tests/unit/cli/commands/licenses/test_check.py
@@ -1,0 +1,388 @@
+"""Tests for licenses check command."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pynetappfoundry.cli.commands.licenses.check import (
+    _build_styled_html,
+    _check_cluster_licenses,
+    _send_license_email,
+    _send_no_issues_email,
+)
+from pynetappfoundry.models.ontap.cluster.licensing.licenses.model import (
+    OntapLicensePackageResponse,
+    OntapLicensePackageResponseLicense,
+)
+from pynetappfoundry.models.ontap.cluster.nodes.model import OntapNodeResponse
+
+
+def _make_license(
+    *,
+    owner: str = "node1",
+    serial: str = "SN-001",
+    expiry: str = "",
+    active: bool = True,
+) -> OntapLicensePackageResponseLicense:
+    """Create a license sub-model with common defaults."""
+    return OntapLicensePackageResponseLicense(
+        owner=owner,
+        serial_number=serial,
+        expiry_time=expiry,
+        active=active,
+    )
+
+
+def _make_package(
+    *,
+    description: str = "Base License",
+    licenses: list[OntapLicensePackageResponseLicense] | None = None,
+) -> OntapLicensePackageResponse:
+    """Create a license package model with common defaults."""
+    return OntapLicensePackageResponse(
+        name="base",
+        description=description,
+        licenses=licenses or [],
+    )
+
+
+def _make_node(*, name: str = "node1", serial_number: str = "NODE-SN-001") -> OntapNodeResponse:
+    """Create a node model with common defaults."""
+    return OntapNodeResponse(name=name, serial_number=serial_number)
+
+
+@pytest.fixture
+def mock_config() -> MagicMock:
+    """Create a mock Config object."""
+    config = MagicMock()
+    config.get_user.return_value = ("admin", "password123")
+    config.get_ontap_api_settings.return_value = MagicMock(
+        base_api_path="/api",
+        timeout=30.0,
+    )
+    return config
+
+
+@pytest.fixture
+def sample_details() -> dict[str, Any]:
+    """Sample cluster connection details."""
+    return {"ip": "10.0.0.1", "bu": "Platform", "env": "Prod"}
+
+
+class TestCheckClusterLicenses:
+    """Tests for _check_cluster_licenses."""
+
+    @patch("pynetappfoundry.cli.commands.licenses.check.QuerySet")
+    @patch("pynetappfoundry.cli.commands.licenses.check.ONTAPAPIClient")
+    def test_expiring_license(
+        self,
+        mock_client_cls: MagicMock,
+        mock_qs_cls: MagicMock,
+        mock_config: MagicMock,
+        sample_details: dict[str, Any],
+    ) -> None:
+        """License expiring within threshold is reported."""
+        expiry = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+        lic = _make_license(expiry=expiry)
+        pkg = _make_package(licenses=[lic])
+        node = _make_node()
+
+        qs_instance = MagicMock()
+        qs_instance.all.side_effect = [[pkg], [node]]
+        mock_qs_cls.return_value = qs_instance
+
+        issues = _check_cluster_licenses("cluster1", sample_details, mock_config)
+
+        assert len(issues) == 1
+        assert issues[0]["error"] == "Expiring license"
+        assert issues[0]["days_checked"] in (9, 10)
+
+    @patch("pynetappfoundry.cli.commands.licenses.check.QuerySet")
+    @patch("pynetappfoundry.cli.commands.licenses.check.ONTAPAPIClient")
+    def test_license_ok(
+        self,
+        mock_client_cls: MagicMock,
+        mock_qs_cls: MagicMock,
+        mock_config: MagicMock,
+        sample_details: dict[str, Any],
+    ) -> None:
+        """License not expiring within threshold generates no issues."""
+        expiry = (datetime.now(UTC) + timedelta(days=100)).isoformat()
+        lic = _make_license(expiry=expiry)
+        pkg = _make_package(licenses=[lic])
+        node = _make_node()
+
+        qs_instance = MagicMock()
+        qs_instance.all.side_effect = [[pkg], [node]]
+        mock_qs_cls.return_value = qs_instance
+
+        issues = _check_cluster_licenses("cluster1", sample_details, mock_config)
+
+        assert len(issues) == 0
+
+    @patch("pynetappfoundry.cli.commands.licenses.check.QuerySet")
+    @patch("pynetappfoundry.cli.commands.licenses.check.ONTAPAPIClient")
+    def test_expired_license(
+        self,
+        mock_client_cls: MagicMock,
+        mock_qs_cls: MagicMock,
+        mock_config: MagicMock,
+        sample_details: dict[str, Any],
+    ) -> None:
+        """Expired license (days < 0) is reported."""
+        expiry = (datetime.now(UTC) - timedelta(days=5)).isoformat()
+        lic = _make_license(expiry=expiry)
+        pkg = _make_package(licenses=[lic])
+        node = _make_node()
+
+        qs_instance = MagicMock()
+        qs_instance.all.side_effect = [[pkg], [node]]
+        mock_qs_cls.return_value = qs_instance
+
+        issues = _check_cluster_licenses("cluster1", sample_details, mock_config)
+
+        assert len(issues) == 1
+        assert issues[0]["days_checked"] < 0
+
+    @patch("pynetappfoundry.cli.commands.licenses.check.QuerySet")
+    @patch("pynetappfoundry.cli.commands.licenses.check.ONTAPAPIClient")
+    def test_no_license_node(
+        self,
+        mock_client_cls: MagicMock,
+        mock_qs_cls: MagicMock,
+        mock_config: MagicMock,
+        sample_details: dict[str, Any],
+    ) -> None:
+        """Node without a license is flagged."""
+        # License owned by node1, but node2 exists without a license
+        expiry = (datetime.now(UTC) + timedelta(days=100)).isoformat()
+        lic = _make_license(owner="node1", expiry=expiry)
+        pkg = _make_package(licenses=[lic])
+        node1 = _make_node(name="node1")
+        node2 = _make_node(name="node2", serial_number="NODE-SN-002")
+
+        qs_instance = MagicMock()
+        qs_instance.all.side_effect = [[pkg], [node1, node2]]
+        mock_qs_cls.return_value = qs_instance
+
+        issues = _check_cluster_licenses("cluster1", sample_details, mock_config)
+
+        assert len(issues) == 1
+        assert issues[0]["error"] == "No License"
+        assert issues[0]["node"] == "node2"
+
+    @patch("pynetappfoundry.cli.commands.licenses.check.QuerySet")
+    @patch("pynetappfoundry.cli.commands.licenses.check.ONTAPAPIClient")
+    def test_serial_prefix_9092(
+        self,
+        mock_client_cls: MagicMock,
+        mock_qs_cls: MagicMock,
+        mock_config: MagicMock,
+        sample_details: dict[str, Any],
+    ) -> None:
+        """Serial prefix 9092 uses 13-day check and Cloud Capacity type."""
+        # 10 days out: under 13-day threshold for 9092 prefix
+        expiry = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+        lic = _make_license(serial="90920001", expiry=expiry)
+        pkg = _make_package(licenses=[lic])
+        node = _make_node()
+
+        qs_instance = MagicMock()
+        qs_instance.all.side_effect = [[pkg], [node]]
+        mock_qs_cls.return_value = qs_instance
+
+        issues = _check_cluster_licenses("cluster1", sample_details, mock_config)
+
+        assert len(issues) == 1
+        assert issues[0]["license_type"] == "ONTAP Cloud Capacity"
+
+    @patch("pynetappfoundry.cli.commands.licenses.check.QuerySet")
+    @patch("pynetappfoundry.cli.commands.licenses.check.ONTAPAPIClient")
+    def test_serial_prefix_2265(
+        self,
+        mock_client_cls: MagicMock,
+        mock_qs_cls: MagicMock,
+        mock_config: MagicMock,
+        sample_details: dict[str, Any],
+    ) -> None:
+        """Serial prefix 2265 uses 13-day check and Data Tiering type."""
+        expiry = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+        lic = _make_license(serial="22650001", expiry=expiry)
+        pkg = _make_package(licenses=[lic])
+        node = _make_node()
+
+        qs_instance = MagicMock()
+        qs_instance.all.side_effect = [[pkg], [node]]
+        mock_qs_cls.return_value = qs_instance
+
+        issues = _check_cluster_licenses("cluster1", sample_details, mock_config)
+
+        assert len(issues) == 1
+        assert issues[0]["license_type"] == "Data Tiering"
+
+    @patch("pynetappfoundry.cli.commands.licenses.check.print_error")
+    @patch("pynetappfoundry.cli.commands.licenses.check.ONTAPAPIClient")
+    def test_error_handling(
+        self,
+        mock_client_cls: MagicMock,
+        mock_print_error: MagicMock,
+        mock_config: MagicMock,
+        sample_details: dict[str, Any],
+    ) -> None:
+        """Connection failure is handled gracefully."""
+        mock_client_cls.side_effect = Exception("Connection refused")
+
+        issues = _check_cluster_licenses("cluster1", sample_details, mock_config)
+
+        assert len(issues) == 1
+        assert "Connection refused" in issues[0]["error"]
+        mock_print_error.assert_called_once()
+
+
+class TestBuildStyledHtml:
+    """Tests for _build_styled_html."""
+
+    def test_expired_issue_has_red_class(self) -> None:
+        """Expired license uses red-white styling."""
+        issues = [
+            {
+                "cluster": "cluster1",
+                "owner": "node1",
+                "serial_number": "SN-001",
+                "license_type": "ONTAP BYOL",
+                "days_checked": -5,
+                "expires": datetime(2026, 3, 27, tzinfo=UTC),
+            }
+        ]
+
+        html = _build_styled_html(issues)
+
+        assert "red-white" in html
+        assert "has expired 5 days ago" in html
+        assert "cluster1" in html
+        assert "node1" in html
+        assert "SN-001" in html
+        assert "ONTAP BYOL" in html
+
+    def test_expiring_issue_has_yellow_class(self) -> None:
+        """Expiring license uses yellow-black styling."""
+        issues = [
+            {
+                "cluster": "cluster1",
+                "owner": "node1",
+                "serial_number": "SN-001",
+                "license_type": "ONTAP BYOL",
+                "days_checked": 10,
+                "expires": datetime(2026, 4, 11, tzinfo=UTC),
+            }
+        ]
+
+        html = _build_styled_html(issues)
+
+        assert "yellow-black" in html
+        assert "expires in 10 days" in html
+
+    def test_html_has_style_tag(self) -> None:
+        """HTML includes style definitions."""
+        html = _build_styled_html([])
+
+        assert "<style>" in html
+        assert "background-color: red" in html
+        assert "background-color: yellow" in html
+
+    def test_html_has_intro_paragraph(self) -> None:
+        """HTML includes introductory text."""
+        html = _build_styled_html([])
+
+        assert "The following licenses should be checked" in html
+
+
+class TestSendLicenseEmail:
+    """Tests for _send_license_email."""
+
+    @patch("pynetappfoundry.cli.commands.licenses.check.send_email")
+    def test_sends_styled_html(
+        self,
+        mock_send: MagicMock,
+        mock_config: MagicMock,
+    ) -> None:
+        """Email body contains styled HTML with issue details."""
+        licensing = MagicMock()
+        licensing.mailfrom = "from@test.com"
+        licensing.mailto = "to@test.com"
+        mock_config.get_licensing_settings.return_value = licensing
+
+        issues = [
+            {
+                "cluster": "cluster1",
+                "owner": "node1",
+                "serial_number": "SN-001",
+                "license_type": "ONTAP BYOL",
+                "days_checked": 10,
+                "expires": datetime(2026, 4, 11, tzinfo=UTC),
+            }
+        ]
+
+        _send_license_email(mock_config, issues)
+
+        mock_send.assert_called_once()
+        call_kwargs = mock_send.call_args
+        body = call_kwargs.kwargs.get("body") or call_kwargs[1].get("body")
+        assert "yellow-black" in body
+        assert "cluster1" in body
+        assert call_kwargs.kwargs.get("high_priority") or call_kwargs[1].get("high_priority")
+
+    @patch("pynetappfoundry.cli.commands.licenses.check.print_warning")
+    def test_no_settings_skips(
+        self,
+        mock_warn: MagicMock,
+        mock_config: MagicMock,
+    ) -> None:
+        """Skips email when licensing settings are not configured."""
+        mock_config.get_licensing_settings.return_value = None
+
+        _send_license_email(mock_config, [])
+
+        mock_warn.assert_called_once()
+
+
+class TestSendNoIssuesEmail:
+    """Tests for _send_no_issues_email."""
+
+    @patch("pynetappfoundry.cli.commands.licenses.check.send_email")
+    def test_sends_no_issues(
+        self,
+        mock_send: MagicMock,
+        mock_config: MagicMock,
+    ) -> None:
+        """Sends 'no issues' email with correct subject."""
+        licensing = MagicMock()
+        licensing.mailfrom = "from@test.com"
+        licensing.mailto = "to@test.com"
+        mock_config.get_licensing_settings.return_value = licensing
+
+        _send_no_issues_email(mock_config)
+
+        mock_send.assert_called_once()
+        call_kwargs = mock_send.call_args
+        subject = call_kwargs.kwargs.get("subject") or call_kwargs[1].get("subject")
+        body = call_kwargs.kwargs.get("body") or call_kwargs[1].get("body")
+        assert "No licensing issues found" in subject
+        assert "No licensing issues" in body
+
+    @patch("pynetappfoundry.cli.commands.licenses.check.print_warning")
+    def test_no_settings_skips(
+        self,
+        mock_warn: MagicMock,
+        mock_config: MagicMock,
+    ) -> None:
+        """Skips email when licensing settings are not configured."""
+        mock_config.get_licensing_settings.return_value = None
+
+        _send_no_issues_email(mock_config)
+
+        mock_warn.assert_called_once()


### PR DESCRIPTION
## Description

Rewrite `licenses check` command with QuerySet and restore styled HTML email formatting from original sysadmin script.

Addresses #93

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Replaced `netapp_ontap` SDK with `QuerySet(OntapLicensePackageResponse, client)` and `QuerySet(OntapNodeResponse, client)`
- Restored CSS-styled HTML email: red-white class for expired licenses, yellow-black for expiring
- Email body now includes full details: cluster, owner, serial number, license type, days, and expiry date
- Added "no issues" email notification when all clusters are clean
- Added 15 unit tests covering license checking, HTML generation, and email sending

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (15 tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
