### PR TITLE
feat: add performance benchmarks for core data paths

### DIFF
--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Performance benchmarks for pynetappfoundry."""

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,207 @@
+"""Shared fixtures for benchmark tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, Field
+
+from pynetappfoundry.cache._base import CacheModel
+
+# ---------------------------------------------------------------------------
+# Lightweight test models (avoid importing real ONTAP models to keep
+# benchmark startup fast and isolated from API schema changes)
+# ---------------------------------------------------------------------------
+
+
+class BenchAutosize(CacheModel):
+    """Sub-model for autosize settings."""
+
+    mode: str = ""
+    grow_threshold: int = 0
+    maximum: int = 0
+    minimum: int = 0
+    shrink_threshold: int = 0
+
+
+class BenchSvm(CacheModel):
+    """Sub-model for SVM reference."""
+
+    name: str = ""
+    uuid: str = ""
+
+
+class BenchAggregate(CacheModel):
+    """Sub-model for aggregate reference."""
+
+    name: str = ""
+    uuid: str = ""
+
+
+class BenchSpace(CacheModel):
+    """Sub-model for space usage."""
+
+    available: int = 0
+    used: int = 0
+    size: int = 0
+    percent_used: int = 0
+    logical_used: int = 0
+
+
+class BenchVolume(CacheModel):
+    """A simplified volume model for benchmarks.
+
+    Has a mix of scalar fields, nested sub-models, and list fields
+    to exercise all serialization paths.
+    """
+
+    name: str = ""
+    uuid: str = ""
+    size: int = 0
+    state: str = ""
+    style: str = ""
+    comment: str = ""
+    language: str = ""
+    access_time_enabled: bool = False
+    is_svm_root: bool = False
+    snapshot_count: int = 0
+    autosize: BenchAutosize = Field(default_factory=BenchAutosize)
+    svm: BenchSvm = Field(default_factory=BenchSvm)
+    aggregates: list[BenchAggregate] = Field(default_factory=list)
+    space: BenchSpace = Field(default_factory=BenchSpace)
+    status: list[str] = Field(default_factory=list)
+    cluster_name: str = ""
+
+
+# For query engine benchmarks — plain BaseModel (not CacheModel)
+class QEAutosize(BaseModel):
+    """Query engine benchmark sub-model."""
+
+    mode: str = ""
+    grow_threshold: int = 0
+    maximum: int = 0
+
+
+class QEAggregate(BaseModel):
+    """Query engine benchmark sub-model."""
+
+    name: str = ""
+    uuid: str = ""
+
+
+class QEVolume(BaseModel):
+    """Query engine benchmark model for filter/SQL tests."""
+
+    name: str = ""
+    uuid: str = ""
+    size: int = 0
+    state: str = ""
+    access_time_enabled: bool = False
+    comment: str | None = None
+    autosize: QEAutosize = Field(default_factory=QEAutosize)
+    aggregates: list[QEAggregate] = Field(default_factory=list)
+    status: list[str] = Field(default_factory=list)
+    score: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Data fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_volume(i: int) -> BenchVolume:
+    """Build a populated BenchVolume for index *i*."""
+    return BenchVolume(
+        name=f"vol_{i:04d}",
+        uuid=f"aaaaaaaa-bbbb-cccc-dddd-{i:012d}",
+        size=1073741824 * (i % 10 + 1),
+        state="online" if i % 5 != 0 else "offline",
+        style="flexvol",
+        comment=f"benchmark volume {i}",
+        language="en_US",
+        access_time_enabled=i % 2 == 0,
+        is_svm_root=False,
+        snapshot_count=i % 50,
+        autosize=BenchAutosize(
+            mode="grow" if i % 3 == 0 else "grow_shrink",
+            grow_threshold=85,
+            maximum=1073741824 * 2,
+            minimum=1073741824,
+            shrink_threshold=50,
+        ),
+        svm=BenchSvm(name=f"svm_{i % 4}", uuid=f"svm-uuid-{i % 4}"),
+        aggregates=[
+            BenchAggregate(name=f"aggr{j}", uuid=f"aggr-uuid-{j}") for j in range(i % 3 + 1)
+        ],
+        space=BenchSpace(
+            available=500_000_000,
+            used=500_000_000,
+            size=1_000_000_000,
+            percent_used=50,
+            logical_used=600_000_000,
+        ),
+        status=["online"],
+        cluster_name="bench-cluster",
+    )
+
+
+@pytest.fixture
+def bench_volumes_10() -> list[BenchVolume]:
+    """10 populated volumes."""
+    return [_make_volume(i) for i in range(10)]
+
+
+@pytest.fixture
+def bench_volumes_100() -> list[BenchVolume]:
+    """100 populated volumes."""
+    return [_make_volume(i) for i in range(100)]
+
+
+@pytest.fixture
+def bench_volumes_1000() -> list[BenchVolume]:
+    """1000 populated volumes."""
+    return [_make_volume(i) for i in range(1000)]
+
+
+@pytest.fixture
+def nested_api_response() -> dict[str, Any]:
+    """A deeply nested dict mimicking an ONTAP API response."""
+    return {
+        "uuid": "aaaaaaaa-bbbb-cccc-dddd-000000000001",
+        "name": "vol_test",
+        "svm": {"name": "svm_0", "uuid": "svm-uuid-0"},
+        "autosize": {
+            "mode": "grow",
+            "grow_threshold": 85,
+            "maximum": 2147483648,
+            "minimum": 1073741824,
+            "shrink_threshold": 50,
+        },
+        "space": {
+            "available": 500000000,
+            "used": 500000000,
+            "size": 1000000000,
+            "snapshot": {
+                "used": 100000,
+                "reserve_percent": 5,
+                "autodelete_enabled": True,
+            },
+        },
+        "aggregates": [{"name": f"aggr{i}", "uuid": f"aggr-uuid-{i}"} for i in range(3)],
+        "cloud": {
+            "provider": "AWS",
+            "region": "us-east-1",
+            "instance": {"type": "m5.xlarge", "id": "i-1234567890abcdef0"},
+        },
+        "nodes": [
+            {
+                "name": f"node-{i:02d}",
+                "uuid": f"node-uuid-{i}",
+                "model": "FAS8200",
+                "uptime": 86400 * (i + 1),
+                "interfaces": [{"name": f"lif-{j}", "address": f"10.0.{i}.{j}"} for j in range(4)],
+            }
+            for i in range(4)
+        ],
+    }

