### PR TITLE
docs: clean up stale CLI references and broken cross-repo links

### DIFF
--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -64,8 +64,8 @@ EOF
 
 | File | Description |
 |------|-------------|
-| [`block-dangerous-commands.py`](../../../tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude and Gemini) |
-| [`test_hook.py`](../../../tools/hooks/ai/test_hook.py) | Test suite to verify hook behavior |
+| [`block-dangerous-commands.py`](https://github.com/endavis/pynetappfoundry/blob/main/tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude and Gemini) |
+| [`test_hook.py`](https://github.com/endavis/pynetappfoundry/blob/main/tools/hooks/ai/test_hook.py) | Test suite to verify hook behavior |
 
 ### Configuration
 
@@ -220,5 +220,5 @@ Then run the test suite to verify.
 ## Related
 
 - [AI Enforcement Principles](enforcement-principles.md) - Why and how we enforce rules in code
-- [AGENTS.md](../../../AGENTS.md) - AI agent rules including "When Blocked Protocol"
+- [AGENTS.md](https://github.com/endavis/pynetappfoundry/blob/main/AGENTS.md) - AI agent rules including "When Blocked Protocol"
 - [AI Agent Setup](../AI_SETUP.md) - Setting up AI coding assistants

--- a/docs/template/decisions/9008-pr-based-development-workflow.md
+++ b/docs/template/decisions/9008-pr-based-development-workflow.md
@@ -21,4 +21,4 @@ Provides clear audit trail linking issues to PRs to commits, enables code review
 ## Related Documentation
 
 - [CI/CD Testing Guide](../../development/ci-cd-testing.md)
-- [CONTRIBUTING.md](../../../.github/CONTRIBUTING.md)
+- [CONTRIBUTING.md](https://github.com/endavis/pynetappfoundry/blob/main/.github/CONTRIBUTING.md)

--- a/docs/template/decisions/9010-use-conventional-commits-format.md
+++ b/docs/template/decisions/9010-use-conventional-commits-format.md
@@ -20,4 +20,4 @@ Provides consistent, readable git history, enables automated changelog generatio
 
 ## Related Documentation
 
-- [CONTRIBUTING.md](../../../.github/CONTRIBUTING.md)
+- [CONTRIBUTING.md](https://github.com/endavis/pynetappfoundry/blob/main/.github/CONTRIBUTING.md)

--- a/docs/usage/basics.md
+++ b/docs/usage/basics.md
@@ -252,31 +252,28 @@ nf cache query -f '{"env":"Prod"}' cluster.ontap_version
 ### License Reporting
 
 ```bash
-# List licenses for all clusters
-nf licenses list
+# Get license information for all clusters
+nf licenses get
 
-# Export licenses to Excel
-nf licenses export --format xlsx --output licenses.xlsx
+# Export licenses to CSV
+nf licenses get --csv -o licenses.csv
 ```
 
-### Space Reporting
+### Reports
 
 ```bash
-# Generate space report
-nf reports space --cluster CLUSTER-PROD-01
-
-# Generate aggregate report
-nf reports aggregate --all-clusters
+# Generate space usage report for a specific cluster
+nf reports space-usage -f '{"name":"CLUSTER-PROD-01"}'
 ```
 
 ### Event Monitoring
 
 ```bash
-# Fetch recent events
-nf events fetch --hours 24
+# Get recent events (most recent 100)
+nf events get -l 100
 
-# List events by severity
-nf events list --severity error
+# Get events by severity
+nf events get -s error
 ```
 
 ## Error Handling


### PR DESCRIPTION
## Description

Cross-`docs/` sweep that mops up stale references left over after the
targeted refreshes in #476–#481. Two kinds of cleanup:

1. Stale CLI command examples in `docs/usage/basics.md` (the only file
   the sweep found with broken `nf` invocations).
2. Cross-repo `../../../` markdown links in
   `docs/development/ai/command-blocking.md` and two
   `docs/template/decisions/` ADRs that pointed to real files outside
   the docs tree but couldn't be resolved by mkdocs. Converted to
   absolute GitHub URLs on `main`.

## Related Issue

Addresses #482

## Type of Change

- [x] Documentation update

## Changes Made

- `docs/usage/basics.md`:
  - `nf licenses list` / `nf licenses export ...` → `nf licenses get` / `nf licenses get --csv -o licenses.csv`
  - `nf reports space --cluster ...` → `nf reports space-usage -f '{"name":"..."}'`
  - Removed `nf reports aggregate --all-clusters` example (no equivalent in current CLI). Renamed "Space Reporting" heading to "Reports".
  - `nf events fetch --hours 24` → `nf events get -l 100`
  - `nf events list --severity error` → `nf events get -s error`
- `docs/development/ai/command-blocking.md`: 3 `../../../` links → absolute GitHub URLs (block-dangerous-commands.py, test_hook.py, AGENTS.md).
- `docs/template/decisions/9008-pr-based-development-workflow.md`: `../../../.github/CONTRIBUTING.md` → absolute GitHub URL.
- `docs/template/decisions/9010-use-conventional-commits-format.md`: same fix.

## Testing

- [x] All existing tests pass (`doit check`)
- [x] Each replacement command verified against `nf <group> <cmd> --help`
- [x] Grep confirms no remaining `licenses list|licenses export|reports space |reports aggregate|events fetch|events list` references in `docs/`

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (not required for docs-only change)

## Additional Notes

This is the seventh and final child of umbrella #474. After this lands,
all stale-doc cleanup from the post-#344 batch is complete.

Issue #482 has the `documentation` label and no `needs-adr`. Per
AGENTS.md ("Doc and chore issues do not need ADRs"), no ADR is required.
