### PR TITLE
feat: add QueryBuilder.where() for SQL-like filter expressions

### DIFF
--- a/docs/decisions/0012-unified-datasource-accessor.md
+++ b/docs/decisions/0012-unified-datasource-accessor.md
@@ -44,6 +44,8 @@ Add a `_fetched_fields: set[str]` instance attribute on `OntapModel` (`src/pynet
 
 `DataSource.query(OntapVolume).filter({"svm.name": "vs1", "autosize.mode": "grow"})` is the canonical form: a positional `dict[str, Any]` whose keys are dotted API paths. `**kwargs` (`filter(name="vol1", state="online")`) remains supported for top-level scalar fields as a convenience. The dunder-to-dot rewrite from today's `QuerySet.filter._attr_to_api_path` is **not** carried forward into `DataSource`. Existing `QuerySet` keeps the rewrite for backwards compatibility during migration and has it removed during Phase 4. This resolves issue #487.
 
+String filter expressions beyond equality land via `DataSource.QueryBuilder.where(*expressions: str)` (issue #512) — e.g. `.where("size > 1000000000", "state != 'offline'")` — which the cache backend concatenates with the dict-derived equality fragments and hands to `ClusterMetadataDB.query_with_filters` as a single ANDed list. v1 supports `.where()` on the cache path only; live and partial-fetch paths raise `NotImplementedError`. The typed field-reference DSL (e.g. `OntapVolume.svm.name == "vs1"`) remains deferred as issue #497 and will eventually compile down to the same string-expression shape that `.where()` already accepts.
+
 ### 4. Per-call source override
 
 `DataSource` accepts `source="auto" | "cache" | "live"` on every read:
@@ -120,6 +122,14 @@ This ADR is Phase 1 of a four-phase plan. The full plan is in issue #495.
 - **Phase 3 — Shim migration.** Five follow-up issues, one per existing surface (`LazyClusterMetadata`, cache CLIs, `QuerySet`, realtime functions, remaining #485 call sites). Each surface becomes a thin shim over `DataSource`. This phase absorbs the remainder of issue #485.
 
   **Phase 3 progress:**
+
+  **Phase 3 prerequisites:**
+
+  - Issue #512 — `DataSource.QueryBuilder.where(*expressions)` for SQL-like
+    filter expressions on the cache path — landed independently of the
+    shim migrations to unblock Phase 3e (`nf cache check` shim, issue
+    #509), whose `--where` flag requires non-equality filter expressions
+    that `filter({...})` cannot express.
 
   - Phase 3a — `OntapBackend.query()` partial-fetch (issue #500, merged in PR #501).
   - Phase 3b — `LazyClusterMetadata` migrated to a `DataSource` shim (issue #502). `_load_field_group()` now routes every per-model read through `DataSource.query(source="cache")`, reassembling the results into the corresponding `CachedClusterMetadata` sub-model. `FieldGroupFetcher` is retained as an opt-in fallback for the live-only call site (`ClusterEntry._build_live_metadata`) and will be removed in Phase 4.

--- a/src/pynetappfoundry/data/backends.py
+++ b/src/pynetappfoundry/data/backends.py
@@ -96,8 +96,23 @@ class Backend(ABC):
         decision: RoutingDecision,
         cluster: str,
         filters: dict[str, Any],
+        *,
+        where_expressions: tuple[str, ...] = (),
     ) -> list[T]:
-        """Fetch a list of instances matching *filters*."""
+        """Fetch a list of instances matching *filters*.
+
+        Args:
+            model_class: The Pydantic model class to fetch.
+            mapping: The :class:`TypeMapping` for the model.
+            decision: The routing decision driving cache vs live vs partial.
+            cluster: Name of the cluster to fetch from.
+            filters: Equality filter dict (dotted API paths as keys).
+            where_expressions: SQL-like filter expression strings
+                (e.g. ``"size > 1000000000"``) ANDed with the dict
+                filters. Only supported on the cache path; live and
+                partial paths raise :class:`NotImplementedError` when
+                non-empty. Defaults to ``()``.
+        """
 
 
 class OntapBackend(Backend):
@@ -324,6 +339,8 @@ class OntapBackend(Backend):
         decision: RoutingDecision,
         cluster: str,
         filters: dict[str, Any],
+        *,
+        where_expressions: tuple[str, ...] = (),
     ) -> list[T]:
         """Fetch a list of instances matching *filters*.
 
@@ -332,8 +349,21 @@ class OntapBackend(Backend):
         defines membership, a single batched live fetch enriches by
         identifier, and results are merged by identifier. See the design
         notes on issue #495 for the full rationale.
+
+        *where_expressions* adds SQL-like filter strings that are ANDed
+        with the dict-derived equality fragments on the cache path. Live
+        and partial-fetch routes raise :class:`NotImplementedError` when
+        *where_expressions* is non-empty; see issue #512.
         """
         if decision.partial:
+            if where_expressions:
+                msg = (
+                    f"DataSource.QueryBuilder.where() is not supported for "
+                    f"partial-fetch (mixed cache + live) routing decisions in v1; "
+                    f"use source='cache' to apply where-expressions on the cache "
+                    f"path only. Expressions were: {list(where_expressions)}"
+                )
+                raise NotImplementedError(msg)
             return self._query_partial(
                 model_class,
                 mapping,
@@ -343,13 +373,23 @@ class OntapBackend(Backend):
             )
 
         if decision.cache_fields:
-            filter_expressions = [f"{key} = '{value}'" for key, value in filters.items()]
+            filter_expressions = [f"{key} = '{value}'" for key, value in filters.items()] + list(
+                where_expressions
+            )
             results = self._fetch_cache(model_class, cluster, filter_expressions)
             for instance in results:
                 self._mark_fetched(instance, decision.cache_fields)
             return results
 
         if decision.live_fields:
+            if where_expressions:
+                msg = (
+                    f"DataSource.QueryBuilder.where() is not supported on the live "
+                    f"path in v1; use .filter({{...}}) for equality filters on "
+                    f"live queries. SQL-like expression translation is tracked as "
+                    f"a follow-up to #512. Expressions were: {list(where_expressions)}"
+                )
+                raise NotImplementedError(msg)
             results = self._fetch_live(model_class, mapping, cluster, filters, decision.live_fields)
             for instance in results:
                 self._mark_fetched(instance, decision.live_fields)

--- a/src/pynetappfoundry/data/source.py
+++ b/src/pynetappfoundry/data/source.py
@@ -205,6 +205,38 @@ class QueryBuilder[T: BaseModel]:
         self._source_mode: SourceMode = source_mode
         self._filters: dict[str, Any] = {}
         self._fields: list[str] | None = None
+        self._where_expressions: list[str] = []
+
+    def where(self, *expressions: str) -> QueryBuilder[T]:
+        """Add SQL-like filter expressions to the query.
+
+        Accepts one or more string expressions (e.g. ``"size > 1000000000"``,
+        ``"state != 'offline'"``) that are ANDed together with any equality
+        filters added via :meth:`filter`. Multiple ``.where()`` calls
+        accumulate; an empty call (``.where()``) is a no-op.
+
+        Expressions are evaluated by the backend's cache substrate
+        (:meth:`ClusterMetadataDB.query_with_filters`) and are only
+        supported on the cache-only path. Using ``.where()`` with a
+        routing decision that requires the live REST API (``source="live"``)
+        or a partial-fetch mix (``source="auto"`` when the model has both
+        cached and realtime fields) raises :class:`NotImplementedError`
+        at iteration time. Use ``source="cache"`` to opt into the
+        cache-only path and apply ``.where()`` expressions there.
+
+        Composes freely with :meth:`filter` — the final filter list is
+        the dict entries translated to ``key = 'value'`` followed by the
+        accumulated where-expressions, in a single ANDed list.
+
+        Args:
+            *expressions: One or more filter expression strings to AND
+                into the query.
+
+        Returns:
+            ``self`` for chaining.
+        """
+        self._where_expressions.extend(expressions)
+        return self
 
     def filter(
         self,
@@ -238,5 +270,6 @@ class QueryBuilder[T: BaseModel]:
             decision,
             self._cluster,
             self._filters,
+            where_expressions=tuple(self._where_expressions),
         )
         return iter(results)

--- a/tests/unit/data/test_backends.py
+++ b/tests/unit/data/test_backends.py
@@ -601,6 +601,189 @@ class TestOntapBackendQueryPartial:
         ]
 
 
+class TestQueryWithWhereExpressions:
+    """Tests for ``where_expressions`` kwarg on :meth:`OntapBackend.query`."""
+
+    def test_cache_path_concatenates_filter_dict_with_where_exprs(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("name", "uuid"), live_fields=())
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = []
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            _patch_metadata_path(backend),
+        ):
+            backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={"svm.name": "vs1"},
+                where_expressions=("size > 1000000000",),
+            )
+
+        mock_db.query_with_filters.assert_called_once_with(
+            "prod1",
+            "storage.fake_volumes",
+            ["svm.name = 'vs1'", "size > 1000000000"],
+        )
+
+    def test_cache_path_where_only(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("name", "uuid"), live_fields=())
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = []
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            _patch_metadata_path(backend),
+        ):
+            backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+                where_expressions=("size > 0",),
+            )
+
+        mock_db.query_with_filters.assert_called_once_with(
+            "prod1", "storage.fake_volumes", ["size > 0"]
+        )
+
+    def test_cache_path_no_where_unchanged(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("name", "uuid"), live_fields=())
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = []
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            _patch_metadata_path(backend),
+        ):
+            backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={"svm.name": "vs1"},
+            )
+
+        mock_db.query_with_filters.assert_called_once_with(
+            "prod1", "storage.fake_volumes", ["svm.name = 'vs1'"]
+        )
+
+    def test_live_path_raises_when_where_used(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=(), live_fields=("iops",))
+
+        with pytest.raises(NotImplementedError, match=r"\.filter") as exc_info:
+            backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+                where_expressions=("iops > 100",),
+            )
+        assert "#512" in str(exc_info.value)
+
+    def test_live_path_no_where_unchanged(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=(), live_fields=("iops",))
+
+        mock_client = MagicMock()
+        mock_client.get_all_records.return_value = {"records": []}
+
+        with (
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.parse_api_response",
+                return_value=[],
+            ),
+        ):
+            result = backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert result == []
+        mock_client.get_all_records.assert_called_once()
+
+    def test_partial_path_raises_when_where_used(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("name",), live_fields=("iops",))
+
+        with pytest.raises(NotImplementedError, match="source='cache'"):
+            backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+                where_expressions=("size > 0",),
+            )
+
+    def test_partial_path_no_where_unchanged(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("name",), live_fields=("iops",))
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = []
+        mock_client = MagicMock()
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            _patch_metadata_path(backend),
+        ):
+            result = backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={"name": "v1"},
+            )
+
+        assert result == []
+        mock_db.query_with_filters.assert_called_once()
+
+
 class TestCountLive:
     """Tests for :meth:`OntapBackend._count_live`.
 

--- a/tests/unit/data/test_source.py
+++ b/tests/unit/data/test_source.py
@@ -200,6 +200,81 @@ class TestDataSourceQuery:
         assert filters_arg == {"svm.name": "vs1", "name": "vol1"}
 
 
+class TestQueryBuilderWhere:
+    """Tests for the ``.where()`` chain method on :class:`QueryBuilder`."""
+
+    def test_where_extends_expressions_list(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        ds = DataSource(mock_config)
+        qb = ds.query(FakeVolume, cluster="prod1")
+        qb.where("a > 1", "b < 2")
+        assert qb._where_expressions == ["a > 1", "b < 2"]
+
+    def test_where_returns_self_for_chaining(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        ds = DataSource(mock_config)
+        qb = ds.query(FakeVolume, cluster="prod1")
+        result = qb.where("a > 1")
+        assert result is qb
+
+    def test_multiple_where_calls_accumulate(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        ds = DataSource(mock_config)
+        qb = ds.query(FakeVolume, cluster="prod1")
+        qb.where("a > 1").where("b < 2")
+        assert qb._where_expressions == ["a > 1", "b < 2"]
+
+    def test_empty_where_is_noop(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        ds = DataSource(mock_config)
+        qb = ds.query(FakeVolume, cluster="prod1")
+        qb.where()
+        assert qb._where_expressions == []
+
+    def test_where_passes_to_backend_via_iter(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        fake_backend.query.return_value = []
+        ds._backends["ontap"] = fake_backend
+
+        list(ds.query(FakeVolume, cluster="prod1").where("a > 1"))
+
+        kwargs = fake_backend.query.call_args.kwargs
+        assert kwargs.get("where_expressions") == ("a > 1",)
+
+    def test_filter_and_where_compose_in_iter(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        fake_backend.query.return_value = []
+        ds._backends["ontap"] = fake_backend
+
+        list(ds.query(FakeVolume, cluster="prod1").filter({"svm.name": "vs1"}).where("size > 0"))
+
+        call = fake_backend.query.call_args
+        assert call.args[4] == {"svm.name": "vs1"}
+        assert call.kwargs.get("where_expressions") == ("size > 0",)
+
+
 class TestBackendsRegistry:
     def test_ontap_backend_registered_at_import(self) -> None:
         assert "ontap" in _BACKENDS


### PR DESCRIPTION
## Description

Adds a new `.where(*expressions: str)` chain method to
`DataSource.QueryBuilder` that accepts SQL-like filter expression
strings (e.g. `"size > 1000000000"`, `"state != 'offline'"`) and
threads them through `OntapBackend.query()` to the existing cache
filter machinery (`ClusterMetadataDB.query_with_filters`). This is
the narrow string-expression precursor that unblocks Phase 3e
(#509 — `nf cache check` shim), whose `--where` flag cannot
round-trip through `DataSource.query().filter({...})` because
`.filter()` is equality-only.

`.where()` composes with `.filter()`: the final cache-path filter
list is the dict entries translated to `key = 'value'` followed by
the accumulated where-expressions, in a single ANDed list. Multiple
`.where()` calls accumulate; an empty `.where()` is a no-op.

```python
# Existing (unchanged):
ds.query(OntapVolume, cluster="prod1").filter({"svm.name": "vs1"})

# New:
ds.query(OntapVolume, cluster="prod1").where(
    "size > 1000000000",
    "autosize.mode != 'grow_shrink'",
)

# Composable:
ds.query(OntapVolume, cluster="prod1") \
    .filter({"svm.name": "vs1"}) \
    .where("size > 1000000000")
```

Addresses #512. Parent: #495 (Phase 3 of unified DataSource
accessor). Unblocks #509 (Phase 3e — `nf cache check` shim).
Related: #497 (typed field-reference DSL — stays deferred; this
issue is the narrower string-expression precursor that #497 will
eventually compile down to).

## Scope

v1 is **cache-path only**. Locked-in scope decisions from the plan:

1. **`Backend.query()` signature change** — gains
   `where_expressions: tuple[str, ...] = ()` as a **keyword-only**
   parameter. Default empty tuple keeps all existing callers and
   mock backends unaffected. Strictly additive, backwards
   compatible.
2. **Partial-fetch (mixed cache + live) + `.where()`** — raises
   `NotImplementedError` with a clear message pointing users at
   `source="cache"` to opt into the cache-only path.
3. **Live path + `.where()`** — raises `NotImplementedError` with
   a message pointing at `.filter({...})` for equality filters on
   live queries. The ONTAP REST query-syntax translator is tracked
   as a follow-up to #512.
4. **Composition** — `.filter({...})` and `.where(*exprs)` compose
   into a single ANDed filter list. Order doesn't matter (AND is
   commutative). Multiple `.where()` calls accumulate.
5. **Empty `.where()`** — no-op. Does not raise.

This PR is **strictly additive**. No existing tests are modified,
no existing call sites change behavior, no breaking changes.

## Files changed

- `src/pynetappfoundry/data/source.py` (+33) — `QueryBuilder.where()`
  chain method + `__iter__` threads `where_expressions` to the
  backend
- `src/pynetappfoundry/data/backends.py` (+44) — `Backend.query()`
  ABC and `OntapBackend.query()` gain keyword-only
  `where_expressions`; partial and live branches raise
  `NotImplementedError` when non-empty; cache branch concatenates
  with dict-derived equality fragments
- `docs/decisions/0012-unified-datasource-accessor.md` (+10) — §3
  references #512 alongside #497; Phase 3 prerequisites entry
  added to track this as an independent unblocker for Phase 3e
- `tests/unit/data/test_source.py` (+75) — `TestQueryBuilderWhere`
  (6 tests)
- `tests/unit/data/test_backends.py` (+183) —
  `TestQueryWithWhereExpressions` (7 tests)

## Test plan

- [x] `doit check` passes (1922 passed, 0 failed)
- [x] `TestQueryBuilderWhere` (6 new tests in `test_source.py`):
  - `.where()` accumulates expressions in
    `_where_expressions`
  - `.where()` returns `self` for chaining
  - Multiple `.where()` calls accumulate
  - Empty `.where()` is a no-op
  - `.filter()` and `.where()` both flow into backend kwargs on
    iteration
- [x] `TestQueryWithWhereExpressions` (7 new tests in
  `test_backends.py`):
  - Cache path concatenates `filters` dict with
    `where_expressions`
  - Cache path accepts where-only (empty filters)
  - Cache path unchanged when `where_expressions=()` (regression)
  - Live path raises `NotImplementedError` when
    `where_expressions` non-empty
  - Live path unchanged when `where_expressions=()` (regression)
  - Partial-fetch path raises `NotImplementedError` when
    `where_expressions` non-empty
  - Partial-fetch path unchanged when `where_expressions=()`
    (regression)
- [x] All pre-existing `test_source.py` and `test_backends.py`
  tests pass unchanged (default `where_expressions=()` kwarg is
  backwards compatible)

## ADR

ADR-0012 updated:

- **§3 (filter input ergonomics)** — now references #512 alongside
  #497 as the string-expression precursor the typed DSL will
  eventually compile down to
- **Phase 3 prerequisites** — new entry under Implementation
  Phases documenting that #512 landed independently of the shim
  migrations to unblock Phase 3e (#509)

No new ADR required; issue #512 is not labeled `needs-adr`.

## Follow-ups (out of scope for this PR)

- ONTAP REST query-syntax translator for the live path (separate
  follow-up issue)
- #509 (Phase 3e) — `nf cache check` shim now unblocked
- #497 — typed field-reference DSL remains deferred