--- a/tests/benchmarks/test_bench_dict_path.py
+++ b/tests/benchmarks/test_bench_dict_path.py
@@ -1,0 +1,77 @@
+"""Benchmarks for nested dictionary path resolution.
+
+get_nested_value() is called per-field per-record during metadata
+collection, making it one of the hottest paths in the codebase.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pynetappfoundry.utils.dict_path import get_nested_value
+
+
+@pytest.mark.benchmark(group="dict_path")
+def test_bench_shallow_key(benchmark: Any, nested_api_response: dict[str, Any]) -> None:
+    """Single top-level key lookup."""
+    benchmark(get_nested_value, nested_api_response, "name")
+
+
+@pytest.mark.benchmark(group="dict_path")
+def test_bench_two_level(benchmark: Any, nested_api_response: dict[str, Any]) -> None:
+    """Two-level nested dict access."""
+    benchmark(get_nested_value, nested_api_response, "svm.name")
+
+
+@pytest.mark.benchmark(group="dict_path")
+def test_bench_three_level(benchmark: Any, nested_api_response: dict[str, Any]) -> None:
+    """Three-level nested dict access."""
+    benchmark(get_nested_value, nested_api_response, "space.snapshot.used")
+
+
+@pytest.mark.benchmark(group="dict_path")
+def test_bench_four_level(benchmark: Any, nested_api_response: dict[str, Any]) -> None:
+    """Four-level nested dict access."""
+    benchmark(get_nested_value, nested_api_response, "cloud.instance.type")
+
+
+@pytest.mark.benchmark(group="dict_path")
+def test_bench_array_index(benchmark: Any, nested_api_response: dict[str, Any]) -> None:
+    """Array index access: nodes[0].name."""
+    benchmark(get_nested_value, nested_api_response, "nodes[0].name")
+
+
+@pytest.mark.benchmark(group="dict_path")
+def test_bench_wildcard(benchmark: Any, nested_api_response: dict[str, Any]) -> None:
+    """Wildcard array access: nodes[*].name (4 items)."""
+    benchmark(get_nested_value, nested_api_response, "nodes[*].name")
+
+
+@pytest.mark.benchmark(group="dict_path")
+def test_bench_wildcard_nested(benchmark: Any, nested_api_response: dict[str, Any]) -> None:
+    """Wildcard with nested access: nodes[*].interfaces (4 items x 4 interfaces)."""
+    benchmark(get_nested_value, nested_api_response, "nodes[*].interfaces")
+
+
+@pytest.mark.benchmark(group="dict_path")
+def test_bench_multi_field_extraction(benchmark: Any, nested_api_response: dict[str, Any]) -> None:
+    """Simulate extracting 10 fields from one record (typical collection loop)."""
+    paths = [
+        "name",
+        "uuid",
+        "svm.name",
+        "svm.uuid",
+        "autosize.mode",
+        "autosize.grow_threshold",
+        "space.available",
+        "space.used",
+        "cloud.provider",
+        "cloud.region",
+    ]
+
+    def extract_all() -> list[Any]:
+        return [get_nested_value(nested_api_response, p) for p in paths]
+
+    benchmark(extract_all)

--- a/tests/benchmarks/test_bench_diff.py
+++ b/tests/benchmarks/test_bench_diff.py
@@ -1,0 +1,149 @@
+"""Benchmarks for change diff computation.
+
+compute_diff() compares two CachedClusterMetadata snapshots field-by-field
+to detect added, removed, and modified entities. It runs on every cache
+update cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pynetappfoundry.cache._metadata import CachedClusterMetadata
+from pynetappfoundry.cache.diff import EntityConfig, _diff_entity_list, compute_diff
+from pynetappfoundry.models.ontap.cluster.model import ClusterInfo
+from pynetappfoundry.models.ontap.cluster.nodes.model import OntapNodeResponse
+from pynetappfoundry.models.ontap.storage.volumes.model import OntapVolume
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_node(i: int, uptime: int = 86400) -> OntapNodeResponse:
+    """Build a minimal OntapNodeResponse."""
+    return OntapNodeResponse(
+        name=f"node-{i:02d}",
+        uuid=f"aaaaaaaa-bbbb-cccc-dddd-{i:012d}",
+        model_="FAS8200",
+        uptime=uptime,
+        serial_number=f"SN{i:08d}",
+    )
+
+
+def _make_vol(i: int, state: str = "online") -> OntapVolume:
+    """Build a minimal OntapVolume."""
+    return OntapVolume(
+        name=f"vol_{i:04d}",
+        uuid=f"bbbbbbbb-cccc-dddd-eeee-{i:012d}",
+        size=1073741824 * (i % 10 + 1),
+        state=state,
+        style="flexvol",
+    )
+
+
+def _make_metadata(
+    *,
+    num_nodes: int = 4,
+    num_volumes: int = 100,
+    node_uptime: int = 86400,
+    vol_state: str = "online",
+) -> CachedClusterMetadata:
+    """Build a CachedClusterMetadata with controllable counts."""
+    from pynetappfoundry.models.ontap.storage.model import StorageInfo
+
+    return CachedClusterMetadata(
+        cluster_name="bench-cluster",
+        cluster=ClusterInfo(
+            cluster_name="bench-cluster",
+            cluster_uuid="cluster-uuid-001",
+            ontap_version="9.14.1",
+        ),
+        nodes=[_make_node(i, uptime=node_uptime) for i in range(num_nodes)],
+        storage=StorageInfo(
+            volumes=[_make_vol(i, state=vol_state) for i in range(num_volumes)],
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_diff benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="diff")
+def test_bench_diff_initial_capture_small(benchmark: Any) -> None:
+    """Initial capture (before=None) with 4 nodes + 50 volumes."""
+    after = _make_metadata(num_nodes=4, num_volumes=50)
+    benchmark(compute_diff, None, after)
+
+
+@pytest.mark.benchmark(group="diff")
+def test_bench_diff_no_changes(benchmark: Any) -> None:
+    """Diff two identical snapshots (no changes) — 4 nodes + 100 volumes."""
+    before = _make_metadata()
+    after = _make_metadata()
+    benchmark(compute_diff, before, after)
+
+
+@pytest.mark.benchmark(group="diff")
+def test_bench_diff_some_modified(benchmark: Any) -> None:
+    """Diff with ~10% volumes modified (state change) — 100 volumes."""
+    before = _make_metadata(num_volumes=100)
+    # Modify every 10th volume
+    after = _make_metadata(num_volumes=100)
+    for i in range(0, 100, 10):
+        after.storage.volumes[i] = _make_vol(i, state="offline")
+    benchmark(compute_diff, before, after)
+
+
+@pytest.mark.benchmark(group="diff")
+def test_bench_diff_added_removed(benchmark: Any) -> None:
+    """Diff with 10 added + 10 removed volumes."""
+    before = _make_metadata(num_volumes=100)
+    after = _make_metadata(num_volumes=100)
+    # Remove first 10, add 10 new
+    after.storage.volumes = after.storage.volumes[10:] + [_make_vol(1000 + i) for i in range(10)]
+    benchmark(compute_diff, before, after)
+
+
+@pytest.mark.benchmark(group="diff")
+def test_bench_diff_large_500_volumes(benchmark: Any) -> None:
+    """Diff with 500 volumes, ~10% modified."""
+    before = _make_metadata(num_volumes=500)
+    after = _make_metadata(num_volumes=500)
+    for i in range(0, 500, 10):
+        after.storage.volumes[i] = _make_vol(i, state="offline")
+    benchmark(compute_diff, before, after)
+
+
+# ---------------------------------------------------------------------------
+# _diff_entity_list micro-benchmark (isolated from metadata traversal)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="diff_entity")
+def test_bench_diff_entity_list_100_no_changes(benchmark: Any) -> None:
+    """Diff 100 identical volume entity lists."""
+    vols = [_make_vol(i) for i in range(100)]
+    config = EntityConfig(
+        key_field="uuid",
+        model_class=OntapVolume,
+        display_field="name",
+    )
+    benchmark(_diff_entity_list, "storage.volumes", vols, list(vols), config)
+
+
+@pytest.mark.benchmark(group="diff_entity")
+def test_bench_diff_entity_list_100_all_modified(benchmark: Any) -> None:
+    """Diff 100 volumes where all have changed state."""
+    before = [_make_vol(i, state="online") for i in range(100)]
+    after = [_make_vol(i, state="offline") for i in range(100)]
+    config = EntityConfig(
+        key_field="uuid",
+        model_class=OntapVolume,
+        display_field="name",
+    )
+    benchmark(_diff_entity_list, "storage.volumes", before, after, config)

--- a/tests/benchmarks/test_bench_query_engine.py
+++ b/tests/benchmarks/test_bench_query_engine.py
@@ -1,0 +1,168 @@
+"""Benchmarks for the SQL query engine filter parsing.
+
+parse_filter() uses regex matching and value parsing on every query.
+There is no caching, so this runs fresh each time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pynetappfoundry.cache.query_engine import (
+    build_sql_condition,
+    build_where_clause,
+    parse_filter,
+    parse_filters,
+    resolve_field_path,
+)
+
+from .conftest import QEVolume
+
+# ---------------------------------------------------------------------------
+# parse_filter benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="query_parse")
+def test_bench_parse_filter_simple_eq(benchmark: Any) -> None:
+    """Parse a simple equality filter."""
+    benchmark(parse_filter, "name = 'vol_0001'")
+
+
+@pytest.mark.benchmark(group="query_parse")
+def test_bench_parse_filter_numeric(benchmark: Any) -> None:
+    """Parse a numeric comparison filter."""
+    benchmark(parse_filter, "size > 1073741824")
+
+
+@pytest.mark.benchmark(group="query_parse")
+def test_bench_parse_filter_dotted(benchmark: Any) -> None:
+    """Parse a dotted JSON path filter."""
+    benchmark(parse_filter, "autosize.mode != 'grow_shrink'")
+
+
+@pytest.mark.benchmark(group="query_parse")
+def test_bench_parse_filter_in_tuple(benchmark: Any) -> None:
+    """Parse an IN filter with tuple value."""
+    benchmark(parse_filter, "state in ('online', 'mixed', 'offline')")
+
+
+@pytest.mark.benchmark(group="query_parse")
+def test_bench_parse_filter_not_in(benchmark: Any) -> None:
+    """Parse a NOT IN filter."""
+    benchmark(parse_filter, "state not in ('offline', 'error')")
+
+
+@pytest.mark.benchmark(group="query_parse")
+def test_bench_parse_filter_boolean(benchmark: Any) -> None:
+    """Parse a boolean filter."""
+    benchmark(parse_filter, "access_time_enabled = true")
+
+
+@pytest.mark.benchmark(group="query_parse")
+def test_bench_parse_filter_null(benchmark: Any) -> None:
+    """Parse a null filter."""
+    benchmark(parse_filter, "comment = null")
+
+
+@pytest.mark.benchmark(group="query_parse")
+def test_bench_parse_filters_batch_10(benchmark: Any) -> None:
+    """Parse 10 filters in a batch."""
+    expressions = [
+        "name = 'vol_0001'",
+        "size > 1073741824",
+        "autosize.mode != 'grow_shrink'",
+        "state in ('online', 'mixed')",
+        "access_time_enabled = true",
+        "comment = null",
+        "score >= 0.5",
+        "size <= 10737418240",
+        "state not in ('offline')",
+        "autosize.grow_threshold > 80",
+    ]
+    benchmark(parse_filters, expressions)
+
+
+# ---------------------------------------------------------------------------
+# resolve_field_path benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="query_resolve")
+def test_bench_resolve_scalar(benchmark: Any) -> None:
+    """Resolve a scalar field path."""
+    benchmark(resolve_field_path, "name", QEVolume)
+
+
+@pytest.mark.benchmark(group="query_resolve")
+def test_bench_resolve_json_subfield(benchmark: Any) -> None:
+    """Resolve a JSON sub-field path (generates json_extract)."""
+    benchmark(resolve_field_path, "autosize.mode", QEVolume)
+
+
+# ---------------------------------------------------------------------------
+# build_sql_condition benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="query_build")
+def test_bench_build_condition_eq(benchmark: Any) -> None:
+    """Build SQL condition for equality."""
+    parsed = parse_filter("name = 'vol_0001'")
+    benchmark(build_sql_condition, parsed, QEVolume)
+
+
+@pytest.mark.benchmark(group="query_build")
+def test_bench_build_condition_in(benchmark: Any) -> None:
+    """Build SQL condition for IN clause."""
+    parsed = parse_filter("state in ('online', 'mixed', 'offline')")
+    benchmark(build_sql_condition, parsed, QEVolume)
+
+
+@pytest.mark.benchmark(group="query_build")
+def test_bench_build_condition_json(benchmark: Any) -> None:
+    """Build SQL condition for JSON sub-field."""
+    parsed = parse_filter("autosize.mode != 'grow_shrink'")
+    benchmark(build_sql_condition, parsed, QEVolume)
+
+
+# ---------------------------------------------------------------------------
+# build_where_clause (end-to-end) benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="query_e2e")
+def test_bench_where_clause_5_filters(benchmark: Any) -> None:
+    """Build complete WHERE clause from 5 parsed filters."""
+    filters = parse_filters(
+        [
+            "name = 'vol_0001'",
+            "size > 1073741824",
+            "state in ('online', 'mixed')",
+            "autosize.mode != 'grow_shrink'",
+            "access_time_enabled = true",
+        ]
+    )
+    benchmark(build_where_clause, filters, QEVolume, cluster_name="bench-cluster")
+
+
+@pytest.mark.benchmark(group="query_e2e")
+def test_bench_where_clause_10_filters(benchmark: Any) -> None:
+    """Build complete WHERE clause from 10 parsed filters."""
+    filters = parse_filters(
+        [
+            "name = 'vol_0001'",
+            "size > 1073741824",
+            "state in ('online', 'mixed')",
+            "autosize.mode != 'grow_shrink'",
+            "access_time_enabled = true",
+            "comment = null",
+            "score >= 0.5",
+            "size <= 10737418240",
+            "state not in ('offline')",
+            "autosize.grow_threshold > 80",
+        ]
+    )
+    benchmark(build_where_clause, filters, QEVolume, cluster_name="bench-cluster")

--- a/tests/benchmarks/test_bench_serialization.py
+++ b/tests/benchmarks/test_bench_serialization.py
@@ -1,0 +1,103 @@
+"""Benchmarks for model-to-row and row-to-model serialization.
+
+These functions are the core path for all cache database reads and writes.
+They handle JSON encoding/decoding of nested sub-models, boolean coercion,
+datetime serialization, and extra field collection.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pynetappfoundry.cache.db import _model_to_row, _row_to_model
+
+from .conftest import BenchVolume, _make_volume
+
+# ---------------------------------------------------------------------------
+# model_to_row benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="serialization")
+def test_bench_model_to_row_single(benchmark: Any) -> None:
+    """Serialize one populated volume to a SQL row dict."""
+    vol = _make_volume(42)
+    benchmark(_model_to_row, vol, BenchVolume)
+
+
+@pytest.mark.benchmark(group="serialization")
+def test_bench_model_to_row_batch_100(benchmark: Any, bench_volumes_100: list[BenchVolume]) -> None:
+    """Serialize 100 volumes to row dicts."""
+
+    def serialize_all() -> list[dict[str, Any]]:
+        return [_model_to_row(v, BenchVolume) for v in bench_volumes_100]
+
+    benchmark(serialize_all)
+
+
+@pytest.mark.benchmark(group="serialization")
+def test_bench_model_to_row_batch_1000(
+    benchmark: Any, bench_volumes_1000: list[BenchVolume]
+) -> None:
+    """Serialize 1000 volumes to row dicts."""
+
+    def serialize_all() -> list[dict[str, Any]]:
+        return [_model_to_row(v, BenchVolume) for v in bench_volumes_1000]
+
+    benchmark(serialize_all)
+
+
+# ---------------------------------------------------------------------------
+# row_to_model benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="deserialization")
+def test_bench_row_to_model_single(benchmark: Any) -> None:
+    """Deserialize one SQL row dict back to a model."""
+    vol = _make_volume(42)
+    row = _model_to_row(vol, BenchVolume)
+    benchmark(_row_to_model, row, BenchVolume)
+
+
+@pytest.mark.benchmark(group="deserialization")
+def test_bench_row_to_model_batch_100(benchmark: Any, bench_volumes_100: list[BenchVolume]) -> None:
+    """Deserialize 100 SQL rows back to models."""
+    rows = [_model_to_row(v, BenchVolume) for v in bench_volumes_100]
+
+    def deserialize_all() -> list[Any]:
+        return [_row_to_model(r, BenchVolume) for r in rows]
+
+    benchmark(deserialize_all)
+
+
+@pytest.mark.benchmark(group="deserialization")
+def test_bench_row_to_model_batch_1000(
+    benchmark: Any, bench_volumes_1000: list[BenchVolume]
+) -> None:
+    """Deserialize 1000 SQL rows back to models."""
+    rows = [_model_to_row(v, BenchVolume) for v in bench_volumes_1000]
+
+    def deserialize_all() -> list[Any]:
+        return [_row_to_model(r, BenchVolume) for r in rows]
+
+    benchmark(deserialize_all)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip benchmark
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="round_trip")
+def test_bench_round_trip_single(benchmark: Any) -> None:
+    """Full serialize -> deserialize round-trip for one volume."""
+    vol = _make_volume(42)
+
+    def round_trip() -> Any:
+        row = _model_to_row(vol, BenchVolume)
+        return _row_to_model(row, BenchVolume)
+
+    benchmark(round_trip)


