### PR TITLE
feat: add nf cache check CLI command for ad-hoc cache queries

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -107,6 +107,7 @@ nf cache [OPTIONS] COMMAND [ARGS]...
 | `refresh` | Refresh the metadata cache for cluster(s) |
 | `show` | Display cached metadata for a cluster |
 | `query` | Query specific fields from cached metadata |
+| `check` | Query cached model data with filtering |
 | `schema` | Display the cache metadata schema |
 | `status` | Show cache status for all clusters |
 | `clear` | Clear the metadata cache |
@@ -267,6 +268,31 @@ nf cache clear --all
 
 # Clear without confirmation
 nf cache clear --all -f
+
+# Check: find volumes where autosize mode is not grow_shrink
+nf cache check cluster1 storage.volumes \
+    -w "autosize.mode != 'grow_shrink'" \
+    -F name,svm.name,autosize.mode
+
+# Check all clusters for a model filter
+nf cache check --all storage.volumes \
+    -w "autosize.mode != 'grow_shrink'"
+
+# Check with cluster filter and data filter
+nf cache check -f '{"env":"Prod"}' storage.volumes \
+    -w "autosize.mode != 'grow_shrink'" \
+    -F name,svm.name,autosize.mode
+
+# Count matching records only
+nf cache check --all storage.volumes \
+    -w "size > 1073741824" --count
+
+# JSON output for scripting
+nf cache check --all nodes -w "model_ = 'FAS8200'" --json
+
+# CSV output
+nf cache check --all storage.volumes \
+    -w "state = 'online'" --csv
 
 # Query cloud console links
 nf cache query cluster1 cloud[0].instance_link

--- a/src/pynetappfoundry/cli/commands/cache/__init__.py
+++ b/src/pynetappfoundry/cli/commands/cache/__init__.py
@@ -2,6 +2,7 @@
 
 import click
 
+from pynetappfoundry.cli.commands.cache.check import check
 from pynetappfoundry.cli.commands.cache.clear import clear
 from pynetappfoundry.cli.commands.cache.history import history
 from pynetappfoundry.cli.commands.cache.inspect import inspect
@@ -26,6 +27,7 @@ def cache() -> None:
     pass
 
 
+cache.add_command(check)
 cache.add_command(clear)
 cache.add_command(history)
 cache.add_command(inspect)

