### PR TITLE
feat: auto-fetch config fields from ONTAP API

### DIFF
--- a/src/pynetappfoundry/cache/_fetcher.py
+++ b/src/pynetappfoundry/cache/_fetcher.py
@@ -1,0 +1,155 @@
+"""Live field-group fetcher for ONTAP cluster metadata.
+
+``FieldGroupFetcher`` lazily creates API/CLI clients and delegates to
+:class:`MetadataCollector` methods to fetch individual field groups
+on demand.  Results are returned in-memory only — nothing is persisted
+to the cache database.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pynetappfoundry.cache.collector import MetadataCollector
+    from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
+    from pynetappfoundry.clients.ontap.cli import ONTAPCLI
+    from pynetappfoundry.core.config import Config
+
+logger = logging.getLogger(__name__)
+
+# Maps field group names to MetadataCollector method names.
+_FIELD_GROUP_METHODS: dict[str, str] = {
+    "cloud": "collect_cloud_metadata",
+    "cluster": "collect_cluster_info",
+    "nodes": "collect_nodes",
+    "network": "collect_network",
+    "storage": "collect_storage",
+    "license_packages": "collect_licenses",
+    "mediator": "collect_mediator",
+    "relationships": "collect_relationships",
+    "protocols": "collect_protocols",
+}
+
+
+class FieldGroupFetcher:
+    """Fetch individual field groups from ONTAP API/CLI on demand.
+
+    Clients and the collector are created lazily on first :meth:`fetch`
+    call to avoid unnecessary network connections when the cache DB
+    already has the data.
+
+    Args:
+        cluster_name: Name of the cluster (used for credentials lookup).
+        cluster_ip: Management IP of the cluster.
+        config: Config instance for credentials and API settings.
+    """
+
+    __slots__ = (
+        "__dict__",  # needed for cached_property
+        "_cluster_ip",
+        "_cluster_name",
+        "_config",
+    )
+
+    def __init__(
+        self,
+        cluster_name: str,
+        cluster_ip: str,
+        config: Config,
+    ) -> None:
+        self._cluster_name = cluster_name
+        self._cluster_ip = cluster_ip
+        self._config = config
+
+    @cached_property
+    def api_client(self) -> ONTAPAPIClient | None:
+        """Lazily create the ONTAP REST API client.
+
+        Returns ``None`` if client creation fails (missing credentials,
+        unreachable cluster, etc.).
+        """
+        try:
+            from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
+            from pynetappfoundry.core.models import ClusterConfig
+
+            cluster_obj = ClusterConfig(name=self._cluster_name, ip=self._cluster_ip)
+            return ONTAPAPIClient(cluster=cluster_obj, config=self._config)
+        except Exception:
+            logger.debug(
+                "Could not create API client for %s: credentials or config unavailable",
+                self._cluster_name,
+                exc_info=True,
+            )
+            return None
+
+    @cached_property
+    def cli_client(self) -> ONTAPCLI | None:
+        """Lazily create the ONTAP CLI (SSH) client.
+
+        Returns ``None`` if client creation fails (missing credentials, etc.).
+        """
+        try:
+            from pynetappfoundry.clients.ontap.cli import ONTAPCLI
+
+            user, password = self._config.get_user("clusters", self._cluster_name)
+            return ONTAPCLI(
+                name=self._cluster_name,
+                host_or_ip=self._cluster_ip,
+                username=user,
+                password=password,
+            )
+        except Exception:
+            logger.debug(
+                "Could not create CLI client for %s: credentials unavailable",
+                self._cluster_name,
+                exc_info=True,
+            )
+            return None
+
+    @cached_property
+    def collector(self) -> MetadataCollector:
+        """Lazily create the :class:`MetadataCollector`."""
+        from pynetappfoundry.cache.collector import MetadataCollector
+
+        return MetadataCollector(
+            api_client=self.api_client,
+            cli_client=self.cli_client,
+            parallel=False,
+        )
+
+    def fetch(self, field_group: str) -> Any:
+        """Fetch a single field group from the live ONTAP system.
+
+        Args:
+            field_group: One of the keys in :data:`_FIELD_GROUP_METHODS`
+                (e.g. ``"cluster"``, ``"storage"``).
+
+        Returns:
+            The collected data (model instance, list, etc.) or ``None``
+            if the field group is unknown or fetching fails.
+        """
+        method_name = _FIELD_GROUP_METHODS.get(field_group)
+        if method_name is None:
+            logger.warning("Unknown field group: %s", field_group)
+            return None
+
+        try:
+            method = getattr(self.collector, method_name)
+            result = method()
+            logger.debug(
+                "Fetched field group '%s' for %s via live API/CLI",
+                field_group,
+                self._cluster_name,
+            )
+            return result
+        except Exception:
+            logger.debug(
+                "Failed to fetch field group '%s' for %s",
+                field_group,
+                self._cluster_name,
+                exc_info=True,
+            )
+            return None

--- a/src/pynetappfoundry/cache/_lazy.py
+++ b/src/pynetappfoundry/cache/_lazy.py
@@ -7,6 +7,11 @@ available immediately without touching the database.
 
 This avoids the overhead of querying all ~29 model tables when the caller
 only needs a small subset (e.g. ``entry.ontap.cloud``).
+
+When a :class:`~pynetappfoundry.cache._fetcher.FieldGroupFetcher` is
+attached, accessing a field group that is missing from the cache DB
+(or when there is no DB at all) will transparently fall back to a live
+ONTAP API/CLI fetch.
 """
 
 from __future__ import annotations
