### PR TITLE
refactor: migrate nf reports html to DataSource shim (phase 3f/5 of #510)

### DIFF
--- a/src/pynetappfoundry/cli/commands/reports/html.py
+++ b/src/pynetappfoundry/cli/commands/reports/html.py
@@ -825,9 +825,10 @@ class ClusterData:
                 )
 
             self.management_ip = ip
-            self.nodes = QuerySet(OntapNodeResponse, client).all()
-            self.svms = QuerySet(OntapSvm, client).all()
-            self.cifs_services = QuerySet(OntapCifsService, client).all()
+            config = self.app_instance.config
+            self.nodes = QuerySet(OntapNodeResponse, client, config=config).all()
+            self.svms = QuerySet(OntapSvm, client, config=config).all()
+            self.cifs_services = QuerySet(OntapCifsService, client, config=config).all()
         except Exception as e:
             print_error(f"Could not gather data from {self.name}: {e}")
 

--- a/tests/unit/cli/commands/reports/test_html.py
+++ b/tests/unit/cli/commands/reports/test_html.py
@@ -518,6 +518,41 @@ class TestClusterData:
         assert cluster.cluster_info is None
         assert cluster.nodes == []
 
+    @patch("pynetappfoundry.cli.commands.reports.html.QuerySet")
+    @patch("pynetappfoundry.cli.commands.reports.html.parse_api_record")
+    @patch("pynetappfoundry.cli.commands.reports.html.ONTAPAPIClient")
+    def test_gather_data_threads_config_to_queryset(
+        self,
+        mock_api_client_class: MagicMock,
+        mock_parse: MagicMock,
+        mock_qs_cls: MagicMock,
+        mock_config: MagicMock,
+    ) -> None:
+        """Test that _gather_data passes config= to every QuerySet call."""
+        mock_builder = MagicMock()
+        mock_builder.config = mock_config
+
+        mock_client = MagicMock()
+        mock_api_client_class.return_value = mock_client
+        mock_client.call_endpoint.return_value = {}
+        mock_parse.return_value = MagicMock(spec=ClusterInfo)
+        mock_qs_cls.return_value.all.return_value = []
+
+        cluster = ClusterData(
+            "test-cluster",
+            mock_builder,
+            div="Div1",
+            bu="BU1",
+            ip="10.0.0.1",
+            tags=[],
+        )
+
+        # 3 QuerySet calls: nodes, svms, cifs_services
+        assert mock_qs_cls.call_count == 3
+        for call in mock_qs_cls.call_args_list:
+            assert call.kwargs.get("config") is mock_config
+        assert cluster.nodes == []
+
 
 class TestCSSAndJS:
     """Tests for CSS and JavaScript constants."""


### PR DESCRIPTION
## Description

Thread `config=config` to all 3 QuerySet constructions in `nf reports html` (`ClusterData._gather_data()`), routing data fetches through DataSource via the Phase 3c shim. The `ClusterEntry.ontap` access in `_build_cloud_info()` was already on DataSource via the Phase 3b LazyClusterMetadata shim — no change needed there.

This is Sub-PR 5 of the Phase 3f tracking issue (#510).

Addresses #510

## Type of Change

- [x] Code refactoring

## Changes Made

- **`reports/html.py`** — Added `config=config` to `QuerySet(OntapNodeResponse, client)`, `QuerySet(OntapSvm, client)`, and `QuerySet(OntapCifsService, client)` calls in `ClusterData._gather_data()`
- **`test_html.py`** — Added `test_gather_data_threads_config_to_queryset` verifying all 3 QuerySet calls receive `config=config`

## Testing

- [x] All existing tests pass
- [x] New test added to verify `config=config` threading
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
