### PR TITLE
feat: add cloud sections to HTML report for clusters and nodes

### DIFF
--- a/src/pynetappfoundry/cli/commands/reports/html.py
+++ b/src/pynetappfoundry/cli/commands/reports/html.py
@@ -36,11 +36,14 @@ from pynetappfoundry.query import QuerySet
 from pynetappfoundry.utils.cloud import (
     build_azure_id,
     build_azure_portal_link,
+    build_azure_vm_name,
+    get_cloud_account_name,
 )
 
 if TYPE_CHECKING:
     from pynetappfoundry.core.cluster_entry import ClusterEntry
     from pynetappfoundry.core.config import Config
+    from pynetappfoundry.models.ontap.cloud.metadata.model import CloudMetadata
 
 # CSS for tree view styling
 CSS_STYLES = """
@@ -748,6 +751,13 @@ class ClusterData:
         self.svms: list[OntapSvm] = []
         self.cifs_services: list[OntapCifsService] = []
         self.management_ip: str = ""
+        self.cloud_metadata: list[CloudMetadata] = []
+        self.cloud_metadata_by_node: dict[str, CloudMetadata] = {}
+        self.cloud_provider: str = ""
+        self.cloud_account_id: str = ""
+        self.cloud_resource_group_name: str = ""
+        self.cloud_region: str = ""
+        self.cloud_resource_group_link: str = ""
         self.app_instance = app_instance
 
         # Build element class for active cluster navigation
@@ -764,9 +774,12 @@ class ClusterData:
         self._gather_data()
 
     def _build_cloud_info(self) -> None:
-        """Build cloud-specific information (Azure subscription IDs, resource URLs).
+        """Build cloud-specific information from cached metadata.
 
-        Uses cached metadata from ClusterEntry.ontap.cloud.
+        Stores the full list of CloudMetadata and a lookup dict keyed by node name.
+        Extracts cluster-level fields (provider, account, region, resource group)
+        from the first entry. Per-node fields (instance_id, instance_type, etc.)
+        are accessed via cloud_metadata_by_node in _format_netapp_node().
         """
         if not self._cluster_entry:
             return
@@ -775,24 +788,15 @@ class ClusterData:
         if not ontap or not ontap.cloud:
             return
 
+        self.cloud_metadata = ontap.cloud
+        self.cloud_metadata_by_node = {cm.node: cm for cm in ontap.cloud}
+
         first_cloud = ontap.cloud[0]
         self.cloud_provider = first_cloud.provider
         self.cloud_account_id = first_cloud.account_id
         self.cloud_resource_group_name = first_cloud.resource_group_name
-        self.cloud_instance_id = first_cloud.instance_id
-        self.cloud_instance_type = first_cloud.instance_type
         self.cloud_region = first_cloud.region
-        self.cloud_primary_ip = first_cloud.primary_ip
-        self.cloud_availability_zone = first_cloud.availability_zone
-
-        if self.cloud_provider.lower() == "azure":
-            sub_id = self.cloud_account_id
-            resource_group = self.cloud_resource_group_name
-            if sub_id and resource_group:
-                self.cloud_resource_group_id = build_azure_id(sub_id, resource_group)
-                self.cloud_resource_group_url = build_azure_portal_link(
-                    self.cloud_resource_group_id
-                )
+        self.cloud_resource_group_link = first_cloud.resource_group_link
 
     def _gather_data(self) -> None:
         """Gather data from the cluster via ONTAP REST API."""
@@ -855,49 +859,44 @@ class ClusterData:
                     self._format_netapp_nodes()
 
     def _format_netapp_cloud_info(self) -> None:
-        """Format cloud provider information for the cluster.
+        """Format cluster-level cloud provider information.
 