--- a/src/pynetappfoundry/cli/commands/cache/check.py
+++ b/src/pynetappfoundry/cli/commands/cache/check.py
@@ -1,0 +1,443 @@
+"""Cache check command for ad-hoc cache queries with filtering.
+
+Exposes the SQL query engine via the CLI, allowing users to filter
+cached model data with expressive ``--where`` expressions and project
+specific fields.
+
+Exit codes follow grep conventions:
+- 0: no matches found
+- 1: matches found
+- 2: error
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from pynetappfoundry.cache import ClusterMetadataDB
+from pynetappfoundry.cache.query_engine import parse_filter
+from pynetappfoundry.cli.utils import print_error, print_exception, print_warning
+from pynetappfoundry.core.config import Config
+from pynetappfoundry.utils.dict_path import get_nested_value
+
+console = Console()
+
+
+def _extract_where_fields(where_exprs: tuple[str, ...]) -> list[str]:
+    """Extract field paths referenced in --where expressions.
+
+    Args:
+        where_exprs: Tuple of filter expression strings.
+
+    Returns:
+        List of unique field paths from the expressions.
+    """
+    fields: list[str] = []
+    for expr in where_exprs:
+        try:
+            parsed = parse_filter(expr)
+            if parsed.field_path not in fields:
+                fields.append(parsed.field_path)
+        except ValueError:
+            # Skip malformed expressions; they'll be caught later
+            pass
+    return fields
+
+
+def _resolve_default_fields(
+    where_exprs: tuple[str, ...],
+    sample_data: dict[str, Any],
+) -> list[str]:
+    """Determine default fields when --fields is not specified.
+
+    Includes ``name`` and ``uuid`` if present on the model, plus
+    any field paths referenced in ``--where`` expressions.
+
+    Args:
+        where_exprs: Filter expression strings.
+        sample_data: A sample model dumped to dict for field detection.
+
+    Returns:
+        Ordered list of field names.
+    """
+    fields: list[str] = []
+    for key in ("name", "uuid"):
+        if key in sample_data:
+            fields.append(key)
+
+    for wf in _extract_where_fields(where_exprs):
+        if wf not in fields:
+            fields.append(wf)
+
+    return fields
+
+
+def _project_row(data: dict[str, Any], fields: list[str]) -> dict[str, Any]:
+    """Project specific fields from a model dict.
+
+    Args:
+        data: Model dumped to dict.
+        fields: Dot-separated field paths.
+
+    Returns:
+        Dict with only the requested fields.
+    """
+    row: dict[str, Any] = {}
+    for field in fields:
+        try:
+            row[field] = get_nested_value(data, field)
+        except Exception:
+            row[field] = None
+    return row
+
+
+def _format_csv_value(value: Any) -> str:
+    """Format a value for CSV output.
+
+    Args:
+        value: Value to format.
+
+    Returns:
+        String suitable for CSV.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    return str(value)
+
+
+def _output_csv(
+    all_rows: dict[str, list[dict[str, Any]]],
+    fields: list[str],
+) -> str:
+    """Format results as CSV.
+
+    Args:
+        all_rows: Cluster name -> list of projected row dicts.
+        fields: Column names.
+
+    Returns:
+        CSV string.
+    """
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["cluster", *fields])
+
+    for cluster_name, rows in all_rows.items():
+        for row in rows:
+            csv_row = [cluster_name]
+            for field in fields:
+                csv_row.append(_format_csv_value(row.get(field)))
+            writer.writerow(csv_row)
+
+    return output.getvalue().rstrip("\r\n")
+
+
+def _output_json(
+    all_rows: dict[str, list[dict[str, Any]]],
+) -> str:
+    """Format results as JSON.
+
+    Args:
+        all_rows: Cluster name -> list of projected row dicts.
+
+    Returns:
+        JSON string.
+    """
+    return json.dumps(all_rows, default=str)
+
+
+def _output_table(
+    all_rows: dict[str, list[dict[str, Any]]],
+    fields: list[str],
+) -> Table:
+    """Build a Rich Table from results.
+
+    Args:
+        all_rows: Cluster name -> list of projected row dicts.
+        fields: Column names.
+
+    Returns:
+        Rich Table instance.
+    """
+    table = Table(title="Cache Check Results")
+    table.add_column("Cluster", style="bold")
+    for field in fields:
+        table.add_column(field, style="cyan")
+
+    for cluster_name, rows in all_rows.items():
+        for row in rows:
+            values = [_format_display(row.get(field)) for field in fields]
+            table.add_row(cluster_name, *values)
+
+    return table
+
+
+def _format_display(value: Any) -> str:
+    """Format a value for table display.
+
+    Args:
+        value: Value to format.
+
+    Returns:
+        String representation.
+    """
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, default=str)
+    return str(value)
+
+
+@click.command()
+@click.argument("cluster", required=False)
+@click.argument("model", required=False)
+@click.option(
+    "--where",
+    "-w",
+    "where_exprs",
+    multiple=True,
+    help="Filter expression (repeatable, AND-joined). E.g. -w \"autosize.mode != 'grow_shrink'\"",
+)
+@click.option(
+    "--fields",
+    "-F",
+    "fields_str",
+    help="Comma-separated field paths for projection.",
+)
+@click.option(
+    "--all",
+    "query_all",
+    is_flag=True,
+    help="Query all cached clusters.",
+)
+@click.option(
+    "--filter",
+    "-f",
+    "filter_str",
+    help='JSON filter for cluster selection: \'{"bu":"Business", "env":"Prod"}\'',
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output as JSON.",
+)
+@click.option(
+    "--csv",
+    "output_csv",
+    is_flag=True,
+    help="Output as CSV with header row.",
+)
+@click.option(
+    "--count",
+    "output_count",
+    is_flag=True,
+    help="Only print match count per cluster.",
+)
+@click.pass_context
+def check(
+    ctx: click.Context,
+    cluster: str | None,
+    model: str | None,
+    where_exprs: tuple[str, ...],
+    fields_str: str | None,
+    query_all: bool,
+    filter_str: str | None,
+    output_json: bool,
+    output_csv: bool,
+    output_count: bool,
+) -> None:
+    """Query cached model data with filtering.
+
+    Filter cached cluster metadata using expressive --where expressions
+    and project specific fields. Useful for ad-hoc checks and CI scripts.
+
+    Exit codes follow grep conventions: 0 = no matches, 1 = matches found,
+    2 = error.
+
+    \b
+    Examples:
+        # Find volumes where autosize mode is not grow_shrink
+        nf cache check cluster1 storage.volumes \\
+            -w "autosize.mode != 'grow_shrink'" \\
+            -F name,svm.name,autosize.mode
+
+        # Check all clusters
+        nf cache check --all storage.volumes \\
+            -w "autosize.mode != 'grow_shrink'"
+
+        # Filtered cluster selection + data filter
+        nf cache check -f '{"env":"Prod"}' storage.volumes \\
+            -w "autosize.mode != 'grow_shrink'" \\
+            -F name,svm.name,autosize.mode
+
+        # Count matches only
+        nf cache check --all storage.volumes \\
+            -w "size > 1073741824" --count
+
+        # JSON output for scripting
+        nf cache check --all nodes -w "model = 'FAS8200'" --json
+
+        # CSV output
+        nf cache check --all storage.volumes \\
+            -w "state = 'online'" --csv
+    """
+    config_dir = ctx.obj.get("config_dir", "config")
+
+    # Check if config directory exists
+    config_path = Path.cwd() / config_dir
+    if not config_path.exists():
+        print_error(f"Configuration directory not found: {config_path}")
+        ctx.exit(2)
+
+    # When --all or --filter is used, Click parses the first positional arg
+    # as 'cluster'. Treat it as the MODEL in that case.
+    effective_model: str
+    effective_cluster: str | None
+
+    if query_all or filter_str:
+        if cluster and model:
+            # Both positional args provided with --all/--filter; cluster is the model
+            effective_model = cluster
+            effective_cluster = None
+        elif cluster:
+            # Only first positional; it's the model
+            effective_model = cluster
+            effective_cluster = None
+        else:
+            print_error("Must specify MODEL argument")
+            ctx.exit(2)
+    else:
+        if not cluster:
+            print_error("Must specify CLUSTER, --all, or --filter/-f")
+            ctx.exit(2)
+        if not model:
+            print_error("Must specify MODEL argument")
+            ctx.exit(2)
+        effective_model = model
+        effective_cluster = cluster
+
+    try:
+        config = Config(config_dir=config_dir, script_name="cache-check")
+    except Exception as e:
+        print_exception(f"Failed to load configuration: {e}", e)
+        ctx.exit(2)
+
+    db = ClusterMetadataDB(config=config)
+
+    # Determine which clusters to query
+    cluster_names: list[str] = []
+    if effective_cluster:
+        cluster_names = [effective_cluster]
+    elif query_all:
+        cached = db.list_clusters()
+        cluster_names = [c["cluster_name"] for c in cached]
+        if not cluster_names:
+            print_warning("No cached clusters found. Use 'nf cache refresh' to populate.")
+            db.close()
+            ctx.exit(0)
+    elif filter_str:
+        try:
+            filter_dict = json.loads(filter_str)
+        except json.JSONDecodeError as e:
+            print_error(f"Invalid filter JSON: {e}")
+            db.close()
+            ctx.exit(2)
+
+        filtered = config.get_clusters(filter_dict)
+        if not filtered:
+            print_warning("No clusters match the filter criteria.")
+            db.close()
+            ctx.exit(0)
+        cluster_names = list(filtered.keys())
+
+    # Parse field list
+    fields: list[str] | None = None
+    if fields_str:
+        fields = [f.strip() for f in fields_str.split(",") if f.strip()]
+
+    # Query each cluster
+    all_rows: dict[str, list[dict[str, Any]]] = {}
+    total_matches = 0
+
+    for name in cluster_names:
+        try:
+            results = db.query_with_filters(name, effective_model, list(where_exprs))
+        except ValueError as e:
+            error_msg = str(e)
+            if "Unknown model name" in error_msg:
+                available = ", ".join(sorted(db._registry.keys()))
+                print_error(f"{error_msg}. Available models: {available}")
+            else:
+                print_error(error_msg)
+            db.close()
+            ctx.exit(2)
+
+        if not results:
+            continue
+
+        # Determine effective fields
+        effective_fields = fields
+        if effective_fields is None:
+            # Default: name + uuid (if present) + where field paths
+            sample = results[0].model_dump()
+            effective_fields = _resolve_default_fields(where_exprs, sample)
+            # If still empty (no name/uuid, no where), show all top-level keys
+            if not effective_fields:
+                effective_fields = list(sample.keys())
+
+        # Project fields
+        rows: list[dict[str, Any]] = []
+        for result in results:
+            dumped = result.model_dump()
+            row = _project_row(dumped, effective_fields)
+            rows.append(row)
+
+        all_rows[name] = rows
+        total_matches += len(rows)
+
+    db.close()
+
+    # If fields were not set yet (no results at all), set for output
+    if fields is None and not all_rows:
+        effective_fields_for_output: list[str] = []
+    elif fields is not None:
+        effective_fields_for_output = fields
+    else:
+        # Use the fields from the first cluster that had results
+        first_rows = next(iter(all_rows.values()))
+        effective_fields_for_output = list(first_rows[0].keys()) if first_rows else []
+
+    # Output
+    if output_count:
+        for name in cluster_names:
+            count = len(all_rows.get(name, []))
+            console.print(f"{name}: {count}")
+        ctx.exit(1 if total_matches > 0 else 0)
+
+    if not all_rows:
+        ctx.exit(0)
+
+    if output_json:
+        console.print(_output_json(all_rows))
+    elif output_csv:
+        console.print(_output_csv(all_rows, effective_fields_for_output))
+    else:
+        table = _output_table(all_rows, effective_fields_for_output)
+        console.print(table)
+
+    ctx.exit(1 if total_matches > 0 else 0)