@@ -20,6 +25,7 @@ from pynetappfoundry.cache._base import _utcnow
 from pynetappfoundry.cache._metadata import CachedClusterMetadata
 
 if TYPE_CHECKING:
+    from pynetappfoundry.cache._fetcher import FieldGroupFetcher
     from pynetappfoundry.cache.db_schema import TableSpec
 
 # Top-level data field names on CachedClusterMetadata (everything except
@@ -56,6 +62,7 @@ class LazyClusterMetadata:
         "_cached_at",
         "_cluster_name",
         "_db_path",
+        "_fetcher",
         "_loaded",
         "_materialized",
         "_registry",
@@ -66,17 +73,22 @@ class LazyClusterMetadata:
         cluster_name: str,
         cached_at: str,
         cache_version: str,
-        db_path: Path | str,
+        db_path: Path | str | None,
         registry: dict[str, TableSpec],
+        *,
+        fetcher: FieldGroupFetcher | None = None,
     ) -> None:
         self._cluster_name = cluster_name
         self._cached_at = cached_at
         self._cache_version = cache_version
-        if isinstance(db_path, str) and db_path.startswith("file:"):
-            self._db_path: Path | str = db_path  # SQLite URI — keep as string
+        if db_path is None:
+            self._db_path: Path | str | None = None
+        elif isinstance(db_path, str) and db_path.startswith("file:"):
+            self._db_path = db_path  # SQLite URI — keep as string
         else:
             self._db_path = Path(db_path) if not isinstance(db_path, Path) else db_path
         self._registry = registry
+        self._fetcher = fetcher
         self._loaded: dict[str, Any] = {}
         self._materialized: CachedClusterMetadata | None = None
 
@@ -112,47 +124,28 @@ class LazyClusterMetadata:
         raise AttributeError(f"'{type(self).__name__}' object has no attribute {name!r}")
 
     def _load_field_group(self, name: str) -> Any:
-        """Query only the registry entries that belong to *name*.
+        """Load a field group via DB, fetcher, or default — in that order.
 