-        Uses cloud_* fields from cluster config (enriched from cache).
+        Shows provider, account/subscription ID, resource group, and region.
+        Per-node fields (instance_id, instance_type, etc.) are rendered
+        in _format_netapp_node() instead.
         """
         tag = self.app_instance.tag
         text = self.app_instance.text
         fmt = self.app_instance.format_table_row_text
         fmt_link = self.app_instance.format_table_row_link
 
-        cloud_provider = getattr(self, "cloud_provider", "")
-        if not cloud_provider:
+        if not self.cloud_provider:
             return
+
+        provider_lower = self.cloud_provider.lower()
+        account_label = get_cloud_account_name(provider_lower).title() + " ID"
 
         with tag("li"):
             with tag("details"):
                 with tag("summary"):
-                    text(f"{cloud_provider} Information")
+                    text(f"Cloud - {self.cloud_provider}")
                 with tag("ul"):
                     with tag("li"):
                         with tag("table", ("class", "custom-table")):
-                            fmt("Provider", cloud_provider)
-                            region = getattr(self, "cloud_region", "")
-                            if region:
-                                fmt("Region", region)
-                            instance_type = getattr(self, "cloud_instance_type", "")
-                            if instance_type:
-                                fmt("Instance Type", instance_type)
-                            instance_id = getattr(self, "cloud_instance_id", "")
-                            if instance_id:
-                                fmt("Instance ID", instance_id)
-
-                            # Azure-specific fields
-                            if cloud_provider.lower() == "azure":
-                                account_id = getattr(self, "cloud_account_id", "")
-                                if account_id:
-                                    fmt("Subscription ID", account_id)
-                                rg_name = getattr(self, "cloud_resource_group_name", "")
-                                if rg_name:
-                                    rg_url = getattr(self, "cloud_resource_group_url", "")
-                                    if rg_url:
-                                        fmt_link("Resource Group", rg_name, rg_url)
-                                    else:
-                                        fmt("Resource Group", rg_name)
+                            fmt("Provider", self.cloud_provider)
+                            if self.cloud_account_id:
+                                fmt(account_label, self.cloud_account_id)
+                            if self.cloud_resource_group_name:
+                                if self.cloud_resource_group_link:
+                                    fmt_link(
+                                        "Resource Group",
+                                        self.cloud_resource_group_name,
+                                        self.cloud_resource_group_link,
+                                    )
+                                else:
+                                    fmt("Resource Group", self.cloud_resource_group_name)
+                            if self.cloud_region:
+                                fmt("Region", self.cloud_region)
 
     def _format_netapp_cluster_info(self) -> None:
         """Format cluster-level information (version, management IPs, DNS, NTP)."""
@@ -1179,34 +1178,11 @@ class ClusterData:
         """
         tag = self.app_instance.tag
         text = self.app_instance.text
+        fmt = self.app_instance.format_table_row_text
+        fmt_link = self.app_instance.format_table_row_link
 
         mgmt_ip = node.management_interface_ip_address
         management_link = f"https://{mgmt_ip}" if mgmt_ip else ""
-
-        # Build VM information for cloud deployments
-        vm_id = None
-        vm_url = None
-        vm_name = None
-        vm_type = None
-        cloud_provider = getattr(self, "cloud_provider", "")
-
-        if cloud_provider.lower() == "azure":
-            node_name = node.name
-            short_name = node_name.split("-")[0] if "-" in node_name else node_name
-
-            try:
-                node_number = int(node_name.split("-")[1]) if "-" in node_name else 1
-            except (ValueError, IndexError):
-                node_number = 1
-
-            vm_type = "Azure VM"
-            vm_name = f"{short_name}-vm{node_number}" if len(self.nodes) > 1 else short_name
-
-            sub_id = getattr(self, "cloud_account_id", "")
-            resource_group = getattr(self, "cloud_resource_group_name", "")
-            if sub_id and resource_group:
-                vm_id = build_azure_id(sub_id, resource_group, resource_name=vm_name)
-                vm_url = build_azure_portal_link(vm_id)
 
         with tag("li"):
             with tag("details"):
@@ -1220,21 +1196,69 @@ class ClusterData:
                     with tag("li"):
                         with tag("table", ("class", "custom-table")):
                             if mgmt_ip:
-                                self.app_instance.format_table_row_text(
-                                    "Node Management IP", mgmt_ip
-                                )
+                                fmt("Node Management IP", mgmt_ip)
                             serial = node.serial_number or "Unknown"
-                            self.app_instance.format_table_row_text("Serial Number", serial)
+                            fmt("Serial Number", serial)
                             if management_link:
-                                self.app_instance.format_table_row_link(
-                                    "System Manager", "Link", management_link
+                                fmt_link("System Manager", "Link", management_link)
+                                fmt_link("SPI", "Link", f"{management_link}/spi")
+
+                    # Per-node cloud section
+                    cloud_meta = self.cloud_metadata_by_node.get(node.name)
+                    if cloud_meta:
+                        self._format_node_cloud_section(node, cloud_meta)
+
+    def _format_node_cloud_section(
+        self,
+        node: OntapNodeResponse,
+        cloud_meta: CloudMetadata,
+    ) -> None:
+        """Format per-node cloud provider information.
+
+        Shows VM name, instance ID, instance type, availability zone,
+        and cloud console links for the given node.
+
+        Args:
+            node: OntapNodeResponse model instance.
+            cloud_meta: CloudMetadata for this node.
+        """
+        tag = self.app_instance.tag
+        text = self.app_instance.text
+        fmt = self.app_instance.format_table_row_text
+        fmt_link = self.app_instance.format_table_row_link
+
+        provider = cloud_meta.provider
+        provider_lower = provider.lower()
+
+        # Derive VM name
+        if provider_lower == "azure":
+            vm_name = build_azure_vm_name(self.name, node.name, is_ha=len(self.nodes) > 1)
+        else:
+            vm_name = node.name
+
+        with tag("li"):
+            with tag("details"):
+                with tag("summary"):
+                    text(f"Cloud - {provider}")
+                with tag("ul"):
+                    with tag("li"):
+                        with tag("table", ("class", "custom-table")):
+                            if vm_name:
+                                fmt("VM Name", vm_name)
+                            if cloud_meta.instance_id:
+                                fmt("Instance ID", cloud_meta.instance_id)
+                            if cloud_meta.instance_type:
+                                fmt("Instance Type", cloud_meta.instance_type)
+                            if cloud_meta.availability_zone:
+                                fmt("Availability Zone", cloud_meta.availability_zone)
+                            if cloud_meta.instance_link:
+                                fmt_link("Cloud Console", "Link", cloud_meta.instance_link)
+                            if cloud_meta.instance_sso_link:
+                                fmt_link(
+                                    "Cloud Console (SSO)",
+                                    "Link",
+                                    cloud_meta.instance_sso_link,
                                 )
-                                self.app_instance.format_table_row_link(
-                                    "SPI", "Link", f"{management_link}/spi"
-                                )
-                            if vm_name and vm_id and vm_url and vm_type:
-                                self.app_instance.format_table_row_text(f"{vm_type} Name", vm_name)
-                                self.app_instance.format_table_row_link(vm_type, vm_id, vm_url)
 
 
 @click.command()

--- a/tests/unit/cli/commands/reports/test_html.py
+++ b/tests/unit/cli/commands/reports/test_html.py
@@ -865,51 +865,129 @@ class TestHTMLFileGeneration:
         from pynetappfoundry.cli.commands.reports.html import ClusterData
 
         # Build mock cloud metadata for each cluster
-        cloud_data_by_cluster: dict[str, dict[str, str]] = {
-            "AZURE-PROD-01": {
-                "provider": "Azure",
-                "region": "eastus",
-                "account_id": "12345678-1234-1234-1234-123456789abc",
-                "resource_group_name": "rg-netapp-prod",
-                "instance_id": "i-azure123",
-                "instance_type": "Standard_DS4_v2",
-                "primary_ip": "10.0.1.100",
-                "availability_zone": "eastus-1",
-            },
-            "AZURE-DEV-01": {
-                "provider": "Azure",
-                "region": "westus",
-                "account_id": "12345678-1234-1234-1234-123456789abc",
-                "resource_group_name": "rg-netapp-dev",
-                "instance_id": "",
-                "instance_type": "",
-                "primary_ip": "",
-                "availability_zone": "",
-            },
-            "AWS-PROD-01": {
-                "provider": "AWS",
-                "region": "us-east-1",
-                "account_id": "123456789012",
-                "resource_group_name": "",
-                "instance_id": "i-0abc123def456",
-                "instance_type": "m5.xlarge",
-                "primary_ip": "10.1.1.100",
-                "availability_zone": "us-east-1a",
-            },
-            "GCP-PROD-01": {
-                "provider": "GCP",
-                "region": "us-central1",
-                "account_id": "my-gcp-project",
-                "resource_group_name": "",
-                "instance_id": "",
-                "instance_type": "n1-standard-4",
-                "primary_ip": "",
-                "availability_zone": "us-central1-a",
-            },
+        cloud_data_by_cluster: dict[str, list[dict[str, str]]] = {
+            "AZURE-PROD-01": [
+                {
+                    "node": "cluster-01",
+                    "provider": "Azure",
+                    "region": "eastus",
+                    "account_id": "12345678-1234-1234-1234-123456789abc",
+                    "resource_group_name": "rg-netapp-prod",
+                    "resource_group_link": (
+                        "https://portal.azure.com/#resource/subscriptions/"
+                        "12345678-1234-1234-1234-123456789abc/"
+                        "resourceGroups/rg-netapp-prod"
+                    ),
+                    "instance_id": "i-azure123",
+                    "instance_type": "Standard_DS4_v2",
+                    "primary_ip": "10.0.1.100",
+                    "availability_zone": "eastus-1",
+                    "instance_link": (
+                        "https://portal.azure.com/#resource/subscriptions/"
+                        "12345678-1234-1234-1234-123456789abc/"
+                        "resourceGroups/rg-netapp-prod/providers/"
+                        "Microsoft.Compute/virtualMachines/test-cluster-vm1"
+                    ),
+                    "instance_sso_link": "",
+                },
+                {
+                    "node": "cluster-02",
+                    "provider": "Azure",
+                    "region": "eastus",
+                    "account_id": "12345678-1234-1234-1234-123456789abc",
+                    "resource_group_name": "rg-netapp-prod",
+                    "resource_group_link": (
+                        "https://portal.azure.com/#resource/subscriptions/"
+                        "12345678-1234-1234-1234-123456789abc/"
+                        "resourceGroups/rg-netapp-prod"
+                    ),
+                    "instance_id": "i-azure456",
+                    "instance_type": "Standard_DS4_v2",
+                    "primary_ip": "10.0.1.101",
+                    "availability_zone": "eastus-2",
+                    "instance_link": (
+                        "https://portal.azure.com/#resource/subscriptions/"
+                        "12345678-1234-1234-1234-123456789abc/"
+                        "resourceGroups/rg-netapp-prod/providers/"
+                        "Microsoft.Compute/virtualMachines/test-cluster-vm2"
+                    ),
+                    "instance_sso_link": "",
+                },
+            ],
+            "AZURE-DEV-01": [
+                {
+                    "node": "cluster-01",
+                    "provider": "Azure",
+                    "region": "westus",
+                    "account_id": "12345678-1234-1234-1234-123456789abc",
+                    "resource_group_name": "rg-netapp-dev",
+                    "resource_group_link": "",
+                    "instance_id": "",
+                    "instance_type": "",
+                    "primary_ip": "",
+                    "availability_zone": "",
+                    "instance_link": "",
+                    "instance_sso_link": "",
+                },
+            ],
+            "AWS-PROD-01": [
+                {
+                    "node": "cluster-01",
+                    "provider": "AWS",
+                    "region": "us-east-1",
+                    "account_id": "123456789012",
+                    "resource_group_name": "",
+                    "resource_group_link": "",
+                    "instance_id": "i-0abc123def456",
+                    "instance_type": "m5.xlarge",
+                    "primary_ip": "10.1.1.100",
+                    "availability_zone": "us-east-1a",
+                    "instance_link": (
+                        "https://us-east-1.console.aws.amazon.com/ec2/home"
+                        "?region=us-east-1#InstanceDetails:instanceId=i-0abc123def456"
+                    ),
+                    "instance_sso_link": "",
+                },
+                {
+                    "node": "cluster-02",
+                    "provider": "AWS",
+                    "region": "us-east-1",
+                    "account_id": "123456789012",
+                    "resource_group_name": "",
+                    "resource_group_link": "",
+                    "instance_id": "i-0abc123def789",
+                    "instance_type": "m5.xlarge",
+                    "primary_ip": "10.1.1.101",
+                    "availability_zone": "us-east-1b",
+                    "instance_link": (
+                        "https://us-east-1.console.aws.amazon.com/ec2/home"
+                        "?region=us-east-1#InstanceDetails:instanceId=i-0abc123def789"
+                    ),
+                    "instance_sso_link": "",
+                },
+            ],
+            "GCP-PROD-01": [
+                {
+                    "node": "cluster-01",
+                    "provider": "GCP",
+                    "region": "us-central1",
+                    "account_id": "my-gcp-project",
+                    "resource_group_name": "",
+                    "resource_group_link": "",
+                    "instance_id": "",
+                    "instance_type": "n1-standard-4",
+                    "primary_ip": "",
+                    "availability_zone": "us-central1-a",
+                    "instance_link": "",
+                    "instance_sso_link": "",
+                },
+            ],
         }
 
         def _make_mock_entry(cluster_name: str, data: dict[str, Any]) -> MagicMock:
             """Create a mock ClusterEntry with cloud metadata."""
+            from pynetappfoundry.models.ontap.cloud.metadata.model import CloudMetadata
+
             mock_entry = MagicMock()
             # Make the mock support dict-like access for **entry unpacking
             mock_entry.keys.return_value = data.keys()
@@ -918,12 +996,9 @@ class TestHTMLFileGeneration:
             mock_entry.__contains__ = lambda self, k: k in data
 
             if cluster_name in cloud_data_by_cluster:
-                cloud_mock = MagicMock()
-                cd = cloud_data_by_cluster[cluster_name]
-                for field, value in cd.items():
-                    setattr(cloud_mock, field, value)
+                cloud_list = [CloudMetadata(**cd) for cd in cloud_data_by_cluster[cluster_name]]
                 ontap_mock = MagicMock()
-                ontap_mock.cloud = [cloud_mock]
+                ontap_mock.cloud = cloud_list
                 mock_entry.ontap = ontap_mock
             else:
                 mock_entry.ontap = None
@@ -993,10 +1068,10 @@ class TestHTMLFileGeneration:
             assert "Research" in html_content
             assert "Corporate" in html_content
 
-            # Verify cloud providers are shown
-            assert "Azure Information" in html_content
-            assert "AWS Information" in html_content
-            assert "GCP Information" in html_content
+            # Verify cloud providers are shown (cluster-level sections)
+            assert "Cloud - Azure" in html_content
+            assert "Cloud - AWS" in html_content
+            assert "Cloud - GCP" in html_content
 
             # Verify Azure-specific fields
             assert "Subscription ID" in html_content
@@ -1024,3 +1099,288 @@ class TestHTMLFileGeneration:
         finally:
             # Restore original method
             ClusterData._gather_data = original_gather_data  # type: ignore[method-assign]
+
+
+class TestCloudSections:
+    """Tests for cloud sections at cluster and node level."""
+
+    @pytest.fixture
+    def mock_builder(self, mock_config: MagicMock) -> MagicMock:
+        """Create a mock HTMLReportBuilder with yattag Doc."""
+        from yattag import Doc
+
+        builder = MagicMock()
+        builder.config = mock_config
+        doc, tag, text = Doc().tagtext()
+        builder.doc = doc
+        builder.tag = tag
+        builder.text = text
+
+        # Wire up format helpers to actual HTMLReportBuilder methods
+        from pynetappfoundry.cli.commands.reports.html import HTMLReportBuilder
+
+        with patch("pynetappfoundry.cli.commands.reports.html.ClusterData"):
+            real_builder = HTMLReportBuilder("Test", {}, mock_config)
+        # Share the same doc/tag/text
+        real_builder.doc = doc
+        real_builder.tag = tag
+        real_builder.text = text
+        builder.format_table_row_text = real_builder.format_table_row_text
+        builder.format_table_row_link = real_builder.format_table_row_link
+        return builder
+
+    def _make_cluster(
+        self,
+        mock_builder: MagicMock,
+        cloud_entries: list[dict[str, str]] | None = None,
+    ) -> ClusterData:
+        """Create a ClusterData with optional cloud metadata."""
+        from pynetappfoundry.models.ontap.cloud.metadata.model import CloudMetadata
+
+        mock_entry = MagicMock()
+        if cloud_entries:
+            cloud_list = [CloudMetadata(**cd) for cd in cloud_entries]
+            ontap_mock = MagicMock()
+            ontap_mock.cloud = cloud_list
+            mock_entry.ontap = ontap_mock
+        else:
+            mock_entry.ontap = None
+
+        with patch.object(ClusterData, "_gather_data"):
+            cluster = ClusterData(
+                "test-cluster",
+                mock_builder,
+                cluster_entry=mock_entry,
+                div="Div1",
+                bu="BU1",
+                app="App1",
+                env="Prod",
+                subapp="",
+                tags=[],
+                ip="10.0.0.1",
+            )
+        # Manually call _build_cloud_info since _gather_data was patched
+        cluster._build_cloud_info()
+        cluster.nodes = [
+            OntapNodeResponse(
+                name="test-cluster-01",
+                serial_number="SN001",
+                management_interface_ip_address="10.0.0.11",
+            ),
+            OntapNodeResponse(
+                name="test-cluster-02",
+                serial_number="SN002",
+                management_interface_ip_address="10.0.0.12",
+            ),
+        ]
+        return cluster
+
+    def test_cluster_cloud_section_azure(self, mock_builder: MagicMock) -> None:
+        """Test cluster-level cloud section for Azure shows correct fields."""
+        cluster = self._make_cluster(
+            mock_builder,
+            [
+                {
+                    "node": "test-cluster-01",
+                    "provider": "Azure",
+                    "region": "eastus",
+                    "account_id": "sub-123",
+                    "resource_group_name": "rg-test",
+                    "resource_group_link": "https://portal.azure.com/#resource/rg-test",
+                    "instance_id": "i-123",
+                    "instance_type": "Standard_DS4_v2",
+                    "availability_zone": "eastus-1",
+                    "instance_link": "https://portal.azure.com/#resource/vm1",
+                    "instance_sso_link": "",
+                },
+            ],
+        )
+        cluster._format_netapp_cloud_info()
+        html = mock_builder.doc.getvalue()
+
+        assert "Cloud - Azure" in html
+        assert "Provider" in html
+        assert "Azure" in html
+        assert "Subscription ID" in html
+        assert "sub-123" in html
+        assert "Resource Group" in html
+        assert "rg-test" in html
+        assert "https://portal.azure.com/#resource/rg-test" in html
+        assert "Region" in html
+        assert "eastus" in html
+        # Instance-level fields should NOT appear at cluster level
+        assert "Instance ID" not in html
+        assert "Instance Type" not in html
+
+    def test_cluster_cloud_section_aws(self, mock_builder: MagicMock) -> None:
+        """Test cluster-level cloud section for AWS uses Account ID label."""
+        cluster = self._make_cluster(
+            mock_builder,
+            [
+                {
+                    "node": "test-cluster-01",
+                    "provider": "AWS",
+                    "region": "us-east-1",
+                    "account_id": "123456789012",
+                    "resource_group_name": "",
+                    "resource_group_link": "",
+                    "instance_id": "i-abc",
+                    "instance_type": "m5.xlarge",
+                    "availability_zone": "us-east-1a",
+                    "instance_link": "https://console.aws.amazon.com/ec2",
+                    "instance_sso_link": "",
+                },
+            ],
+        )
+        cluster._format_netapp_cloud_info()
+        html = mock_builder.doc.getvalue()
+
+        assert "Cloud - AWS" in html
+        assert "Account ID" in html
+        assert "123456789012" in html
+        # No resource group for AWS
+        assert "Resource Group" not in html
+
+    def test_node_cloud_section_azure(self, mock_builder: MagicMock) -> None:
+        """Test per-node cloud section for Azure with VM name and links."""
+        cluster = self._make_cluster(
+            mock_builder,
+            [
+                {
+                    "node": "test-cluster-01",
+                    "provider": "Azure",
+                    "region": "eastus",
+                    "account_id": "sub-123",
+                    "resource_group_name": "rg-test",
+                    "resource_group_link": "",
+                    "instance_id": "i-123",
+                    "instance_type": "Standard_DS4_v2",
+                    "availability_zone": "eastus-1",
+                    "instance_link": "https://portal.azure.com/#resource/vm1",
+                    "instance_sso_link": "",
+                },
+                {
+                    "node": "test-cluster-02",
+                    "provider": "Azure",
+                    "region": "eastus",
+                    "account_id": "sub-123",
+                    "resource_group_name": "rg-test",
+                    "resource_group_link": "",
+                    "instance_id": "i-456",
+                    "instance_type": "Standard_DS4_v2",
+                    "availability_zone": "eastus-2",
+                    "instance_link": "https://portal.azure.com/#resource/vm2",
+                    "instance_sso_link": "",
+                },
+            ],
+        )
+        node = cluster.nodes[0]
+        cluster._format_netapp_node(node)
+        html = mock_builder.doc.getvalue()
+
+        assert "Cloud - Azure" in html
+        assert "VM Name" in html
+        assert "test-cluster-vm1" in html
+        assert "Instance ID" in html
+        assert "i-123" in html
+        assert "Instance Type" in html
+        assert "Standard_DS4_v2" in html
+        assert "Availability Zone" in html
+        assert "eastus-1" in html
+        assert "Cloud Console" in html
+        assert "https://portal.azure.com/#resource/vm1" in html
+
+    def test_node_cloud_section_aws(self, mock_builder: MagicMock) -> None:
+        """Test per-node cloud section for AWS with console link."""
+        cluster = self._make_cluster(
+            mock_builder,
+            [
+                {
+                    "node": "test-cluster-01",
+                    "provider": "AWS",
+                    "region": "us-east-1",
+                    "account_id": "123456789012",
+                    "resource_group_name": "",
+                    "resource_group_link": "",
+                    "instance_id": "i-0abc123",
+                    "instance_type": "m5.xlarge",
+                    "availability_zone": "us-east-1a",
+                    "instance_link": "https://us-east-1.console.aws.amazon.com/ec2",
+                    "instance_sso_link": "https://sso.awsapps.com/start/#/console",
+                },
+            ],
+        )
+        node = cluster.nodes[0]
+        cluster._format_netapp_node(node)
+        html = mock_builder.doc.getvalue()
+
+        assert "Cloud - AWS" in html
+        assert "VM Name" in html
+        assert "test-cluster-01" in html
+        assert "Instance ID" in html
+        assert "i-0abc123" in html
+        assert "Cloud Console" in html
+        assert "https://us-east-1.console.aws.amazon.com/ec2" in html
+        assert "Cloud Console (SSO)" in html
+        assert "https://sso.awsapps.com/start/#/console" in html
+
+    def test_no_cloud_section_when_no_data(self, mock_builder: MagicMock) -> None:
+        """Test no cloud sections appear when cloud data is absent."""
+        cluster = self._make_cluster(mock_builder, cloud_entries=None)
+        cluster._format_netapp_cloud_info()
+        html = mock_builder.doc.getvalue()
+
+        assert "Cloud -" not in html
+        assert "Provider" not in html
+
+    def test_no_node_cloud_section_when_no_data(self, mock_builder: MagicMock) -> None:
+        """Test no per-node cloud section appears when no cloud metadata."""
+        cluster = self._make_cluster(mock_builder, cloud_entries=None)
+        node = cluster.nodes[0]
+        cluster._format_netapp_node(node)
+        html = mock_builder.doc.getvalue()
+
+        # Node info should be present but no cloud section
+        assert "test-cluster-01" in html
+        assert "SN001" in html
+        assert "Cloud -" not in html
+
+    def test_cloud_metadata_by_node_lookup(self, mock_builder: MagicMock) -> None:
+        """Test cloud_metadata_by_node dict is keyed correctly by node name."""
+        cluster = self._make_cluster(
+            mock_builder,
+            [
+                {
+                    "node": "test-cluster-01",
+                    "provider": "Azure",
+                    "region": "eastus",
+                    "account_id": "sub-123",
+                    "resource_group_name": "rg-test",
+                    "resource_group_link": "",
+                    "instance_id": "i-111",
+                    "instance_type": "Standard_DS4_v2",
+                    "availability_zone": "",
+                    "instance_link": "",
+                    "instance_sso_link": "",
+                },
+                {
+                    "node": "test-cluster-02",
+                    "provider": "Azure",
+                    "region": "eastus",
+                    "account_id": "sub-123",
+                    "resource_group_name": "rg-test",
+                    "resource_group_link": "",
+                    "instance_id": "i-222",
+                    "instance_type": "Standard_DS4_v2",
+                    "availability_zone": "",
+                    "instance_link": "",
+                    "instance_sso_link": "",
+                },
+            ],
+        )
+
+        assert "test-cluster-01" in cluster.cloud_metadata_by_node
+        assert "test-cluster-02" in cluster.cloud_metadata_by_node
+        assert cluster.cloud_metadata_by_node["test-cluster-01"].instance_id == "i-111"
+        assert cluster.cloud_metadata_by_node["test-cluster-02"].instance_id == "i-222"
+        assert len(cluster.cloud_metadata) == 2


### PR DESCRIPTION
## Description

Restructure the HTML report cloud sections to show cluster-level fields (provider, account/subscription ID, resource group, region) separately from per-node fields (VM name, instance ID, instance type, availability zone, cloud console links). Previously all cloud fields were shown only at the cluster level with Azure-specific hardcoding. Now each node gets its own cloud sub-section with instance-level details and console links.

## Related Issue

Addresses #440

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Refactored `ClusterData._build_cloud_info()` to store full cloud metadata list and a per-node lookup dict instead of flattening instance-level fields to cluster level
- Refactored `_format_netapp_cloud_info()` to render only cluster-level fields (provider, account ID with provider-specific label, resource group with optional link, region)
- Added `_format_node_cloud_section()` to render per-node cloud details (VM name, instance ID, instance type, availability zone, cloud console links including SSO)
- Updated `_format_netapp_node()` to call per-node cloud section when metadata exists
- Replaced Azure-specific hardcoded VM name derivation with `build_azure_vm_name()` utility
- Replaced hardcoded "Subscription ID" label with `get_cloud_account_name()` for provider-aware labeling
- Removed `getattr()` fallback pattern in favor of direct attribute access on initialized fields
- Updated existing integration test to use real `CloudMetadata` models with multi-node data
- Added `TestCloudSections` test class with 7 focused tests covering Azure/AWS cluster-level sections, Azure/AWS per-node sections, no-data scenarios, and metadata lookup verification

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

No user-facing CLI changes. The HTML output structure changed (section headers now say "Cloud - Azure" instead of "Azure Information"), but this is purely visual in generated HTML reports. No documentation updates needed.
