### PR TITLE
feat: add SQL query engine with json_extract() support for cache DB

### DIFF
--- a/src/pynetappfoundry/cache/__init__.py
+++ b/src/pynetappfoundry/cache/__init__.py
@@ -83,6 +83,12 @@ from pynetappfoundry.cache.db import ClusterMetadataDB  # noqa: E402
 from pynetappfoundry.cache.diff import ChangeEntry, compute_diff, format_diff_summary  # noqa: E402
 from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping  # noqa: E402
 from pynetappfoundry.cache.history_db import CacheHistoryDB  # noqa: E402
+from pynetappfoundry.cache.query_engine import (  # noqa: E402
+    ParsedFilter,
+    SQLCondition,
+    parse_filter,
+    parse_filters,
+)
 from pynetappfoundry.models.ontap.cluster.mediators.model import OntapMediatorResponse  # noqa: E402
 
 __all__ = [
@@ -101,13 +107,17 @@ __all__ = [
     "MetadataCollector",
     "OntapMediatorResponse",
     "OntapUUID",
+    "ParsedFilter",
     "ProgressCallback",
     "ProgressInfo",
     "RelationshipsInfo",
+    "SQLCondition",
     "TypeMapping",
     "compute_diff",
     "format_diff_summary",
     "is_schema_compatible",
     "model_registry",
+    "parse_filter",
+    "parse_filters",
     "parse_schema_version",
 ]

--- a/src/pynetappfoundry/cache/db.py
+++ b/src/pynetappfoundry/cache/db.py
@@ -34,6 +34,7 @@ from pynetappfoundry.cache.db_schema import (
     generate_table_ddl,
     generate_uuid_column_index_ddl,
 )
+from pynetappfoundry.cache.query_engine import build_where_clause, parse_filters
 from pynetappfoundry.db.base import SQLiteDB
 
 if TYPE_CHECKING:
@@ -701,6 +702,66 @@ class ClusterMetadataDB(SQLiteDB):
             params.append(val)
 
         sql = f"SELECT * FROM {spec.table_name} WHERE {' AND '.join(conditions)}"
+        cursor = self.conn.execute(sql, params)
+        rows = [dict(r) for r in cursor.fetchall()]
+
+        return [
+            _row_to_model(
+                {k: v for k, v in row.items() if k not in ("cluster_name", "_row_id")},
+                spec.model_class,
+            )
+            for row in rows
+        ]
+
+    def query_with_filters(
+        self,
+        cluster_name: str,
+        model_name: str,
+        filters: list[str],
+    ) -> list[BaseModel]:
+        """Query a model table with expressive filter expressions.
+
+        Supports equality, comparison, in/not in, null checks, and
+        nested JSON field filtering via ``json_extract()``.
+
+        Filter expression format::
+
+            name = 'vol1'
+            autosize.mode != 'grow_shrink'
+            size > 1073741824
+            state in ('online', 'mixed')
+            comment = null
+
+        Multiple filters are AND-joined.
+
+        Args:
+            cluster_name: Name of the cluster.
+            model_name: The metadata_path key (e.g. ``"storage.volumes"``).
+            filters: List of filter expression strings.
+
+        Returns:
+            List of deserialized model instances matching all filters.
+
+        Raises:
+            ValueError: If cluster_name is invalid, model_name not found,
+                or a filter expression is malformed.
+        """
+        _validate_cluster_name(cluster_name)
+        spec = self._registry.get(model_name)
+        if spec is None:
+            raise ValueError(f"Unknown model name: {model_name!r}")
+
+        parsed = parse_filters(filters)
+        where_clause, params = build_where_clause(
+            parsed,
+            spec.model_class,
+            cluster_name=cluster_name,
+        )
+
+        sql = f"SELECT * FROM {spec.table_name}"
+        if where_clause:
+            sql = f"{sql} {where_clause}"
+
         cursor = self.conn.execute(sql, params)
         rows = [dict(r) for r in cursor.fetchall()]
 

--- a/src/pynetappfoundry/cache/query_engine.py
+++ b/src/pynetappfoundry/cache/query_engine.py
@@ -1,0 +1,435 @@
+"""SQL query engine with json_extract() support for cache DB.
+
+Parses human-readable filter expressions into parameterized SQL
+conditions, supporting both scalar columns and nested JSON fields
+via SQLite ``json_extract()``.
+
+Filter expression format::
+
+    name = 'vol1'
+    autosize.mode != 'grow_shrink'
+    size > 1073741824
+    autosize.grow_threshold >= 85
+    state in ('online', 'mixed')
+    state not in ('offline')
+    comment = null
+    access_time_enabled = true
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, get_args, get_origin
+
+from pydantic import BaseModel
+
+from pynetappfoundry.cache.db_schema import _is_json_column, _unwrap_annotation
+
+# Supported comparison operators
+_OPERATORS = frozenset({"=", "!=", "<", ">", "<=", ">=", "in", "not in"})
+
+# Regex for valid JSON sub-paths (prevents injection)
+_JSON_PATH_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
+
+# Main filter expression pattern.
+# Captures: field_path, operator, value
+# Examples:
+#   name = 'vol1'
+#   autosize.mode != 'grow_shrink'
+#   state in ('online', 'mixed')
+#   state not in ('offline')
+_FILTER_RE = re.compile(
+    r"^\s*"
+    r"(?P<field>[a-zA-Z_][a-zA-Z0-9_.]*)"  # field path
+    r"\s+"
+    r"(?P<op>not\s+in|in|!=|<=|>=|<|>|=)"  # operator
+    r"\s+"
+    r"(?P<value>.+?)"  # value (rest of line)
+    r"\s*$",
+)
+
+# Pattern for tuple values: ('a', 'b', 'c')
+_TUPLE_RE = re.compile(r"^\((.+)\)$")
+
+
+@dataclass(frozen=True)
+class ParsedFilter:
+    """A parsed filter expression.
+
+    Attributes:
+        field_path: Dot-separated field path (e.g. ``"autosize.mode"``).
+        operator: Comparison operator (e.g. ``"="``, ``"!="``, ``"in"``).
+        value: The parsed value (string, int, float, bool, None, or list).
+    """
+
+    field_path: str
+    operator: str
+    value: Any
+
+
+@dataclass(frozen=True)
+class SQLCondition:
+    """A parameterized SQL condition.
+
+    Attributes:
+        clause: SQL WHERE clause fragment (e.g. ``'"name" = ?'``).
+        params: Parameter values for the clause.
+    """
+
+    clause: str
+    params: tuple[Any, ...]
+
+
+def _parse_value(raw: str) -> Any:
+    """Parse a raw value string into a Python object.
+
+    - Quoted strings → strip quotes
+    - ``null`` / ``none`` → None
+    - ``true`` / ``false`` → bool
+    - Numeric → int or float
+    - Tuple → list of parsed values
+
+    Args:
+        raw: Raw value string from filter expression.
+
+    Returns:
+        Parsed Python value.
+    """
+    stripped = raw.strip()
+
+    # Tuple: ('a', 'b')
+    tuple_match = _TUPLE_RE.match(stripped)
+    if tuple_match:
+        inner = tuple_match.group(1)
+        # Split on commas, respecting quoted strings
+        items: list[Any] = []
+        for item in _split_tuple_items(inner):
+            items.append(_parse_value(item.strip()))
+        return items
+
+    # Quoted string
+    if (stripped.startswith("'") and stripped.endswith("'")) or (
+        stripped.startswith('"') and stripped.endswith('"')
+    ):
+        return stripped[1:-1]
+
+    # Null
+    lower = stripped.lower()
+    if lower in ("null", "none"):
+        return None
+
+    # Boolean
+    if lower == "true":
+        return True
+    if lower == "false":
+        return False
+
+    # Integer
+    try:
+        return int(stripped)
+    except ValueError:
+        pass
+
+    # Float
+    try:
+        return float(stripped)
+    except ValueError:
+        pass
+
+    raise ValueError(f"Cannot parse value: {raw!r}")
+
+
+def _split_tuple_items(inner: str) -> list[str]:
+    """Split comma-separated tuple items, respecting quoted strings.
+
+    Args:
+        inner: The content inside parentheses.
+
+    Returns:
+        List of individual item strings.
+    """
+    items: list[str] = []
+    current: list[str] = []
+    in_quote: str | None = None
+
+    for char in inner:
+        if in_quote:
+            current.append(char)
+            if char == in_quote:
+                in_quote = None
+        elif char in ("'", '"'):
+            in_quote = char
+            current.append(char)
+        elif char == ",":
+            items.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+
+    if current:
+        items.append("".join(current))
+
+    return items
+
+
+def parse_filter(expression: str) -> ParsedFilter:
+    """Parse a human-readable filter expression.
+
+    Args:
+        expression: Filter string, e.g. ``"name = 'vol1'"``
+            or ``"autosize.mode != 'grow_shrink'"``.
+
+    Returns:
+        ParsedFilter with field_path, operator, and parsed value.
+
+    Raises:
+        ValueError: If the expression cannot be parsed.
+    """
+    match = _FILTER_RE.match(expression)
+    if not match:
+        raise ValueError(
+            f"Malformed filter expression: {expression!r}. "
+            "Expected format: <field> <operator> <value>"
+        )
+
+    field_path = match.group("field")
+    operator = re.sub(r"\s+", " ", match.group("op")).strip()
+    raw_value = match.group("value")
+
+    if operator not in _OPERATORS:
+        raise ValueError(f"Unsupported operator: {operator!r}")
+
+    value = _parse_value(raw_value)
+
+    # Validate: in/not in requires a list
+    if operator in ("in", "not in") and not isinstance(value, list):
+        raise ValueError(
+            f"Operator {operator!r} requires a tuple value, e.g. ('a', 'b'), got {raw_value!r}"
+        )
+
+    return ParsedFilter(field_path=field_path, operator=operator, value=value)
+
+
+def parse_filters(expressions: list[str]) -> list[ParsedFilter]:
+    """Parse multiple filter expressions.
+
+    Args:
+        expressions: List of filter strings.
+
+    Returns:
+        List of ParsedFilter instances.
+
+    Raises:
+        ValueError: If any expression cannot be parsed.
+    """
+    return [parse_filter(expr) for expr in expressions]
+
+
+def resolve_field_path(
+    field_path: str,
+    model_class: type[BaseModel],
+) -> str:
+    """Resolve a dotted field path to a SQL column expression.
+
+    For scalar fields like ``"name"``, returns ``'"name"'``.
+    For JSON sub-fields like ``"autosize.mode"``, returns
+    ``'json_extract("autosize", '$.mode')'``.
+
+    Args:
+        field_path: Dot-separated field path.
+        model_class: The Pydantic model class to resolve against.
+
+    Returns:
+        SQL column expression string.
+
+    Raises:
+        ValueError: If the field path is invalid.
+    """
+    parts = field_path.split(".", 1)
+    column = parts[0]
+
+    # Validate column exists in model
+    if column not in model_class.model_fields:
+        raise ValueError(
+            f"Unknown field {column!r} on {model_class.__name__}. "
+            f"Available fields: {', '.join(sorted(model_class.model_fields))}"
+        )
+
+    field_info = model_class.model_fields[column]
+    annotation = field_info.annotation
+    is_json = _is_json_column(annotation)
+
+    if len(parts) == 1:
+        # No dot-path — must be a scalar column
+        if is_json:
+            raise ValueError(
+                f"Cannot filter on bare JSON column {column!r}. "
+                f"Use a sub-field path like '{column}.field_name'."
+            )
+        return f'"{column}"'
+
+    # Has sub-path — must be a JSON column
+    json_path = parts[1]
+
+    if not is_json:
+        raise ValueError(
+            f"Cannot use dot-path on scalar field {column!r}. Use '{column}' without a sub-path."
+        )
+
+    # Check for list[BaseModel] or list[scalar] — not supported in phase 1
+    core = _unwrap_annotation(annotation)
+    origin = get_origin(core)
+    if origin is list:
+        args = get_args(core)
+        if args and isinstance(args[0], type) and issubclass(args[0], BaseModel):
+            raise ValueError(
+                f"Cannot filter sub-fields of list[BaseModel] column {column!r}. "
+                "Filtering into JSON arrays is not supported."
+            )
+        raise ValueError(
+            f"Cannot filter sub-fields of list column {column!r}. "
+            "Filtering into JSON arrays is not supported."
+        )
+
+    # Validate json_path
+    if not _JSON_PATH_RE.match(json_path):
+        raise ValueError(
+            f"Invalid JSON sub-path: {json_path!r}. "
+            "Only alphanumeric characters, underscores, and dots are allowed."
+        )
+
+    return f"""json_extract("{column}", '$.{json_path}')"""
+
+
+def _is_bool_field(
+    field_path: str,
+    model_class: type[BaseModel],
+) -> bool:
+    """Check if a field path resolves to a boolean type.
+
+    For scalar fields, checks the model annotation directly.
+    For JSON sub-fields, we cannot introspect the nested model
+    statically, so we return False (no coercion needed for JSON
+    booleans — SQLite json_extract returns 1/0 natively).
+
+    Args:
+        field_path: Dot-separated field path.
+        model_class: The Pydantic model class.
+
+    Returns:
+        True if the resolved field is a scalar bool column.
+    """
+    parts = field_path.split(".", 1)
+    if len(parts) > 1:
+        return False
+    column = parts[0]
+    if column not in model_class.model_fields:
+        return False
+    annotation = model_class.model_fields[column].annotation
+    core = _unwrap_annotation(annotation)
+    return core is bool
+
+
+def build_sql_condition(
+    parsed: ParsedFilter,
+    model_class: type[BaseModel],
+) -> SQLCondition:
+    """Build a parameterized SQL condition from a parsed filter.
+
+    Args:
+        parsed: A ParsedFilter instance.
+        model_class: The Pydantic model class for field resolution.
+
+    Returns:
+        SQLCondition with clause and params.
+
+    Raises:
+        ValueError: If the field path is invalid.
+    """
+    col_expr = resolve_field_path(parsed.field_path, model_class)
+
+    # Handle null
+    if parsed.value is None:
+        if parsed.operator == "=":
+            return SQLCondition(clause=f"{col_expr} IS NULL", params=())
+        if parsed.operator == "!=":
+            return SQLCondition(clause=f"{col_expr} IS NOT NULL", params=())
+        raise ValueError(
+            f"Operator {parsed.operator!r} is not valid with null. Use '=' or '!=' for null checks."
+        )
+
+    # Handle in / not in
+    if parsed.operator in ("in", "not in"):
+        values = parsed.value
+        placeholders = ", ".join("?" for _ in values)
+        keyword = "IN" if parsed.operator == "in" else "NOT IN"
+        # Coerce booleans in list if targeting a bool field
+        is_bool = _is_bool_field(parsed.field_path, model_class)
+        coerced = [
+            int(v) if isinstance(v, bool) or (is_bool and isinstance(v, bool)) else v
+            for v in values
+        ]
+        return SQLCondition(
+            clause=f"{col_expr} {keyword} ({placeholders})",
+            params=tuple(coerced),
+        )
+
+    # Handle boolean coercion for scalar bool columns
+    value = parsed.value
+    if isinstance(value, bool) and _is_bool_field(parsed.field_path, model_class):
+        value = int(value)
+
+    op_map = {
+        "=": "=",
+        "!=": "!=",
+        "<": "<",
+        ">": ">",
+        "<=": "<=",
+        ">=": ">=",
+    }
+    sql_op = op_map[parsed.operator]
+
+    return SQLCondition(
+        clause=f"{col_expr} {sql_op} ?",
+        params=(value,),
+    )
+
+
+def build_where_clause(
+    filters: list[ParsedFilter],
+    model_class: type[BaseModel],
+    *,
+    cluster_name: str | None = None,
+) -> tuple[str, list[Any]]:
+    """Build a complete WHERE clause from multiple parsed filters.
+
+    Args:
+        filters: List of ParsedFilter instances.
+        model_class: The Pydantic model class for field resolution.
+        cluster_name: If provided, prepend a ``cluster_name = ?`` condition.
+
+    Returns:
+        Tuple of (where_clause_string, params_list).
+        The where_clause_string includes the ``WHERE`` keyword.
+        If no conditions, returns ``("", [])``.
+
+    Raises:
+        ValueError: If any field path is invalid.
+    """
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if cluster_name is not None:
+        conditions.append('"cluster_name" = ?')
+        params.append(cluster_name)
+
+    for parsed in filters:
+        cond = build_sql_condition(parsed, model_class)
+        conditions.append(cond.clause)
+        params.extend(cond.params)
+
+    if not conditions:
+        return ("", [])
+
+    return ("WHERE " + " AND ".join(conditions), params)

--- a/tests/unit/cache/test_db.py
+++ b/tests/unit/cache/test_db.py
@@ -522,6 +522,168 @@ class TestClusterMetadataDB:
         assert got.storage.volumes[0].size == 1073741824
 
 
+class TestQueryWithFilters:
+    """Tests for ClusterMetadataDB.query_with_filters()."""
+
+    @pytest.fixture
+    def db(self) -> ClusterMetadataDB:
+        """Create an in-memory test database."""
+        return ClusterMetadataDB(db_path=":memory:")
+
+    @pytest.fixture
+    def db_with_volumes(self, db: ClusterMetadataDB) -> ClusterMetadataDB:
+        """Database with sample volume data including JSON fields."""
+        from pynetappfoundry.models.ontap.storage.model import StorageInfo
+        from pynetappfoundry.models.ontap.storage.volumes.model import OntapVolumeAutosize
+
+        meta = CachedClusterMetadata(
+            cluster_name="test-cluster",
+            storage=StorageInfo(
+                volumes=[
+                    OntapVolume(
+                        name="vol1",
+                        uuid="11111111-1111-1111-1111-111111111111",
+                        size=1073741824,
+                        state="online",
+                        autosize=OntapVolumeAutosize(
+                            mode="grow_shrink",
+                            grow_threshold=85,
+                            maximum=2147483648,
+                        ),
+                    ),
+                    OntapVolume(
+                        name="vol2",
+                        uuid="22222222-2222-2222-2222-222222222222",
+                        size=536870912,
+                        state="online",
+                        autosize=OntapVolumeAutosize(
+                            mode="off",
+                            grow_threshold=0,
+                            maximum=0,
+                        ),
+                    ),
+                    OntapVolume(
+                        name="vol3",
+                        uuid="33333333-3333-3333-3333-333333333333",
+                        size=2147483648,
+                        state="offline",
+                        autosize=OntapVolumeAutosize(
+                            mode="grow_shrink",
+                            grow_threshold=90,
+                            maximum=4294967296,
+                        ),
+                    ),
+                ],
+            ),
+        )
+        db.set("test-cluster", meta)
+        return db
+
+    def test_filter_by_scalar_column(self, db_with_volumes: ClusterMetadataDB) -> None:
+        """Filter by scalar column returns matching models."""
+        results = db_with_volumes.query_with_filters(
+            "test-cluster", "storage.volumes", ["name = 'vol1'"]
+        )
+        assert len(results) == 1
+        assert results[0].name == "vol1"
+
+    def test_filter_by_json_sub_field(self, db_with_volumes: ClusterMetadataDB) -> None:
+        """Filter by JSON sub-field returns matching models."""
+        results = db_with_volumes.query_with_filters(
+            "test-cluster",
+            "storage.volumes",
+            ["autosize.mode = 'grow_shrink'"],
+        )
+        assert len(results) == 2
+        names = {r.name for r in results}
+        assert names == {"vol1", "vol3"}
+
+    def test_filter_comparison_on_json_numeric(self, db_with_volumes: ClusterMetadataDB) -> None:
+        """Filter with comparison on JSON numeric field."""
+        results = db_with_volumes.query_with_filters(
+            "test-cluster",
+            "storage.volumes",
+            ["autosize.grow_threshold >= 85"],
+        )
+        assert len(results) == 2
+        names = {r.name for r in results}
+        assert names == {"vol1", "vol3"}
+
+    def test_multiple_filters_and(self, db_with_volumes: ClusterMetadataDB) -> None:
+        """Multiple filters narrow results (AND logic)."""
+        results = db_with_volumes.query_with_filters(
+            "test-cluster",
+            "storage.volumes",
+            [
+                "state = 'online'",
+                "autosize.mode = 'grow_shrink'",
+            ],
+        )
+        assert len(results) == 1
+        assert results[0].name == "vol1"
+
+    def test_no_matches_returns_empty(self, db_with_volumes: ClusterMetadataDB) -> None:
+        """No matches returns empty list."""
+        results = db_with_volumes.query_with_filters(
+            "test-cluster",
+            "storage.volumes",
+            ["name = 'nonexistent'"],
+        )
+        assert results == []
+
+    def test_invalid_model_name_raises(self, db_with_volumes: ClusterMetadataDB) -> None:
+        """Invalid model name raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown model name"):
+            db_with_volumes.query_with_filters(
+                "test-cluster", "nonexistent.path", ["name = 'vol1'"]
+            )
+
+    def test_invalid_field_raises(self, db_with_volumes: ClusterMetadataDB) -> None:
+        """Invalid field path raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown field"):
+            db_with_volumes.query_with_filters("test-cluster", "storage.volumes", ["bogus = 'val'"])
+
+    def test_empty_filters_returns_all(self, db_with_volumes: ClusterMetadataDB) -> None:
+        """Empty filters list returns all rows for cluster."""
+        results = db_with_volumes.query_with_filters("test-cluster", "storage.volumes", [])
+        assert len(results) == 3
+
+    def test_filter_by_size_greater_than(self, db_with_volumes: ClusterMetadataDB) -> None:
+        """Filter by scalar numeric comparison."""
+        results = db_with_volumes.query_with_filters(
+            "test-cluster",
+            "storage.volumes",
+            ["size > 1073741824"],
+        )
+        assert len(results) == 1
+        assert results[0].name == "vol3"
+
+    def test_in_operator(self, db_with_volumes: ClusterMetadataDB) -> None:
+        """Filter with in operator."""
+        results = db_with_volumes.query_with_filters(
+            "test-cluster",
+            "storage.volumes",
+            ["state in ('online', 'offline')"],
+        )
+        assert len(results) == 3
+
+    def test_inequality_json_field(self, db_with_volumes: ClusterMetadataDB) -> None:
+        """Filter JSON sub-field with inequality."""
+        results = db_with_volumes.query_with_filters(
+            "test-cluster",
+            "storage.volumes",
+            ["autosize.mode != 'off'"],
+        )
+        assert len(results) == 2
+        names = {r.name for r in results}
+        assert names == {"vol1", "vol3"}
+
+    def test_invalid_cluster_name_raises(self, db_with_volumes: ClusterMetadataDB) -> None:
+        """Invalid cluster name raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid cluster name"):
+            db_with_volumes.query_with_filters("123invalid", "storage.volumes", ["name = 'vol1'"])
+
+
 class TestClusterMetadataDBMigration:
     """Tests for v1 → v2 migration."""
 

--- a/tests/unit/cache/test_query_engine.py
+++ b/tests/unit/cache/test_query_engine.py
@@ -1,0 +1,351 @@
+"""Tests for the SQL query engine with json_extract() support."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, Field
+
+from pynetappfoundry.cache.query_engine import (
+    ParsedFilter,
+    SQLCondition,
+    build_sql_condition,
+    build_where_clause,
+    parse_filter,
+    parse_filters,
+    resolve_field_path,
+)
+
+# ---------------------------------------------------------------------------
+# Test models (mimicking OntapVolume structure)
+# ---------------------------------------------------------------------------
+
+
+class _Autosize(BaseModel):
+    mode: str = ""
+    grow_threshold: int = 0
+    maximum: int = 0
+
+
+class _Aggregate(BaseModel):
+    name: str = ""
+    uuid: str = ""
+
+
+class _AnalyticsInit(BaseModel):
+    state: str = ""
+
+
+class _Analytics(BaseModel):
+    initialization: _AnalyticsInit = Field(default_factory=_AnalyticsInit)
+    state: str = ""
+
+
+class _TestVolume(BaseModel):
+    name: str = ""
+    uuid: str = ""
+    size: int = 0
+    state: str = ""
+    access_time_enabled: bool = False
+    comment: str | None = None
+    autosize: _Autosize = Field(default_factory=_Autosize)
+    aggregates: list[_Aggregate] = Field(default_factory=list)
+    analytics: _Analytics = Field(default_factory=_Analytics)
+    status: list[str] = Field(default_factory=list)
+    score: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# parse_filter tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseFilter:
+    """Tests for parse_filter()."""
+
+    def test_equality_string(self) -> None:
+        result = parse_filter("name = 'vol1'")
+        assert result == ParsedFilter(field_path="name", operator="=", value="vol1")
+
+    def test_equality_double_quotes(self) -> None:
+        result = parse_filter('name = "vol1"')
+        assert result == ParsedFilter(field_path="name", operator="=", value="vol1")
+
+    def test_inequality(self) -> None:
+        result = parse_filter("autosize.mode != 'grow_shrink'")
+        assert result == ParsedFilter(
+            field_path="autosize.mode", operator="!=", value="grow_shrink"
+        )
+
+    def test_greater_than(self) -> None:
+        result = parse_filter("size > 1073741824")
+        assert result == ParsedFilter(field_path="size", operator=">", value=1073741824)
+
+    def test_less_than(self) -> None:
+        result = parse_filter("size < 100")
+        assert result == ParsedFilter(field_path="size", operator="<", value=100)
+
+    def test_greater_equal(self) -> None:
+        result = parse_filter("autosize.grow_threshold >= 85")
+        assert result == ParsedFilter(field_path="autosize.grow_threshold", operator=">=", value=85)
+
+    def test_less_equal(self) -> None:
+        result = parse_filter("size <= 500")
+        assert result == ParsedFilter(field_path="size", operator="<=", value=500)
+
+    def test_in_operator(self) -> None:
+        result = parse_filter("state in ('online', 'mixed')")
+        assert result == ParsedFilter(field_path="state", operator="in", value=["online", "mixed"])
+
+    def test_not_in_operator(self) -> None:
+        result = parse_filter("state not in ('offline')")
+        assert result == ParsedFilter(field_path="state", operator="not in", value=["offline"])
+
+    def test_numeric_integer(self) -> None:
+        result = parse_filter("size = 1024")
+        assert result.value == 1024
+        assert isinstance(result.value, int)
+
+    def test_numeric_float(self) -> None:
+        result = parse_filter("score = 3.14")
+        assert result.value == 3.14
+        assert isinstance(result.value, float)
+
+    def test_boolean_true(self) -> None:
+        result = parse_filter("access_time_enabled = true")
+        assert result.value is True
+
+    def test_boolean_false(self) -> None:
+        result = parse_filter("access_time_enabled = false")
+        assert result.value is False
+
+    def test_null(self) -> None:
+        result = parse_filter("comment = null")
+        assert result.value is None
+
+    def test_none_keyword(self) -> None:
+        result = parse_filter("comment = none")
+        assert result.value is None
+
+    def test_malformed_expression_raises(self) -> None:
+        with pytest.raises(ValueError, match="Malformed filter expression"):
+            parse_filter("bad")
+
+    def test_malformed_no_value_raises(self) -> None:
+        with pytest.raises(ValueError, match="Malformed filter expression"):
+            parse_filter("name =")
+
+    def test_in_without_tuple_raises(self) -> None:
+        with pytest.raises(ValueError, match="requires a tuple value"):
+            parse_filter("state in 'online'")
+
+    def test_deep_path(self) -> None:
+        result = parse_filter("analytics.initialization.state = 'running'")
+        assert result.field_path == "analytics.initialization.state"
+        assert result.value == "running"
+
+    def test_in_with_numbers(self) -> None:
+        result = parse_filter("size in (100, 200, 300)")
+        assert result.value == [100, 200, 300]
+
+    def test_whitespace_tolerance(self) -> None:
+        result = parse_filter("  name   =   'vol1'  ")
+        assert result == ParsedFilter(field_path="name", operator="=", value="vol1")
+
+
+class TestParseFilters:
+    """Tests for parse_filters()."""
+
+    def test_multiple_filters(self) -> None:
+        results = parse_filters(
+            [
+                "name = 'vol1'",
+                "size > 100",
+            ]
+        )
+        assert len(results) == 2
+        assert results[0].field_path == "name"
+        assert results[1].field_path == "size"
+
+    def test_empty_list(self) -> None:
+        results = parse_filters([])
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_field_path tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFieldPath:
+    """Tests for resolve_field_path()."""
+
+    def test_scalar_field(self) -> None:
+        result = resolve_field_path("name", _TestVolume)
+        assert result == '"name"'
+
+    def test_scalar_int_field(self) -> None:
+        result = resolve_field_path("size", _TestVolume)
+        assert result == '"size"'
+
+    def test_json_sub_field(self) -> None:
+        result = resolve_field_path("autosize.mode", _TestVolume)
+        assert result == """json_extract("autosize", '$.mode')"""
+
+    def test_deep_json_path(self) -> None:
+        result = resolve_field_path("analytics.initialization.state", _TestVolume)
+        assert result == """json_extract("analytics", '$.initialization.state')"""
+
+    def test_unknown_field_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown field 'bogus'"):
+            resolve_field_path("bogus", _TestVolume)
+
+    def test_dot_path_on_scalar_raises(self) -> None:
+        with pytest.raises(ValueError, match="Cannot use dot-path on scalar field"):
+            resolve_field_path("name.sub", _TestVolume)
+
+    def test_bare_json_column_raises(self) -> None:
+        with pytest.raises(ValueError, match="Cannot filter on bare JSON column"):
+            resolve_field_path("autosize", _TestVolume)
+
+    def test_list_basemodel_sub_field_raises(self) -> None:
+        with pytest.raises(ValueError, match="list\\[BaseModel\\]"):
+            resolve_field_path("aggregates.name", _TestVolume)
+
+    def test_list_scalar_sub_field_raises(self) -> None:
+        with pytest.raises(ValueError, match="list column"):
+            resolve_field_path("status.something", _TestVolume)
+
+    def test_bool_field(self) -> None:
+        result = resolve_field_path("access_time_enabled", _TestVolume)
+        assert result == '"access_time_enabled"'
+
+
+# ---------------------------------------------------------------------------
+# build_sql_condition tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSqlCondition:
+    """Tests for build_sql_condition()."""
+
+    def test_equality(self) -> None:
+        parsed = ParsedFilter(field_path="name", operator="=", value="vol1")
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result == SQLCondition(clause='"name" = ?', params=("vol1",))
+
+    def test_inequality(self) -> None:
+        parsed = ParsedFilter(field_path="name", operator="!=", value="vol1")
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result == SQLCondition(clause='"name" != ?', params=("vol1",))
+
+    def test_greater_than(self) -> None:
+        parsed = ParsedFilter(field_path="size", operator=">", value=100)
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result == SQLCondition(clause='"size" > ?', params=(100,))
+
+    def test_less_equal(self) -> None:
+        parsed = ParsedFilter(field_path="size", operator="<=", value=500)
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result == SQLCondition(clause='"size" <= ?', params=(500,))
+
+    def test_null_equality(self) -> None:
+        parsed = ParsedFilter(field_path="comment", operator="=", value=None)
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result == SQLCondition(clause='"comment" IS NULL', params=())
+
+    def test_null_inequality(self) -> None:
+        parsed = ParsedFilter(field_path="comment", operator="!=", value=None)
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result == SQLCondition(clause='"comment" IS NOT NULL', params=())
+
+    def test_null_with_gt_raises(self) -> None:
+        parsed = ParsedFilter(field_path="comment", operator=">", value=None)
+        with pytest.raises(ValueError, match="not valid with null"):
+            build_sql_condition(parsed, _TestVolume)
+
+    def test_in_operator(self) -> None:
+        parsed = ParsedFilter(field_path="state", operator="in", value=["online", "mixed"])
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result == SQLCondition(clause='"state" IN (?, ?)', params=("online", "mixed"))
+
+    def test_not_in_operator(self) -> None:
+        parsed = ParsedFilter(field_path="state", operator="not in", value=["offline"])
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result == SQLCondition(clause='"state" NOT IN (?)', params=("offline",))
+
+    def test_boolean_coercion_true(self) -> None:
+        parsed = ParsedFilter(field_path="access_time_enabled", operator="=", value=True)
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result == SQLCondition(clause='"access_time_enabled" = ?', params=(1,))
+
+    def test_boolean_coercion_false(self) -> None:
+        parsed = ParsedFilter(field_path="access_time_enabled", operator="=", value=False)
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result == SQLCondition(clause='"access_time_enabled" = ?', params=(0,))
+
+    def test_json_extract_equality(self) -> None:
+        parsed = ParsedFilter(field_path="autosize.mode", operator="=", value="grow_shrink")
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result.clause == """json_extract("autosize", '$.mode') = ?"""
+        assert result.params == ("grow_shrink",)
+
+    def test_json_extract_comparison(self) -> None:
+        parsed = ParsedFilter(field_path="autosize.grow_threshold", operator=">=", value=85)
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result.clause == """json_extract("autosize", '$.grow_threshold') >= ?"""
+        assert result.params == (85,)
+
+    def test_float_value(self) -> None:
+        parsed = ParsedFilter(field_path="score", operator=">", value=2.5)
+        result = build_sql_condition(parsed, _TestVolume)
+        assert result == SQLCondition(clause='"score" > ?', params=(2.5,))
+
+
+# ---------------------------------------------------------------------------
+# build_where_clause tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWhereClause:
+    """Tests for build_where_clause()."""
+
+    def test_single_filter(self) -> None:
+        filters = [ParsedFilter(field_path="name", operator="=", value="vol1")]
+        clause, params = build_where_clause(filters, _TestVolume)
+        assert clause == 'WHERE "name" = ?'
+        assert params == ["vol1"]
+
+    def test_multiple_filters(self) -> None:
+        filters = [
+            ParsedFilter(field_path="name", operator="=", value="vol1"),
+            ParsedFilter(field_path="size", operator=">", value=100),
+        ]
+        clause, params = build_where_clause(filters, _TestVolume)
+        assert clause == 'WHERE "name" = ? AND "size" > ?'
+        assert params == ["vol1", 100]
+
+    def test_with_cluster_name(self) -> None:
+        filters = [ParsedFilter(field_path="name", operator="=", value="vol1")]
+        clause, params = build_where_clause(filters, _TestVolume, cluster_name="test-cluster")
+        assert clause == 'WHERE "cluster_name" = ? AND "name" = ?'
+        assert params == ["test-cluster", "vol1"]
+
+    def test_cluster_name_only(self) -> None:
+        clause, params = build_where_clause([], _TestVolume, cluster_name="test-cluster")
+        assert clause == 'WHERE "cluster_name" = ?'
+        assert params == ["test-cluster"]
+
+    def test_empty_filters_no_cluster(self) -> None:
+        clause, params = build_where_clause([], _TestVolume)
+        assert clause == ""
+        assert params == []
+
+    def test_multiple_json_filters(self) -> None:
+        filters = [
+            ParsedFilter(field_path="autosize.mode", operator="!=", value="grow_shrink"),
+            ParsedFilter(field_path="autosize.grow_threshold", operator=">=", value=85),
+        ]
+        clause, params = build_where_clause(filters, _TestVolume)
+        assert "json_extract" in clause
+        assert "AND" in clause
+        assert params == ["grow_shrink", 85]


### PR DESCRIPTION
## Description

Add a SQL query engine that parses human-readable filter expressions into
parameterized SQL conditions, with `json_extract()` support for nested JSON
columns. Expose a new `query_with_filters()` method on `ClusterMetadataDB`
that accepts expressive filter strings (e.g. `name = 'vol1'`,
`autosize.mode != 'grow_shrink'`, `size > 1073741824`).

This is the foundational query layer for the CLI filtering feature planned
in the umbrella issue.

## Related Issue

Addresses #453
Part of #448

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- New `query_engine.py` module with filter parsing (`parse_filter`, `parse_filters`), field resolution (`resolve_field_path`), and SQL condition building (`build_sql_condition`, `build_where_clause`)
- Supports operators: `=`, `!=`, `<`, `>`, `<=`, `>=`, `in`, `not in`
- Supports value types: strings, integers, floats, booleans, null, and tuples
- Resolves dotted field paths to `json_extract()` expressions for nested JSON columns
- Validates field paths against Pydantic model definitions; rejects bare JSON columns, list columns, and unknown fields
- Boolean coercion for scalar bool columns (SQLite stores 0/1)
- New `ClusterMetadataDB.query_with_filters()` method integrating the engine
- Exported `ParsedFilter`, `SQLCondition`, `parse_filter`, `parse_filters` from `cache.__init__`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

New test coverage:
- `tests/unit/cache/test_query_engine.py`: 50+ unit tests covering `parse_filter`, `parse_filters`, `resolve_field_path`, `build_sql_condition`, and `build_where_clause` with scalar fields, JSON sub-fields, all operators, null handling, boolean coercion, and error cases
- `tests/unit/cache/test_db.py`: 12 integration tests for `query_with_filters()` exercising scalar filters, JSON sub-field filters, numeric comparisons, `in` operator, multiple AND filters, empty filters, and error cases

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- All SQL queries use parameterized placeholders (`?`) -- no string interpolation of user values
- JSON field paths are validated against a strict regex to prevent injection
- This is an internal API addition; no CLI or user-facing behavior changes yet (CLI integration is tracked in #448)