### PR DESCRIPTION
## Description

Add 37 performance benchmarks covering the critical data flow paths: collect -> transform -> cache -> query -> diff.

## Related Issue

Addresses #460

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test improvement

## Changes Made

- **tests/benchmarks/conftest.py** — Shared fixtures: lightweight Pydantic models (BenchVolume, QEVolume), volume factories, nested API response dict
- **test_bench_dict_path.py** (8 benchmarks) — `get_nested_value()` at 1-4 levels, array index, wildcard, wildcard nested, multi-field extraction
- **test_bench_serialization.py** (7 benchmarks) — `_model_to_row`/`_row_to_model` single and batch (100/1000), round-trip
- **test_bench_query_engine.py** (15 benchmarks) — `parse_filter` (7 variants), `parse_filters` batch, `resolve_field_path` (2), `build_sql_condition` (3), `build_where_clause` (2)
- **test_bench_diff.py** (7 benchmarks) — `compute_diff` initial capture, no changes, ~10% modified, added/removed, large 500 volumes, `_diff_entity_list` micro-benchmarks

## Testing

- [x] All existing tests pass (`doit check`)
- [x] All 37 benchmarks pass (`pytest tests/benchmarks/ --benchmark-enable --benchmark-only`)
- [x] All pre-commit hooks pass

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings