### PR TITLE
refactor: migrate nf utils validate to DataSource shim (phase 3f/4 of #510)

### DIFF
--- a/src/pynetappfoundry/cli/commands/utils/validate.py
+++ b/src/pynetappfoundry/cli/commands/utils/validate.py
@@ -105,8 +105,8 @@ def _validate_cluster(
         response = client.call_endpoint("/cluster")
         cluster_name = response.get("name", "") if isinstance(response, dict) else ""
 
-        node_count = QuerySet(OntapNodeResponse, client).count()
-        vol_count = QuerySet(OntapVolume, client).count()
+        node_count = QuerySet(OntapNodeResponse, client, config=config).count()
+        vol_count = QuerySet(OntapVolume, client, config=config).count()
 
         print_success("  API: Connected successfully")
         success = True

--- a/tests/unit/cli/commands/utils/test_validate.py
+++ b/tests/unit/cli/commands/utils/test_validate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -11,6 +11,8 @@ from pynetappfoundry.cli.commands.utils.validate import (
     _validate_cluster,
     _validate_ssh,
 )
+from pynetappfoundry.models.ontap.cluster.nodes.model import OntapNodeResponse
+from pynetappfoundry.models.ontap.storage.volumes.model import OntapVolume
 
 MODULE = "pynetappfoundry.cli.commands.utils.validate"
 
@@ -58,6 +60,11 @@ class TestValidateCluster:
         assert node_count == 2
         assert vol_count == 5
         assert success is True
+
+        assert mock_qs_cls.call_args_list == [
+            call(OntapNodeResponse, mock_client, config=mock_config),
+            call(OntapVolume, mock_client, config=mock_config),
+        ]
 
     @patch(f"{MODULE}.print_warning")
     @patch(f"{MODULE}.QuerySet")


### PR DESCRIPTION
## Description

Thread `config=config` to the QuerySet constructions in `nf utils validate`, routing the `.count()` data fetches through DataSource via the Phase 3c shim. The raw REST call (`client.call_endpoint("/cluster")`) and ONTAPCLI (SSH) sections are left unchanged — this is a partial migration.

This is Sub-PR 4 of the Phase 3f tracking issue (#510).

Addresses #510

## Type of Change

- [x] Code refactoring

## Changes Made

- **`utils/validate.py`** — Added `config=config` to both `QuerySet(OntapNodeResponse, client).count()` and `QuerySet(OntapVolume, client).count()` calls
- **`test_validate.py`** — Added assertion verifying both QuerySet calls receive `config=config`

## Testing

- [x] All existing tests pass
- [x] Test assertions added to verify `config=config` threading
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
