### PR TITLE
docs: document the QuerySet query layer and fluent builder

### DIFF
--- a/docs/decisions/0004-declarative-field-mapping-framework.md
+++ b/docs/decisions/0004-declarative-field-mapping-framework.md
@@ -129,7 +129,9 @@ annotated mappings from API specs, with per-field customization via TOML overlay
 - Issue #312: fix: remove hardcoded collector endpoints and wire cache_strategy into parsing
 - Issue #317: feat: collector ?fields= expansion for expensive ONTAP fields
 - Issue #444: refactor: evaluate nested models to replace flat model pattern (see ADR-0011)
+- Issue #478: doc: document the QuerySet query layer and fluent builder (consumes `TypeMapping` / `cache_attr` / realtime field annotations)
 
 ## Related Documentation
 
 - [Field Mapping Framework Developer Guide](../development/field-mapping.md)
+- [Query Layer guide](../usage/query-layer.md)

--- a/docs/usage/ontap-access-patterns.md
+++ b/docs/usage/ontap-access-patterns.md
@@ -20,7 +20,7 @@ pynetappfoundry provides three different ways to interact with ONTAP clusters. E
 | Pattern | Connection | Best For |
 |---------|------------|----------|
 | `ClusterEntry.ontap` namespace | Cache DB + HTTPS REST (+ SSH for `cloud`) | High-level reads of cached cluster metadata with on-demand fetch fallback |
-| `QuerySet` + `Mutation` | HTTPS REST | Type-safe ONTAP queries and writes with model attribute translation |
+| `QuerySet` + `Mutation` | HTTPS REST | Type-safe ONTAP queries and writes with model attribute translation (see [Query Layer](query-layer.md)) |
 | `netapp_ontap` SDK | HTTPS REST | Structured data retrieval, reports, typed objects |
 | `ONTAPCLI` | SSH | Ad-hoc CLI commands, operations not in REST API |
 | `APIWrapper` | HTTPS REST | Custom queries, OpenAPI-based workflows, DII integration |
