### PR TITLE
fix: use full command path for CLI output directory naming

### DIFF
--- a/src/pynetappfoundry/cli/decorators.py
+++ b/src/pynetappfoundry/cli/decorators.py
@@ -37,8 +37,14 @@ def with_config(action: str) -> Callable[[F], F]:
             debug = ctx.obj.get("debug", False)
             filter_str = kwargs.pop("filter", None)
 
-            # Get command name for script_name
-            script_name = ctx.info_name or "unknown"
+            # Build script_name from full command path (e.g., "licenses_get")
+            parts: list[str] = []
+            c: click.Context | None = ctx
+            while c:
+                if c.info_name and c.info_name != "nf":
+                    parts.append(c.info_name)
+                c = c.parent
+            script_name = "_".join(reversed(parts)) or "unknown"
 
             # Setup logging
             setup_logger(script_name)

--- a/tests/unit/cli/test_decorators.py
+++ b/tests/unit/cli/test_decorators.py
@@ -1,0 +1,92 @@
+"""Tests for CLI decorators."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import click
+from click.testing import CliRunner
+
+from pynetappfoundry.cli.decorators import with_config
+
+
+class TestWithConfigScriptName:
+    """Tests for script_name derivation from command path."""
+
+    def _make_cli(self) -> click.Group:
+        """Build a test CLI with nested commands."""
+
+        @click.group()
+        @click.pass_context
+        def nf(ctx: click.Context) -> None:
+            ctx.ensure_object(dict)
+            ctx.obj["config_dir"] = "config"
+            ctx.obj["output_dir"] = ""
+            ctx.obj["debug"] = False
+
+        @nf.group()
+        def licenses() -> None:
+            pass
+
+        @licenses.command()
+        @with_config("test failed")
+        def get(config: object, clusters: object) -> None:
+            # Echo the script_name so we can verify it
+            click.echo(config.script_name)  # type: ignore[union-attr]
+
+        @nf.group()
+        def events() -> None:
+            pass
+
+        @events.command()
+        @with_config("test failed")
+        def get2(config: object, clusters: object) -> None:
+            click.echo(config.script_name)  # type: ignore[union-attr]
+
+        # Register get2 as "get" in events group
+        events.add_command(get2, "get")
+
+        return nf
+
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_licenses_get_script_name(self, mock_config_cls: MagicMock) -> None:
+        """Test that 'nf licenses get' produces script_name 'licenses_get'."""
+        mock_config = MagicMock()
+        mock_config.script_name = ""
+        mock_config_cls.return_value = mock_config
+        mock_config_cls.return_value.get_clusters.return_value = {}
+
+        # Capture the script_name passed to Config
+        def capture_config(*args: object, **kwargs: object) -> MagicMock:
+            mock_config.script_name = kwargs.get("script_name", "")
+            mock_config.get_clusters = MagicMock(return_value={})
+            return mock_config
+
+        mock_config_cls.side_effect = capture_config
+
+        runner = CliRunner()
+        cli = self._make_cli()
+        result = runner.invoke(cli, ["licenses", "get"])
+
+        assert result.exit_code == 0
+        assert mock_config.script_name == "licenses_get"
+
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_events_get_script_name(self, mock_config_cls: MagicMock) -> None:
+        """Test that 'nf events get' produces script_name 'events_get'."""
+        mock_config = MagicMock()
+        mock_config_cls.return_value = mock_config
+
+        def capture_config(*args: object, **kwargs: object) -> MagicMock:
+            mock_config.script_name = kwargs.get("script_name", "")
+            mock_config.get_clusters = MagicMock(return_value={})
+            return mock_config
+
+        mock_config_cls.side_effect = capture_config
+
+        runner = CliRunner()
+        cli = self._make_cli()
+        result = runner.invoke(cli, ["events", "get"])
+
+        assert result.exit_code == 0
+        assert mock_config.script_name == "events_get"


### PR DESCRIPTION
## Description

Fix CLI output directory using ambiguous leaf command name. `nf licenses get` and `nf events get` both wrote to `data/get/output/`. Now they write to `data/licenses_get/output/` and `data/events_get/output/` respectively.

Addresses #432

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `cli/decorators.py`: Build `script_name` from full Click command path by walking `ctx.parent` (e.g., `licenses_get` instead of `get`)
- Added 2 tests verifying `licenses get` → `licenses_get` and `events get` → `events_get`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (2 tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
