### PR TITLE
docs: add DataSource user guide and reposition QuerySet docs

### DIFF
--- a/docs/decisions/0012-unified-datasource-accessor.md
+++ b/docs/decisions/0012-unified-datasource-accessor.md
@@ -141,7 +141,7 @@ This ADR is Phase 1 of a four-phase plan. The full plan is in issue #495.
 
 ### Links to Documentation
 
-The user-facing guide for `DataSource` (`docs/usage/data-source.md`) does **not** exist yet — it will be created in Phase 4. This ADR will be updated with the doc link when that PR lands.
+- [DataSource User Guide](../usage/data-source.md) — comprehensive guide covering `DataSource.query()`, `DataSource.get()`, source modes, `QueryBuilder` chaining (`.filter()`, `.where()`, `.fields()`), and common patterns.
 
 ## Related Issues
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ client = ONTAPAPIClient(config, "cluster1")
 
 - **[Installation](getting-started/installation.md)** - How to install the package
 - **[Usage Guide](usage/basics.md)** - How to use the package
+- **[DataSource Guide](usage/data-source.md)** - Unified entry point for reading cluster data
 - **[ONTAP Access Patterns](usage/ontap-access-patterns.md)** - Guide to choosing between SDK, SSH, and REST access
 - **[Configuration Schema](reference/config-schema.md)** - Complete TOML configuration reference
 - **[CLI Reference](reference/cli.md)** - Command-line interface documentation

