### PR TITLE
fix: include realtime fields in QuerySet live queries

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -17,6 +17,7 @@ from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
+from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from pydantic import BaseModel
@@ -28,9 +29,13 @@ from pynetappfoundry.cache._metadata import (
 from pynetappfoundry.cache._registry import model_registry
 from pynetappfoundry.cache.field_mapping import (
     TypeMapping,
-    parse_api_record,
-    parse_api_response,
     parse_cli_records,
+)
+from pynetappfoundry.cache.field_mapping import (
+    parse_api_record as _parse_api_record_raw,
+)
+from pynetappfoundry.cache.field_mapping import (
+    parse_api_response as _parse_api_response_raw,
 )
 from pynetappfoundry.cache.ontap.cloud.metadata.mapping import CLOUD_METADATA_MAPPING
 from pynetappfoundry.cache.ontap.cloud.targets.mapping import ONTAPCLOUDTARGET_MAPPING
@@ -116,6 +121,10 @@ from pynetappfoundry.utils.cloud import (
     build_cloud_instance_sso_link,
     build_cloud_resource_group_link,
 )
+
+# Cache collector skips realtime fields (volatile metrics not persisted).
+parse_api_record = partial(_parse_api_record_raw, skip_realtime=True)
+parse_api_response = partial(_parse_api_response_raw, skip_realtime=True)
 
 if TYPE_CHECKING:
     from pynetappfoundry.clients.ontap.api import ONTAPAPIClient

--- a/src/pynetappfoundry/cache/field_mapping.py
+++ b/src/pynetappfoundry/cache/field_mapping.py
@@ -285,6 +285,8 @@ def parse_api_record(
     mapping: TypeMapping,
     record: dict[str, Any],
     log_prefix: str,
+    *,
+    skip_realtime: bool = False,
 ) -> BaseModel:
     """Parse a single API response record into a model instance.
 
@@ -297,13 +299,15 @@ def parse_api_record(
         mapping: Type mapping definition.
         record: Single API response record dict.
         log_prefix: Prefix for log messages.
+        skip_realtime: If True, skip realtime/derived fields (used by cache
+            collector to exclude volatile metrics from storage).
 
     Returns:
         Populated model instance.
     """
     kwargs: dict[str, Any] = {}
     for field in mapping.fields:
-        if field.cache_strategy != "cache":
+        if skip_realtime and field.cache_strategy != "cache":
             continue  # realtime/derived fields not collected during bulk
         if field.transform is not None:
             try:
@@ -379,6 +383,8 @@ def parse_api_response(
         [dict[str, Any], list[str], str, str],
         None,
     ],
+    *,
+    skip_realtime: bool = False,
 ) -> list[BaseModel]:
     """Parse a full API response into a list of model instances.
 
@@ -391,6 +397,8 @@ def parse_api_response(
         response: Full API response dict or None.
         log_prefix: Prefix for log messages.
         log_missing_fn: Callback for logging missing fields.
+        skip_realtime: If True, skip realtime/derived fields (passed through
+            to ``parse_api_record``).
 
     Returns:
         List of populated model instances.
@@ -409,7 +417,7 @@ def parse_api_response(
     for record in records:
         record_id = record.get(mapping.id_field, record.get("uuid", "unknown"))
         log_missing_fn(record, expected, mapping.name, record_id)
-        results.append(parse_api_record(mapping, record, log_prefix))
+        results.append(parse_api_record(mapping, record, log_prefix, skip_realtime=skip_realtime))
 
     return results
 

--- a/tests/unit/cache/test_field_mapping.py
+++ b/tests/unit/cache/test_field_mapping.py
@@ -1150,8 +1150,8 @@ class TestBuildCollectionUrl:
 class TestCacheStrategyFiltering:
     """Tests for cache_strategy filtering in parse_api_record."""
 
-    def test_skips_realtime_fields(self) -> None:
-        """Realtime fields are skipped and get model defaults."""
+    def test_includes_realtime_fields_by_default(self) -> None:
+        """Realtime fields are included when skip_realtime=False (default)."""
         tm = TypeMapping(
             name="T",
             model_class=_SampleModel,
@@ -1169,11 +1169,31 @@ class TestCacheStrategyFiltering:
         record = {"name": "test1", "value": 99}
         result = parse_api_record(tm, record, "[test]")
         assert result.name == "test1"
-        # value is realtime, should get model default (0), not 99
+        assert result.value == 99
+
+    def test_skips_realtime_fields_when_requested(self) -> None:
+        """Realtime fields are skipped when skip_realtime=True."""
+        tm = TypeMapping(
+            name="T",
+            model_class=_SampleModel,
+            api_endpoint="/t",
+            fields=(
+                FieldMapping(cache_attr="name", api_path="name"),
+                FieldMapping(
+                    cache_attr="value",
+                    api_path="value",
+                    default=0,
+                    cache_strategy="realtime",
+                ),
+            ),
+        )
+        record = {"name": "test1", "value": 99}
+        result = parse_api_record(tm, record, "[test]", skip_realtime=True)
+        assert result.name == "test1"
         assert result.value == 0
 
-    def test_skips_derived_fields(self) -> None:
-        """Derived fields are skipped and get model defaults."""
+    def test_skips_derived_fields_when_requested(self) -> None:
+        """Derived fields are skipped when skip_realtime=True."""
         tm = TypeMapping(
             name="T",
             model_class=_SampleModel,
@@ -1189,7 +1209,7 @@ class TestCacheStrategyFiltering:
             ),
         )
         record = {"name": "test1", "value": 42}
-        result = parse_api_record(tm, record, "[test]")
+        result = parse_api_record(tm, record, "[test]", skip_realtime=True)
         assert result.name == "test1"
         assert result.value == 0
 
@@ -1247,7 +1267,7 @@ class TestPostCollection:
             ),
         )
         response = {"records": [{"name": "a"}, {"name": "b"}]}
-        results = parse_api_response(tm, response, "[t]", MagicMock())
+        results = parse_api_response(tm, response, "[t]", MagicMock(), skip_realtime=True)
         assert len(results) == 2
         # post_collection should NOT have been called
         assert call_log == []
@@ -1265,5 +1285,5 @@ class TestPostCollection:
         )
         response = {"records": [{"name": "a"}]}
         # Should not raise
-        results = parse_api_response(tm, response, "[t]", MagicMock())
+        results = parse_api_response(tm, response, "[t]", MagicMock(), skip_realtime=True)
         assert len(results) == 1


### PR DESCRIPTION
## Description

`parse_api_record()` unconditionally skipped realtime fields (`space_used`, `metric_iops_read`, etc.), which was correct for cache storage but caused QuerySet live queries to return default values (0) for metrics fields. Add `skip_realtime` parameter (default `False`). Cache collector passes `True` to preserve existing cache behavior.

Discovered when `nf reports space-usage` showed "Used TiB" as 0 for all volumes after QuerySet conversion.

Addresses #434

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `cache/field_mapping.py`: Add `skip_realtime` kwarg to `parse_api_record()` and `parse_api_response()`, default `False`
- `cache/collector.py`: Use `functools.partial` to wrap both functions with `skip_realtime=True` for cache-specific usage
- Updated 4 tests to match new default behavior, added 2 new tests for both modes

## Testing

- [x] All existing tests pass
- [x] Added new tests verifying both `skip_realtime=True` and `False` behavior

## Checklist

- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
