### PR TITLE
refactor: migrate nf licenses check/savings to DataSource shim (phase 3f/1 of #510)

### DIFF
--- a/src/pynetappfoundry/cli/commands/licenses/check.py
+++ b/src/pynetappfoundry/cli/commands/licenses/check.py
@@ -80,10 +80,12 @@ def _check_cluster_licenses(
         client = ONTAPAPIClient(cluster=cluster_config, config=config)
 
         packages: list[OntapLicensePackageResponse] = QuerySet(
-            OntapLicensePackageResponse, client
+            OntapLicensePackageResponse, client, config=config
         ).all()
 
-        nodes_response: list[OntapNodeResponse] = QuerySet(OntapNodeResponse, client).all()
+        nodes_response: list[OntapNodeResponse] = QuerySet(
+            OntapNodeResponse, client, config=config
+        ).all()
 
         nodes_data: dict[str, dict[str, Any]] = {}
         for node in nodes_response:

--- a/src/pynetappfoundry/cli/commands/licenses/savings.py
+++ b/src/pynetappfoundry/cli/commands/licenses/savings.py
@@ -49,7 +49,7 @@ def _analyze_cluster_savings(
         client = ONTAPAPIClient(cluster=cluster_config, config=config)
 
         packages: list[OntapLicensePackageResponse] = QuerySet(
-            OntapLicensePackageResponse, client
+            OntapLicensePackageResponse, client, config=config
         ).all()
 
         table = Table(title=f"License Usage for {name}")

--- a/tests/unit/cli/commands/licenses/test_check.py
+++ b/tests/unit/cli/commands/licenses/test_check.py
@@ -100,6 +100,9 @@ class TestCheckClusterLicenses:
         assert len(issues) == 1
         assert issues[0]["error"] == "Expiring license"
         assert issues[0]["days_checked"] in (9, 10)
+        # Verify config= is threaded to QuerySet (DataSource shim)
+        for call in mock_qs_cls.call_args_list:
+            assert call.kwargs.get("config") is mock_config
 
     @patch("pynetappfoundry.cli.commands.licenses.check.QuerySet")
     @patch("pynetappfoundry.cli.commands.licenses.check.ONTAPAPIClient")
@@ -123,6 +126,9 @@ class TestCheckClusterLicenses:
         issues = _check_cluster_licenses("cluster1", sample_details, mock_config)
 
         assert len(issues) == 0
+        # Verify config= is threaded to QuerySet (DataSource shim)
+        for call in mock_qs_cls.call_args_list:
+            assert call.kwargs.get("config") is mock_config
 
     @patch("pynetappfoundry.cli.commands.licenses.check.QuerySet")
     @patch("pynetappfoundry.cli.commands.licenses.check.ONTAPAPIClient")

--- a/tests/unit/cli/commands/licenses/test_savings.py
+++ b/tests/unit/cli/commands/licenses/test_savings.py
@@ -83,6 +83,8 @@ class TestAnalyzeClusterSavings:
         _analyze_cluster_savings("cluster1", sample_details, mock_config)
 
         mock_console.print.assert_called_once()
+        # Verify config= is threaded to QuerySet (DataSource shim)
+        assert mock_qs_cls.call_args.kwargs.get("config") is mock_config
 
     @patch("pynetappfoundry.cli.commands.licenses.savings.console")
     @patch("pynetappfoundry.cli.commands.licenses.savings.QuerySet")


### PR DESCRIPTION
## Description

Thread `config=config` to all QuerySet constructions in `nf licenses check` and `nf licenses savings`, routing data fetches through DataSource via the Phase 3c shim.

This is Sub-PR 1 of the Phase 3f tracking issue (#510).

Addresses #510

## Type of Change

- [x] Code refactoring

## Changes Made

- **`licenses/check.py`** — Added `config=config` to both `QuerySet(OntapLicensePackageResponse, client)` and `QuerySet(OntapNodeResponse, client)` calls
- **`licenses/savings.py`** — Added `config=config` to the `QuerySet(OntapLicensePackageResponse, client)` call
- **`test_check.py`** — Added assertions verifying `config=` is passed to QuerySet
- **`test_savings.py`** — Added assertion verifying `config=` is passed to QuerySet

## Testing

- [x] All existing tests pass
- [x] Test assertions added to verify `config=config` threading
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
