### PR TITLE
refactor: migrate nf reports locks to DataSource shim (phase 3f/2 of #510)

### DIFF
--- a/src/pynetappfoundry/cli/commands/reports/locks.py
+++ b/src/pynetappfoundry/cli/commands/reports/locks.py
@@ -63,7 +63,7 @@ def _gather_lock_data(
         cluster_config = ClusterConfig(**details)
         client = ONTAPAPIClient(cluster=cluster_config, config=config)
 
-        locks_data: list[OntapClientLock] = QuerySet(OntapClientLock, client).all()
+        locks_data: list[OntapClientLock] = QuerySet(OntapClientLock, client, config=config).all()
 
         ws = wb.create_sheet(name)
         ws.append(["Volume", "Protocol", "Type", "Path", "Lock", "State", "IP Address"])

--- a/tests/unit/cli/commands/reports/test_locks.py
+++ b/tests/unit/cli/commands/reports/test_locks.py
@@ -91,6 +91,9 @@ class TestGatherLockData:
         assert ws.cell(row=1, column=7).value == "IP Address"
         # Data row
         assert ws.cell(row=2, column=1).value == "vol1"
+        # Verify config= is threaded to QuerySet (DataSource shim)
+        for call in mock_qs_cls.call_args_list:
+            assert call.kwargs.get("config") is mock_config
 
     @patch("pynetappfoundry.cli.commands.reports.locks.QuerySet")
     @patch("pynetappfoundry.cli.commands.reports.locks.ONTAPAPIClient")
@@ -124,6 +127,9 @@ class TestGatherLockData:
         assert ws.cell(row=2, column=5).value == "read_write"
         assert ws.cell(row=2, column=6).value == "granted"
         assert ws.cell(row=2, column=7).value == "192.168.1.10"
+        # Verify config= is threaded to QuerySet (DataSource shim)
+        for call in mock_qs_cls.call_args_list:
+            assert call.kwargs.get("config") is mock_config
 
     @patch("pynetappfoundry.cli.commands.reports.locks.QuerySet")
     @patch("pynetappfoundry.cli.commands.reports.locks.ONTAPAPIClient")
@@ -152,6 +158,9 @@ class TestGatherLockData:
         ws = wb["cluster1"]
         assert ws.cell(row=2, column=3).value == "op_lock"
         assert ws.cell(row=2, column=5).value == "batch"
+        # Verify config= is threaded to QuerySet (DataSource shim)
+        for call in mock_qs_cls.call_args_list:
+            assert call.kwargs.get("config") is mock_config
 
     @patch("pynetappfoundry.cli.commands.reports.locks.print_error")
     @patch("pynetappfoundry.cli.commands.reports.locks.ONTAPAPIClient")
@@ -200,3 +209,6 @@ class TestGatherLockData:
         ws = wb["cluster1"]
         assert ws.cell(row=1, column=1).value == "Volume"
         assert ws.cell(row=2, column=1).value is None
+        # Verify config= is threaded to QuerySet (DataSource shim)
+        for call in mock_qs_cls.call_args_list:
+            assert call.kwargs.get("config") is mock_config


### PR DESCRIPTION
## Description

Thread `config=config` to the QuerySet construction in `nf reports locks`, routing the data fetch through DataSource via the Phase 3c shim.

This is Sub-PR 2 of the Phase 3f tracking issue (#510).

Addresses #510

## Type of Change

- [x] Code refactoring

## Changes Made

- **`reports/locks.py`** — Added `config=config` to `QuerySet(OntapClientLock, client)` call
- **`test_locks.py`** — Added assertions verifying `config=` is passed to QuerySet in all 4 relevant tests

## Testing

- [x] All existing tests pass
- [x] Test assertions added to verify `config=config` threading
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