-        Opens a short-lived SQLite connection, queries matching tables,
-        builds Pydantic models, closes the connection, and caches the
-        result in ``_loaded``.
+        1. **DB** (existing path) — skipped when ``_db_path is None``.
+        2. **Fetcher** — live API/CLI fetch when a
+           :class:`FieldGroupFetcher` is attached.
+        3. **Default** — the ``CachedClusterMetadata`` field default.
+
+        Results are cached in ``_loaded`` for subsequent reads.
         """
-        from pynetappfoundry.cache.db import _query_registry_subset
+        value: Any = None
 
-        # Select registry entries whose path equals *name* or starts with
-        # ``name.`` (e.g. ``storage.volumes``, ``storage.aggregates``).
-        subset = {
-            path: spec
-            for path, spec in self._registry.items()
-            if path == name or path.startswith(f"{name}.")
-        }
+        # --- Step 1: try the cache DB ---
+        if self._db_path is not None:
+            value = self._load_from_db(name)
 
-        is_uri = isinstance(self._db_path, str) and str(self._db_path).startswith("file:")
-        conn = sqlite3.connect(self._db_path, detect_types=sqlite3.PARSE_DECLTYPES, uri=is_uri)
-        conn.row_factory = sqlite3.Row
-        try:
-            root_kwargs = _query_registry_subset(conn, self._cluster_name, subset)
-        finally:
-            conn.close()
+        # --- Step 2: try the live fetcher ---
+        if value is None and self._fetcher is not None:
+            value = self._fetcher.fetch(name)
 
-        # Determine the value to cache.
-        # For a container field like ``storage`` the result dict may look
-        # like ``{"storage": {"volumes": [...], ...}}`` (nested) or just
-        # ``{"storage": <model>}`` for a singleton.
-        value = root_kwargs.get(name)
-
-        # If the field was not present in any table, fall back to the
-        # CachedClusterMetadata default.
+        # --- Step 3: fall back to model default ---
         if value is None:
-            field_info = CachedClusterMetadata.model_fields.get(name)
-            if field_info is not None and field_info.default_factory is not None:
-                factory = field_info.default_factory
-                value = factory()  # type: ignore[call-arg]
-            elif field_info is not None:
-                value = field_info.default
-            else:
-                value = None
+            value = self._get_default(name)
 
         # For container fields (e.g. storage, network) that are represented
         # as nested dicts, validate them into the actual Pydantic model.
@@ -165,6 +158,45 @@ class LazyClusterMetadata:
 
         self._loaded[name] = value
         return value
+
+    def _load_from_db(self, name: str) -> Any:
+        """Query the cache DB for the given field group.
+
+        Returns the value if found, or ``None`` if the DB has no data
+        for this group.
+        """
+        from pynetappfoundry.cache.db import _query_registry_subset
+
+        subset = {
+            path: spec
+            for path, spec in self._registry.items()
+            if path == name or path.startswith(f"{name}.")
+        }
+
+        is_uri = isinstance(self._db_path, str) and str(self._db_path).startswith("file:")
+        conn = sqlite3.connect(
+            self._db_path,  # type: ignore[arg-type]
+            detect_types=sqlite3.PARSE_DECLTYPES,
+            uri=is_uri,
+        )
+        conn.row_factory = sqlite3.Row
+        try:
+            root_kwargs = _query_registry_subset(conn, self._cluster_name, subset)
+        finally:
+            conn.close()
+
+        return root_kwargs.get(name)
+
+    @staticmethod
+    def _get_default(name: str) -> Any:
+        """Return the ``CachedClusterMetadata`` default for *name*."""
+        field_info = CachedClusterMetadata.model_fields.get(name)
+        if field_info is not None and field_info.default_factory is not None:
+            factory = field_info.default_factory
+            return factory()  # type: ignore[call-arg]
+        if field_info is not None:
+            return field_info.default
+        return None
 
     # ------------------------------------------------------------------
     # Materialization (full CachedClusterMetadata)

--- a/src/pynetappfoundry/core/cluster_entry.py
+++ b/src/pynetappfoundry/core/cluster_entry.py
@@ -5,6 +5,11 @@ compatibility, and provides lazy ``@cached_property`` accessors for
 per-namespace cached metadata (e.g. ``.ontap``, ``.occm``).
 
 The cache database is never opened until a namespace property is accessed.
+
+When a :class:`~pynetappfoundry.core.config.Config` reference is available,
+accessing ``.ontap`` on a cluster with no cache DB will transparently
+create a :class:`~pynetappfoundry.cache._fetcher.FieldGroupFetcher` so
+that field groups can be fetched live from the ONTAP API/CLI.
 """
 
 from __future__ import annotations
@@ -13,9 +18,13 @@ import logging
 from collections.abc import Iterator, MutableMapping
 from functools import cached_property
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pynetappfoundry.cache._lazy import LazyClusterMetadata
+
+if TYPE_CHECKING:
+    from pynetappfoundry.cache._fetcher import FieldGroupFetcher
+    from pynetappfoundry.core.config import Config
 
 _file_name = Path(__file__).name
 
@@ -35,19 +44,22 @@ class ClusterEntry(MutableMapping[str, Any]):
         name: Cluster name (key in the clusters dict).
         config_data: The raw TOML config dict for this cluster.
         cache_db_path: Path to the cluster metadata cache database file.
+        config: Optional Config instance for live API/CLI fetching.
     """
 
-    __slots__ = ("__dict__", "_cache_db_path", "_data", "_name")
+    __slots__ = ("__dict__", "_cache_db_path", "_config", "_data", "_name")
 
     def __init__(
         self,
         name: str,
         config_data: dict[str, Any],
         cache_db_path: Path,
+        config: Config | None = None,
     ) -> None:
         self._name = name
         self._data = config_data
         self._cache_db_path = cache_db_path
+        self._config = config
 
     # ------------------------------------------------------------------
     # Dict-like interface
@@ -149,24 +161,75 @@ class ClusterEntry(MutableMapping[str, Any]):
     # ------------------------------------------------------------------
 
     def _load_cached_metadata(self) -> LazyClusterMetadata | None:
-        """Open the cache DB, fetch lazy metadata for this cluster, close, return."""
-        if not self._cache_db_path.exists():
-            logging.debug(f"{_file_name} : no cache DB at {self._cache_db_path} for {self._name}")
-            return None
+        """Open the cache DB, fetch lazy metadata for this cluster, close, return.
 
