### PR TITLE
docs: refresh cache architecture documentation

### DIFF
--- a/docs/decisions/0001-use-sqlite-for-cluster-metadata-caching.md
+++ b/docs/decisions/0001-use-sqlite-for-cluster-metadata-caching.md
@@ -38,10 +38,12 @@ changed to enable SQL-level queries and per-field indexing.
 - Issue #32: feat: add cluster metadata cache for ONTAP clusters
 - Issue #38: refactor: move cluster metadata cache to config directory
 - Issue #130: feat: add nf cache query command
+- Issue #479: doc: refresh cache architecture documentation
 
 ## Related Documentation
 
 - Cache module: `src/pynetappfoundry/cache/`
+- [Cache System Reference](../reference/cache.md)
 - CLI commands: `nf cache refresh`, `nf cache show`, `nf cache query`, `nf cache schema`, `nf cache status`, `nf cache clear`
 - CLI Reference: [docs/reference/cli.md](../reference/cli.md#cache)
 - Usage Guide: [docs/usage/basics.md](../usage/basics.md#cluster-metadata-caching)

--- a/docs/decisions/0004-declarative-field-mapping-framework.md
+++ b/docs/decisions/0004-declarative-field-mapping-framework.md
@@ -130,8 +130,10 @@ annotated mappings from API specs, with per-field customization via TOML overlay
 - Issue #317: feat: collector ?fields= expansion for expensive ONTAP fields
 - Issue #444: refactor: evaluate nested models to replace flat model pattern (see ADR-0011)
 - Issue #478: doc: document the QuerySet query layer and fluent builder (consumes `TypeMapping` / `cache_attr` / realtime field annotations)
+- Issue #479: doc: refresh cache architecture documentation
 
 ## Related Documentation
 
 - [Field Mapping Framework Developer Guide](../development/field-mapping.md)
 - [Query Layer guide](../usage/query-layer.md)
+- [Cache System Reference](../reference/cache.md) — Field Mapping section

--- a/docs/decisions/0009-sql-table-storage.md
+++ b/docs/decisions/0009-sql-table-storage.md
@@ -67,9 +67,11 @@ model field definitions:
 
 - Issue #309: feat: per-model SQL table storage for cache layer
 - Issue #301: feat: field annotations, OpenAPI codegen, and SQL cache storage
+- Issue #479: doc: refresh cache architecture documentation
 
 ## Related Documentation
 
 - Cache module: `src/pynetappfoundry/cache/`
+- [Cache System Reference](../reference/cache.md) — Storage Architecture section documents the per-model SQL table layout
 - ADR-0001: [Use SQLite for cluster metadata caching](0001-use-sqlite-for-cluster-metadata-caching.md)
 - ADR-0003: [Base SQLiteDB class with version-based migrations](0003-use-base-sqlitedb-class-with-version-based-migrations.md)

--- a/docs/decisions/0011-nested-models-to-replace-flat-model-pattern.md
+++ b/docs/decisions/0011-nested-models-to-replace-flat-model-pattern.md
@@ -95,7 +95,9 @@ The codegen tool (ADR-0008) can leverage `datamodel-code-generator` more directl
 - Issue #443: refactor: fix all sub-model transforms to use declarative field mapping (superseded)
 - Issue #440: fix: HTML report bugs - missing data, title formatting, cloud section placement (catalyst)
 - Issue #447: refactor: simplify or remove FieldMapping after nested model migration
+- Issue #479: doc: refresh cache architecture documentation
 
 ## Related Documentation
 
 - [Field Mapping Framework Developer Guide](../development/field-mapping.md)
+- [Cache System Reference](../reference/cache.md) — Nested Models Pattern section

--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -1,69 +1,454 @@
+---
+title: Cache System
+description: Architecture, storage layout, lazy loading, and CLI for the cluster metadata cache
+audience:
+  - users
+  - contributors
+tags:
+  - reference
+  - cache
+  - sqlite
+  - ontap
+---
+
 # Cache System
 
-The cache system stores ONTAP cluster metadata locally to enable fast lookups without
-repeatedly querying clusters. This document covers the cache architecture, schema
-versioning, history tracking, and maintenance.
+The cache system stores ONTAP cluster metadata locally so that lookups, reports,
+and queries can run without re-hitting every cluster on every command. This
+document covers the cache architecture, the per-model SQL storage layout,
+schema versioning and migrations, lazy loading with on-demand fetch, the field
+mapping framework, the OpenAPI codegen pipeline, history tracking, the CLI,
+and the public API.
 
 ## Overview
 
-The cache system consists of three main components:
+The cache system is composed of three storage layers and three runtime
+components:
 
-1. **ClusterMetadataDB** - Main cache storing current cluster metadata
-2. **CacheHistoryDB** - History database tracking changes over time
-3. **MetadataCollector** - Collects metadata from ONTAP clusters
+1. **`ClusterMetadataDB`** — Per-model SQLite tables holding the current
+   cached snapshot for each cluster (see [Storage Architecture](#storage-architecture)).
+2. **`CacheHistoryDB`** — Append-only history of changes between snapshots,
+   stored in a separate SQLite file for data isolation.
+3. **`MetadataCollector`** — All-or-nothing collector that pulls metadata from
+   ONTAP REST and (optionally) the CLI and produces a `CachedClusterMetadata`.
+4. **`LazyClusterMetadata`** — Lazy proxy returned by
+   `ClusterMetadataDB.get_lazy()`. Defers per-field-group SQL queries until
+   the caller actually touches a data attribute.
+5. **`FieldGroupFetcher`** — Optional live API/CLI fallback used when a lazy
+   proxy is asked for data that is missing from the cache database.
+6. **Field mapping framework (`FieldMapping` / `TypeMapping`)** — Declarative
+   metadata that drives both the collector (what to fetch, what to persist)
+   and the codegen pipeline.
 
 ```
-┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
-│  ONTAP Cluster  │────▶│ MetadataCollector│────▶│ ClusterMetadata │
-└─────────────────┘     └──────────────────┘     │       DB        │
-                                │                └─────────────────┘
-                                │
-                                ▼
-                        ┌──────────────────┐
-                        │  CacheHistoryDB  │
-                        └──────────────────┘
+                                    +----------------------+
++-----------------+                 |  ClusterMetadataDB   |
+|  ONTAP Cluster  |--+              |  (per-model tables)  |
++-----------------+  |              |                      |
+                     |  +---------+ |  envelope            |
+                     +->|Collector|>|  + ontapvolume       |
+                     |  +---------+ |  + ontapsvm          |
+                     |              |  + ontapipinterface  |
+                     |              |  + ...               |
+                     |              +----------+-----------+
+                     |                         |
+                     |              +----------v-----------+
+                     |              |  LazyClusterMetadata |
+                     |              |  (per-field-group    |
+                     |              |   deferred load)     |
+                     |              +----------+-----------+
+                     |                         | cache miss
+                     |              +----------v-----------+
+                     +------------->|  FieldGroupFetcher   |
+                                    |  (live API/CLI)      |
+                                    +----------------------+
 ```
 
 ## Database Files
 
-Both databases are SQLite files stored in the config directory:
+Both databases are SQLite files stored in the user's config directory:
 
 | Database | File | Purpose |
 |----------|------|---------|
-| ClusterMetadataDB | `{config_dir}/.cache/cluster_metadata.db` | Current cache |
-| CacheHistoryDB | `{config_dir}/.cache/cache_history.db` | Change history |
+| `ClusterMetadataDB` | `{config_dir}/.cache/cluster_metadata.db` | Current per-cluster snapshot |
+| `CacheHistoryDB` | `{config_dir}/.cache/cache_history.db` | Append-only change history |
 
-## Schema Architecture
+!!! info "User-facing access guide"
+    For a task-oriented walkthrough of the three ONTAP access patterns
+    (cache, lazy proxy, live), see
+    [ONTAP Access Patterns](../usage/ontap-access-patterns.md).
 
-### CachedClusterMetadata Model
+## Storage Architecture
 
-The `CachedClusterMetadata` Pydantic model defines the structure of cached data:
+The cache database is **not** a single JSON blob. Per ADR-0009, each storable
+Pydantic model in `CachedClusterMetadata` gets its own SQLite table, generated
+at import time from the model's field definitions.
 
-```python
-class CachedClusterMetadata(CacheModel, register=False):
-    # Cache metadata
-    cluster_name: str
-    cached_at: datetime
-    cache_version: str = "1.0"  # Schema version
+### Table registry
 
-    # Data categories
-    cloud: list[CloudMetadata]                          # Cloud provider info per node
-    cluster: ClusterInfo                                # Cluster identity
-    nodes: list[OntapNodeResponse]                      # Node information
-    network: NetworkInfo                                 # IP interfaces, broadcast domains, DNS, subnets
-    storage: StorageInfo                                 # Aggregates, SVMs, volumes, LUNs, etc.
-    license_packages: list[OntapLicensePackageResponse]  # License information
-    mediator: OntapMediatorResponse                      # ONTAP Mediator configuration
-    relationships: RelationshipsInfo                     # SnapMirror, cluster/SVM peering
-    protocols: ProtocolsInfo                             # Export policies, CIFS, NFS, S3
+`ClusterMetadataDB` builds a `TABLE_REGISTRY` (`db.py:_ensure_registry`) by
+walking `CachedClusterMetadata.model_fields`
+(`db_schema.build_table_registry`):
+
+- `list[Model]` fields at the top level (e.g. `nodes`, `cloud`,
+  `license_packages`) become a single table per item type.
+- Singleton `Model` fields that contain only scalars (e.g. `cluster`,
+  `mediator`) become a singleton table.
+- Container models with `list[Model]` sub-fields (e.g. `StorageInfo`,
+  `NetworkInfo`, `ProtocolsInfo`, `RelationshipsInfo`) are **not** stored as
+  tables themselves. The walker descends into them and registers each list
+  child as its own table. The container is only registered as a singleton if
+  it has additional non-list scalar fields (e.g. `NetworkInfo.ipspaces:
+  list[str]`).
+
+Each entry in the registry is a `TableSpec` with the SQL table name (the
+lowercased model class name), the model class, the dot-path on
+`CachedClusterMetadata` (e.g. `"storage.volumes"`), an `is_list` flag, and a
+`has_uuid` flag.
+
+### Envelope table
+
+A small fixed envelope table holds one row per cluster with the cache
+metadata. This is the entry point used by `get`, `get_lazy`, `is_stale`,
+`list_clusters`, and `get_status` (which need only the envelope, not the full
+data set):
+
+```sql
+CREATE TABLE cluster_metadata (
+    cluster_name TEXT PRIMARY KEY,
+    cached_at TEXT NOT NULL,
+    cache_version TEXT NOT NULL
+)
 ```
 
-### UUID Cross-Reference Index
+### Per-model table layout
 
-`CachedClusterMetadata` exposes a `uuid_index` cached property that builds a flat
-`dict[str, HasUUID]` mapping UUID strings to their corresponding model objects across
-all 18 UUID-bearing types. This enables O(1) resolution of foreign-key UUID references
-stored in cache objects.
+Per-model tables are generated by `db_schema.generate_table_ddl()`. Each table
+has:
+
+- A `cluster_name TEXT NOT NULL` column (omitted if the model itself defines
+  `cluster_name`).
+- An auto-incrementing `_row_id INTEGER PRIMARY KEY AUTOINCREMENT`.
+- One column per Pydantic field, quoted to dodge SQLite reserved words. SQL
+  types are derived from the Python annotation: `str` and `OntapUUID` →
+  `TEXT`, `int` and `bool` → `INTEGER`, `float` → `REAL`, `datetime` → `TEXT`,
+  and any `list`, `dict`, or nested `BaseModel` field → `TEXT` storing JSON.
+- An `_extra_json TEXT DEFAULT NULL` column at the end that captures
+  `extra="allow"` fields from newer ONTAP versions for forward compatibility.
+
+Two indices are created per table: `idx_{table}_cluster` on `cluster_name`
+(always), and `idx_{table}_uuid` on `(cluster_name, uuid)` if the model has a
+`uuid` field.
+
+!!! note "Why `_row_id` is the primary key"
+    Many ONTAP objects have empty or missing UUIDs in test fixtures and on
+    fresh clusters. Using a synthetic auto-increment PK avoids unique-key
+    collisions and lets the cache store multiple anonymous rows per cluster
+    without ad-hoc disambiguation.
+
+### Read and write paths
+
+- **Write** (`set`): the envelope row is upserted, then `_delete_model_data`
+  clears all per-cluster rows from every model table inside a single
+  transaction, then `_insert_model_data` walks the registry and inserts new
+  rows for each table. Each row goes through `_model_to_row` which serialises
+  list/dict/sub-model fields to JSON, coerces booleans to `0/1`, and
+  collects extra fields into `_extra_json`.
+- **Read** (`get` / `get_lazy`): the envelope row is fetched first.
+  `get` then calls `_reconstruct_metadata`, which delegates to
+  `_query_registry_subset` to query every table and rebuild the full
+  `CachedClusterMetadata`. `get_lazy` skips the data queries entirely and
+  returns a [`LazyClusterMetadata`](#lazy-loading-and-on-demand-fetch) proxy.
+- **Query** (`query_model`, `query_with_filters`): targeted SQL against a
+  single per-model table. See [Public API Reference](#public-api-reference).
+
+## Schema Versioning and Migrations
+
+Two version constants live in `cache/_base.py`:
+
+```python
+METADATA_SCHEMA_VERSION = "2.0"        # current cache_version on new snapshots
+METADATA_SCHEMA_MIN_COMPATIBLE = "2.0" # oldest version that can be loaded
+```
+
+`METADATA_SCHEMA_VERSION` is the data-model version stamped into each
+snapshot's envelope row as `cache_version`. The `MAJOR.MINOR` format follows
+semantic versioning: bump MINOR for backward-compatible additions (new
+optional fields), bump MAJOR for breaking changes (removed/renamed fields,
+type changes).
+
+`is_schema_compatible(snapshot_version)` returns `True` only if the snapshot
+is at or above `METADATA_SCHEMA_MIN_COMPATIBLE`. When the cache layer loads a
+historical snapshot it uses this check to decide whether the snapshot can be
+deserialised against the current Pydantic models.
+
+### Snapshot schema version history
+
+| `cache_version` | Changes |
+|-----------------|---------|
+| `2.0` | Renamed cache fields to match the ONTAP REST URL hierarchy: `network.lifs` → `network.ip_interfaces`, `network.broadcast_domains` → `network.ethernet_broadcast_domains`, `network.subnets` → `network.ip_subnets`, `protocols.export_policies` → `protocols.nfs_export_policies`. |
+| `1.0` | Initial schema with comprehensive model coverage. |
+
+### SQLite database schema versioning
+
+In addition to the `cache_version` stamped into each snapshot,
+`ClusterMetadataDB` tracks the **on-disk SQLite schema** version through the
+shared `SQLiteDB` base class. The current value is `SCHEMA_VERSION = 4`, and
+the DB applies the following upgrades on open:
+
+| DB schema | Migration | What it does |
+|-----------|-----------|--------------|
+| `v1` → `v2` | `_upgrade_to_v2` | Reads the old `metadata_json` blob, decomposes each cluster into per-model tables (ADR-0009), then drops the JSON column from the envelope table. |
+| `v2` → `v3` | `_upgrade_to_v3` | Drops the unused `_uuid_index` table. UUID resolution moved to the in-memory `CachedClusterMetadata.uuid_index` cached property (ADR-0005). |
+| `v3` → `v4` | `_upgrade_to_v4` | Drops and recreates every per-model table to switch column names from the old flat naming (`ip_address`) to the new nested-model layout (`ip` stored as JSON), per ADR-0011. The envelope is cleared so callers detect a missing snapshot and trigger a fresh collection. |
+
+!!! warning "v3 → v4 is destructive"
+    The v4 migration deletes existing cached rows. After upgrading,
+    `nf cache refresh` (or `--all`) must be run to repopulate the cache.
+
+## Lazy Loading and On-Demand Fetch
+
+Loading the full `CachedClusterMetadata` requires hitting every per-model
+table. For commands that only need one slice of the data (e.g. just
+`storage.volumes`), this is wasteful. `LazyClusterMetadata` defers the SQL
+queries until the caller actually touches a data attribute.
+
+### `LazyClusterMetadata`
+
+Returned by `ClusterMetadataDB.get_lazy(cluster_name)`. The proxy is **not** a
+Pydantic model — it is a thin object stored in `__slots__` with three
+envelope properties (`cluster_name`, `cached_at`, `cache_version`) populated
+eagerly from the envelope row, plus a `_loaded` cache for materialised field
+groups.
+
+The nine top-level data field names — `cloud`, `cluster`, `nodes`, `network`,
+`storage`, `license_packages`, `mediator`, `relationships`, `protocols` —
+form `_DATA_FIELDS`. Access goes through `__getattr__`, which calls
+`_load_field_group(name)` on first read and caches the result for subsequent
+reads.
+
+### `_load_field_group` fallback chain
+
+`_load_field_group` tries three sources in order and returns the first one
+that produces a value:
+
+1. **Cache database** (`_load_from_db`). Skipped when the proxy was created
+   without a `db_path`. Uses `_query_registry_subset` against a registry
+   subset filtered to the current field group (path equal to *name* or
+   prefixed with `name.`).
+2. **Live fetcher** (`FieldGroupFetcher.fetch`). Skipped when no fetcher is
+   attached. Maps the field group to a `MetadataCollector` method via
+   `_FIELD_GROUP_METHODS` (e.g. `"storage"` → `collect_storage`) and runs the
+   live API/CLI collection for that group only.
+3. **Model default** (`_get_default`). Returns the
+   `CachedClusterMetadata.model_fields[name]` default factory (or `default`),
+   so callers get an empty container instead of `None`.
+
+If the resolved value is a plain `dict` and the target field is a nested
+Pydantic container, it is validated via `model_class.model_validate(value)`
+before being cached.
+
+### Materialisation
+
+Calling `_materialize()` forces all nine field groups to load and returns a
+real `CachedClusterMetadata`. The `to_flat_dict`, `uuid_index`, `model_dump`,
+and `model_dump_json` methods on the proxy go through `_materialize()`, so
+using any of them triggers a full load.
+
+`is_stale(ttl_days=30)` is the only delegated method that does **not**
+materialise — it computes age from the envelope `cached_at` directly.
+
+### `FieldGroupFetcher`
+
+`FieldGroupFetcher` (in `cache/_fetcher.py`) provides the live fallback. It
+takes a cluster name, the cluster IP, and a `Config`, and lazily creates the
+ONTAP API client, the ONTAP CLI client, and a `MetadataCollector` on first
+`fetch()` call. Failure modes (missing credentials, unreachable cluster) are
+swallowed and logged at debug level — `fetch()` returns `None` and the
+fallback chain proceeds to the model default.
+
+!!! info "User-facing equivalent"
+    The user-facing guide for choosing between `get`, `get_lazy`, and the
+    direct API client lives in
+    [ONTAP Access Patterns](../usage/ontap-access-patterns.md).
+
+## Field Mapping Framework
+
+The collector and the cache write path are both driven by **field mappings**
+(see ADR-0004). Each ONTAP object type has a `TypeMapping` and one
+`FieldMapping` per model attribute. The full developer guide lives in
+[Field Mapping Framework](../development/field-mapping.md) and the user-facing
+query syntax in [Query Layer](../usage/query-layer.md). This section covers
+only the cache-relevant aspects.
+
+`FieldMapping` carries a `cache_strategy` literal that controls how the
+collector and cache treat the field:
+
+| Strategy | Collected during bulk refresh | Persisted to SQLite | Notes |
+|----------|------------------------------|---------------------|-------|
+| `"cache"` (default) | Yes | Yes | Standard cached field. |
+| `"realtime"` | No | No | Skipped on cache write, fetched live per-object on demand. |
+| `"derived"` | No directly | Yes (after post-collection) | Computed from other fields by `post_collection` callbacks once all phases finish. |
+
+`TypeMapping` exposes three convenience accessors backed by these flags:
+
+- `cached_fields()` — fields with `cache_strategy="cache"`.
+- `realtime_fields()` — fields with `cache_strategy="realtime"`.
+- `derived_fields()` — fields with `cache_strategy="derived"`.
+
+The collector uses `parse_api_record(..., skip_realtime=True)` to drop
+realtime and derived fields when building model instances destined for the
+cache, so volatile metrics never leave the live API path.
+
+## Realtime Field Handling
+
+`cache_strategy="realtime"` means a field is excluded **at the database write
+boundary**. The exclusion path is:
+
+1. `realtime_attrs(model_class)` (`db.py`) calls
+   `model_registry.get_mapping(model_class.__name__)` and returns the set of
+   `cache_attr` names whose mapping has `cache_strategy="realtime"`. The
+   result is `functools.cache`-memoised per class.
+2. `_insert_model_data` looks up that set once per model spec and passes it
+   as `exclude` to `_model_to_row` for every row.
+3. `_model_to_row` checks `if field_name in exclude: continue` while
+   building the row dict, so realtime fields never become SQL columns
+   during INSERT.
+
+A second helper, `all_realtime_attrs()`, returns the union across **every**
+registered model — used elsewhere when a global filter is needed.
+
+### Concrete example
+
+If `OntapVolume` defines `space_used` with `cache_strategy="realtime"`:
+
+- A `nf cache refresh` inserts an `ontapvolume` row with no value in the
+  `space_used` column (the column still exists in the table — only the value
+  is omitted at write time, so the row reads back as `None` and the field
+  falls through to the model default on `_row_to_model`).
+- A subsequent `db.get(...).storage.volumes[0].space_used` returns the model
+  default (empty string / zero) unless a `LazyClusterMetadata` proxy with an
+  attached `FieldGroupFetcher` is used to refresh the field live.
+
+## OpenAPI Codegen Pipeline
+
+Most `Ontap*Response` models in the [Model Reference](#model-reference) are
+**generated** from the ONTAP OpenAPI 3.0 spec rather than written by hand.
+The codegen tool lives at `tools/codegen/openapi_codegen.py`.
+
+### Inputs and outputs
+
+```bash
+uv run python tools/codegen/openapi_codegen.py \
+    --spec docs/example-config/apis/ontap/openapi3.json \
+    --output src/pynetappfoundry/cache/ontap/ \
+    --api-type ontap
+```
+
+- **Input**: an OpenAPI 3.0 JSON spec
+  (`docs/example-config/apis/ontap/openapi3.json` for ONTAP).
+- **Output**: per-endpoint module trees under
+  `src/pynetappfoundry/cache/ontap/<api-path>/` containing a generated
+  `model.py` (the Pydantic model class), `mapping.py` (the `TypeMapping` and
+  `FieldMapping` definitions), and one or more `*.toml` overlay files for
+  field strategy overrides.
+- `--api-type` selects the API tag (`ontap`, `aiqum`, `dii`, `occm`).
+- `--endpoints` filters generation to a specific list of paths.
+- `--dry-run` prints the plan without writing files.
+
+### Endpoint deduplication
+
+Two OpenAPI endpoints frequently resolve to the same module path — for
+example `/storage/volumes` (the list endpoint) and
+`/storage/volumes/{uuid}` (the get-by-id endpoint) both map to
+`storage/volumes`. `_deduplicate_endpoints` groups endpoints by their target
+module path and keeps the candidate with the most leaf fields (the richer
+schema), so the generated model is always the union view.
+
+### Doit task wrapper
+
+A doit task in `tools/doit/codegen.py` wraps the same entry point so the
+codegen can be run via `doit` alongside the rest of the build. Run `doit
+list` to discover the current task name.
+
+## Nested Models Pattern
+
+Per ADR-0011, all cache models use **nested sub-objects that mirror the
+ONTAP REST API response shape** rather than flat attributes with dot-encoded
+names. This means user code can write `iface.ip.address` instead of the older
+`iface.ip_address`, matching the API documentation directly.
+
+```python
+# Before (flat)
+class OntapSvmIpInterface(OntapModel):
+    ip_address: str = ""
+    ip_netmask: str = ""
+    location_home_node_name: str = ""
+
+# After (nested)
+class OntapSvmIpInterface(OntapModel):
+    class Ip(OntapModel):
+        address: str = ""
+        netmask: str = ""
+    class Location(OntapModel):
+        class HomeNode(OntapModel):
+            name: str = ""
+        home_node: HomeNode = HomeNode()
+    ip: Ip = Ip()
+    location: Location = Location()
+```
+
+### Cache-boundary translation
+
+The cache layer is the only consumer that needs a flat representation. The
+translation happens at the SQL boundary:
+
+- **Write**: `_model_to_row` serialises each nested sub-model field to a JSON
+  string in its own `TEXT` column (because `_is_json_column` returns `True`
+  for `BaseModel` annotations).
+- **Read**: `_row_to_model` reverses the process, parsing the JSON column
+  back into a `dict` that Pydantic validates into the nested sub-model when
+  reconstructing the parent model.
+
+This is why the v3 → v4 migration drops and recreates every per-model table:
+the column names changed from flat (`ip_address`) to nested
+(`ip` storing JSON).
+
+## CachedClusterMetadata Reference
+
+The root cache container is `CachedClusterMetadata` (in
+`cache/_metadata.py`). It carries three envelope fields and nine data field
+groups:
+
+```python
+class CachedClusterMetadata(CacheModel):
+    # Envelope
+    cluster_name: str
+    cached_at: datetime = Field(default_factory=_utcnow)
+    cache_version: str = METADATA_SCHEMA_VERSION
+
+    # Data field groups
+    cloud: list[CloudMetadata] = Field(default_factory=list)
+    cluster: ClusterInfo = Field(default_factory=ClusterInfo)
+    nodes: list[OntapNodeResponse] = Field(default_factory=list)
+    network: NetworkInfo = Field(default_factory=NetworkInfo)
+    storage: StorageInfo = Field(default_factory=StorageInfo)
+    license_packages: list[OntapLicensePackageResponse] = Field(default_factory=list)
+    mediator: OntapMediatorResponse = Field(default_factory=OntapMediatorResponse)
+    relationships: RelationshipsInfo = Field(default_factory=RelationshipsInfo)
+    protocols: ProtocolsInfo = Field(default_factory=ProtocolsInfo)
+```
+
+`is_stale(ttl_days=30)` reports staleness from `cached_at`. `to_flat_dict()`
+returns a flat dictionary of commonly-merged fields used by report and
+template code paths.
+
+### UUID cross-reference index
+
+`CachedClusterMetadata.uuid_index` is a `cached_property` that builds a flat
+`dict[str, HasUUID]` mapping UUID strings to their corresponding model
+objects across all UUID-bearing types in the snapshot. This enables O(1)
+resolution of foreign-key UUID references stored in cache objects.
 
 ```python
 cached = cache_db.get("cluster-name")
@@ -78,63 +463,41 @@ for rel in cached.relationships.snapmirror_destinations:
         print(f"{rel.destination_path} uses schedule: {schedule.name}")
 ```
 
-The index is built lazily on first access and cached for the lifetime of the object.
-UUID-bearing types are discovered automatically via introspection — new types with a
-`uuid: str` field are picked up with no manual registration. Objects with empty UUID
-strings are excluded. The index does not appear in `model_dump()` or `model_dump_json()`
-output.
-
-### Schema Version Tracking
-
-The cache uses semantic versioning to track schema compatibility:
-
-```python
-# Current schema version
-METADATA_SCHEMA_VERSION = "1.0"
-
-# Minimum version that can be loaded without migration
-METADATA_SCHEMA_MIN_COMPATIBLE = "1.0"
-```
-
-**Version Format:** `MAJOR.MINOR`
-
-- **MAJOR** - Increment for breaking changes (removed fields, type changes)
-- **MINOR** - Increment for backward-compatible changes (new optional fields)
-
-### Schema Version History
-
-| Version | Changes |
-|---------|---------|
-| 2.0 | Rename cache fields to match ONTAP API endpoint hierarchy: `network.lifs` -> `network.ip_interfaces`, `network.broadcast_domains` -> `network.ethernet_broadcast_domains`, `network.subnets` -> `network.ip_subnets`, `protocols.export_policies` -> `protocols.nfs_export_policies` |
-| 1.0 | Initial schema with comprehensive model coverage |
+The index is built lazily on first access and cached for the lifetime of the
+object. UUID-bearing types are discovered automatically via introspection —
+walking model fields and nested `BaseModel` containers and indexing any list
+item that satisfies the `HasUUID` protocol. Objects with empty UUID strings
+are excluded. The index does not appear in `model_dump()` or
+`model_dump_json()` output. See ADR-0005 for the rationale.
 
 ## History Tracking
 
-### How It Works
+### How it works
 
 Every time `nf cache refresh` runs:
 
-1. Load the previous snapshot from history (if exists)
-2. Check schema compatibility
-3. Collect new metadata from the cluster
-4. Compute diff between old and new metadata
-5. If changes detected (or initial capture), record in history
-6. Update the main cache
+1. Load the previous snapshot from history (if any).
+2. Check schema compatibility via `is_schema_compatible`.
+3. Collect new metadata from the cluster.
+4. Compute the diff between old and new metadata.
+5. If changes are detected (or this is the initial capture), record the
+   change in `CacheHistoryDB`.
+6. Update the main cache via `ClusterMetadataDB.set`.
 
-### Change Records
+### Change records
 
-Each history record contains:
+Each row in the `cache_changes` table contains:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | INTEGER | Auto-incrementing ID |
-| `cluster_name` | TEXT | Cluster identifier |
-| `changed_at` | TEXT | ISO timestamp of change |
-| `before_json` | TEXT | Previous metadata (NULL for initial) |
-| `after_json` | TEXT | New metadata snapshot |
-| `summary_json` | TEXT | List of changes (added/removed/modified) |
+| `id` | `INTEGER` | Auto-incrementing primary key |
+| `cluster_name` | `TEXT` | Cluster identifier |
+| `changed_at` | `TEXT` | ISO timestamp of the change |
+| `before_json` | `TEXT` | Previous metadata snapshot, `NULL` for the initial capture |
+| `after_json` | `TEXT` | New metadata snapshot |
+| `summary_json` | `TEXT` | List of change entries (added / removed / modified) |
 
-### Diff Summary Format
+### Diff summary format
 
 Changes are tracked as a list of change entries:
 
@@ -163,7 +526,7 @@ Changes are tracked as a list of change entries:
 
 ## CLI Commands
 
-### Refresh Cache
+### Refresh cache
 
 ```bash
 # Refresh single cluster
@@ -179,13 +542,13 @@ nf cache refresh --all -f '{"env": "Prod"}'
 nf cache refresh --all -v
 ```
 
-### View History
+### View history
 
 ```bash
 # List all change history
 nf cache history list
 
-# List history for specific cluster
+# List history for a specific cluster
 nf cache history list cluster1
 
 # Filter by date range
@@ -195,7 +558,7 @@ nf cache history list --since 2024-01-01 --until 2024-06-30
 nf cache history list -n 50 --offset 20
 ```
 
-### View Change Details
+### View change details
 
 ```bash
 # Show full change details
@@ -207,32 +570,130 @@ nf cache history show 5 --json
 # Show formatted diff
 nf cache history diff 5
 
-# Filter diff to specific category
+# Filter diff to a specific category
 nf cache history diff 5 -c nodes
 nf cache history diff 5 -c storage.aggregates
 ```
 
-### Point-in-Time Snapshots
+### Point-in-time snapshots
 
 ```bash
-# View cache state at specific date
+# View cache state at a specific date
 nf cache history snapshot cluster1 --date 2024-01-15
 
 # Get full JSON snapshot
 nf cache history snapshot cluster1 -d 2024-06-01T12:00:00 --json
 
-# Restore cache to previous state
+# Restore cache to a previous state
 nf cache history snapshot cluster1 -d 2024-01-15 --restore
+```
+
+### Query cached data (`nf cache check`)
+
+`nf cache check` runs ad-hoc filter expressions against cached model data
+using the same filter language as `query_with_filters`. Exit codes follow
+grep conventions (0 = no matches, 1 = matches found, 2 = error), which
+makes it suitable for CI scripts.
+
+```bash
+# Find volumes where autosize mode is not grow_shrink on one cluster
+nf cache check cluster1 storage.volumes \
+    -w "autosize.mode != 'grow_shrink'" \
+    -F name,svm.name,autosize.mode
+
+# Check all cached clusters, JSON output
+nf cache check --all nodes -w "model = 'FAS8200'" --json
+
+# Filter clusters first with --filter (-f), then run the data check
+nf cache check -f '{"env":"Prod"}' storage.volumes \
+    -w "size > 1073741824" --count
+```
+
+### Compliance checks (`nf cache compliance`)
+
+`nf cache compliance` evaluates compliance rules (defined in TOML config)
+against cached cluster metadata. Each rule specifies a model and a filter
+expression; any matching records are reported as violations. Exit codes
+match `nf cache check` (0 = clean, 1 = violations, 2 = error).
+
+```bash
+# Run all compliance rules against one cluster
+nf cache compliance cluster1
+
+# Run against every cached Prod cluster, errors only
+nf cache compliance --all -f '{"env":"Prod"}' -s error
+
+# Run a single named rule
+nf cache compliance --all -k vol_autosize
+```
+
+Both `check` and `compliance` are driven by the cache query engine — they
+never hit live ONTAP, so they are safe to run in tight loops against the
+cached snapshot.
+
+### Field projection (`nf cache query`)
+
+`nf cache query` retrieves a specific set of field paths from cached
+snapshots, across one or many clusters, with CSV/JSON/table output.
+
+```bash
+nf cache query --all storage.volumes -F name,svm.name,size
+```
+
+### Raw cache views (`nf cache show` and `nf cache inspect`)
+
+`nf cache show` pretty-prints the cached snapshot for a cluster as a
+tree, optionally filtered to one section. `nf cache inspect` compares
+cache, live CLI, and live API data for a single named object — useful
+for debugging field-mapping issues.
+
+```bash
+nf cache show cluster1
+nf cache show cluster1 storage.volumes --json
+nf cache inspect cluster1 volume-name storage.volumes
+```
+
+### Schema view (`nf cache schema`)
+
+`nf cache schema` renders the current `CachedClusterMetadata` schema as a
+tree (or flat list) of field paths and Python types. Useful for
+discovering valid paths for `query`, `check`, and `history diff -c`.
+
+```bash
+nf cache schema
+nf cache schema --flat
+nf cache schema --json
+```
+
+### Cluster cache status (`nf cache status`)
+
+`nf cache status` lists every cluster currently in the cache with its
+`cached_at` timestamp, age, and stale flag (relative to a configurable
+TTL).
+
+```bash
+nf cache status
+nf cache status --ttl 7
+```
+
+### Clearing the cache (`nf cache clear`)
+
+`nf cache clear` removes cached rows for a single cluster or every
+cluster. Cached history is **not** touched.
+
+```bash
+nf cache clear cluster1         # Single cluster (prompts for confirmation)
+nf cache clear --all --force    # All clusters, no prompt
 ```
 
 ## Schema Compatibility
 
-### Compatibility Checking
+### Compatibility checking
 
 When loading historical snapshots, the system checks schema compatibility:
 
 ```python
-from pynetappfoundry.cache import is_schema_compatible
+from pynetappfoundry.cache import is_schema_compatible, CachedClusterMetadata
 
 # Check if a snapshot version can be loaded
 if is_schema_compatible(snapshot_data.get("cache_version")):
@@ -242,262 +703,270 @@ else:
     pass
 ```
 
-### What Happens with Incompatible Schemas
+### What happens with incompatible schemas
 
-| Operation | Incompatible Schema Behavior |
+| Operation | Incompatible schema behaviour |
 |-----------|------------------------------|
 | `cache refresh` | Treats as initial capture, logs warning |
 | `history snapshot --restore` | Rejects with error message |
 | `history show --json` | Returns raw JSON (no validation) |
 | `history diff` | Shows summary from stored data |
 
-## Keeping Schemas in Sync
+## Schema Update Checklist
 
-### When to Update Schema Version
+When modifying the cache schema, work through this checklist:
 
-Update `METADATA_SCHEMA_VERSION` when modifying `CachedClusterMetadata`:
+1. **Update the model** in the appropriate
+   `src/pynetappfoundry/models/<api-type>/<api-path>/model.py` file. Use
+   nested sub-models per ADR-0011.
+2. **Decide the strategy for any new field** — `cache`, `realtime`, or
+   `derived`. Update the corresponding `FieldMapping` (or TOML overlay) so
+   the collector and cache write path agree.
+3. **Update the snapshot schema version** in `cache/_base.py` if the change
+   is observable in stored snapshots:
 
-| Change Type | Version Update | Example |
-|-------------|----------------|---------|
-| Add optional field | Increment MINOR | Add `new_field: str = ""` |
-| Add required field | Increment MAJOR | Add `new_field: str` (no default) |
-| Remove field | Increment MAJOR | Delete existing field |
-| Rename field | Increment MAJOR | `old_name` → `new_name` |
-| Change field type | Increment MAJOR | `count: int` → `count: str` |
-| Change nested model | Depends on change | Follow same rules recursively |
+    ```python
+    METADATA_SCHEMA_VERSION = "2.1"  # MINOR for additive
+    # or
+    METADATA_SCHEMA_VERSION = "3.0"  # MAJOR for breaking
+    ```
 
-### Schema Update Checklist
+4. **Update minimum compatible version** if the change is breaking:
 
-When modifying the cache schema:
+    ```python
+    METADATA_SCHEMA_MIN_COMPATIBLE = "3.0"
+    ```
 
-1. **Update the model** in the appropriate `src/pynetappfoundry/models/<api-type>/<api-path>/model.py` file
+5. **Document the change** in the
+   [Snapshot schema version history](#snapshot-schema-version-history)
+   table above.
+6. **Bump the SQLite schema version** (`ClusterMetadataDB.SCHEMA_VERSION`)
+   and add an `_upgrade_to_vN` method if the **on-disk column layout** has
+   to change. The v3 → v4 migration is the reference example for a
+   destructive recreate-and-clear migration.
+7. **Update the collector** (`src/pynetappfoundry/cache/collector.py`) if
+   new fields need to be populated.
+8. **Diff logic updates automatically** — tracked fields are derived at
+   runtime from each model's `model_fields`, so new fields on cache models
+   are picked up without manual changes to
+   `src/pynetappfoundry/cache/diff.py`.
+9. **Add tests** for new fields in `tests/unit/cache/`.
+10. **Run the full check suite**:
 
-2. **Update version constant**:
-   ```python
-   METADATA_SCHEMA_VERSION = "1.1"  # or "2.0" for breaking changes
-   ```
+    ```bash
+    doit check
+    ```
 
-3. **Update minimum compatible version** (if breaking):
-   ```python
-   METADATA_SCHEMA_MIN_COMPATIBLE = "1.1"
-   ```
+### Migration strategies
 
-4. **Document the change** in the Schema Version History table (in `base.py` docstring and this document)
-
-5. **Update collector** if new fields need to be populated:
-   - `src/pynetappfoundry/cache/collector.py`
-
-6. **Diff logic updates automatically** — tracked fields are derived at runtime from
-   each model's `model_fields`, so new fields on cache models are picked up without
-   manual changes to `src/pynetappfoundry/cache/diff.py`.
-
-7. **Add tests** for new fields:
-   - `tests/unit/cache/test_models.py`
-   - `tests/unit/cache/test_diff.py`
-
-8. **Run full test suite**:
-   ```bash
-   doit check
-   ```
-
-### Migration Strategies
-
-For future breaking schema changes, consider these strategies:
-
-#### Option 1: Clean Break (Recommended for Major Changes)
+#### Option 1: Clean break (recommended for major changes)
 
 Set `METADATA_SCHEMA_MIN_COMPATIBLE` to the new version. Old snapshots
 become read-only (viewable via `--json` but not restorable).
 
 ```python
-METADATA_SCHEMA_VERSION = "2.0"
-METADATA_SCHEMA_MIN_COMPATIBLE = "2.0"
+METADATA_SCHEMA_VERSION = "3.0"
+METADATA_SCHEMA_MIN_COMPATIBLE = "3.0"
 ```
 
-#### Option 2: Migration Function (For Recoverable Changes)
+#### Option 2: Migration function (for recoverable changes)
 
 Add migration logic when loading old snapshots:
 
 ```python
 def migrate_snapshot(data: dict, from_version: str) -> dict:
-    """Migrate snapshot data to current schema."""
+    """Migrate snapshot data to the current schema."""
     major, minor = parse_schema_version(from_version)
     # Add migration steps as needed
     data["cache_version"] = METADATA_SCHEMA_VERSION
     return data
 ```
 
-## Troubleshooting
-
-### Common Issues
-
-#### "Incompatible schema version" Error
-
-**Cause:** Trying to restore a snapshot created with an older schema version.
-
-**Solution:**
-- Use `--json` to view the raw data
-- Manually extract needed information
-- Or refresh the cache to create a new snapshot
-
-#### History Not Recording Changes
-
-**Cause:** Cache refresh completed but no history entry created.
-
-**Explanation:** History is only recorded when:
-- It's the initial capture (no previous snapshot)
-- Changes are detected between old and new metadata
-
-If metadata is identical, no history entry is created.
-
-#### Large History Database
-
-**Cause:** Many clusters with frequent changes.
-
-**Solution:** History is append-only by design. To manage size:
-- Query with `--limit` and `--offset` for pagination
-- Consider periodic archival of old records (manual process)
-
-### Debugging
-
-Enable debug logging to see cache operations:
-
-```bash
-# Verbose refresh shows phase timings
-nf cache refresh cluster1 -v
-
-# Check log file for detailed information
-# Log path is shown at start of refresh
-```
-
 ## Model Reference
 
-All models use `ConfigDict(extra="allow")` for forward compatibility with new API fields.
+All models use `ConfigDict(extra="allow")` for forward compatibility with new
+API fields. Codegen-generated models are produced from the ONTAP OpenAPI spec
+via [the codegen pipeline](#openapi-codegen-pipeline).
 
-### Cloud & Cluster
+### Cloud and cluster
 
-| Model | Key Fields | Description |
+| Model | Key fields | Description |
 |-------|------------|-------------|
-| `CloudMetadata` | node, instance_id, provider, region, instance_type | Cloud provider metadata per node (CLI-only) |
-| `ClusterInfo` | cluster_name, cluster_uuid, ontap_version, version_generation, version_major, version_minor, contact, location, is_ha, san_optimized | Core cluster identity |
-| `OntapNodeResponse` | uuid, name, serial_number, model, location, membership, version_full | Cluster node information (codegen-generated, ~118 fields) |
-| `OntapLicensePackageResponse` | name, scope, state | License package (codegen-generated) |
-| `OntapMediatorResponse` | ip_address, ca_certificate, dr_group_id | ONTAP Mediator configuration (codegen-generated) |
+| `CloudMetadata` | `node`, `instance_id`, `provider`, `region`, `instance_type`, `availability_zone` | Cloud provider metadata per node (CLI-only) |
+| `ClusterInfo` | `cluster_name`, `cluster_uuid`, `ontap_version`, `contact`, `location`, `is_ha`, `san_optimized` | Core cluster identity |
+| `OntapNodeResponse` | `uuid`, `name`, `state`, `serial_number`, `location`, `membership`, `version`, `controller`, `ha` | Cluster node information (codegen-generated) |
+| `OntapLicensePackageResponse` | `name`, `scope`, `state`, `description`, `entitlement`, `licenses` | License package (codegen-generated) |
+| `OntapMediatorResponse` | `uuid`, `ip_address`, `port`, `reachable`, `peer_cluster`, `dr_group` | ONTAP Mediator configuration (codegen-generated) |
 
 ### Network
 
-| Model | Key Fields | Description |
+| Model | Key fields | Description |
 |-------|------------|-------------|
-| `OntapIpInterface` | uuid, name, ip_address, netmask, enabled, state, scope | Logical interface (codegen-generated, ~49 fields) |
-| `OntapBroadcastDomain` | uuid, name, mtu | Broadcast domain configuration (codegen-generated) |
-| `OntapIpSubnet` | uuid, name, subnet, gateway | IP subnet (codegen-generated) |
-| `OntapDns` | uuid, domains, servers | DNS configuration (codegen-generated) |
+| `OntapIpInterface` | `uuid`, `name`, `enabled`, `state`, `scope`, `ip`, `location`, `svm` | Logical interface (codegen-generated) |
+| `OntapBroadcastDomain` | `uuid`, `name`, `mtu`, `ipspace`, `ports` | Broadcast domain (codegen-generated) |
+| `OntapIpSubnet` | `uuid`, `name`, `gateway`, `subnet`, `ipspace`, `broadcast_domain` | IP subnet (codegen-generated) |
+| `OntapDns` | `uuid`, `domains`, `servers`, `scope`, `svm` | DNS configuration (codegen-generated) |
 
-**Container:** `NetworkInfo` holds `ip_interfaces`, `ethernet_broadcast_domains`, `ipspaces`, `dns`, `ip_subnets`.
+**Container:** `NetworkInfo` holds `ip_interfaces`,
+`ethernet_broadcast_domains`, `ipspaces`, `dns`, `ip_subnets`.
 
 ### Storage
 
-| Model | Key Fields | Description |
+| Model | Key fields | Description |
 |-------|------------|-------------|
-| `OntapAggregate` | uuid, name, state | Storage aggregate (codegen-generated, ~128 fields) |
-| `OntapSvm` | uuid, name, state, subtype | Storage VM (codegen-generated, ~109 fields) |
-| `OntapVolume` | uuid, name, state, type, style, size | Volume (codegen-generated, ~512 fields) |
-| `OntapQtree` | uuid, name, security_style | Qtree (codegen-generated, ~52 fields) |
-| `OntapCloudTarget` | uuid, name, provider_type, server, container | Cloud object store target (codegen-generated) |
-| `OntapFlexcache` | uuid, name, size | FlexCache volume (codegen-generated) |
-| `OntapSnapshotPolicy` | uuid, name, enabled, scope | Snapshot policy (codegen-generated) |
-| `OntapSchedule` | uuid, name, type, scope | Job schedule (codegen-generated) |
-| `OntapLun` | uuid, name, size, os_type, serial_number, enabled | LUN (codegen-generated, ~105 fields) |
-| `OntapIgroup` | uuid, name, protocol, os_type | Initiator group (codegen-generated) |
-| `OntapQosPolicy` | uuid, name, scope | QoS policy (codegen-generated) |
+| `OntapAggregate` | `uuid`, `name`, `state`, `node`, `volume_count`, `space` | Storage aggregate (codegen-generated) |
+| `OntapSvm` | `uuid`, `name`, `state`, `subtype`, `language`, `comment` | Storage VM (codegen-generated) |
+| `OntapVolume` | `uuid`, `name`, `state`, `style`, `size`, `type_`, `svm`, `space` | Volume (codegen-generated) |
+| `OntapQtree` | `id`, `name`, `path`, `security_style`, `svm`, `volume` | Qtree (codegen-generated) |
+| `OntapCloudTarget` | `uuid`, `name`, `provider_type`, `server`, `container`, `scope` | Cloud object store target (codegen-generated) |
+| `OntapFlexcache` | `uuid`, `name`, `size`, `path`, `svm`, `origins` | FlexCache volume (codegen-generated) |
+| `OntapSnapshotPolicy` | `uuid`, `name`, `enabled`, `scope`, `comment`, `svm`, `copies` | Snapshot policy (codegen-generated) |
+| `OntapSchedule` | `uuid`, `name`, `type_`, `scope`, `cron`, `svm` | Job schedule (codegen-generated) |
+| `OntapLun` | `uuid`, `name`, `enabled`, `os_type`, `serial_number`, `svm`, `space`, `status` | LUN (codegen-generated) |
+| `OntapIgroup` | `uuid`, `name`, `protocol`, `os_type`, `svm`, `initiators` | Initiator group (codegen-generated) |
+| `OntapQosPolicy` | `uuid`, `name`, `scope`, `policy_class`, `svm` | QoS policy (codegen-generated) |
 
-**Container:** `StorageInfo` holds `aggregates`, `svms`, `cloud_targets`, `volumes`, `qtrees`, `snapshot_policies`, `schedules`, `luns`, `igroups`, `qos_policies`, `flexcaches`.
+**Container:** `StorageInfo` holds `aggregates`, `svms`, `cloud_targets`,
+`volumes`, `qtrees`, `snapshot_policies`, `schedules`, `luns`, `igroups`,
+`qos_policies`, `flexcaches`, `svm_top_metrics_users`.
 
 ### Protocols
 
-| Model | Key Fields | Description |
+| Model | Key fields | Description |
 |-------|------------|-------------|
-| `OntapExportPolicy` | id, name | NFS export policy (codegen-generated) |
-| `OntapCifsShare` | name, path | CIFS/SMB share (codegen-generated) |
-| `OntapCifsService` | name, enabled | CIFS service config (codegen-generated, ~99 fields) |
-| `OntapNfsService` | enabled, state | NFS service config (codegen-generated, ~158 fields) |
-| `OntapS3Bucket` | uuid, name, type, size | S3 bucket (codegen-generated) |
+| `OntapExportPolicy` | `index`, `protocols`, `clients`, `ro_rule`, `rw_rule`, `superuser` | NFS export policy rule (codegen-generated) |
+| `OntapCifsShare` | `name`, `path`, `comment`, `volume`, `svm`, `acls` | CIFS/SMB share (codegen-generated) |
+| `OntapCifsService` | `name`, `enabled`, `comment`, `ad_domain`, `security`, `svm` | CIFS service config (codegen-generated) |
+| `OntapNfsService` | `enabled`, `state`, `protocol`, `security`, `transport`, `svm` | NFS service config (codegen-generated) |
+| `OntapS3Bucket` | `uuid`, `name`, `type_`, `size`, `comment`, `svm`, `volume` | S3 bucket (codegen-generated) |
 
-**Container:** `ProtocolsInfo` holds `nfs_export_policies`, `cifs_shares`, `nfs_services`, `cifs_services`, `s3_buckets`.
+**Container:** `ProtocolsInfo` holds `nfs_export_policies`, `cifs_shares`,
+`nfs_services`, `cifs_services`, `s3_buckets`.
 
 ### Relationships
 
-| Model | Key Fields | Description |
+| Model | Key fields | Description |
 |-------|------------|-------------|
-| `OntapSnapmirrorRelationship` | uuid, source_path, destination_path, state | SnapMirror relationship (codegen-generated, ~69 fields) |
-| `OntapClusterPeer` | uuid, name | Cluster peer (codegen-generated) |
-| `OntapSvmPeer` | uuid, name, state | SVM peer (codegen-generated) |
+| `OntapSnapmirrorRelationship` | `uuid`, `state`, `healthy`, `source`, `destination`, `policy`, `transfer`, `lag_time` | SnapMirror relationship (codegen-generated) |
+| `OntapClusterPeer` | `uuid`, `name`, `ip_address`, `remote`, `status`, `version` | Cluster peer (codegen-generated) |
+| `OntapSvmPeer` | `uuid`, `name`, `state`, `applications`, `peer`, `svm` | SVM peer (codegen-generated) |
 
-**Container:** `RelationshipsInfo` holds `snapmirror_destinations`, `cluster_peers`, `svm_peers`.
+**Container:** `RelationshipsInfo` holds `snapmirror_destinations`,
+`cluster_peers`, `svm_peers`.
 
-### Collection Phases
+## Collection Phases
 
-The `MetadataCollector` uses all-or-nothing collection semantics: every API phase must succeed completely or the entire collection is aborted — no partial cache updates. Cloud metadata is the only CLI-based phase and is optional (failure logs a warning but does not abort collection).
+`MetadataCollector` uses all-or-nothing collection semantics: every API phase
+must succeed completely or the entire collection is aborted — no partial cache
+updates. Cloud metadata is the only CLI-based phase and is optional (failure
+logs a warning but does not abort collection).
 
 | Phase | Source | Required | Endpoints |
 |-------|--------|----------|-----------|
-| `CLOUD` | CLI | No | Cloud provider metadata (`virtual-machine instance show`) |
+| `CLOUD` | CLI | No | `virtual-machine instance show` (ONTAP CLI, one row per node) |
 | `CLUSTER` | API | Yes | `/cluster` |
 | `NODES` | API | Yes | `/cluster/nodes` |
-| `NETWORK` | API | Yes | `/network/ip/interfaces`, `/network/ethernet/broadcast-domains`, `/cluster/peers` (for ipspaces), `/name-services/dns`, `/network/ip/subnets` |
+| `NETWORK` | API | Yes | `/network/ip/interfaces`, `/network/ethernet/broadcast-domains`, `/network/ipspaces`, `/name-services/dns`, `/network/ip/subnets` |
 | `STORAGE` | API | Yes | `/storage/aggregates`, `/svm/svms`, `/cloud/targets`, `/storage/volumes`, `/storage/qtrees`, `/storage/snapshot-policies`, `/cluster/schedules`, `/storage/luns`, `/protocols/san/igroups`, `/storage/qos/policies`, `/storage/flexcache/flexcaches` |
-| `LICENSES` | API | Yes | `/cluster/licensing/licenses`, `/cluster/licensing/capacity-pools` |
+| `LICENSES` | API | Yes | `/cluster/licensing/licenses` |
 | `MEDIATOR` | API | Yes | `/cluster/mediators` |
 | `RELATIONSHIPS` | API | Yes | `/snapmirror/relationships`, `/cluster/peers`, `/svm/peers` |
 | `PROTOCOLS` | API | Yes | `/protocols/nfs/export-policies`, `/protocols/cifs/shares`, `/protocols/nfs/services`, `/protocols/cifs/services`, `/protocols/s3/buckets` |
 
-## API Reference
+After all phases complete, `collect_all` runs a post-collection pass that
+populates parameterized per-SVM endpoints (currently
+`svm_top_metrics_users` on `StorageInfo`). These follow-up calls are keyed
+off the SVMs returned by the `STORAGE` phase.
 
-### Core Classes
+## Public API Reference
+
+### Imports
 
 ```python
-# Infrastructure (from pynetappfoundry.cache)
 from pynetappfoundry.cache import (
     CachedClusterMetadata,
     CacheHistoryDB,
     ClusterMetadataDB,
-    HasUUID,
+    LazyClusterMetadata,
     MetadataCollector,
+    CollectionError,
+    CollectionPhase,
+    FieldMapping,
+    TypeMapping,
+    HasUUID,
+    METADATA_SCHEMA_VERSION,
+    METADATA_SCHEMA_MIN_COMPATIBLE,
     compute_diff,
     format_diff_summary,
     is_schema_compatible,
+    parse_schema_version,
+    model_registry,
 )
-
-# Models (import from models/ or via cache re-exports)
-from pynetappfoundry.models.ontap.cloud.metadata import CloudMetadata
-from pynetappfoundry.models.ontap.cluster import ClusterInfo
-from pynetappfoundry.models.ontap.cluster.mediators import MediatorInfo
-from pynetappfoundry.models.ontap.cluster.nodes import NodeInfo
-from pynetappfoundry.models.ontap.cluster.peers import ClusterPeer
-from pynetappfoundry.models.ontap.network import NetworkInfo
-from pynetappfoundry.models.ontap.network.ip.interfaces import NetworkLIF
-from pynetappfoundry.models.ontap.storage import StorageInfo
-from pynetappfoundry.models.ontap.storage.aggregates import AggregateInfo
-from pynetappfoundry.models.ontap.storage.volumes import VolumeInfo
-# ... etc. — see models/ontap/ URL-tree structure for all model paths
 ```
 
-### ClusterMetadataDB
+Concrete model classes live in their per-endpoint modules under
+`src/pynetappfoundry/models/ontap/<api-path>/model.py`. For example:
+
+```python
+from pynetappfoundry.models.ontap.cluster.model import ClusterInfo
+from pynetappfoundry.models.ontap.cluster.nodes.model import OntapNodeResponse
+from pynetappfoundry.models.ontap.cluster.mediators.model import OntapMediatorResponse
+from pynetappfoundry.models.ontap.cluster.peers.model import OntapClusterPeer
+from pynetappfoundry.models.ontap.network.model import NetworkInfo
+from pynetappfoundry.models.ontap.network.ip.interfaces.model import OntapIpInterface
+from pynetappfoundry.models.ontap.storage.model import StorageInfo
+from pynetappfoundry.models.ontap.storage.aggregates.model import OntapAggregate
+from pynetappfoundry.models.ontap.storage.volumes.model import OntapVolume
+```
+
+### `ClusterMetadataDB`
 
 ```python
 db = ClusterMetadataDB(config=config)
 
-# Store metadata
+# Store metadata (decomposes into per-model tables in a single transaction)
 db.set("cluster1", metadata)
 
-# Retrieve metadata
-metadata = db.get("cluster1")  # Returns CachedClusterMetadata or None
+# Retrieve full metadata (queries every per-model table)
+metadata = db.get("cluster1")  # CachedClusterMetadata or None
 
-# List all clusters
-clusters = db.list_clusters()  # Returns list of dicts with cluster info
+# Retrieve a lazy proxy (envelope only — data fields load on first access)
+lazy = db.get_lazy("cluster1")  # LazyClusterMetadata or None
+volumes = lazy.storage.volumes  # triggers a single field-group query
+
+# Staleness check (envelope-only, no data queries)
+stale = db.is_stale("cluster1", ttl_days=30)  # True / False / None
+
+# List clusters with envelope info
+clusters = db.list_clusters()  # list[dict[str, str]]
+
+# List clusters with cached_at, age_days, is_stale
+status = db.get_status(ttl_days=30)
+
+# Targeted query against a single per-model table (equality filters)
+volumes = db.query_model("cluster1", "storage.volumes", state="online")
+
+# Expressive filter expressions (comparison, in/not in, null, json_extract)
+volumes = db.query_with_filters(
+    "cluster1",
+    "storage.volumes",
+    [
+        "state = 'online'",
+        "size > 1073741824",
+        "autosize.mode != 'grow_shrink'",
+    ],
+)
+
+# JSON export / import (round-trips through CachedClusterMetadata)
+json_str = db.export_json("cluster1")
+db.import_json("cluster1", json_str)
+
+# Clear (single cluster or all)
+deleted = db.clear("cluster1")
+deleted = db.clear()
 ```
 
-### CacheHistoryDB
+### `CacheHistoryDB`
 
 ```python
 db = CacheHistoryDB(config=config)
@@ -510,55 +979,138 @@ change_id = db.record_change(
     summary=changes,  # List of change dicts from compute_diff()
 )
 
-# Get latest snapshot
+# Get the most recent snapshot
 snapshot = db.get_latest_snapshot("cluster1")
 # Returns: {"after_json": "...", "changed_at": "..."}
 
-# Get snapshot at specific date
+# Get the snapshot at a specific date
 snapshot = db.get_snapshot_at_date("cluster1", "2024-01-15")
 
-# Query history
+# Query history with optional filters
 records = db.get_change_history(
-    cluster_name="cluster1",  # Optional filter
+    cluster_name="cluster1",
     limit=50,
     offset=0,
-    since="2024-01-01",  # Optional date filter
-    until="2024-06-30",  # Optional date filter
+    since="2024-01-01",
+    until="2024-06-30",
 )
 
-# Get specific change
+# Get a specific change
 record = db.get_change_by_id(5)
 
-# Get total count
+# Total count
 count = db.get_history_count(cluster_name="cluster1")
 
 db.close()
 ```
 
-### MetadataCollector
+### `MetadataCollector`
 
 ```python
 collector = MetadataCollector(
-    api_client=api_client,      # ONTAPAPIClient instance
-    cli_client=cli_client,      # ONTAPCLI instance (optional)
-    progress_callback=callback,  # Optional progress updates
-    aws_sso_config=sso_config,  # Optional AWS SSO config
+    api_client=api_client,           # ONTAPAPIClient instance
+    cli_client=cli_client,           # ONTAPCLI instance (optional)
+    progress_callback=callback,      # Optional progress updates
+    aws_sso_config=sso_config,       # Optional AWS SSO config
+    parallel=True,                   # Run independent phases in parallel
+    max_workers=8,
 )
 
 # Collect all metadata for a cluster
 metadata = collector.collect_all("cluster1")
 ```
 
-### Diff Functions
+### Diff functions
 
 ```python
 from pynetappfoundry.cache import compute_diff, format_diff_summary
 
 # Compute changes between two snapshots
 changes = compute_diff(old_metadata, new_metadata)
-# Returns: List[ChangeEntry]
+# Returns: list[ChangeEntry]
 
 # Format for display
 formatted = format_diff_summary(changes)
 # Returns: Rich-formatted string
 ```
+
+## Benchmarks
+
+Performance benchmarks for the core cache data paths live under
+`tests/benchmarks/` and run as part of the broader pytest-benchmark suite.
+
+| File | What it measures |
+|------|------------------|
+| `test_bench_serialization.py` | `_model_to_row` / `_row_to_model` — the core path for every cache DB read and write, including JSON encoding of nested sub-models, boolean coercion, datetime serialisation, and `_extra_json` collection. |
+| `test_bench_dict_path.py` | `get_nested_value` — called per-field per-record during metadata collection, one of the hottest paths in the codebase. |
+| `test_bench_diff.py` | `compute_diff` — runs on every cache update cycle to compare two `CachedClusterMetadata` snapshots field-by-field. |
+| `test_bench_query_engine.py` | `parse_filter` / `parse_filters` / `build_where_clause` — the SQL query engine filter parser, run uncached on every `query_with_filters` call. |
+
+## Troubleshooting
+
+### Common issues
+
+#### "Incompatible schema version" error
+
+**Cause:** Trying to restore a snapshot created with an older schema
+version.
+
+**Solution:**
+
+- Use `--json` to view the raw data.
+- Manually extract needed information.
+- Or refresh the cache to create a new snapshot.
+
+#### History not recording changes
+
+**Cause:** Cache refresh completed but no history entry was created.
+
+**Explanation:** History is only recorded when:
+
+- It is the initial capture (no previous snapshot).
+- Changes are detected between old and new metadata.
+
+If metadata is identical, no history entry is created.
+
+#### Large history database
+
+**Cause:** Many clusters with frequent changes.
+
+**Solution:** History is append-only by design. To manage size:
+
+- Query with `--limit` and `--offset` for pagination.
+- Consider periodic archival of old records (manual process).
+
+#### Cache empty after upgrade
+
+**Cause:** The v3 → v4 SQLite schema migration drops and recreates every
+per-model table because of the nested-model column rename.
+
+**Solution:** Run `nf cache refresh --all` to repopulate the cache.
+
+### Debugging
+
+Enable verbose logging to see cache operations:
+
+```bash
+# Verbose refresh shows phase timings
+nf cache refresh cluster1 -v
+
+# Check the log file for detailed information
+# The log path is shown at the start of refresh
+```
+
+## See Also
+
+- [ONTAP Access Patterns](../usage/ontap-access-patterns.md) — user-facing
+  guide for choosing between full load, lazy proxy, and live API access.
+- [Query Layer](../usage/query-layer.md) — user-facing query syntax built on
+  `query_with_filters`.
+- [Field Mapping Framework](../development/field-mapping.md) — developer
+  guide to `FieldMapping` / `TypeMapping`.
+- ADR-0001 — SQLite metadata cache (original decision).
+- ADR-0003 — Base `SQLiteDB` class with version-based migrations.
+- ADR-0004 — Declarative field mapping framework.
+- ADR-0005 — UUID index for cache cross-references.
+- ADR-0009 — Per-model SQL table storage for the cache layer.
+- ADR-0011 — Nested models to replace the flat model pattern.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
   - Reference:
       - CLI Reference: reference/cli.md
       - API Reference: reference/api.md
+      - Cache: reference/cache.md
   - Examples:
       - Overview: examples/README.md
       - API Examples: examples/api.md

--- a/src/pynetappfoundry/cache/_metadata.py
+++ b/src/pynetappfoundry/cache/_metadata.py
@@ -58,6 +58,11 @@ class CachedClusterMetadata(CacheModel):
     This is the top-level model containing all cached data categories.
 
     Schema Version History:
+        2.0 - Renamed cache fields to match the ONTAP REST URL hierarchy:
+              network.lifs -> network.ip_interfaces,
+              network.broadcast_domains -> network.ethernet_broadcast_domains,
+              network.subnets -> network.ip_subnets,
+              protocols.export_policies -> protocols.nfs_export_policies
         1.0 - Initial schema with comprehensive model coverage
 
     Note: The cache_version field tracks the schema version of the stored data.


### PR DESCRIPTION
## Description

Refreshes `docs/reference/cache.md` from the legacy ~565-line layout into a comprehensive architecture reference (~1100 lines, 20 top-level sections). The previous document predated several major cache architectural changes and was actively misleading: schema version was wrong (claimed 1.0 while constant is 2.0), per-model SQL table storage (ADR-0009) was completely undocumented, and lazy loading / field mapping / realtime field exclusion / OpenAPI codegen / nested models (ADR-0011) were all missing.

Also wires the page into the MkDocs Reference nav (it existed on disk but wasn't reachable from the site), and touches up a stale docstring in `cache/_metadata.py` so the `CachedClusterMetadata` schema-version history block reflects the current 2.0 schema.

## Related Issue

Addresses #479

## Type of Change

- [x] Documentation update

## Changes Made

### Restructured `docs/reference/cache.md`

New top-level sections (20 total):

1. Overview
2. Database Files
3. **Storage Architecture** (NEW — per-model SQL tables, ADR-0009)
4. Schema Versioning and Migrations (now includes v1→v2→v3→v4 history)
5. **Lazy Loading and On-Demand Fetch** (NEW — `LazyClusterMetadata`, `FieldGroupFetcher`)
6. **Field Mapping Framework** (NEW — `FieldMapping`, `TypeMapping`, `cache_strategy`)
7. **Realtime Field Handling** (NEW — exclusion at DB write boundary)
8. **OpenAPI Codegen Pipeline** (NEW — `tools/codegen/openapi_codegen.py`)
9. **Nested Models Pattern** (NEW — ADR-0011, flat↔nested at the cache boundary)
10. CachedClusterMetadata Reference (refreshed)
11. History Tracking (preserved)
12. CLI Commands (expanded — added 8 missing subcommands)
13. Schema Compatibility (preserved)
14. Schema Update Checklist (refreshed)
15. Model Reference (full audit pass — see below)
16. Collection Phases (corrected endpoints)
17. Public API Reference (refreshed — added `.get_lazy()`, `.query_model()`, `.query_with_filters()`, `.is_stale()`, `.clear()`, `.get_status()`)
18. **Benchmarks** (NEW — pointer to `tests/benchmarks/`)
19. Troubleshooting (preserved)
20. See Also (refreshed)

The Storage Architecture section gets dedicated top-level placement per the per-model SQL tables being the most important architectural fact about the cache today.

### Audit corrections (full pass over all 28 model reference rows)

Caught real bugs in the previous content where the doc was inventing API surface:

- `OntapExportPolicy` had **completely wrong fields** (claimed `id`, `name`) — it actually represents an export *rule*, not a named policy. Real fields are `index`, `protocols`, `clients`, `ro_rule`, `rw_rule`, `superuser`.
- `OntapMediatorResponse.dr_group_id` doesn't exist — it's nested as `dr_group`.
- `OntapNodeResponse.version_full` doesn't exist — it's nested as `version`.
- All 28 rows updated to list actual top-level fields from the current Pydantic models, with nested-model containers shown by name (`ip`, `location`, `svm`) rather than dotted paths.

### Collection Phases corrections

Three bogus endpoints fixed against `cache/collector.py`:

- `NETWORK` falsely claimed `/cluster/peers (for ipspaces)` — collector actually calls `/network/ipspaces`.
- `LICENSES` falsely claimed `/cluster/licensing/capacity-pools` — collector only calls `/cluster/licensing/licenses`.
- `CLOUD` description tightened to the exact CLI command `virtual-machine instance show`.
- Added a paragraph noting the post-collection parameterized pass for `svm_top_metrics_users`.

### CLI Commands expansion

Only 2 of 10 `nf cache` subcommands were documented. Added brief subsections with example invocations for the 8 missing ones: `check`, `compliance`, `query`, `show`, `inspect`, `schema`, `status`, `clear`. Explicitly noted that `check`/`compliance` use the cache query engine and never hit live ONTAP.

### Schema version contradiction fixed

The previous doc claimed `METADATA_SCHEMA_VERSION = "1.0"` (line 47) while the version history table on the same page already listed 2.0 — a self-contradiction. Real value in `_base.py:21` is `"2.0"`. All references updated.

### Stale import paths fixed

The previous "API Reference" section had imports of classes that don't exist (`MediatorInfo`, `NodeInfo`, `ClusterPeer`, `NetworkLIF`, `AggregateInfo`, `VolumeInfo`). Replaced with real exports: `OntapNodeResponse`, `OntapMediatorResponse`, `OntapClusterPeer`, `OntapIpInterface`, `OntapAggregate`, `OntapVolume`, etc.

### Diagram update

Replaced the old ASCII diagram with one that shows the three layers: storage (per-model tables) → lazy proxy (`LazyClusterMetadata`) → on-demand fetcher (`FieldGroupFetcher`).

### Nav wiring

`mkdocs.yml` — added `Cache: reference/cache.md` under Reference. The page existed on disk but was not in `nav`, so it was unreachable from the rendered site (same situation we hit on PR #486 with `ontap-access-patterns.md`).

### Docstring touch-up

`src/pynetappfoundry/cache/_metadata.py` — added a 2.0 entry to the `CachedClusterMetadata` Schema Version History docstring block. The previous docstring still claimed 1.0 was current. **Docstring-only edit, no behavior change — classified as `docs:` by the issue author.**

### ADR backlinks

Added `Issue #479` to the Related Issues section and a link to `docs/reference/cache.md` to the Related Documentation section of:

- ADR-0001 (use SQLite for cluster metadata caching) — foundational decision the entire cache rests on
- ADR-0004 (declarative field mapping framework) — covered in the Field Mapping Framework section
- ADR-0009 (per-model SQL table storage) — covered in the Storage Architecture section
- ADR-0011 (nested models to replace flat model pattern) — covered in the Nested Models Pattern section

Each ADR already had both sections, so the additions are pure backlinks with no padding.

## Testing

- [x] `doit check` passes (format, lint, type-check, security, spell-check, tests)
- [x] `doit docs_build` passes with no new warnings on the modified pages
- [x] Manually verified the new Cache page is reachable from the Reference nav and all in-page anchors resolve
- [x] Cross-doc anchor sweep — no other doc references `cache.md#anchor`, so no link rot from the section restructure

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

Tests N/A — documentation-only PR.

## Additional Notes

- No behavior changes. The `_metadata.py` edit is docstring-only and was explicitly classified as `docs:` by the issue author.
- No `needs-adr` label on the issue and no new ADRs introduced — only backlinks were added to existing ADRs where natural slots already existed.
- The Model Reference table audit was thorough but its "Key Fields" column will drift over time as codegen output changes; a future periodic re-audit may be worthwhile.