--- a/tests/unit/cli/commands/cache/test_check.py
+++ b/tests/unit/cli/commands/cache/test_check.py
@@ -1,0 +1,533 @@
+"""Tests for cache check CLI command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from pynetappfoundry.cli.main import nf
+from pynetappfoundry.models.ontap.cluster.nodes.model import OntapNodeResponse
+
+
+class TestCacheCheckCommand:
+    """Tests for nf cache check command."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_config_dir(self, tmp_path: Path) -> Path:
+        """Create a mock config directory."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.toml").write_text(
+            """
+[ontapapi]
+[ontapapi.general]
+base_api_path = "/api"
+"""
+        )
+        return config_dir
+
+    @pytest.fixture
+    def sample_nodes(self) -> list[OntapNodeResponse]:
+        """Create sample node models for testing."""
+        return [
+            OntapNodeResponse(
+                name="node-01",
+                uuid="00000000-0000-0000-0000-000000000001",
+                serial_number="SN001",
+                model_="FAS8200",
+                state="up",
+            ),
+            OntapNodeResponse(
+                name="node-02",
+                uuid="00000000-0000-0000-0000-000000000002",
+                serial_number="SN002",
+                model_="FAS8200",
+                state="up",
+            ),
+            OntapNodeResponse(
+                name="node-03",
+                uuid="00000000-0000-0000-0000-000000000003",
+                serial_number="SN003",
+                model_="AFF-A400",
+                state="up",
+            ),
+        ]
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_single_cluster_with_where(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_nodes: list[OntapNodeResponse],
+    ) -> None:
+        """Test single cluster query with --where filter returns matching results."""
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = sample_nodes[:2]
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "test-cluster",
+                "nodes",
+                "-w",
+                "model_ = 'FAS8200'",
+            ],
+        )
+
+        assert result.exit_code == 1  # matches found
+        mock_db.query_with_filters.assert_called_once_with(
+            "test-cluster", "nodes", ["model_ = 'FAS8200'"]
+        )
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_all_queries_multiple_clusters(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_nodes: list[OntapNodeResponse],
+    ) -> None:
+        """Test --all queries all cached clusters."""
+        mock_db = MagicMock()
+        mock_db.list_clusters.return_value = [
+            {"cluster_name": "cluster1"},
+            {"cluster_name": "cluster2"},
+        ]
+        mock_db.query_with_filters.side_effect = [
+            sample_nodes[:1],
+            sample_nodes[1:2],
+        ]
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "--all",
+                "nodes",
+                "-w",
+                "state = 'up'",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert mock_db.query_with_filters.call_count == 2
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_fields_projection(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_nodes: list[OntapNodeResponse],
+    ) -> None:
+        """Test --fields projects only requested fields."""
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = sample_nodes[:1]
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "test-cluster",
+                "nodes",
+                "-F",
+                "name,serial_number",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "node-01" in result.output
+        assert "SN001" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_json_output(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_nodes: list[OntapNodeResponse],
+    ) -> None:
+        """Test --json output is valid JSON."""
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = [sample_nodes[0]]
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "test-cluster",
+                "nodes",
+                "-F",
+                "name,uuid",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 1
+        output = json.loads(result.output)
+        assert "test-cluster" in output
+        assert output["test-cluster"][0]["name"] == "node-01"
+        assert output["test-cluster"][0]["uuid"] == "00000000-0000-0000-0000-000000000001"
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_csv_output(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_nodes: list[OntapNodeResponse],
+    ) -> None:
+        """Test --csv output has header and data rows."""
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = [sample_nodes[0]]
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "test-cluster",
+                "nodes",
+                "-F",
+                "name,serial_number",
+                "--csv",
+            ],
+        )
+
+        assert result.exit_code == 1
+        lines = result.output.strip().split("\n")
+        assert lines[0] == "cluster,name,serial_number"
+        assert "test-cluster,node-01,SN001" in lines[1]
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_count_output(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_nodes: list[OntapNodeResponse],
+    ) -> None:
+        """Test --count outputs match count per cluster."""
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = sample_nodes[:2]
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "test-cluster",
+                "nodes",
+                "--count",
+            ],
+        )
+
+        assert result.exit_code == 1  # matches found
+        assert "test-cluster: 2" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_exit_code_0_no_matches(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test exit code 0 when no matches found."""
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = []
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "test-cluster",
+                "nodes",
+                "-w",
+                "name = 'nonexistent'",
+            ],
+        )
+
+        assert result.exit_code == 0
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_exit_code_1_matches_found(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_nodes: list[OntapNodeResponse],
+    ) -> None:
+        """Test exit code 1 when matches found."""
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = [sample_nodes[0]]
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "test-cluster",
+                "nodes",
+            ],
+        )
+
+        assert result.exit_code == 1
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_exit_code_2_invalid_model_name(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test exit code 2 on invalid model name."""
+        mock_db = MagicMock()
+        mock_db.query_with_filters.side_effect = ValueError("Unknown model name: 'invalid.model'")
+        mock_db._registry = {"nodes": None, "storage.volumes": None}
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "test-cluster",
+                "invalid.model",
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "Unknown model name" in result.output
+        assert "Available models:" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_multiple_where_filters_and_joined(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_nodes: list[OntapNodeResponse],
+    ) -> None:
+        """Test multiple --where expressions are AND-joined."""
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = [sample_nodes[0]]
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "test-cluster",
+                "nodes",
+                "-w",
+                "model_ = 'FAS8200'",
+                "-w",
+                "state = 'up'",
+            ],
+        )
+
+        assert result.exit_code == 1
+        mock_db.query_with_filters.assert_called_once_with(
+            "test-cluster", "nodes", ["model_ = 'FAS8200'", "state = 'up'"]
+        )
+
+    def test_no_cluster_selection_error(
+        self,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test error when no cluster selection method specified."""
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "check", "nodes"],
+        )
+
+        # Click will parse "nodes" as cluster, and there's no MODEL.
+        # This should trigger a Click missing argument error or our validation.
+        assert result.exit_code == 2
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_default_fields_include_name_uuid_where(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_nodes: list[OntapNodeResponse],
+    ) -> None:
+        """Test default fields include name, uuid, and where field paths."""
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = [sample_nodes[0]]
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "test-cluster",
+                "nodes",
+                "-w",
+                "model_ = 'FAS8200'",
+            ],
+        )
+
+        assert result.exit_code == 1
+        # Default fields should include name, uuid, and model_ (from --where)
+        assert "name" in result.output
+        assert "uuid" in result.output
+        assert "model_" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.check.Config")
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_filter_cluster_selection(
+        self,
+        mock_db_class: MagicMock,
+        mock_config_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+        sample_nodes: list[OntapNodeResponse],
+    ) -> None:
+        """Test --filter for cluster selection."""
+        mock_config = MagicMock()
+        mock_config.get_clusters.return_value = {"prod-cluster": {"name": "prod-cluster"}}
+        mock_config_class.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = [sample_nodes[0]]
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "-f",
+                '{"env":"prod"}',
+                "nodes",
+                "-F",
+                "name",
+            ],
+        )
+
+        assert result.exit_code == 1
+        mock_db.query_with_filters.assert_called_once_with("prod-cluster", "nodes", [])
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_count_zero_matches(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test --count with zero matches gives exit code 0."""
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = []
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "check",
+                "test-cluster",
+                "nodes",
+                "-w",
+                "name = 'nonexistent'",
+                "--count",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "test-cluster: 0" in result.output
+
+    def test_config_not_found_error(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Test error when config directory doesn't exist."""
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(tmp_path / "nonexistent"),
+                "cache",
+                "check",
+                "cluster1",
+                "nodes",
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "not found" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.check.ClusterMetadataDB")
+    def test_empty_cache_with_all(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Test --all with empty cache exits 0."""
+        mock_db = MagicMock()
+        mock_db.list_clusters.return_value = []
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            ["-c", str(mock_config_dir), "cache", "check", "--all", "nodes"],
+        )
+
+        assert result.exit_code == 0
+        assert "No cached clusters" in result.output


### PR DESCRIPTION
## Description

Add `nf cache check` CLI command that exposes the SQL query engine for ad-hoc
cache queries with expressive `--where` filtering, field projection, and
multiple output formats (table, JSON, CSV, count). Exit codes follow grep
conventions (0 = no matches, 1 = matches found, 2 = error) for easy use in
CI scripts and pipelines.

## Related Issue

Addresses #454
Part of #448

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- New `src/pynetappfoundry/cli/commands/cache/check.py` implementing the `nf cache check` command
- Registered `check` subcommand in `src/pynetappfoundry/cli/commands/cache/__init__.py`
- 16 unit tests in `tests/unit/cli/commands/cache/test_check.py` covering all options and exit codes
- Updated `docs/reference/cli.md` with `check` subcommand in the cache table and usage examples

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

`doit check` passes (test, lint, type-check, security, spell-check, format).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Exit codes follow grep conventions for scriptability:
- **0**: no matches found
- **1**: matches found
- **2**: error (bad model name, missing config, invalid filter)
