### PR TITLE
fix: add cache-miss to live fallback for DataSource source=auto

### DIFF
--- a/docs/decisions/0012-unified-datasource-accessor.md
+++ b/docs/decisions/0012-unified-datasource-accessor.md
@@ -50,9 +50,9 @@ String filter expressions beyond equality land via `DataSource.QueryBuilder.wher
 
 `DataSource` accepts `source="auto" | "cache" | "live"` on every read:
 
-- `auto` (default) honors the per-field `cache_strategy` declared on `FieldMapping`.
-- `cache` raises if asked for a `realtime` field.
-- `live` bypasses the cache entirely.
+- `auto` (default) honors the per-field `cache_strategy` declared on `FieldMapping`. If the cache returns no results, automatically retries with live routing (cache-miss fallback, issue #528). The fallback excludes derived fields (cache-only) and is skipped when `.where()` expressions are present.
+- `cache` raises if asked for a `realtime` field. No fallback on empty results.
+- `live` bypasses the cache entirely. No fallback.
 
 The CLI `--live` flag from issue #472 becomes a passthrough to `source="live"`, which generalizes the existing narrow override to every read path.
 

--- a/docs/usage/data-source.md
+++ b/docs/usage/data-source.md
@@ -175,9 +175,12 @@ Every `DataSource` method accepts a `source=` parameter that controls where data
 
 | Mode | Behavior | When to use |
 |------|----------|-------------|
-| `"auto"` (default) | Serves cached and derived fields from cache; fetches realtime and `requires_explicit_fetch` fields live only when explicitly named in `fields=` | General-purpose reads |
-| `"cache"` | Forces all requested fields through the cache; raises `ValueError` if any field is realtime-only | Fast, deterministic reads against local data |
-| `"live"` | Forces all requested fields through the live REST API; raises `ValueError` if any field is derived (derived fields exist only in cache) | Fresh data from the cluster, bypassing cache |
+| `"auto"` (default) | Serves cached and derived fields from cache; fetches realtime and `requires_explicit_fetch` fields live only when explicitly named in `fields=`. **If the cache returns no results, automatically retries with live routing** (cache-miss fallback). | General-purpose reads |
+| `"cache"` | Forces all requested fields through the cache; raises `ValueError` if any field is realtime-only. No fallback on empty results. | Fast, deterministic reads against local data |
+| `"live"` | Forces all requested fields through the live REST API; raises `ValueError` if any field is derived (derived fields exist only in cache). No fallback. | Fresh data from the cluster, bypassing cache |
+
+!!! note "Auto mode cache-miss fallback"
+    When `source="auto"` and the initial cache-routed request returns no results (`None` for `.get()`, empty list for `.query()`), DataSource transparently retries with live routing. This means callers get data regardless of whether the cache has been populated for a given cluster. The fallback is skipped when `.where()` expressions are present, since those are cache-only and cannot be evaluated on the live path.
 
 ```python
 # Default: auto-routing based on field metadata

--- a/src/pynetappfoundry/data/source.py
+++ b/src/pynetappfoundry/data/source.py
@@ -37,6 +37,14 @@ _BACKENDS: dict[str, type[Backend]] = {
 }
 
 
