### PR TITLE
feat: add Config.no_cache flag and --live CLI option to bypass cache

### DIFF
--- a/docs/decisions/0010-clusterentry-and-namespace-access-pattern.md
+++ b/docs/decisions/0010-clusterentry-and-namespace-access-pattern.md
@@ -56,6 +56,7 @@ Integration point: `Config._wrap_clusters()` replaces each raw cluster dict with
 - Issue #301: feat: field annotations, OpenAPI codegen, and SQL cache storage
 - Issue #352: refactor: lazy `_reconstruct_metadata` to avoid loading all model tables on every `get()`
 - Issue #464: refactor: convert `nf licenses get` to use cache + on-demand fetch (pilot migration to ClusterEntry namespace access)
+- Issue #472: feat: add Config.no_cache flag and --live CLI option to bypass cache (extends namespace access with cache-bypass mode)
 
 ## Related Documentation
 

--- a/src/pynetappfoundry/cli/commands/licenses/get.py
+++ b/src/pynetappfoundry/cli/commands/licenses/get.py
@@ -44,6 +44,17 @@ LicenseRow = tuple[str, str, str, str, str]
     default=None,
     help="CSV output file path (default: timestamped file in output dir).",
 )
+@click.option(
+    "--live",
+    "live",
+    is_flag=True,
+    default=False,
+    help=(
+        "Bypass the cache and fetch licenses live from each cluster. "
+        "This is significantly slower than reading from the cache because "
+        "every field group is fetched over the network."
+    ),
+)
 @with_config("Get licenses failed")
 def get(
     config: Config,

--- a/src/pynetappfoundry/cli/decorators.py
+++ b/src/pynetappfoundry/cli/decorators.py
@@ -36,6 +36,7 @@ def with_config(action: str) -> Callable[[F], F]:
             output_dir = ctx.obj.get("output_dir", "")
             debug = ctx.obj.get("debug", False)
             filter_str = kwargs.pop("filter", None)
+            live = kwargs.pop("live", False)
 
             # Build script_name from full command path (e.g., "licenses_get")
             parts: list[str] = []
@@ -60,7 +61,12 @@ def with_config(action: str) -> Callable[[F], F]:
                     filter_dict = json.loads(filter_str)
 
                 # Create config
-                config = Config(config_dir, output_dir, script_name=script_name)
+                config = Config(
+                    config_dir,
+                    output_dir,
+                    script_name=script_name,
+                    no_cache=live,
+                )
                 clusters = config.get_clusters(filter_dict)
 
                 return func(*args, config=config, clusters=clusters, **kwargs)

--- a/src/pynetappfoundry/core/cluster_entry.py
+++ b/src/pynetappfoundry/core/cluster_entry.py
@@ -45,9 +45,19 @@ class ClusterEntry(MutableMapping[str, Any]):
         config_data: The raw TOML config dict for this cluster.
         cache_db_path: Path to the cluster metadata cache database file.
         config: Optional Config instance for live API/CLI fetching.
+        no_cache: When True, ``.ontap`` bypasses the cache database entirely
+            and returns a fetcher-only proxy that fetches every field group
+            live from the ONTAP API/CLI. Requires ``config`` to be set.
     """
 
-    __slots__ = ("__dict__", "_cache_db_path", "_config", "_data", "_name")
+    __slots__ = (
+        "__dict__",
+        "_cache_db_path",
+        "_config",
+        "_data",
+        "_name",
+        "_no_cache",
+    )
 
     def __init__(
         self,
@@ -55,11 +65,14 @@ class ClusterEntry(MutableMapping[str, Any]):
         config_data: dict[str, Any],
         cache_db_path: Path,
         config: Config | None = None,
+        *,
+        no_cache: bool = False,
     ) -> None:
         self._name = name
         self._data = config_data
         self._cache_db_path = cache_db_path
         self._config = config
+        self._no_cache = no_cache
 
     # ------------------------------------------------------------------
     # Dict-like interface
@@ -130,15 +143,23 @@ class ClusterEntry(MutableMapping[str, Any]):
 
     @cached_property
     def ontap(self) -> LazyClusterMetadata | None:
-        """Lazily load ONTAP cached metadata for this cluster.
+        """Lazily load ONTAP metadata for this cluster.
 
         Opens the cache database on first access, retrieves a lazy-loading
         proxy that defers per-field-group queries until attribute access,
         closes the database, and caches the result.
 
+        When ``no_cache=True`` was passed to the constructor (typically via
+        :class:`~pynetappfoundry.core.config.Config`), this returns a
+        fetcher-only proxy that bypasses the cache database entirely and
+        fetches every field group live from the ONTAP API/CLI.
+
         Returns:
-            LazyClusterMetadata proxy if cache data exists, None otherwise.
+            LazyClusterMetadata proxy if cache data exists or a live fetcher
+            can be built, None otherwise.
         """
+        if self._no_cache:
+            return self._build_live_metadata()
         return self._load_cached_metadata()
 
     @cached_property
@@ -195,22 +216,43 @@ class ClusterEntry(MutableMapping[str, Any]):
                 # Fall through to fetcher-only path below.
 
         # No cache DB (or DB load failed) — try fetcher-only mode.
-        if fetcher is not None:
-            from pynetappfoundry.cache._base import METADATA_SCHEMA_VERSION, _utcnow
-            from pynetappfoundry.cache.db_schema import _ensure_registry
-
+        live = self._build_live_metadata(fetcher=fetcher)
+        if live is not None:
             logging.debug(f"{_file_name} : no cache DB for {self._name}, using live fetcher")
-            return LazyClusterMetadata(
-                cluster_name=self._name,
-                cached_at=_utcnow().isoformat(),
-                cache_version=METADATA_SCHEMA_VERSION,
-                db_path=None,
-                registry=_ensure_registry(),
-                fetcher=fetcher,
-            )
+            return live
 
         logging.debug(f"{_file_name} : no cache DB at {self._cache_db_path} for {self._name}")
         return None
+
+    def _build_live_metadata(
+        self, fetcher: FieldGroupFetcher | None = None
+    ) -> LazyClusterMetadata | None:
+        """Construct a fetcher-only :class:`LazyClusterMetadata` (no cache DB).
+
+        Args:
+            fetcher: Optional pre-built fetcher. If None, one is built from
+                the cluster's Config.
+
+        Returns:
+            Fetcher-backed LazyClusterMetadata, or None when no fetcher
+            can be built (no Config or no cluster IP).
+        """
+        if fetcher is None:
+            fetcher = self._build_fetcher()
+        if fetcher is None:
+            return None
+
+        from pynetappfoundry.cache._base import METADATA_SCHEMA_VERSION, _utcnow
+        from pynetappfoundry.cache.db_schema import _ensure_registry
+
+        return LazyClusterMetadata(
+            cluster_name=self._name,
+            cached_at=_utcnow().isoformat(),
+            cache_version=METADATA_SCHEMA_VERSION,
+            db_path=None,
+            registry=_ensure_registry(),
+            fetcher=fetcher,
+        )
 
     def _build_fetcher(self) -> FieldGroupFetcher | None:
         """Create a :class:`FieldGroupFetcher` if Config is available.

--- a/src/pynetappfoundry/core/config.py
+++ b/src/pynetappfoundry/core/config.py
@@ -97,6 +97,8 @@ class Config:
         output_dir: str | Path = "",
         script_name: str = "",
         args: Any = None,
+        *,
+        no_cache: bool = False,
     ) -> None:
         """Initialize the configuration manager.
 
@@ -106,9 +108,14 @@ class Config:
             output_dir: Directory for output files. If empty, uses data/{script_name}/output.
             script_name: Name of the calling script (used for directory naming).
             args: Optional parsed arguments object.
+            no_cache: When True, every wrapped :class:`ClusterEntry` is built
+                with ``no_cache=True``, causing ``.ontap`` accesses to bypass
+                the cache database and fetch field groups live from the
+                ONTAP API/CLI. Typically set via the ``--live`` CLI flag.
         """
         self.data: dict[str, dict[str, dict[str, Any]]] = {}
         self.args = args
+        self.no_cache = no_cache
         self.config_dir = Path.cwd() / config_dir
         self.data_types = ["aiqums", "connectors", "cloudinsights", "clusters", "azure"]
         self.settings: dict[str, Any] = {}
@@ -297,7 +304,13 @@ class Config:
         clusters = self.data.get("clusters", {})
         for name, data in clusters.items():
             if not isinstance(data, ClusterEntry):
-                clusters[name] = ClusterEntry(name, data, cache_db_path, config=self)  # type: ignore[assignment]
+                clusters[name] = ClusterEntry(  # type: ignore[assignment]  # pyright: ignore[reportArgumentType]
+                    name,
+                    data,
+                    cache_db_path,
+                    config=self,
+                    no_cache=self.no_cache,
+                )
 
     def parse_toml(self, file: Path) -> None:
         """Parse a single TOML file.

--- a/tests/unit/cli/commands/licenses/test_get.py
+++ b/tests/unit/cli/commands/licenses/test_get.py
@@ -6,11 +6,13 @@ from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
+from click.testing import CliRunner
 
 from pynetappfoundry.cli.commands.licenses.get import (
     _get_cluster_licenses,
     _print_table,
     _write_csv,
+    get,
 )
 from pynetappfoundry.models.ontap.cluster.licensing.licenses.model import (
     OntapLicensePackageResponse,
@@ -264,3 +266,49 @@ class TestWriteCsv:
         lines = content.strip().split("\n")
         assert len(lines) == 1  # header only
         assert "Cluster" in lines[0]
+
+
+class TestLiveFlag:
+    """Tests for the --live CLI flag wiring."""
+
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_live_flag_accepted_by_command(self, mock_config_cls: MagicMock) -> None:
+        """`nf licenses get --live` runs and passes no_cache=True to Config."""
+        captured: dict[str, object] = {}
+
+        def capture_config(*args: object, **kwargs: object) -> MagicMock:
+            captured.update(kwargs)
+            mock = MagicMock()
+            mock.no_cache = kwargs.get("no_cache", False)
+            mock.get_clusters = MagicMock(return_value={})
+            mock.output_dir = Path("/tmp")
+            return mock
+
+        mock_config_cls.side_effect = capture_config
+
+        runner = CliRunner()
+        result = runner.invoke(get, ["--live"], obj={})
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("no_cache") is True
+
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_no_live_flag_defaults_no_cache_false(self, mock_config_cls: MagicMock) -> None:
+        """Without --live, Config is built with no_cache=False."""
+        captured: dict[str, object] = {}
+
+        def capture_config(*args: object, **kwargs: object) -> MagicMock:
+            captured.update(kwargs)
+            mock = MagicMock()
+            mock.no_cache = kwargs.get("no_cache", False)
+            mock.get_clusters = MagicMock(return_value={})
+            mock.output_dir = Path("/tmp")
+            return mock
+
+        mock_config_cls.side_effect = capture_config
+
+        runner = CliRunner()
+        result = runner.invoke(get, [], obj={})
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("no_cache") is False

--- a/tests/unit/cli/test_decorators.py
+++ b/tests/unit/cli/test_decorators.py
@@ -90,3 +90,66 @@ class TestWithConfigScriptName:
 
         assert result.exit_code == 0
         assert mock_config.script_name == "events_get"
+
+
+class TestWithConfigLiveFlag:
+    """Tests for the --live flag wiring through with_config."""
+
+    def _make_cli(self) -> click.Group:
+        """Build a test CLI with a --live flag on a leaf command."""
+
+        @click.group()
+        @click.pass_context
+        def nf(ctx: click.Context) -> None:
+            ctx.ensure_object(dict)
+            ctx.obj["config_dir"] = "config"
+            ctx.obj["output_dir"] = ""
+            ctx.obj["debug"] = False
+
+        @nf.command()
+        @click.option("--live", "live", is_flag=True, default=False)
+        @with_config("test failed")
+        def cmd(config: object, clusters: object) -> None:
+            click.echo(f"no_cache={config.no_cache}")  # type: ignore[union-attr]
+
+        return nf
+
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_live_flag_sets_no_cache_true(self, mock_config_cls: MagicMock) -> None:
+        """Invoking with --live calls Config(no_cache=True)."""
+        captured: dict[str, object] = {}
+
+        def capture_config(*args: object, **kwargs: object) -> MagicMock:
+            captured.update(kwargs)
+            mock = MagicMock()
+            mock.no_cache = kwargs.get("no_cache", False)
+            mock.get_clusters = MagicMock(return_value={})
+            return mock
+
+        mock_config_cls.side_effect = capture_config
+
+        runner = CliRunner()
+        result = runner.invoke(self._make_cli(), ["cmd", "--live"])
+
+        assert result.exit_code == 0
+        assert captured.get("no_cache") is True
+
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_no_live_flag_defaults_to_false(self, mock_config_cls: MagicMock) -> None:
+        """Invoking without --live calls Config(no_cache=False)."""
+        captured: dict[str, object] = {}
+
+        def capture_config(*args: object, **kwargs: object) -> MagicMock:
+            captured.update(kwargs)
+            mock = MagicMock()
+            mock.no_cache = kwargs.get("no_cache", False)
+            mock.get_clusters = MagicMock(return_value={})
+            return mock
+
+        mock_config_cls.side_effect = capture_config
+
+        runner = CliRunner()
+        result = runner.invoke(self._make_cli(), ["cmd"])
+
+        assert result.exit_code == 0
+        assert captured.get("no_cache") is False

--- a/tests/unit/core/test_cluster_entry.py
+++ b/tests/unit/core/test_cluster_entry.py
@@ -321,6 +321,61 @@ class TestConfigAwareFetcher:
         assert entry._config is None
 
 
+class TestNoCacheBypass:
+    """Tests for the no_cache constructor flag."""
+
+    def test_no_cache_default_false(self, entry: ClusterEntry) -> None:
+        """Default constructor leaves _no_cache False."""
+        assert entry._no_cache is False
+
+    def test_no_cache_stored(self, sample_data: dict[str, Any], cache_db_path: Path) -> None:
+        """no_cache=True is stored on the entry."""
+        entry = ClusterEntry("test-cluster", sample_data, cache_db_path, no_cache=True)
+        assert entry._no_cache is True
+
+    def test_no_cache_skips_db_even_when_present(
+        self, sample_data: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """When no_cache=True, .ontap does not open the cache DB."""
+        from pynetappfoundry.cache._lazy import LazyClusterMetadata
+
+        cache_path = tmp_path / ".cache" / "cluster_metadata.db"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.touch()
+
+        mock_config = MagicMock()
+        mock_config.get_user.return_value = ("admin", "pass")
+
+        with (
+            patch("pynetappfoundry.cache.db.ClusterMetadataDB") as mock_db_cls,
+            patch("pynetappfoundry.cache._fetcher.FieldGroupFetcher") as mock_fetcher_cls,
+        ):
+            mock_fetcher = MagicMock()
+            mock_fetcher_cls.return_value = mock_fetcher
+
+            entry = ClusterEntry(
+                "test-cluster",
+                sample_data,
+                cache_path,
+                config=mock_config,
+                no_cache=True,
+            )
+            result = entry.ontap
+
+            mock_db_cls.assert_not_called()
+            assert isinstance(result, LazyClusterMetadata)
+            assert result._db_path is None
+            assert result._fetcher is mock_fetcher
+
+    def test_no_cache_returns_none_without_config(
+        self, sample_data: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """no_cache=True without a Config returns None (no fetcher possible)."""
+        cache_path = tmp_path / ".cache" / "cluster_metadata.db"
+        entry = ClusterEntry("test-cluster", sample_data, cache_path, no_cache=True)
+        assert entry.ontap is None
+
+
 class TestRepr:
     """Tests for ClusterEntry repr."""
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -838,6 +838,55 @@ class TestClusterEntryWrapping:
         finally:
             os.chdir(original_cwd)
 
+    def test_no_cache_default_false(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """Config() default leaves wrapped ClusterEntry _no_cache=False."""
+        import os
+
+        from pynetappfoundry.core.cluster_entry import ClusterEntry
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            assert config.no_cache is False
+            for cluster in config.data["clusters"].values():
+                assert isinstance(cluster, ClusterEntry)
+                assert cluster._no_cache is False
+        finally:
+            os.chdir(original_cwd)
+
+    def test_no_cache_propagates_to_cluster_entries(
+        self, temp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Config(no_cache=True) propagates to wrapped ClusterEntry instances."""
+        import os
+
+        from pynetappfoundry.core.cluster_entry import ClusterEntry
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+                no_cache=True,
+            )
+            assert config.no_cache is True
+            for cluster in config.data["clusters"].values():
+                assert isinstance(cluster, ClusterEntry)
+                assert cluster._no_cache is True
+        finally:
+            os.chdir(original_cwd)
+
     def test_cluster_entry_static_access(self, temp_config_dir: Path, tmp_path: Path) -> None:
         """Test that TOML fields are accessible via entry['key'] and entry.key."""
         import os


### PR DESCRIPTION
## Description

Adds a global cache-bypass mechanism rooted in `Config`, plus a `--live` CLI option on `nf licenses get` as the pilot consumer. When `Config(no_cache=True)` is set, the flag propagates to every wrapped `ClusterEntry`, and `ClusterEntry.ontap` routes through a new `_build_live_metadata()` helper instead of consulting the cache. This gives users an explicit, opt-in way to force on-demand fetches when they need fresh data.

This builds on the on-demand fetch pilot from #464, which converted `nf licenses get` to use the fetcher path. With the cache layer now in place across the wider codebase, users need a way to bypass it deliberately — `--live` is that switch.

## Related Issue

Addresses #472

Follow-up: user-facing documentation for the cache, on-demand fetch, and `--live` flag is tracked in #474. This PR documents the flag only via inline `--help` text on the Click option.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `src/pynetappfoundry/core/config.py` — `Config` accepts a `no_cache` constructor parameter and propagates it through `_wrap_clusters` to every `ClusterEntry`.
- `src/pynetappfoundry/core/cluster_entry.py` — `ClusterEntry` accepts `no_cache`; the `ontap` property checks `_no_cache` and routes to a new `_build_live_metadata()` helper (refactored from the existing fetcher-only fallback path).
- `src/pynetappfoundry/cli/decorators.py` — `with_config` pops `live` from kwargs and passes it as `no_cache=live` to `Config(...)`, mirroring the existing `filter` pattern.
- `src/pynetappfoundry/cli/commands/licenses/get.py` — adds a single `@click.option("--live", ...)` flag as the pilot consumer.
- `docs/decisions/0010-clusterentry-and-namespace-access-pattern.md` — added #472 backreference link in the Related section. No other docs changes (deferred to #474).

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes locally (lint, format, type-check, security, spell-check, tests)

10 new tests added across 4 test files, all passing:

- `tests/unit/core/test_cluster_entry.py` — `TestNoCacheBypass` (4 tests): verifies `_no_cache` storage, that `ontap` bypasses cache when set, and that `_build_live_metadata` is invoked.
- `tests/unit/test_config.py` — 2 tests in `TestClusterEntryWrapping`: default `no_cache=False` and propagation to wrapped clusters.
- `tests/unit/cli/test_decorators.py` — `TestWithConfigLiveFlag` (2 tests): verifies `live` is popped from kwargs and forwarded as `no_cache`.
- `tests/unit/cli/commands/licenses/test_get.py` — `TestLiveFlag` (2 `CliRunner` tests): verifies `--live` is accepted and reaches `Config`.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] Related ADR updated with issue link (ADR-0010)
- [ ] User-facing docs — deferred to #474

## Additional Notes

- No new ADRs required. ADR-0010 (ClusterEntry access pattern) is the relevant decision and has been updated with the #472 link.
- `--live` is currently wired only into `nf licenses get`. Other commands can opt in by adding the same one-line Click option; the plumbing is fully in place.