--- a/docs/usage/data-source.md
+++ b/docs/usage/data-source.md
@@ -1,0 +1,229 @@
+---
+title: DataSource
+description: Unified entry point for reading cluster data from cache or live API
+audience:
+  - users
+tags:
+  - datasource
+  - query
+  - cache
+  - api
+---
+
+# DataSource
+
+`DataSource` is the unified entry point for all cluster reads in pynetappfoundry. It routes requests through cache or live API based on per-field metadata and a per-call `source=` override, and returns typed Pydantic model instances regardless of the underlying path.
+
+## Overview
+
+| Surface | Best for | Returns |
+|---------|----------|---------|
+| `DataSource` | All new read code: cached, derived, and realtime fields | Pydantic model instances |
+| `QuerySet` | Direct REST operations: mutations, job tracking, relationship traversal | Pydantic model instances |
+| `LazyClusterMetadata` | Legacy cache reads (migrated to `DataSource` shim internally) | Pydantic model instances |
+
+!!! note "Use DataSource for new code"
+    `DataSource` supersedes direct use of `QuerySet` for reads and the `fetch_realtime` family for realtime fields. Both remain available for use cases `DataSource` does not cover (writes, job tracking, relationship traversal). See [Query Layer](query-layer.md) for the full `QuerySet` API.
+
+## Quick Start
+
+```python
+from pynetappfoundry.core.config import Config
+from pynetappfoundry.data.source import DataSource
+from pynetappfoundry.models.ontap.storage.volumes.model import OntapVolume
+
+config = Config()
+ds = DataSource(config)
+
+# Query: iterate all online volumes for a cluster
+for vol in ds.query(OntapVolume, cluster="prod1").filter(state="online"):
+    print(vol.name, vol.size)
+
+# Get: fetch a single volume by UUID
+vol = ds.get(OntapVolume, cluster="prod1", id="abc-123-def")
+if vol is not None:
+    print(vol.name)
+```
+
+## Querying Data
+
+`DataSource.query()` returns a `QueryBuilder` -- a lazy, chainable object that executes only when iterated.
+
+```python
+qb = ds.query(OntapVolume, cluster="prod1")
+```
+
+The `QueryBuilder` supports three chaining methods: `.filter()`, `.where()`, and `.fields()`. Each returns `self`, so calls compose freely.
+
+### Filtering with `.filter()`
+
+`.filter()` accepts a positional dict (supports dotted keys for nested fields) and/or keyword arguments (convenience for top-level scalars). On collision, kwargs win.
+
+```python
+# Dotted-key dict for nested fields (canonical form)
+qb = ds.query(OntapVolume, cluster="prod1").filter({"svm.name": "vs1"})
+
+# Keyword arguments for top-level fields
+qb = ds.query(OntapVolume, cluster="prod1").filter(state="online")
+
+# Both together
+qb = ds.query(OntapVolume, cluster="prod1").filter(
+    {"svm.name": "vs1", "autosize.mode": "grow"},
+    state="online",
+)
+```
+
+!!! note "Dotted keys, not dunder"
+    `DataSource` uses dotted-string keys (`"svm.name"`) in filter dicts instead of the `svm__name` dunder syntax used by `QuerySet`. Top-level scalar kwargs like `state="online"` work the same in both.
+
+### SQL-like Expressions with `.where()`
+
+`.where()` accepts one or more string expressions that support comparison operators beyond simple equality. Expressions are ANDed together with any `.filter()` entries.
+
+```python
+large_vols = ds.query(OntapVolume, cluster="prod1", source="cache").where(
+    "size > 1000000000",
+    "state != 'offline'",
+)
+for vol in large_vols:
+    print(vol.name, vol.size)
+```
+
+!!! warning "Cache-only"
+    `.where()` expressions are evaluated by the cache query engine and are only supported when the routing decision uses the cache path. Use `source="cache"` to opt in explicitly. Combining `.where()` with `source="live"` raises `NotImplementedError` at iteration time.
+
+### Field Projection with `.fields()`
+
+`.fields()` restricts which fields are populated on the returned models. Use it to reduce response size and parsing cost on large collections.
+
+```python
+qb = ds.query(OntapVolume, cluster="prod1").filter(state="online").fields(
+    "name", "uuid", "size",
+)
+```
+
+Fields not included in the projection fall back to their model defaults (`""`, `0`, `False`, etc.).
+
+### Chaining
+
+All three methods compose in any order. Multiple `.filter()` and `.where()` calls accumulate; `.fields()` replaces any previously set projection.
+
+```python
+results = list(
+    ds.query(OntapVolume, cluster="prod1", source="cache")
+    .filter({"svm.name": "vs1"})
+    .where("size > 500000000")
+    .fields("name", "size", "state")
+)
+```
+
+### Iterating Results
+
+`QueryBuilder` implements `__iter__`, so you can use it directly in a `for` loop or wrap it with `list()` to collect all results.
+
+```python
+# Iterate lazily
+for vol in ds.query(OntapVolume, cluster="prod1").filter(state="online"):
+    process(vol)
+
+# Collect into a list
+all_vols = list(ds.query(OntapVolume, cluster="prod1"))
+```
+
+## Fetching a Single Instance
+
+`DataSource.get()` fetches one model instance by its identifier. It returns `T | None` -- `None` if no match exists.
+
+### Single-Key Models
+
+Most models have a single identifier field (typically `uuid`).
+
+```python
+vol = ds.get(OntapVolume, cluster="prod1", id="abc-123-def")
+if vol is not None:
+    print(vol.name)
+```
+
+### Composite-Key Models
+
+Some models have composite identifiers. Pass `id=` as a dict containing all required key fields.
+
+```python
+from pynetappfoundry.models.ontap.networking.ip.interfaces.model import OntapIpInterface
+
+lif = ds.get(
+    OntapIpInterface,
+    cluster="prod1",
+    id={"svm_name": "vs1", "name": "lif1"},
+)
+```
+
+### Field Projection on `.get()`
+
+Like `.query()`, `.get()` accepts an optional `fields=` parameter.
+
+```python
+vol = ds.get(
+    OntapVolume, cluster="prod1", id="abc-123-def",
+    fields=["name", "size", "state"],
+)
+```
+
+## Source Modes
+
+Every `DataSource` method accepts a `source=` parameter that controls where data is read from. The type is `SourceMode`, a literal union of three strings.
+
+| Mode | Behavior | When to use |
+|------|----------|-------------|
+| `"auto"` (default) | Serves cached and derived fields from cache; fetches realtime and `requires_explicit_fetch` fields live only when explicitly named in `fields=` | General-purpose reads |
+| `"cache"` | Forces all requested fields through the cache; raises `ValueError` if any field is realtime-only | Fast, deterministic reads against local data |
+| `"live"` | Forces all requested fields through the live REST API; raises `ValueError` if any field is derived (derived fields exist only in cache) | Fresh data from the cluster, bypassing cache |
+
+```python
+# Default: auto-routing based on field metadata
+vol = ds.get(OntapVolume, cluster="prod1", id="abc-123-def")
+
+# Cache-only: fast, no network calls
+vol = ds.get(OntapVolume, cluster="prod1", id="abc-123-def", source="cache")
+
+# Live: bypass cache entirely
+vol = ds.get(OntapVolume, cluster="prod1", id="abc-123-def", source="live")
+```
+
+!!! note "Relationship to CLI --live"
+    The `--live` flag on CLI commands like `nf cache check` sets `source="live"` internally. Note that `--live` and `--where` are mutually exclusive on `nf cache check` because `.where()` expressions only work on cached data.
+
+## Common Patterns
+
+### Counting Results
+
+Wrap a query in `list()` and take the length, or use a generator expression.
+
+```python
+count = sum(1 for _ in ds.query(OntapVolume, cluster="prod1").filter(state="online"))
+```
+
+### Existence Check
+
+```python
+has_offline = any(
+    True for _ in ds.query(OntapVolume, cluster="prod1").filter(state="offline")
+)
+```
+
+### Error Handling
+
+`DataSource` raises `ValueError` for unregistered models, missing identifiers, and impossible source-mode combinations (e.g. requesting a realtime field with `source="cache"`).
+
+```python
+try:
+    vol = ds.get(OntapVolume, cluster="prod1", id="bad-uuid", source="cache")
+except ValueError as exc:
+    print(f"Configuration error: {exc}")
+```
+
+## See Also
+
+- [ADR-0012: Unified DataSource accessor](../decisions/0012-unified-datasource-accessor.md) -- design rationale and implementation phases
+- [Query Layer](query-layer.md) -- `QuerySet`, `Mutation`, `JobTracker`, relationship traversal, and realtime functions
+- [ONTAP Access Patterns](ontap-access-patterns.md) -- decision matrix for choosing between access surfaces

