### PR TITLE
fix: request ip_interfaces.location explicitly in SVM mapping for LIF home node

### DIFF
--- a/src/pynetappfoundry/cache/field_mapping.py
+++ b/src/pynetappfoundry/cache/field_mapping.py
@@ -231,9 +231,10 @@ class TypeMapping:
         """Build the collection URL with dynamically appended expensive fields.
 
         Strips ``{id}`` path placeholders (like :attr:`collection_endpoint`).
-        If the endpoint contains ``?fields=*``, appends the top-level API
-        field names for fields that require explicit fetch.  Otherwise
-        returns the endpoint unchanged (after placeholder stripping).
+        If the endpoint contains ``?fields=*``, preserves any extra fields
+        appended after the ``*`` (e.g. nested array paths) and merges with
+        expensive (``requires_explicit_fetch``) fields.  Otherwise returns
+        the endpoint unchanged (after placeholder stripping).
 
         Returns:
             Endpoint URL suitable for bulk collection.
@@ -248,9 +249,17 @@ class TypeMapping:
         if not query.startswith("fields=*"):
             return f"{path}?{query}"
 
+        # Preserve extra fields after fields=* in the base endpoint
+        # (e.g. "fields=*,ip_interfaces.location") and merge with
+        # expensive (requires_explicit_fetch) fields.
+        base_fields_part = query.split("&", 1)[0]  # "fields=*,extra,..."
+        extra = base_fields_part.removeprefix("fields=*").lstrip(",")
+        extra_list = [f for f in extra.split(",") if f]
+
         expensive = self.explicit_fetch_api_fields()
-        if expensive:
-            return f"{path}?fields=*,{','.join(expensive)}"
+        all_extra = extra_list + expensive
+        if all_extra:
+            return f"{path}?fields=*,{','.join(all_extra)}"
         return f"{path}?fields=*"
 
     @property

--- a/src/pynetappfoundry/cache/ontap/svm/svms/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/svm/svms/mapping.py
@@ -38,7 +38,7 @@ def _transform_routes(record: dict[str, Any]) -> list[OntapSvmRoute]:
 ONTAPSVM_MAPPING = TypeMapping(
     name="OntapSvm",
     model_class=OntapSvm,
-    api_endpoint="/svm/svms?fields=*",
+    api_endpoint="/svm/svms?fields=*,ip_interfaces.location",
     api_type="ontap",
     fields=(
         FieldMapping(

--- a/tests/unit/cache/test_field_mapping.py
+++ b/tests/unit/cache/test_field_mapping.py
@@ -1280,6 +1280,13 @@ class TestBuildCollectionUrl:
         )
         assert tm.build_collection_url() == "/storage/volumes"
 
+    def test_svm_mapping_requests_ip_interfaces_location(self) -> None:
+        """SVM mapping explicitly requests ip_interfaces.location for nested data."""
+        from pynetappfoundry.cache.ontap.svm.svms.mapping import ONTAPSVM_MAPPING
+
+        url = ONTAPSVM_MAPPING.build_collection_url()
+        assert "ip_interfaces.location" in url
+
 
 # ---------------------------------------------------------------------------
 # cache_strategy filtering in parse_api_record tests


### PR DESCRIPTION
## Description

Fix `nf reports html` showing "Unknown" for LIF home node by explicitly requesting `ip_interfaces.location` in the SVM mapping's `api_endpoint`. ONTAP's `fields=*` doesn't return deeply nested sub-fields for array objects without explicit requests.

Also fixes `build_collection_url()` to preserve extra fields appended after `fields=*` in the base endpoint, so they aren't dropped when expensive fields are merged in.

Addresses #524

## Type of Change

- [x] Bug fix

## Changes Made

- **`cache/field_mapping.py`** — `build_collection_url()` now preserves extra fields after `fields=*` in the base endpoint (e.g. `ip_interfaces.location`) when merging with expensive fields
- **`cache/ontap/svm/svms/mapping.py`** — Changed `api_endpoint` from `"/svm/svms?fields=*"` to `"/svm/svms?fields=*,ip_interfaces.location"` so ONTAP returns nested location data (home_node, home_port, broadcast_domain) for each LIF
- **`tests/unit/cache/test_field_mapping.py`** — Added test verifying the SVM mapping URL includes `ip_interfaces.location`

## Testing

- [x] All existing tests pass
- [x] New test for SVM mapping URL
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Notes

The systemic version of this issue (89+ array fields across all mappings) is tracked in #525.