@@ -164,167 +164,13 @@ The `--live` flag is wired through `@with_config`, which constructs `Config(no_c
 
 ---
 
-### 2. QuerySet + Mutation (Recommended for New Code)
+### 2. QuerySet + Mutation (Query Layer)
 
-pynetappfoundry's native query and mutation layer uses the project's own Pydantic models (`OntapModel` subclasses) with declarative field mappings. `QuerySet` handles reads, `Mutation` handles writes.
+`pynetappfoundry.query` is a thin, fluent layer over the ONTAP REST API that uses the project's `TypeMapping` metadata to translate model attribute filters into API requests and to parse responses back into Pydantic models. It covers reads (`QuerySet`), writes (`Mutation`), async job polling (`JobTracker`), relationship traversal (`related` / `related_one`), and on-demand realtime field access.
 
-**When to Use:**
+Choose `cluster_entry.ontap` for cached field-group reads with a `--live` bypass, and reach for `QuerySet` / `Mutation` whenever you need ad-hoc filtering, projection, or any write operation.
 
-- Querying ONTAP resources with type-safe filtering
-- Creating, updating, or deleting ONTAP resources
-- When you want model attribute names (e.g., `svm_name`) instead of raw API paths (`svm.name`)
-- Building automation that leverages the project's config-driven connections
-
-**Advantages:**
-
-- Fluent, chainable query API with field projection, ordering, and limits
-- Automatic translation between model attributes and API field paths
-- Write operations build nested JSON from flat kwargs
-- Retry safety — POST disables retry (non-idempotent), PATCH/DELETE use default retry
-- Type-safe Pydantic model instances as return values
-- Works with any registered `TypeMapping` (296 ONTAP resource types)
-
-**Limitations:**
-
-- Requires the model's `TypeMapping` to be registered (import its mapping module)
-- Async job tracking via `poll=True` or `JobTracker` (returns `OntapJob` on completion)
-- Parameterized endpoints (child resources) not yet supported
-
-**Example Usage:**
-
-```python
-from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
-from pynetappfoundry.query import QuerySet, Mutation
-from pynetappfoundry.models.ontap.storage.volumes import OntapVolume
-
-# Setup client from config
-client = ONTAPAPIClient(cluster, config)
-
-# Query: list online volumes for an SVM
-vols = (QuerySet(OntapVolume, client)
-    .filter(svm_name="vs1", state="online")
-    .fields("name", "uuid", "size")
-    .order_by("name")
-    .limit(50)
-    .all())
-
-# Query: get a single volume
-vol = QuerySet(OntapVolume, client).get(uuid="abc-123-def")
-
-# Query: count matching resources
-count = QuerySet(OntapVolume, client).filter(state="online").count()
-
-# Query: iterate with wildcards
-for vol in QuerySet(OntapVolume, client).filter(name="*_backup"):
-    print(vol.name)
-
-# Create a volume
-result = Mutation(OntapVolume, client).create(
-    name="vol1",
-    svm_name="vs1",
-    size=1073741824,
-)
-
-# Update a volume
-result = Mutation(OntapVolume, client).update(
-    uuid="abc-123-def",
-    size=2147483648,
-)
-
-# Delete a volume
-Mutation(OntapVolume, client).delete(uuid="abc-123-def")
-
-# Create with job tracking (blocks until the async job completes)
-from pynetappfoundry.query import JobTracker, JobError
-
-job = Mutation(OntapVolume, client).create(
-    poll=True,          # wait for async job
-    poll_interval=5,    # seconds between polls (default)
-    poll_timeout=300,   # max wait in seconds (default)
-    name="vol1",
-    svm_name="vs1",
-    size=1073741824,
-)
-print(f"Job {job.uuid} completed: {job.state}")
-
-# Manual job tracking for finer control
-response = Mutation(OntapVolume, client).create(name="vol1", svm_name="vs1")
-if isinstance(response, dict) and "job" in response:
-    tracker = JobTracker.from_response(response, client)
-    # Non-blocking: check current state
-    current = tracker.poll()
-    print(f"State: {current.state}")
-    # Blocking: wait for completion
-    try:
-        final = tracker.wait()
-    except JobError as e:
-        print(f"Job failed: {e.message} (code={e.error_code})")
-```
-
-#### Relationship Traversal
-
-ONTAP resources have rich relationships (volumes belong to SVMs, LUNs map to igroups, etc.). The `related()` and `related_one()` functions provide a convenient way to traverse these relationships using model attribute filters.
-
-```python
-from pynetappfoundry.query import related, related_one
-from pynetappfoundry.models.ontap.storage.volumes import OntapVolume
-from pynetappfoundry.models.ontap.svm.svms import OntapSvm
-
-# Fetch all volumes belonging to an SVM
-vols = related(OntapVolume, client, svm_uuid="abc-123")
-
-# Fetch the SVM for a specific volume (one-to-one)
-svm = related_one(OntapSvm, client, uuid="svm-uuid-123")
-
-# Combine multiple filters
-vols = related(OntapVolume, client, svm_name="vs1", state="online")
-```
-
-These are equivalent to `QuerySet(...).filter(...).all()` and `QuerySet(...).filter(...).first()` respectively, but express relationship-traversal intent more clearly.
-
-#### Realtime Fields
-
-Many ONTAP models define fields with `cache_strategy="realtime"` (metrics like IOPS, latency, space usage) that are excluded from cache storage because they change constantly. The `query.realtime` module provides on-demand access to these fields.
-
-```python
-from pynetappfoundry.query import (
-    fetch_realtime,
-    fetch_realtime_collection,
-    watch_realtime,
-    compare_realtime,
-)
-from pynetappfoundry.models.ontap.storage.volumes import OntapVolume
-
-# Fetch realtime metrics for a single volume
-metrics = fetch_realtime(OntapVolume, client, uuid="abc-123-def")
-print(f"IOPS read: {metrics['iops_read']}")
-
-# Fetch only specific realtime fields
-metrics = fetch_realtime(
-    OntapVolume, client, uuid="abc-123-def",
-    fields=["iops_read", "iops_write"],
-)
-
-# Fetch realtime metrics for multiple volumes (with filtering)
-all_metrics = fetch_realtime_collection(
-    OntapVolume, client, svm_name="vs1",
-)
-for m in all_metrics:
-    print(f"{m['name']}: read={m['iops_read']}, write={m['iops_write']}")
-
-# Poll metrics every 10 seconds (3 snapshots)
-for snapshot in watch_realtime(
-    OntapVolume, client, uuid="abc-123-def",
-    interval=10, count=3,
-):
-    print(f"[{snapshot['_timestamp']}] IOPS: {snapshot['iops_read']}")
-
-# Compare current metrics against a baseline
-baseline = fetch_realtime(OntapVolume, client, uuid="abc-123-def")
-# ... time passes ...
-diff = compare_realtime(OntapVolume, client, uuid="abc-123-def", baseline=baseline)
-print(f"IOPS read delta: {diff['iops_read']['delta']}")
-```
+See the dedicated [Query Layer](query-layer.md) guide for the full API reference, worked examples, and exception semantics.
 
 ---
 
@@ -571,12 +417,12 @@ Use this matrix to choose the right pattern:
 | Read cached cluster metadata (licenses, nodes, storage, etc.) | `ClusterEntry.ontap` | Sub-ms SQLite reads, transparent fallback |
 | Read cluster metadata when the cache is empty | `ClusterEntry.ontap` | On-demand `FieldGroupFetcher` fallback, no caller changes needed |
 | Force-live read of cluster metadata | `ClusterEntry.ontap` with `Config(no_cache=True)` / `--live` | Bypasses cache entirely, same call site |
-| Query ONTAP resources | `QuerySet` | Type-safe filtering, model attribute translation |
-| Create/update/delete resources | `Mutation` | Nested JSON from flat attrs, retry safety |
-| List volumes/aggregates | `QuerySet` | Fluent API, field projection, pagination |
-| Fetch live IOPS/latency metrics | `fetch_realtime` | On-demand realtime fields |
-| Poll metrics over time | `watch_realtime` | Generator-based polling |
-| Bulk data export | `QuerySet` | Handles pagination, typed results |
+| Query ONTAP resources | `QuerySet` | Type-safe filtering, model attribute translation — see [Query Layer](query-layer.md) |
+| Create/update/delete resources | `Mutation` | Nested JSON from flat attrs, retry safety — see [Query Layer](query-layer.md) |
+| List volumes/aggregates | `QuerySet` | Fluent API, field projection, pagination — see [Query Layer](query-layer.md) |
+| Fetch live IOPS/latency metrics | `fetch_realtime` | On-demand realtime fields — see [Query Layer](query-layer.md) |
+| Poll metrics over time | `watch_realtime` | Generator-based polling — see [Query Layer](query-layer.md) |
+| Bulk data export | `QuerySet` | Handles pagination, typed results — see [Query Layer](query-layer.md) |
 | Generate a report | `netapp_ontap` SDK | Typed objects, well-documented |
 | Check license status | `netapp_ontap` SDK | LicensePackage resource available |
 | Run CLI-only command | `ONTAPCLI` | No REST equivalent |

--- a/docs/usage/query-layer.md
+++ b/docs/usage/query-layer.md
@@ -1,0 +1,380 @@
+---
+title: Query Layer
+description: Guide to the REST query layer (QuerySet, Mutation, JobTracker, related, realtime)
+audience:
+  - users
+  - contributors
+tags:
+  - ontap
+  - api
+  - query
+  - mutation
+  - realtime
+---
+
+# Query Layer
+
+`pynetappfoundry.query` is a thin, fluent layer on top of the ONTAP REST API client. It uses the same declarative `TypeMapping` metadata that drives the cache (see [ADR-0004](../decisions/0004-declarative-field-mapping-framework.md)) to translate model attribute names into API field paths and to parse responses back into Pydantic model instances.
+
+The layer ships five public surfaces:
+
+- `QuerySet` — fluent, lazy reads
+- `Mutation` — POST / PATCH / DELETE writes
+- `JobTracker` (and `JobError`) — polling for async ONTAP jobs
+- `related` / `related_one` — relationship-traversal sugar over `QuerySet`
+- `fetch_realtime`, `fetch_realtime_collection`, `watch_realtime`, `compare_realtime` — on-demand access to fields marked `cache_strategy="realtime"`
+
+## Overview
+
+| Use case | Use this |
+|----------|----------|
+| Type-safe ad-hoc reads with filters / projection / ordering | `QuerySet` |
+| Create / update / delete a resource | `Mutation` |
+| Wait for an async ONTAP job | `JobTracker` (or `poll=True` shortcut on `Mutation`) |
+| Express "fetch related X for this Y" intent | `related` / `related_one` |
+| Read fields excluded from the cache (IOPS, latency, ...) | `fetch_realtime` family |
+
+!!! note "Prerequisite: TypeMapping must be registered"
+    Every entry point in this module looks the model class up in the model registry. If you see `ValueError: No TypeMapping registered for 'OntapXxx'`, import the matching mapping module (e.g. `import pynetappfoundry.cache.ontap.storage.volumes.mapping`) before constructing the `QuerySet` / `Mutation`. Importing the cache subpackage is usually enough — most CLI entry points already trigger this transitively.
+
+For the wider context of when to use the query layer instead of `ClusterEntry.ontap`, see the [decision section](#combining-with-clusterentryontap) below and the [ONTAP Access Patterns](ontap-access-patterns.md) guide.
+
+## QuerySet Reads
+
+`QuerySet` is a lazy, chainable query builder. Each chaining call returns a **new** `QuerySet` (cloned filters/fields/ordering/limit), so you can safely fork a base query.
+
+```python
+from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
+from pynetappfoundry.core.config import Config
+from pynetappfoundry.models.ontap.storage.volumes.model import OntapVolume
+from pynetappfoundry.query import QuerySet
+
+config = Config()
+cluster = config.clusters["mycluster"]
+client = ONTAPAPIClient(cluster, config)
+
+base = QuerySet(OntapVolume, client).filter(state="online")
+```
+
+### Filtering: `.filter(**kwargs)`
+
+`.filter()` accepts model attribute names as keyword arguments. Each key is translated to an API field path via three lookup strategies, in order:
+
+1. **Exact `cache_attr` match.** If the model's `TypeMapping` has a `FieldMapping` whose `cache_attr` equals the kwarg name, the corresponding `api_path` is used. For example, if `cache_attr="name"` then `name="vol1"` becomes `name=vol1`.
+2. **Dunder-to-dot translation.** Python kwargs cannot contain `.`, so `svm__name="vs1"` is rewritten to `svm.name="vs1"` and re-matched against `cache_attr` values. This is how you target nested fields. Real ONTAP mappings use dotted `cache_attr` values (e.g. `svm.name`, `autosize.mode`), so the dunder form is the recommended way to filter on them from Python code.
+3. **Pass-through.** If no mapping match is found, the attribute name is sent to the API verbatim. This lets you use raw API field paths when you know what you want.
+
+```python
+# Dotted cache_attr via dunder kwargs (the common ONTAP case)
+qs = QuerySet(OntapVolume, client).filter(svm__name="vs1", autosize__mode="grow")
+
+# Top-level cache_attr (state, name, uuid, size all exist on OntapVolume)
+qs = QuerySet(OntapVolume, client).filter(state="online")
+
+# Raw API field path (pass-through)
+qs = QuerySet(OntapVolume, client).filter(**{"space.size": 1073741824})
+```
+
+!!! warning "Filtering is server-side; wildcards are an ONTAP feature"
+    Values are sent verbatim to ONTAP. Wildcard semantics (e.g. `name="*_backup"`) are interpreted by the ONTAP REST API itself, not by `QuerySet`. Refer to the ONTAP REST documentation for the supported syntax for the field you are filtering on.
+
+### Projection: `.fields(*names)`
+
+`.fields()` overrides the default `fields=*` projection that the `TypeMapping` ships in `api_endpoint`. Names are translated using the same logic as `.filter()` (cache_attr, then dunder, then pass-through).
+
+```python
+qs = (
+    QuerySet(OntapVolume, client)
+    .filter(svm__name="vs1")
+    .fields("name", "uuid", "size", "state")
+)
+```
+
+Use projection on large collections to reduce response size and parsing cost.
+
+### Ordering: `.order_by(*specs)`
+
+Each spec is an attribute name optionally followed by a space and `asc` or `desc`. The attribute portion is translated; the suffix is preserved as-is.
+
+```python
+QuerySet(OntapVolume, client).order_by("name asc", "size desc")
+```
+
+### Limiting: `.limit(n)`
+
+`.limit(n)` sets the `max_records` query parameter.
+
+```python
+QuerySet(OntapVolume, client).filter(state="online").limit(50)
+```
+
+### Terminal methods
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `.all()` | `list[Model]` | Executes the query, paginates via `client.get_all_records`, parses every record into a model instance. |
+| `.first()` | `Model \| None` | Equivalent to `.limit(1).all()[0]` (or `None`). |
+| `.get(**kwargs)` | `Model` | Convenience for `.filter(**kwargs).all()` that **must** return exactly one row. Raises `NotFoundError` for zero rows or `MultipleResultsError` for more than one. |
+| `.count()` | `int` | Issues the query with `return_records=false` and reads `num_records` from the response. Does not fetch records. |
+| `iter(qs)` | iterator | `__iter__` calls `.all()` once and yields its contents. |
+
+```python
+from pynetappfoundry.query import MultipleResultsError, NotFoundError
+
+# All matching volumes, projected and ordered
+volumes = (
+    QuerySet(OntapVolume, client)
+    .filter(svm__name="vs1", state="online")
+    .fields("name", "uuid", "size")
+    .order_by("name asc")
+    .limit(50)
+    .all()
+)
+
+# Exactly one (raises if zero or many)
+try:
+    vol = QuerySet(OntapVolume, client).get(uuid="abc-123-def")
+except NotFoundError:
+    print("No such volume")
+except MultipleResultsError as exc:
+    print(f"Ambiguous filter, got {exc.count} rows")
+
+# Count without fetching records
+total = QuerySet(OntapVolume, client).filter(state="online").count()
+```
+
+!!! note "Server-side filter vs. cache query engine"
+    For complex predicates (`autosize.mode != 'grow_shrink'`, ranges, NOT, OR), the cache SQL query engine — used by `nf cache check` and `nf cache compliance` — is usually a better fit because it operates on the local SQLite cache without round-tripping to the cluster. `QuerySet` is the right tool when you want live data, single-cluster access, and the simple equality / wildcard semantics that ONTAP REST exposes natively.
+
+## Mutation Writes
+
+`Mutation` wraps the same `TypeMapping` to translate flat model-attribute kwargs into the nested JSON body that ONTAP REST expects.
+
+```python
+from pynetappfoundry.query import Mutation
+
+m = Mutation(OntapVolume, client)
+```
+
+### `.create(**kwargs)`
+
+POST to the collection endpoint. Body construction calls `_attr_to_api_path` for every kwarg and merges sibling dotted paths into nested dicts (so `svm__name="vs1"` and `svm__uuid="..."` both become children of a single `svm` object).
+
+POST is non-idempotent, so retry is **disabled** for `.create()` (`RetryConfig(enabled=False)`).
+
+```python
+new_vol = m.create(
+    name="vol1",
+    svm__name="vs1",
+    size=1073741824,
+)
+```
+
+### `.update(uuid, **kwargs)`
+
+PATCH against `<collection>/<uuid>` with the same flat-to-nested body translation. PATCH uses the client's default retry behavior.
+
+```python
+m.update("abc-123-def", size=2147483648, state="offline")
+```
+
+### `.delete(uuid, **kwargs)`
+
+DELETE against `<collection>/<uuid>`. Optional kwargs become a body (e.g. for force flags accepted by certain ONTAP endpoints).
+
+```python
+m.delete("abc-123-def")
+```
+
+### Return value parsing
+
+`.create()` and `.update()` parse the API response back into a model instance when the response looks like a record (i.e. it contains at least one top-level key that the `TypeMapping` knows about). For 202-style async responses (`{"job": {...}}`) the raw dict is returned — see the next section for how to track the job.
+
+## Async Job Tracking
+
+Many ONTAP write endpoints return HTTP 202 with a job descriptor instead of the resource itself. The query layer offers two ways to wait for completion.
+
+### Shortcut: `poll=True` on `Mutation`
+
+`Mutation.create()` and `.update()` accept three keyword-only arguments to handle the job inline:
+
+| Kwarg | Default | Purpose |
+|-------|---------|---------|
+| `poll` | `False` | When `True` and the response contains `job`, build a `JobTracker` and call `.wait()`. |
+| `poll_interval` | `5` (seconds) | Delay between polls. |
+| `poll_timeout` | `300` (seconds) | Maximum wall-clock wait before raising `TimeoutError`. |
+
+When `poll=True` actually fires, the return value is the completed `OntapJob`, not a parsed resource model.
+
+```python
+from pynetappfoundry.query import JobError
+
+try:
+    job = m.create(
+        poll=True,
+        poll_interval=5,
+        poll_timeout=300,
+        name="vol1",
+        svm__name="vs1",
+        size=1073741824,
+    )
+    print(f"Job {job.uuid} state={job.state}")
+except JobError as exc:
+    print(f"Volume create failed: {exc.message} (code={exc.error_code})")
+except TimeoutError as exc:
+    print(f"Gave up waiting: {exc}")
+```
+
+### Manual: `JobTracker.from_response`
+
+For finer control (non-blocking polls, custom retry, surfacing intermediate state), use `JobTracker` directly.
+
+```python
+from pynetappfoundry.query import JobError, JobTracker
+
+response = m.create(name="vol1", svm__name="vs1", size=1073741824)
+if isinstance(response, dict) and "job" in response:
+    tracker = JobTracker.from_response(response, client, poll_interval=2, poll_timeout=120)
+
+    # Single non-blocking poll
+    snapshot = tracker.poll()
+    print(f"Current state: {snapshot.state}")
+    print(f"Terminal? {tracker.is_complete}")
+
+    # Or block until terminal
+    try:
+        final = tracker.wait()
+        print(f"Job {final.uuid} succeeded")
+    except JobError as exc:
+        # exc.job is the failed OntapJob; exc.message and exc.error_code are populated
+        print(f"Job failed: {exc.message}")
+```
+
+`JobTracker.from_response` raises `ValueError` if the response dict has no `job.uuid`. `JobTracker.wait()` raises `JobError` on terminal `failure` and `TimeoutError` if `poll_timeout` elapses without the job reaching `success` or `failure`.
+
+The `is_complete` property reports whether the **last polled** job state was terminal (`success` or `failure`); it returns `False` until you have polled at least once.
+
+## Relationship Traversal
+
+`related()` and `related_one()` are thin wrappers that express relationship-traversal intent more clearly than a raw `QuerySet().filter().all()` chain. Both **require** at least one filter kwarg and raise `ValueError` if called with none.
+
+```python
+from pynetappfoundry.models.ontap.storage.volumes.model import OntapVolume
+from pynetappfoundry.models.ontap.svm.svms.model import OntapSvm
+from pynetappfoundry.query import related, related_one
+
+# Many: all volumes for an SVM
+vols = related(OntapVolume, client, svm__uuid="abc-123")
+
+# One-to-one: the SVM for a known UUID
+svm = related_one(OntapSvm, client, uuid="svm-uuid-123")
+```
+
+`related(...)` is exactly `QuerySet(model, client).filter(**kwargs).all()`. `related_one(...)` is `.filter(**kwargs).first()`. Use them when the call site is clearly traversing a relationship; reach for `QuerySet` directly when you also need projection, ordering, or limiting.
+
+## Realtime Fields
+
+ONTAP exposes per-resource counters (IOPS, latency, throughput, deduplication savings, ...) that are too volatile to cache. The `cache.field_mapping.FieldMapping` framework marks these with `cache_strategy="realtime"`, which excludes them from bulk cache collection and surfaces them via `TypeMapping.realtime_fields()`. The four functions in `pynetappfoundry.query.realtime` are how you read those values on demand.
+
+All four functions resolve the model's `TypeMapping`, optionally filter the realtime field set down to a `fields=` whitelist (matched on `cache_attr`), and project a request that asks ONTAP only for the top-level API keys actually needed.
+
+### `fetch_realtime(model_class, client, uuid, fields=None)`
+
+Fetch current realtime values for a single resource by UUID. Returns a flat `dict[cache_attr, value]`.
+
+```python
+from pynetappfoundry.query import fetch_realtime
+
+metrics = fetch_realtime(
+    OntapVolume,
+    client,
+    uuid="abc-123-def",
+    fields=["metric.iops.read", "metric.iops.write", "metric.latency.read"],
+)
+print(metrics["metric.iops.read"], metrics["metric.iops.write"])
+```
+
+If the model has no realtime fields (or none survive the `fields=` filter), the function returns `{}` without making a request.
+
+### `fetch_realtime_collection(model_class, client, fields=None, **filters)`
+
+Fetch realtime values for many resources in one request. `**filters` are translated via the same `cache_attr` lookup that `QuerySet.filter` uses (without the dunder rewrite — pass dotted API paths as `**{"svm.name": "vs1"}` if you need them). The response always includes `uuid` and `name` for identification.
+
+```python
+from pynetappfoundry.query import fetch_realtime_collection
+
+rows = fetch_realtime_collection(
+    OntapVolume,
+    client,
+    fields=["metric.iops.read", "metric.iops.write"],
+    state="online",
+)
+for row in rows:
+    print(row["name"], row["metric.iops.read"], row["metric.iops.write"])
+```
+
+### `watch_realtime(model_class, client, uuid, fields=None, interval=5, count=None)`
+
+Generator that calls `fetch_realtime` in a loop, adding an ISO-8601 UTC `_timestamp` key to each yielded dict. `count=None` runs forever; pass an integer to stop after N samples. `interval` is seconds between polls.
+
+```python
+from pynetappfoundry.query import watch_realtime
+
+for snapshot in watch_realtime(
+    OntapVolume,
+    client,
+    uuid="abc-123-def",
+    fields=["metric.iops.read"],
+    interval=10,
+    count=3,
+):
+    print(snapshot["_timestamp"], snapshot["metric.iops.read"])
+```
+
+### `compare_realtime(model_class, client, uuid, baseline, fields=None)`
+
+Fetches the current realtime values and diffs them against a `baseline` dict (typically captured earlier with `fetch_realtime`). For numeric values, the result includes `baseline`, `current`, and `delta`. For non-numeric values, only `baseline` and `current`. Fields present in `current` but absent from `baseline` get a `current`-only entry.
+
+```python
+from pynetappfoundry.query import compare_realtime, fetch_realtime
+
+baseline = fetch_realtime(
+    OntapVolume, client, uuid="abc-123-def",
+    fields=["metric.iops.read", "metric.iops.write"],
+)
+# ... time passes, workload runs ...
+diff = compare_realtime(
+    OntapVolume, client, uuid="abc-123-def", baseline=baseline,
+    fields=["metric.iops.read", "metric.iops.write"],
+)
+print(diff["metric.iops.read"]["delta"])
+```
+
+## Combining with `ClusterEntry.ontap`
+
+The query layer and `ClusterEntry.ontap` are complementary, not competing:
+
+- Use **`cluster_entry.ontap`** for high-level reads of cached cluster metadata field groups (licenses, nodes, storage, network, ...). It serves sub-millisecond SQLite reads when the cache is populated and falls back to a live `FieldGroupFetcher` on a miss. `--live` (`Config(no_cache=True)`) bypasses the cache without changing call sites.
+- Use **`QuerySet`** for ad-hoc reads that don't fit a pre-defined field group: arbitrary filters, custom projections, ordering / limit, or models the cache does not collect.
+- Use **`Mutation`** for any write. There is no write surface on `ClusterEntry.ontap`.
+- Use **`fetch_realtime`** (and friends) for fields the cache deliberately excludes.
+
+For the full decision matrix, see [ONTAP Access Patterns](ontap-access-patterns.md).
+
+## Exceptions Reference
+
+| Exception | Raised by | Meaning |
+|-----------|-----------|---------|
+| `NotFoundError` | `QuerySet.get()` | Filter matched zero rows. |
+| `MultipleResultsError` | `QuerySet.get()` | Filter matched more than one row; the count is on `exc.count`. |
+| `JobError` | `JobTracker.wait()` (and `Mutation` with `poll=True`) | The polled `OntapJob` reached the `failure` state. The failed job is on `exc.job`; `exc.message` and `exc.error_code` mirror the job's error fields. |
+| `TimeoutError` | `JobTracker.wait()` (and `Mutation` with `poll=True`) | `poll_timeout` elapsed without the job reaching a terminal state. |
+| `ValueError` | `QuerySet`, `Mutation`, `JobTracker.from_response`, `related`, `related_one`, the realtime functions | The model class has no registered `TypeMapping`, the API response has no `job.uuid`, or `related`/`related_one` was called without filter kwargs. |
+
+`NotFoundError` and `MultipleResultsError` live in `pynetappfoundry.query.exceptions` and are also re-exported from `pynetappfoundry.query`.
+
+## See Also
+
+- [ONTAP Access Patterns](ontap-access-patterns.md) — when to use `ClusterEntry.ontap` vs. the query layer vs. the SDK vs. SSH.
+- [ADR-0010: ClusterEntry and namespace access pattern](../decisions/0010-clusterentry-and-namespace-access-pattern.md) — rationale for the cache-first read namespace.
+- [ADR-0004: Declarative field mapping framework](../decisions/0004-declarative-field-mapping-framework.md) — the `FieldMapping` / `TypeMapping` model that the query layer reads from.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
   - Usage:
       - Basics: usage/basics.md
       - ONTAP Access Patterns: usage/ontap-access-patterns.md
+      - Query Layer: usage/query-layer.md
   - Reference:
       - CLI Reference: reference/cli.md
       - API Reference: reference/api.md


### PR DESCRIPTION
## Description

Adds a dedicated guide for the `pynetappfoundry.query` REST query layer and shrinks the duplicated section in `ontap-access-patterns.md` down to a stub that points at the new page. The new page is the canonical reference for `QuerySet`, `Mutation`, `JobTracker`, `related` / `related_one`, and the `fetch_realtime` family.

The previous `ontap-access-patterns.md` Section #2 (added in PR #486) had several incorrect API examples; those are corrected in the new guide rather than re-introduced in the access-patterns page.

## Related Issue

Addresses #478

## Type of Change

- [x] Documentation update

## Changes Made

- New `docs/usage/query-layer.md` (~380 lines) covering:
  - `QuerySet` fluent API: `.filter()` (cache_attr / dunder-to-dot / pass-through), `.fields()`, `.order_by()`, `.limit()`, terminal methods (`.all()`, `.first()`, `.get()`, `.count()`, iteration), and `NotFoundError` / `MultipleResultsError`.
  - `Mutation`: `.create()` (POST, retry disabled), `.update()` (PATCH), `.delete()`, flat-to-nested body translation, and response parsing.
  - Async job tracking: the `poll=True` / `poll_interval` / `poll_timeout` shortcut on `Mutation`, and the manual `JobTracker.from_response` flow with `JobError` and `TimeoutError` semantics.
  - `related` / `related_one` relationship-traversal sugar (and the empty-kwargs `ValueError`).
  - Realtime field access: `fetch_realtime`, `fetch_realtime_collection`, `watch_realtime`, `compare_realtime` — including the dotted-string filter form for `fetch_realtime_collection` and the dotted result keys returned by all four functions.
  - `TypeMapping` registration prerequisite, server-side filter caveat, and an exceptions reference table.
  - Cross-links back to ADR-0004, ADR-0010, and `ontap-access-patterns.md`.
- `docs/usage/ontap-access-patterns.md` Section #2 reduced from ~170 lines of duplicated detail to a short stub that links to `query-layer.md`. Overview table and 6 Decision Matrix rows updated to reference the new guide.
- `mkdocs.yml`: added `Query Layer: usage/query-layer.md` to the Usage nav, immediately after `ONTAP Access Patterns`.
- `docs/decisions/0004-declarative-field-mapping-framework.md`: added a `#478` backlink under Related Issues and a link to the new query-layer guide under Related Documentation, since the query layer is the primary runtime consumer of `cache_attr` / `TypeMapping` / realtime field annotations.

### Corrections vs. PR #486

The previous draft of Section #2 (introduced in PR #486) had several inaccurate examples that are fixed in the new guide:

- Filter kwargs use the dunder form (`svm__name="vs1"`) which is rewritten to `svm.name`, not `svm_name`.
- Realtime fields are addressed by their full API path (`metric.iops.read`, not `iops_read`).
- `OntapSnapshot` is a parameterized mapping (parent volume UUID), so it is not a drop-in `QuerySet` example; it has been removed from the guide.

## Follow-up Issues

The current API has two awkward shapes that this PR documents as-is, because the goal is to describe current behavior. Both have follow-up issues opened during review:

- **#487** — refactor: prefer dotted-string filter keys over the dunder rewrite in `QuerySet`. Proposes letting callers pass `**{"svm.name": "vs1"}` directly without the implicit `__` -> `.` rewrite.
- **#488** — refactor: investigate dotted-string result keys in realtime function output dicts. The `fetch_realtime` family currently returns keys like `"metric.iops.read"`; #488 tracks whether nested or attribute-style access would be more ergonomic.

When either of these lands, the corresponding section of `query-layer.md` will be updated. Until then, the doc reflects the actual current API.

## Testing

- [x] All existing tests pass (`doit check` — tests, lint, type-check, format, security, spell-check)
- [x] `doit docs_build` succeeds with no warnings on the new or modified pages
- [x] Manually verified internal links: `ontap-access-patterns.md` -> `query-layer.md`, `query-layer.md` -> ADR-0004 / ADR-0010 / `ontap-access-patterns.md`, ADR-0004 -> `query-layer.md`
- [x] Verified no other docs link into anchors of the deleted Section #2 content

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (not applicable: docs-only change)
- [x] My changes generate no new warnings

## Additional Notes

- Issue #478 has labels `documentation` and `needs-triage` (no `needs-adr`), so per AGENTS.md no new ADR is required. ADR-0004 was updated only because it has natural Related Issues / Related Documentation slots and the query layer is a primary consumer of its `TypeMapping` framework. ADR-0010 was intentionally left alone because its Related Documentation section does not currently list query-layer.md as a target.
- This PR does not change runtime code; #487 and #488 will revise the doc when they land.