-        try:
-            from pynetappfoundry.cache.db import ClusterMetadataDB
+        Fallback order:
 
-            db = ClusterMetadataDB(db_path=self._cache_db_path)
+        1. **Cache DB exists** — load from DB with an optional fetcher
+           attached for missing/stale field groups.
+        2. **No cache DB, Config available** — return a DB-less
+           ``LazyClusterMetadata`` backed entirely by a live fetcher.
+        3. **No cache DB, no Config** — return ``None`` (original behaviour).
+        """
+        fetcher = self._build_fetcher()
+
+        if self._cache_db_path.exists():
             try:
-                result = db.get_lazy(self._name)
-                logging.debug(
-                    f"{_file_name} : loaded cache for {self._name}: "
-                    f"{'found' if result else 'not found'}"
-                )
-                return result
-            finally:
-                db.close()
-        except Exception as e:
-            logging.debug(f"{_file_name} : could not load cache for {self._name}: {e}")
+                from pynetappfoundry.cache.db import ClusterMetadataDB
+
+                db = ClusterMetadataDB(db_path=self._cache_db_path)
+                try:
+                    result = db.get_lazy(self._name)
+                    logging.debug(
+                        f"{_file_name} : loaded cache for {self._name}: "
+                        f"{'found' if result else 'not found'}"
+                    )
+                    # Attach fetcher so missing groups can be fetched live.
+                    if result is not None and fetcher is not None:
+                        result._fetcher = fetcher
+                    return result
+                finally:
+                    db.close()
+            except Exception as e:
+                logging.debug(f"{_file_name} : could not load cache for {self._name}: {e}")
+                # Fall through to fetcher-only path below.
+
+        # No cache DB (or DB load failed) — try fetcher-only mode.
+        if fetcher is not None:
+            from pynetappfoundry.cache._base import METADATA_SCHEMA_VERSION, _utcnow
+            from pynetappfoundry.cache.db_schema import _ensure_registry
+
+            logging.debug(f"{_file_name} : no cache DB for {self._name}, using live fetcher")
+            return LazyClusterMetadata(
+                cluster_name=self._name,
+                cached_at=_utcnow().isoformat(),
+                cache_version=METADATA_SCHEMA_VERSION,
+                db_path=None,
+                registry=_ensure_registry(),
+                fetcher=fetcher,
+            )
+
+        logging.debug(f"{_file_name} : no cache DB at {self._cache_db_path} for {self._name}")
+        return None
+
+    def _build_fetcher(self) -> FieldGroupFetcher | None:
+        """Create a :class:`FieldGroupFetcher` if Config is available.
+
+        Returns ``None`` when no Config is set or the cluster has no ``ip``
+        in its config data.
+        """
+        if self._config is None:
             return None
+
+        cluster_ip = self._data.get("ip", "")
+        if not cluster_ip:
+            logging.debug(f"{_file_name} : no IP for {self._name}, cannot create fetcher")
+            return None
+
+        from pynetappfoundry.cache._fetcher import FieldGroupFetcher
+
+        return FieldGroupFetcher(
+            cluster_name=self._name,
+            cluster_ip=cluster_ip,
+            config=self._config,
+        )

--- a/src/pynetappfoundry/core/config.py
+++ b/src/pynetappfoundry/core/config.py
@@ -297,7 +297,7 @@ class Config:
         clusters = self.data.get("clusters", {})
         for name, data in clusters.items():
             if not isinstance(data, ClusterEntry):
-                clusters[name] = ClusterEntry(name, data, cache_db_path)  # type: ignore[assignment]
+                clusters[name] = ClusterEntry(name, data, cache_db_path, config=self)  # type: ignore[assignment]
 
     def parse_toml(self, file: Path) -> None:
         """Parse a single TOML file.

