### PR TITLE
fix: use startswith check for fields=* preservation in live URL builder

### DIFF
--- a/src/pynetappfoundry/data/backends.py
+++ b/src/pynetappfoundry/data/backends.py
@@ -215,8 +215,9 @@ class OntapBackend(Backend):
             # ONTAP's fields=* returns all fields, which is a superset
             # of any explicit field list. Enumerating individual fields
             # can produce URLs too long for ONTAP to accept (400 error).
-            existing = query.get("fields", [])
-            if existing != ["*"]:
+            # The value may be "*" or "*,nested.path" — both start with *.
+            existing = query.get("fields", [""])[0]
+            if not existing.startswith("*"):
                 query["fields"] = [",".join(api_paths)]
 
         for key, value in params.items():
@@ -565,8 +566,8 @@ class OntapBackend(Backend):
             query = {k: list(v) for k, v in base_query.items()}
             if api_paths:
                 # Preserve fields=* from the base endpoint when present.
-                existing = query.get("fields", [])
-                if existing != ["*"]:
+                existing = query.get("fields", [""])[0]
+                if not existing.startswith("*"):
                     query["fields"] = [",".join(api_paths)]
             query[identifier_field] = ["|".join(chunk)]
             url = urlunparse(parsed._replace(query=urlencode(query, doseq=True)))


### PR DESCRIPTION
## Description

Fix the `fields=*` preservation check in `_build_live_url()` and `_fetch_live_by_identifiers()` to use `startswith("*")` instead of exact equality `== ["*"]`. The original fix (#523) only matched bare `fields=*`, but `collection_endpoint` can return `fields=*,ip_interfaces.location` (when mappings append nested paths per #524), causing the check to fail and field enumeration to resume.

Addresses #522

## Type of Change

- [x] Bug fix

## Changes Made

- **`backends.py`** — Changed both `fields=*` preservation checks from `existing != ["*"]` to `not existing.startswith("*")`, handling values like `*,ip_interfaces.location`

## Testing

- [x] All existing tests pass (including the 3 tests from the original #523 fix)
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
