### PR TITLE
refactor: convert nf licenses get to cache + on-demand fetch

### DIFF
--- a/docs/decisions/0010-clusterentry-and-namespace-access-pattern.md
+++ b/docs/decisions/0010-clusterentry-and-namespace-access-pattern.md
@@ -55,6 +55,7 @@ Integration point: `Config._wrap_clusters()` replaces each raw cluster dict with
 - Issue #320: feat: replace `_enrich_with_cache` with ClusterEntry lazy cache accessors
 - Issue #301: feat: field annotations, OpenAPI codegen, and SQL cache storage
 - Issue #352: refactor: lazy `_reconstruct_metadata` to avoid loading all model tables on every `get()`
+- Issue #464: refactor: convert `nf licenses get` to use cache + on-demand fetch (pilot migration to ClusterEntry namespace access)
 
 ## Related Documentation
 

--- a/src/pynetappfoundry/cli/commands/licenses/get.py
+++ b/src/pynetappfoundry/cli/commands/licenses/get.py
@@ -5,21 +5,15 @@ from __future__ import annotations
 import csv
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import click
 from rich.table import Table
 
-import pynetappfoundry.cache.ontap.cluster.licensing.licenses.mapping  # noqa: F401 - register TypeMapping
 from pynetappfoundry.cli.decorators import with_config
 from pynetappfoundry.cli.utils import console, print_error, print_info
-from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
+from pynetappfoundry.core.cluster_entry import ClusterEntry
 from pynetappfoundry.core.config import Config
-from pynetappfoundry.core.models import ClusterConfig
-from pynetappfoundry.models.ontap.cluster.licensing.licenses import (
-    OntapLicensePackageResponse,
-)
-from pynetappfoundry.query import QuerySet
 
 # Column headers used for both table and CSV output
 COLUMNS = ("Cluster", "License Description", "Node", "Serial #", "Expiration")
@@ -65,9 +59,9 @@ def get(
     """
     all_rows: list[LicenseRow] = []
 
-    for name, details in clusters.items():
+    for name in clusters:
         print_info(f"Getting licenses for {name}...")
-        rows = _get_cluster_licenses(name, details, config)
+        rows = _get_cluster_licenses(name, config)
         all_rows.extend(rows)
 
     if csv_output:
@@ -78,34 +72,30 @@ def get(
 
 def _get_cluster_licenses(
     name: str,
-    details: dict[str, Any],
     config: Config,
 ) -> list[LicenseRow]:
-    """Get licenses from a single cluster.
+    """Get licenses from a single cluster via cache + on-demand fetch.
 
     Args:
         name: Cluster name.
-        details: Cluster connection details.
         config: Application configuration.
 
     Returns:
         List of license row tuples for this cluster.
     """
     try:
-        cluster_config = ClusterConfig(**details)
-        client = ONTAPAPIClient(cluster=cluster_config, config=config)
-
-        packages: list[OntapLicensePackageResponse] = QuerySet(
-            OntapLicensePackageResponse, client
-        ).all()
+        cluster_entry = cast(ClusterEntry, config.data["clusters"][name])
+        metadata = cluster_entry.ontap
+        if metadata is None:
+            print_error(f"No cached or fetchable data for {name}")
+            return []
+        packages = metadata.license_packages or []
 
         rows: list[LicenseRow] = []
-
         for pkg in packages:
             for lic in pkg.licenses:
                 if not lic.owner or lic.owner.lower() == "none":
                     continue
-
                 rows.append(
                     (
                         name,
@@ -115,9 +105,7 @@ def _get_cluster_licenses(
                         lic.expiry_time or "No expiry",
                     )
                 )
-
         return rows
-
     except Exception as e:
         print_error(f"Could not retrieve licenses for {name}: {e}")
         return []

--- a/tests/unit/cli/commands/licenses/test_get.py
+++ b/tests/unit/cli/commands/licenses/test_get.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -46,6 +45,26 @@ def _make_package(
     )
 
 
+def _make_cluster_entry_mock(
+    packages: list[OntapLicensePackageResponse] | None,
+) -> MagicMock:
+    """Build a mock cluster entry whose .ontap.license_packages returns packages."""
+    metadata = MagicMock()
+    metadata.license_packages = packages
+    entry = MagicMock()
+    entry.ontap = metadata
+    return entry
+
+
+def _setup_config_with_packages(
+    mock_config: MagicMock,
+    name: str,
+    packages: list[OntapLicensePackageResponse] | None,
+) -> None:
+    """Populate mock_config.data with a cluster entry exposing packages."""
+    mock_config.data = {"clusters": {name: _make_cluster_entry_mock(packages)}}
+
+
 @pytest.fixture
 def mock_config() -> MagicMock:
     """Create a mock Config object."""
@@ -60,30 +79,16 @@ def mock_config() -> MagicMock:
     return config
 
 
-@pytest.fixture
-def sample_details() -> dict[str, Any]:
-    """Sample cluster connection details."""
-    return {"ip": "10.0.0.1", "bu": "Platform", "env": "Prod"}
-
-
 class TestGetClusterLicenses:
     """Tests for _get_cluster_licenses."""
 
-    @patch("pynetappfoundry.cli.commands.licenses.get.QuerySet")
-    @patch("pynetappfoundry.cli.commands.licenses.get.ONTAPAPIClient")
-    def test_returns_filtered_rows(
-        self,
-        mock_client_cls: MagicMock,
-        mock_qs_cls: MagicMock,
-        mock_config: MagicMock,
-        sample_details: dict[str, Any],
-    ) -> None:
+    def test_returns_filtered_rows(self, mock_config: MagicMock) -> None:
         """Test that licenses with expiry and valid owner are included."""
         lic = _make_license()
         pkg = _make_package(description="Cloud ONTAP License", licenses=[lic])
-        mock_qs_cls.return_value.all.return_value = [pkg]
+        _setup_config_with_packages(mock_config, "cluster1", [pkg])
 
-        rows = _get_cluster_licenses("cluster1", sample_details, mock_config)
+        rows = _get_cluster_licenses("cluster1", mock_config)
 
         assert len(rows) == 1
         assert rows[0] == (
@@ -94,87 +99,78 @@ class TestGetClusterLicenses:
             "2026-12-31T00:00:00Z",
         )
 
-    @patch("pynetappfoundry.cli.commands.licenses.get.QuerySet")
-    @patch("pynetappfoundry.cli.commands.licenses.get.ONTAPAPIClient")
-    def test_no_expiry_shows_as_no_expiry(
-        self,
-        mock_client_cls: MagicMock,
-        mock_qs_cls: MagicMock,
-        mock_config: MagicMock,
-        sample_details: dict[str, Any],
-    ) -> None:
+    def test_no_expiry_shows_as_no_expiry(self, mock_config: MagicMock) -> None:
         """Test that licenses without expiry_time show 'No expiry'."""
         lic = _make_license(expiry="")
         pkg = _make_package(description="Cloud ONTAP License", licenses=[lic])
-        mock_qs_cls.return_value.all.return_value = [pkg]
+        _setup_config_with_packages(mock_config, "cluster1", [pkg])
 
-        rows = _get_cluster_licenses("cluster1", sample_details, mock_config)
+        rows = _get_cluster_licenses("cluster1", mock_config)
 
         assert len(rows) == 1
         assert rows[0] == ("cluster1", "Cloud ONTAP License", "node1", "SN-001", "No expiry")
 
-    @patch("pynetappfoundry.cli.commands.licenses.get.QuerySet")
-    @patch("pynetappfoundry.cli.commands.licenses.get.ONTAPAPIClient")
-    def test_filters_owner_none(
-        self,
-        mock_client_cls: MagicMock,
-        mock_qs_cls: MagicMock,
-        mock_config: MagicMock,
-        sample_details: dict[str, Any],
-    ) -> None:
+    def test_filters_owner_none(self, mock_config: MagicMock) -> None:
         """Test that licenses with owner 'none' are excluded."""
         lic = _make_license(owner="none")
         pkg = _make_package(description="Cloud ONTAP License", licenses=[lic])
-        mock_qs_cls.return_value.all.return_value = [pkg]
+        _setup_config_with_packages(mock_config, "cluster1", [pkg])
 
-        rows = _get_cluster_licenses("cluster1", sample_details, mock_config)
+        rows = _get_cluster_licenses("cluster1", mock_config)
 
         assert rows == []
 
-    @patch("pynetappfoundry.cli.commands.licenses.get.QuerySet")
-    @patch("pynetappfoundry.cli.commands.licenses.get.ONTAPAPIClient")
-    def test_filters_empty_owner(
-        self,
-        mock_client_cls: MagicMock,
-        mock_qs_cls: MagicMock,
-        mock_config: MagicMock,
-        sample_details: dict[str, Any],
-    ) -> None:
+    def test_filters_empty_owner(self, mock_config: MagicMock) -> None:
         """Test that licenses with empty owner are excluded."""
         lic = _make_license(owner="")
         pkg = _make_package(description="Cloud ONTAP License", licenses=[lic])
-        mock_qs_cls.return_value.all.return_value = [pkg]
+        _setup_config_with_packages(mock_config, "cluster1", [pkg])
 
-        rows = _get_cluster_licenses("cluster1", sample_details, mock_config)
+        rows = _get_cluster_licenses("cluster1", mock_config)
 
         assert rows == []
 
     @patch("pynetappfoundry.cli.commands.licenses.get.print_error")
-    @patch("pynetappfoundry.cli.commands.licenses.get.ONTAPAPIClient")
     def test_error_handling_returns_empty(
         self,
-        mock_client_cls: MagicMock,
         mock_print_error: MagicMock,
         mock_config: MagicMock,
-        sample_details: dict[str, Any],
     ) -> None:
-        """Test that connection errors are handled gracefully."""
-        mock_client_cls.side_effect = Exception("Connection refused")
+        """Test that exceptions during access are handled gracefully."""
+        entry = MagicMock()
+        type(entry).ontap = PropertyMock(side_effect=Exception("boom"))
+        mock_config.data = {"clusters": {"cluster1": entry}}
 
-        rows = _get_cluster_licenses("cluster1", sample_details, mock_config)
+        rows = _get_cluster_licenses("cluster1", mock_config)
 
         assert rows == []
         mock_print_error.assert_called_once()
 
-    @patch("pynetappfoundry.cli.commands.licenses.get.QuerySet")
-    @patch("pynetappfoundry.cli.commands.licenses.get.ONTAPAPIClient")
-    def test_multiple_packages_and_licenses(
+    @patch("pynetappfoundry.cli.commands.licenses.get.print_error")
+    def test_no_metadata_returns_empty(
         self,
-        mock_client_cls: MagicMock,
-        mock_qs_cls: MagicMock,
+        mock_print_error: MagicMock,
         mock_config: MagicMock,
-        sample_details: dict[str, Any],
     ) -> None:
+        """Test that a None .ontap returns [] and logs an error."""
+        entry = MagicMock()
+        entry.ontap = None
+        mock_config.data = {"clusters": {"cluster1": entry}}
+
+        rows = _get_cluster_licenses("cluster1", mock_config)
+
+        assert rows == []
+        mock_print_error.assert_called_once()
+
+    def test_empty_license_packages(self, mock_config: MagicMock) -> None:
+        """Test that an empty license_packages list returns []."""
+        _setup_config_with_packages(mock_config, "cluster1", [])
+
+        rows = _get_cluster_licenses("cluster1", mock_config)
+
+        assert rows == []
+
+    def test_multiple_packages_and_licenses(self, mock_config: MagicMock) -> None:
         """Test processing multiple packages with multiple licenses."""
         lic1 = _make_license(owner="node1", serial="SN-001")
         lic2 = _make_license(owner="node2", serial="SN-002")
@@ -183,9 +179,9 @@ class TestGetClusterLicenses:
         lic3 = _make_license(owner="node1", serial="SN-003")
         pkg2 = _make_package(description="NFS License", licenses=[lic3])
 
-        mock_qs_cls.return_value.all.return_value = [pkg1, pkg2]
+        _setup_config_with_packages(mock_config, "cluster1", [pkg1, pkg2])
 
-        rows = _get_cluster_licenses("cluster1", sample_details, mock_config)
+        rows = _get_cluster_licenses("cluster1", mock_config)
 
         assert len(rows) == 3
         assert rows[0][3] == "SN-001"


### PR DESCRIPTION
## Description

Refactors `nf licenses get` to use the `ClusterEntry` namespace access pattern (ADR-0010) instead of instantiating `ONTAPAPIClient` + `QuerySet` directly. License packages are now retrieved via `cluster_entry.ontap.license_packages`, which transparently uses the SQLite cache when available and falls back to on-demand fetching via the existing `LazyClusterMetadata` + `FieldGroupFetcher` infrastructure.

This is the **pilot migration** for converting reports and scripts to the cache + on-demand fetch pattern. Subsequent commands can follow the same template.

User-facing CLI behavior is unchanged: same options, same output, same exit codes.

## Related Issue

Addresses #464

## Type of Change

- [x] Code refactoring

## Changes Made

- Replaced `ONTAPAPIClient` + `QuerySet` construction in `_get_cluster_licenses` with `cluster_entry.ontap.license_packages` access
- Simplified `_get_cluster_licenses` signature from `(name, details, config)` to `(name, config)` — the cluster entry is now looked up directly via `Config.data["clusters"][name]`
- Used `cast(ClusterEntry, ...)` at the lookup site to satisfy both mypy and Pyright
- Updated `tests/unit/cli/commands/licenses/test_get.py` to mock the new access path (15 tests, up from 13, all passing)
- Added issue link to ADR-0010 (`docs/decisions/0010-clusterentry-and-namespace-access-pattern.md`) since this refactor implements the pattern described there

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes
- [x] `doit check` passes locally (tests, lint, type-check, security, spell-check, format)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (ADR-0010 issue link)
- [ ] I have updated the CHANGELOG.md (N/A — no user-facing behavior change)
- [x] My changes generate no new warnings

## Additional Notes

- **Follow-up:** Issue #472 tracks a potential `--live` cache-bypass flag. We briefly explored it on this branch but reverted it as scope creep so this PR stays focused on the pilot refactor.
- **No ADR needed:** This implements the existing ADR-0010 pattern; no new architectural decision is introduced. The `needs-adr` label is not set.
- **Pilot template:** Future report/script migrations to the cache + on-demand fetch pattern should follow the structure established here.
