### PR TITLE
fix: preserve fields=* in DataSource live URL builder to avoid ONTAP 400 errors

### DIFF
--- a/src/pynetappfoundry/data/backends.py
+++ b/src/pynetappfoundry/data/backends.py
@@ -211,7 +211,13 @@ class OntapBackend(Backend):
             else:
                 api_paths.append(attr)
         if api_paths:
-            query["fields"] = [",".join(api_paths)]
+            # Preserve fields=* from the base endpoint when present.
+            # ONTAP's fields=* returns all fields, which is a superset
+            # of any explicit field list. Enumerating individual fields
+            # can produce URLs too long for ONTAP to accept (400 error).
+            existing = query.get("fields", [])
+            if existing != ["*"]:
+                query["fields"] = [",".join(api_paths)]
 
         for key, value in params.items():
             query[key] = [str(value)]
@@ -558,7 +564,10 @@ class OntapBackend(Backend):
         for chunk in self._chunked(list(identifiers), _BATCH_SIZE):
             query = {k: list(v) for k, v in base_query.items()}
             if api_paths:
-                query["fields"] = [",".join(api_paths)]
+                # Preserve fields=* from the base endpoint when present.
+                existing = query.get("fields", [])
+                if existing != ["*"]:
+                    query["fields"] = [",".join(api_paths)]
             query[identifier_field] = ["|".join(chunk)]
             url = urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
             response = client.get_all_records(url)

--- a/tests/unit/data/test_backends.py
+++ b/tests/unit/data/test_backends.py
@@ -90,7 +90,7 @@ class TestOntapBackendGet:
         mock_client.get_all_records.assert_called_once()
         url = mock_client.get_all_records.call_args[0][0]
         assert "uuid=abc-123" in url
-        assert "fields=iops" in url
+        assert "fields=%2A" in url or "fields=*" in url
         parse_mock.assert_called_once()
         assert "iops" in result._fetched_fields  # type: ignore[union-attr]
 
@@ -564,7 +564,7 @@ class TestOntapBackendQueryPartial:
         url = mock_client.get_all_records.call_args[0][0]
         # urlencode quotes `|` as %7C
         assert "uuid=u1%7Cu2%7Cu3" in url
-        assert "fields=iops" in url
+        assert "fields=%2A" in url or "fields=*" in url
 
     def test_partial_query_identifier_extract_single_key(self) -> None:
         instances = [
@@ -868,3 +868,68 @@ class TestCountLive:
 
         url = mock_client.call_endpoint.call_args[0][0]
         assert "svm.name=vs1" in url
+
+
+class TestBuildLiveUrlFieldsStar:
+    """Tests for :meth:`OntapBackend._build_live_url` preserving ``fields=*``."""
+
+    def test_fields_star_preserved_when_base_endpoint_has_star(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """When api_endpoint has ``fields=*``, _build_live_url must not
+        overwrite it with enumerated field names (#522)."""
+        backend = _make_backend(mock_config)
+        url = backend._build_live_url(
+            fake_volume_mapping,
+            params={"svm.name": "vs1"},
+            live_field_paths=("iops",),
+        )
+        # fields=* must survive; must NOT become fields=iops
+        assert "fields=%2A" in url or "fields=*" in url
+        assert "fields=iops" not in url
+        assert "svm.name=vs1" in url
+
+    def test_fields_enumerated_when_base_endpoint_has_no_star(
+        self,
+        mock_config: Any,
+    ) -> None:
+        """When api_endpoint does NOT have ``fields=*``, _build_live_url
+        must enumerate individual field api_paths as before."""
+        from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+
+        mapping = TypeMapping(
+            name="NoStar",
+            model_class=FakeVolume,
+            api_endpoint="/storage/volumes",
+            api_type="ontap",
+            identifier_field="uuid",
+            fields=(
+                FieldMapping(cache_attr="uuid", cache_strategy="cache"),
+                FieldMapping(cache_attr="iops", cache_strategy="realtime"),
+            ),
+        )
+        backend = _make_backend(mock_config)
+        url = backend._build_live_url(
+            mapping,
+            params={},
+            live_field_paths=("iops",),
+        )
+        assert "fields=iops" in url
+
+    def test_fields_star_preserved_with_return_records_false(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Preserve ``fields=*`` even when return_records=False."""
+        backend = _make_backend(mock_config)
+        url = backend._build_live_url(
+            fake_volume_mapping,
+            params={},
+            live_field_paths=("iops",),
+            return_records=False,
+        )
+        assert "fields=%2A" in url or "fields=*" in url
+        assert "return_records=false" in url


### PR DESCRIPTION
## Description

Fix `OntapBackend._build_live_url()` and `_fetch_live_by_identifiers()` to preserve `fields=*` from the TypeMapping's base endpoint URL instead of expanding it to individual `api_path` values. The expansion produced URLs too long for ONTAP to accept, causing 400 Bad Request errors on models with many fields (e.g. `OntapNodeResponse` with 109 fields).

Addresses #522

## Type of Change

- [x] Bug fix

## Changes Made

- **`backends.py`** — In both `_build_live_url()` and `_fetch_live_by_identifiers()`, check if the base URL already has `fields=*` before overwriting with enumerated field paths. If present, skip enumeration — ONTAP's `fields=*` returns all fields, which is a superset of any explicit field list.
- **`test_backends.py`** — Added 3 new tests verifying `fields=*` preservation (with/without `return_records=False`, and enumeration when endpoint has no `fields=*`). Updated 2 existing assertions to match new behavior.

## Testing

- [x] All existing tests pass
- [x] 3 new tests for `fields=*` preservation
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