--- a/docs/usage/query-layer.md
+++ b/docs/usage/query-layer.md
@@ -12,6 +12,17 @@ tags:
   - realtime
 ---
 
+!!! note "Prefer DataSource for new code"
+    `DataSource` is the recommended entry point for reading cluster data.
+    It routes reads through cache or live API based on the `source=` parameter
+    and supports `.filter()`, `.where()`, and `.fields()` chaining.
+    See the [DataSource guide](data-source.md) for details.
+
+    `QuerySet` remains available as the lower-level REST query surface
+    used internally by `DataSource` and for direct REST operations
+    (mutations, job tracking, relationship traversal) that `DataSource`
+    does not cover.
+
 # Query Layer
 
 `pynetappfoundry.query` is a thin, fluent layer on top of the ONTAP REST API client. It uses the same declarative `TypeMapping` metadata that drives the cache (see [ADR-0004](../decisions/0004-declarative-field-mapping-framework.md)) to translate model attribute names into API field paths and to parse responses back into Pydantic model instances.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
   - Usage:
       - Basics: usage/basics.md
       - ONTAP Access Patterns: usage/ontap-access-patterns.md
+      - DataSource: usage/data-source.md
       - Query Layer: usage/query-layer.md
       - Compliance Checks: usage/compliance-checks.md
   - Reference:


### PR DESCRIPTION
## Description

Add a comprehensive DataSource user guide and reposition QuerySet documentation to reflect the DataSource-first architecture introduced in ADR-0012.

Addresses #516
Parent tracking issue: #495 (Phase 4 — documentation)

## Related Issue

Addresses #516

## Type of Change

- [x] Documentation update

## Changes Made

- **`docs/usage/data-source.md`** (NEW) — Complete user guide covering `DataSource.query()`, `DataSource.get()`, source modes (`auto`/`cache`/`live`), `QueryBuilder` chaining (`.filter()`, `.where()`, `.fields()`), composite-key models, and common patterns
- **`docs/usage/query-layer.md`** — Added admonition at the top repositioning `QuerySet` as the lower-level REST surface, directing readers to `DataSource` for new code
- **`mkdocs.yml`** — Added nav entry for DataSource guide above Query Layer
- **`docs/index.md`** — Added DataSource Guide link to the documentation index
- **`docs/decisions/0012-unified-datasource-accessor.md`** — Updated "Links to Documentation" section to reference the new guide (replacing the placeholder note)

## Testing

- [x] All existing tests pass (`doit check` — format, lint, type-check, spell-check, security, tests)
- [x] No code changes — documentation only

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This completes Phase 4 (documentation) of the DataSource migration tracked in #495. ADR-0012 has been updated with the doc link as required by project conventions.