+def _field_strategy(mapping: TypeMapping, cache_attr: str) -> str | None:
+    """Return the ``cache_strategy`` for *cache_attr*, or ``None`` if unknown."""
+    for f in mapping.fields:
+        if f.cache_attr == cache_attr:
+            return f.cache_strategy
+    return None
+
+
 class DataSource:
     """Unified accessor for model instances across cache and live API.
 
@@ -159,7 +167,18 @@ class DataSource:
         identifier = self._normalize_identifier(mapping, id)
         backend = self._get_backend(mapping.api_type)
         decision = decide_path(mapping, fields, source)
-        return backend.get(model_class, mapping, decision, cluster, identifier)
+        result = backend.get(model_class, mapping, decision, cluster, identifier)
+        # Cache-miss fallback: if auto routed to cache and got nothing, try live.
+        # Pass the cache_fields explicitly so derived fields are excluded
+        # (derived fields cannot be fetched live and would raise ValueError).
+        if result is None and source == "auto" and decision.cache_fields:
+            live_fields = [
+                f for f in decision.cache_fields if _field_strategy(mapping, f) != "derived"
+            ]
+            if live_fields:
+                live_decision = decide_path(mapping, live_fields, "live")
+                result = backend.get(model_class, mapping, live_decision, cluster, identifier)
+        return result
 
     def query(
         self,
@@ -272,4 +291,27 @@ class QueryBuilder[T: BaseModel]:
             self._filters,
             where_expressions=tuple(self._where_expressions),
         )
+        # Cache-miss fallback: if auto routed to cache and got nothing, try live.
+        # Skip if where_expressions are present (cache-only, would raise on live).
+        # Pass the cache_fields explicitly so derived fields are excluded
+        # (derived fields cannot be fetched live and would raise ValueError).
+        if (
+            not results
+            and self._source_mode == "auto"
+            and decision.cache_fields
+            and not self._where_expressions
+        ):
+            live_fields = [
+                f for f in decision.cache_fields if _field_strategy(self._mapping, f) != "derived"
+            ]
+            if live_fields:
+                live_decision = decide_path(self._mapping, live_fields, "live")
+                results = backend.query(
+                    self._model_class,
+                    self._mapping,
+                    live_decision,
+                    self._cluster,
+                    self._filters,
+                    where_expressions=(),
+                )
         return iter(results)

--- a/tests/unit/data/test_source.py
+++ b/tests/unit/data/test_source.py
@@ -90,7 +90,8 @@ class TestDataSourceGet:
         ds._backends["ontap"] = fake_backend
 
         ds.get(FakeVolume, cluster="prod1", id="abc-123")
-        identifier = fake_backend.get.call_args.args[4]
+        # Check the first call (cache path) for identifier normalization.
+        identifier = fake_backend.get.call_args_list[0].args[4]
         assert identifier == {"uuid": "abc-123"}
 
     def test_get_normalizes_dict_id_for_composite_key_model(
@@ -196,7 +197,8 @@ class TestDataSourceQuery:
         ds._backends["ontap"] = fake_backend
 
         list(ds.query(FakeVolume, cluster="prod1").filter({"svm.name": "vs1"}, name="vol1"))
-        filters_arg = fake_backend.query.call_args.args[4]
+        # Check the first call (cache path) for filter merging.
+        filters_arg = fake_backend.query.call_args_list[0].args[4]
         assert filters_arg == {"svm.name": "vs1", "name": "vol1"}
 
 
@@ -309,3 +311,137 @@ class TestRealOntapVolumeRouting:
         )
 
         assert ONTAPVOLUME_MAPPING.identifier_field == "uuid"
+
+
+class TestAutoFallback:
+    """Tests for source="auto" cache-miss → live fallback."""
+
+    def test_query_auto_cache_hit_no_fallback(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """When cache returns data, no live call is made."""
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        fake_backend.query.return_value = [FakeVolume(uuid="u1")]
+        ds._backends["ontap"] = fake_backend
+
+        results = list(ds.query(FakeVolume, cluster="prod1"))
+
+        assert len(results) == 1
+        assert fake_backend.query.call_count == 1
+
+    def test_query_auto_cache_miss_falls_back_to_live(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """When cache returns empty, retries with live routing."""
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        live_vol = FakeVolume(uuid="live1")
+        # First call (cache) returns empty, second call (live) returns data.
+        fake_backend.query.side_effect = [[], [live_vol]]
+        ds._backends["ontap"] = fake_backend
+
+        results = list(ds.query(FakeVolume, cluster="prod1"))
+
+        assert results == [live_vol]
+        assert fake_backend.query.call_count == 2
+        # Second call should use a live routing decision (no cache_fields).
+        second_decision = fake_backend.query.call_args_list[1].args[2]
+        assert not second_decision.cache_fields
+        assert second_decision.live_fields
+
+    def test_query_auto_cache_miss_live_also_empty(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """When both cache and live return empty, result is empty."""
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        fake_backend.query.side_effect = [[], []]
+        ds._backends["ontap"] = fake_backend
+
+        results = list(ds.query(FakeVolume, cluster="prod1"))
+
+        assert results == []
+        assert fake_backend.query.call_count == 2
+
+    def test_query_auto_with_where_no_fallback(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """When where_expressions present, cache empty does NOT fall back."""
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        fake_backend.query.return_value = []
+        ds._backends["ontap"] = fake_backend
+
+        results = list(ds.query(FakeVolume, cluster="prod1").where("size > 100"))
+
+        assert results == []
+        assert fake_backend.query.call_count == 1
+
+    def test_query_cache_mode_no_fallback(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """source='cache' with empty result does NOT fall back to live."""
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        fake_backend.query.return_value = []
+        ds._backends["ontap"] = fake_backend
+
+        results = list(ds.query(FakeVolume, cluster="prod1", source="cache"))
+
+        assert results == []
+        assert fake_backend.query.call_count == 1
+
+    def test_query_live_mode_no_cache_attempt(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """source='live' goes directly to live, no fallback logic."""
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        fake_backend.query.return_value = [FakeVolume(uuid="live1")]
+        ds._backends["ontap"] = fake_backend
+
+        # Use explicit non-derived fields to avoid ValueError on derived 'is_root'.
+        results = list(
+            ds.query(FakeVolume, cluster="prod1", source="live").fields("name", "uuid", "size")
+        )
+
+        assert len(results) == 1
+        assert fake_backend.query.call_count == 1
+        # The decision should have no cache_fields (live mode).
+        decision = fake_backend.query.call_args.args[2]
+        assert not decision.cache_fields
+
+    def test_get_auto_cache_miss_falls_back_to_live(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """get() with auto: cache returns None → retries live."""
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        live_vol = FakeVolume(uuid="abc-123", name="live-vol")
+        # First call (cache) returns None, second call (live) returns data.
+        fake_backend.get.side_effect = [None, live_vol]
+        ds._backends["ontap"] = fake_backend
+
+        result = ds.get(FakeVolume, cluster="prod1", id="abc-123")
+
+        assert result is live_vol
+        assert fake_backend.get.call_count == 2
+        # Second call should use a live routing decision.
+        second_decision = fake_backend.get.call_args_list[1].args[2]
+        assert not second_decision.cache_fields
+        assert second_decision.live_fields


### PR DESCRIPTION
## Description

Add cache-miss → live fallback to DataSource's `source="auto"` mode. When auto routes to cache and gets no results, transparently retries with live routing. This matches the original intent from #495: "callers ask for data without knowing or caring where it comes from."

`source="cache"` and `source="live"` remain single-attempt with no fallback.

Addresses #528

## Type of Change

- [x] Bug fix

## Changes Made

- **`source.py`** — Added fallback logic to `DataSource.get()` and `QueryBuilder.__iter__()`. When `source="auto"`, cache returns empty, and no `.where()` expressions are present, retries with `source="live"` routing. Derived fields are excluded from the live retry (they only exist in cache). Added `_field_strategy()` helper.
- **`test_source.py`** — 7 new tests in `TestAutoFallback`: cache hit (no fallback), cache miss (falls back to live), both empty, where_expressions guard, cache-only mode, live-only mode, get() fallback.
- **`data-source.md`** — Updated Source Modes section to document fallback behavior.
- **`0012-unified-datasource-accessor.md`** — Updated §4 to clarify auto = cache-first with live fallback.

## Testing

- [x] All existing tests pass
- [x] 7 new fallback tests
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