--- a/tests/unit/cache/test_fetcher.py
+++ b/tests/unit/cache/test_fetcher.py
@@ -1,0 +1,169 @@
+"""Tests for FieldGroupFetcher."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pynetappfoundry.cache._fetcher import _FIELD_GROUP_METHODS, FieldGroupFetcher
+
+
+@pytest.fixture
+def mock_config() -> MagicMock:
+    """Mock Config instance with get_user and get_ontap_api_settings."""
+    config = MagicMock()
+    config.get_user.return_value = ("admin", "password123")
+    config.get_ontap_api_settings.return_value = MagicMock(
+        base_api_path="/api",
+        timeout=30,
+    )
+    config.get_schema_location.return_value = MagicMock(__truediv__=lambda self, x: "/fake/path")
+    return config
+
+
+@pytest.fixture
+def fetcher(mock_config: MagicMock) -> FieldGroupFetcher:
+    """Create a FieldGroupFetcher instance."""
+    return FieldGroupFetcher(
+        cluster_name="test-cluster",
+        cluster_ip="10.0.0.1",
+        config=mock_config,
+    )
+
+
+class TestLazyClientCreation:
+    """Clients are not created until fetch() is called."""
+
+    def test_no_clients_at_init(self, fetcher: FieldGroupFetcher) -> None:
+        """API and CLI clients are not created during __init__."""
+        # cached_property stores in __dict__; it should be empty at init.
+        assert "api_client" not in fetcher.__dict__
+        assert "cli_client" not in fetcher.__dict__
+        assert "collector" not in fetcher.__dict__
+
+    def test_clients_created_on_fetch(self, fetcher: FieldGroupFetcher) -> None:
+        """Collector is accessed (and thus created) on first fetch()."""
+        mock_collector = MagicMock()
+        mock_collector.collect_cluster_info.return_value = MagicMock()
+
+        # Inject a pre-built collector into the cached_property slot
+        fetcher.__dict__["collector"] = mock_collector
+
+        fetcher.fetch("cluster")
+        mock_collector.collect_cluster_info.assert_called_once()
+
+
+class TestAPIClientCreation:
+    """Tests for lazy API client creation."""
+
+    def test_api_client_returns_none_on_failure(self, mock_config: MagicMock) -> None:
+        """api_client returns None when client creation fails."""
+        with patch(
+            "pynetappfoundry.clients.ontap.api.ONTAPAPIClient.__init__",
+            side_effect=Exception("fail"),
+        ):
+            fetcher = FieldGroupFetcher("test-cluster", "10.0.0.1", mock_config)
+            result = fetcher.api_client
+            assert result is None
+
+    def test_api_client_created_successfully(self, mock_config: MagicMock) -> None:
+        """api_client returns client when creation succeeds."""
+        mock_client = MagicMock()
+        with patch(
+            "pynetappfoundry.clients.ontap.api.ONTAPAPIClient",
+            return_value=mock_client,
+        ):
+            fetcher = FieldGroupFetcher("test-cluster", "10.0.0.1", mock_config)
+            result = fetcher.api_client
+            assert result is mock_client
+
+
+class TestCLIClientCreation:
+    """Tests for lazy CLI client creation."""
+
+    def test_cli_client_returns_none_on_failure(self, mock_config: MagicMock) -> None:
+        """cli_client returns None when credentials are unavailable."""
+        mock_config.get_user.side_effect = Exception("No credentials")
+        fetcher = FieldGroupFetcher("test-cluster", "10.0.0.1", mock_config)
+        result = fetcher.cli_client
+        assert result is None
+
+    def test_cli_client_created_successfully(self, mock_config: MagicMock) -> None:
+        """cli_client returns client when creation succeeds."""
+        mock_client = MagicMock()
+        with patch(
+            "pynetappfoundry.clients.ontap.cli.ONTAPCLI",
+            return_value=mock_client,
+        ):
+            fetcher = FieldGroupFetcher("test-cluster", "10.0.0.1", mock_config)
+            result = fetcher.cli_client
+            assert result is mock_client
+
+
+class TestFieldGroupMapping:
+    """Each field group maps to the correct collector method."""
+
+    @pytest.mark.parametrize(
+        ("field_group", "method_name"),
+        list(_FIELD_GROUP_METHODS.items()),
+    )
+    def test_fetch_calls_correct_method(
+        self,
+        field_group: str,
+        method_name: str,
+        fetcher: FieldGroupFetcher,
+    ) -> None:
+        """fetch() delegates to the correct collector method."""
+        mock_collector = MagicMock()
+        expected_result = MagicMock()
+        getattr(mock_collector, method_name).return_value = expected_result
+
+        # Inject mock collector into cached_property slot
+        fetcher.__dict__["collector"] = mock_collector
+
+        result = fetcher.fetch(field_group)
+        getattr(mock_collector, method_name).assert_called_once()
+        assert result is expected_result
+
+
+class TestFetchFailureHandling:
+    """Fetch failures return None instead of raising."""
+
+    def test_fetch_returns_none_on_exception(self, fetcher: FieldGroupFetcher) -> None:
+        """fetch() returns None when collector method raises."""
+        mock_collector = MagicMock()
+        mock_collector.collect_cluster_info.side_effect = Exception("API error")
+
+        fetcher.__dict__["collector"] = mock_collector
+
+        result = fetcher.fetch("cluster")
+        assert result is None
+
+    def test_fetch_unknown_group_returns_none(self, fetcher: FieldGroupFetcher) -> None:
+        """fetch() returns None for unknown field groups."""
+        result = fetcher.fetch("nonexistent_field_group")
+        assert result is None
+
+
+class TestCollectorCreation:
+    """Tests for lazy collector creation."""
+
+    def test_collector_created_with_clients(self, fetcher: FieldGroupFetcher) -> None:
+        """Collector is created with the api_client and cli_client."""
+        mock_api = MagicMock()
+        mock_cli = MagicMock()
+
+        # Inject mock clients into cached_property slots
+        fetcher.__dict__["api_client"] = mock_api
+        fetcher.__dict__["cli_client"] = mock_cli
+
+        with patch(
+            "pynetappfoundry.cache.collector.MetadataCollector",
+        ) as mock_mc_cls:
+            _ = fetcher.collector
+            mock_mc_cls.assert_called_once_with(
+                api_client=mock_api,
+                cli_client=mock_cli,
+                parallel=False,
+            )

--- a/tests/unit/cache/test_lazy.py
+++ b/tests/unit/cache/test_lazy.py
@@ -377,6 +377,136 @@ class TestGetLazy:
         assert lazy._materialize().model_dump() == eager.model_dump()
 
 
+class TestFetcherFallback:
+    """Tests for the DB -> fetcher -> default fallback chain."""
+
+    def test_db_first_then_fetcher_not_called(
+        self,
+        populated_db: ClusterMetadataDB,
+    ) -> None:
+        """When DB has data, fetcher.fetch() is never called."""
+        from unittest.mock import MagicMock
+
+        mock_fetcher = MagicMock()
+        lazy = populated_db.get_lazy("test-cluster")
+        assert lazy is not None
+        lazy._fetcher = mock_fetcher
+
+        # Access cloud — should come from DB
+        result = lazy.cloud
+        assert len(result) == 1
+        assert result[0].provider == "AWS"
+        mock_fetcher.fetch.assert_not_called()
+
+    def test_fetcher_called_when_db_empty(self, db_path: str) -> None:
+        """When DB has no data for a group, fetcher is used."""
+        from unittest.mock import MagicMock
+
+        from pynetappfoundry.cache.db_schema import _ensure_registry
+
+        mock_fetcher = MagicMock()
+        mock_cluster = ClusterInfo(cluster_name="fetched", ontap_version="9.15.0")
+        mock_fetcher.fetch.return_value = mock_cluster
+
+        # Create a DB-less lazy metadata with fetcher
+        lazy = LazyClusterMetadata(
+            cluster_name="test-cluster",
+            cached_at="2024-01-01T00:00:00+00:00",
+            cache_version="1.0",
+            db_path=None,
+            registry=_ensure_registry(),
+            fetcher=mock_fetcher,
+        )
+
+        result = lazy.cluster
+        mock_fetcher.fetch.assert_called_once_with("cluster")
+        assert result.ontap_version == "9.15.0"
+
+    def test_fetcher_result_cached_in_loaded(self, db_path: str) -> None:
+        """Fetcher result is cached — second access does not call fetch again."""
+        from unittest.mock import MagicMock
+
+        from pynetappfoundry.cache.db_schema import _ensure_registry
+
+        mock_fetcher = MagicMock()
+        mock_fetcher.fetch.return_value = ClusterInfo(cluster_name="cached", ontap_version="9.14.0")
+
+        lazy = LazyClusterMetadata(
+            cluster_name="test-cluster",
+            cached_at="2024-01-01T00:00:00+00:00",
+            cache_version="1.0",
+            db_path=None,
+            registry=_ensure_registry(),
+            fetcher=mock_fetcher,
+        )
+
+        result1 = lazy.cluster
+        result2 = lazy.cluster
+        assert result1 is result2
+        mock_fetcher.fetch.assert_called_once()
+
+    def test_default_when_no_db_and_no_fetcher(self) -> None:
+        """Without DB or fetcher, model defaults are returned."""
+        from pynetappfoundry.cache.db_schema import _ensure_registry
+
+        lazy = LazyClusterMetadata(
+            cluster_name="test-cluster",
+            cached_at="2024-01-01T00:00:00+00:00",
+            cache_version="1.0",
+            db_path=None,
+            registry=_ensure_registry(),
+        )
+
+        # cloud default is an empty list
+        assert lazy.cloud == []
+        # cluster default is an empty ClusterInfo
+        assert isinstance(lazy.cluster, ClusterInfo)
+
+    def test_default_when_fetcher_returns_none(self) -> None:
+        """When fetcher returns None, model defaults are used."""
+        from unittest.mock import MagicMock
+
+        from pynetappfoundry.cache.db_schema import _ensure_registry
+
+        mock_fetcher = MagicMock()
+        mock_fetcher.fetch.return_value = None
+
+        lazy = LazyClusterMetadata(
+            cluster_name="test-cluster",
+            cached_at="2024-01-01T00:00:00+00:00",
+            cache_version="1.0",
+            db_path=None,
+            registry=_ensure_registry(),
+            fetcher=mock_fetcher,
+        )
+
+        result = lazy.cloud
+        assert result == []
+        mock_fetcher.fetch.assert_called_once_with("cloud")
+
+    def test_db_less_materialize(self) -> None:
+        """Materialization works in DB-less fetcher-only mode."""
+        from unittest.mock import MagicMock
+
+        from pynetappfoundry.cache.db_schema import _ensure_registry
+
+        mock_fetcher = MagicMock()
+        mock_fetcher.fetch.return_value = None  # All groups return None -> defaults
+
+        lazy = LazyClusterMetadata(
+            cluster_name="test-cluster",
+            cached_at="2024-01-01T00:00:00+00:00",
+            cache_version="1.0",
+            db_path=None,
+            registry=_ensure_registry(),
+            fetcher=mock_fetcher,
+        )
+
+        full = lazy._materialize()
+        assert isinstance(full, CachedClusterMetadata)
+        assert full.cluster_name == "test-cluster"
+
+
 class TestDataFieldsConstant:
     """Verify _DATA_FIELDS matches CachedClusterMetadata data fields."""
 

--- a/tests/unit/core/test_cluster_entry.py
+++ b/tests/unit/core/test_cluster_entry.py
@@ -232,6 +232,95 @@ class TestFutureNamespaces:
         assert entry.dii is None
 
 
+class TestConfigAwareFetcher:
+    """Tests for Config-aware ontap property with live fetcher."""
+
+    def test_ontap_returns_lazy_with_fetcher_when_no_cache_but_config(
+        self, sample_data: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """When no cache DB but Config is available, ontap returns fetcher-backed lazy."""
+        from pynetappfoundry.cache._lazy import LazyClusterMetadata
+
+        cache_path = tmp_path / ".cache" / "cluster_metadata.db"
+        # cache_path does NOT exist
+        mock_config = MagicMock()
+        mock_config.get_user.return_value = ("admin", "pass")
+
+        with patch("pynetappfoundry.cache._fetcher.FieldGroupFetcher") as mock_fetcher_cls:
+            mock_fetcher = MagicMock()
+            mock_fetcher_cls.return_value = mock_fetcher
+
+            entry = ClusterEntry("test-cluster", sample_data, cache_path, config=mock_config)
+            result = entry.ontap
+
+            assert result is not None
+            assert isinstance(result, LazyClusterMetadata)
+            assert result._fetcher is mock_fetcher
+
+    def test_ontap_returns_none_when_no_cache_and_no_config(
+        self, sample_data: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """When no cache DB and no Config, ontap returns None."""
+        cache_path = tmp_path / ".cache" / "cluster_metadata.db"
+        entry = ClusterEntry("test-cluster", sample_data, cache_path)
+        assert entry.ontap is None
+
+    def test_ontap_returns_none_when_no_cache_no_ip_but_config(self, tmp_path: Path) -> None:
+        """When no cache DB and no IP in config data, ontap returns None."""
+        cache_path = tmp_path / ".cache" / "cluster_metadata.db"
+        data: dict[str, Any] = {"name": "test-cluster"}  # no 'ip' key
+        mock_config = MagicMock()
+        entry = ClusterEntry("test-cluster", data, cache_path, config=mock_config)
+        assert entry.ontap is None
+
+    def test_ontap_attaches_fetcher_when_cache_exists_and_config(
+        self, sample_data: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """When cache DB exists and Config available, fetcher is attached to lazy result."""
+        cache_path = tmp_path / ".cache" / "cluster_metadata.db"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.touch()
+
+        mock_metadata = MagicMock()
+        mock_metadata._fetcher = None
+        mock_db_instance = MagicMock()
+        mock_db_instance.get_lazy.return_value = mock_metadata
+
+        mock_config = MagicMock()
+        mock_config.get_user.return_value = ("admin", "pass")
+
+        with (
+            patch(
+                "pynetappfoundry.cache.db.ClusterMetadataDB",
+                return_value=mock_db_instance,
+            ),
+            patch("pynetappfoundry.cache._fetcher.FieldGroupFetcher") as mock_fetcher_cls,
+        ):
+            mock_fetcher = MagicMock()
+            mock_fetcher_cls.return_value = mock_fetcher
+
+            entry = ClusterEntry("test-cluster", sample_data, cache_path, config=mock_config)
+            result = entry.ontap
+
+            assert result is mock_metadata
+            assert result._fetcher is mock_fetcher
+
+    def test_config_passed_through_from_config_class(
+        self, sample_data: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """ClusterEntry stores the config reference."""
+        cache_path = tmp_path / ".cache" / "cluster_metadata.db"
+        mock_config = MagicMock()
+        entry = ClusterEntry("test-cluster", sample_data, cache_path, config=mock_config)
+        assert entry._config is mock_config
+
+    def test_config_default_is_none(self, sample_data: dict[str, Any], tmp_path: Path) -> None:
+        """ClusterEntry without config kwarg has _config=None."""
+        cache_path = tmp_path / ".cache" / "cluster_metadata.db"
+        entry = ClusterEntry("test-cluster", sample_data, cache_path)
+        assert entry._config is None
+
+
 class TestRepr:
     """Tests for ClusterEntry repr."""
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -920,9 +920,13 @@ class TestClusterEntryWrapping:
         finally:
             os.chdir(original_cwd)
 
-    def test_cluster_entry_no_cache(self, temp_config_dir: Path, tmp_path: Path) -> None:
-        """Test that entry.ontap returns None when no cache file exists."""
+    def test_cluster_entry_no_cache_returns_fetcher_backed(
+        self, temp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """When no cache DB exists, entry.ontap returns fetcher-backed lazy metadata."""
         import os
+
+        from pynetappfoundry.cache._lazy import LazyClusterMetadata
 
         original_cwd = os.getcwd()
         os.chdir(tmp_path)
@@ -941,6 +945,10 @@ class TestClusterEntryWrapping:
             )
 
             cluster = config.data["clusters"]["test-cluster-1"]
-            assert cluster.ontap is None
+            # With Config available, ontap returns a fetcher-backed lazy proxy
+            result = cluster.ontap
+            assert isinstance(result, LazyClusterMetadata)
+            assert result._fetcher is not None
+            assert result._db_path is None
         finally:
             os.chdir(original_cwd)


### PR DESCRIPTION
## Description

Add transparent live-fetching of ONTAP field groups when no cache DB exists (or when the DB is missing data for a particular group). A new `FieldGroupFetcher` sits between `LazyClusterMetadata` and the ONTAP API/CLI clients, creating connections lazily on first access.

Addresses #445

## Related Issue

Addresses #445

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- **`cache/_fetcher.py`** (new) — `FieldGroupFetcher` with lazy `cached_property` clients (API, CLI, collector) and a `fetch(field_group)` dispatcher keyed by `_FIELD_GROUP_METHODS`.
- **`cache/_lazy.py`** — Refactored `_load_field_group` into a three-step fallback chain (DB → fetcher → model default). Extracted `_load_from_db` and `_get_default` helpers. `db_path` now accepts `None` for DB-less mode.
- **`core/cluster_entry.py`** — `ClusterEntry` accepts an optional `Config` reference; `_load_cached_metadata` builds a `FieldGroupFetcher` when Config is available and attaches it to both DB-backed and DB-less lazy proxies.
- **`core/config.py`** — Passes `self` (Config) to `ClusterEntry` during cluster wrapping.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### New tests (30 total)

- **`tests/unit/cache/test_fetcher.py`** — 18 tests covering lazy client creation, collector creation, fetch dispatch, error handling, and `_FIELD_GROUP_METHODS` completeness.
- **`tests/unit/cache/test_lazy.py`** — 6 new tests for DB → fetcher → default fallback chain, caching behaviour, and DB-less materialization.
- **`tests/unit/core/test_cluster_entry.py`** — 6 new tests for Config-aware fetcher construction, attachment to DB-backed results, and no-IP/no-config edge cases.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- **Documentation gap:** `docs/reference/cache.md` should be updated to describe `FieldGroupFetcher` and the fallback chain. This can be done in a follow-up doc PR or included before merge.
- No breaking changes — `ClusterEntry` and `LazyClusterMetadata` remain backward-compatible (new parameters are optional/keyword-only).
