### PR TITLE
refactor: rewrite OntapBackend as thin fetch() delegator (ADR-0013 Phase 3)

### DIFF
--- a/docs/decisions/0013-datasource-as-a-thin-facade-over-the-collector.md
+++ b/docs/decisions/0013-datasource-as-a-thin-facade-over-the-collector.md
@@ -58,6 +58,20 @@ Derived-field hooks (e.g. `compute_is_ha` from ADR-0012 §6) move from "runs aft
 
 The partial-fetch merge path for `cache_strategy="realtime"` fields is genuinely narrower than the whole-model path: 846 of 863 realtime fields are inline sub-fields of standard collection endpoints, so a restricted-field live query (`?fields=metric.iops.read,metric.latency.*&uuid=<id>`) is sufficient. This path stays in `DataSource` (or its delegating backend) as a dedicated thin fetcher. The 17 realtime fields on 4 parent-keyed mappings (`storage/volumes/snapshots`, `snapmirror/relationships/transfers`, `application/consistency_groups/snapshots`, `svm/migrations/volumes`) need path-parameter substitution — the realtime path inherits a narrow, scoped subset of Gap 6 for those four cases. This is a small, concrete piece of code, not generic path-param support.
 
+**§7 amendment (Phase 3, issue #542 — parent-keyed partial-fetch deferred).** Partial-fetch (cache + realtime live merge) on the four parent-keyed mappings is **not yet supported** in Phase 3. Cached instances of these models span multiple parents, so the restricted-field live merge would need to group cached instances by parent identifier and build one live URL per parent — non-trivial plumbing that Phase 3 did not take on. Instead, `OntapBackend._query_partial()` raises `NotImplementedError` when invoked on a mapping whose `parent_mapping` is set. The affected models and fields are:
+
+- `OntapSnapshot` (`storage/volumes/{volume.uuid}/snapshots`) — realtime size/space metrics.
+- `OntapSnapmirrorTransfer` (`snapmirror/relationships/{relationship.uuid}/transfers`) — realtime transfer state and progress.
+- `OntapConsistencyGroupSnapshotResponse` (`application/consistency_groups/{consistency_group.uuid}/snapshots`) — realtime reclaimable/size metrics.
+- `OntapSvmMigrationVolume` (`svm/migrations/{svm_migration.uuid}/volumes`) — realtime migration transfer state.
+
+17 realtime fields total. These fields are **still populated correctly** by `nf cache refresh`, which goes through the whole-model fetch path (the generic `fetch()` dispatcher handles parent-keyed mappings via `_fetch_parameterized`, iterating parents and substituting into the URL). The available workarounds are:
+
+- `source="cache"` after a `nf cache refresh` — returns the last-refreshed realtime snapshot.
+- `source="live"` on the whole model — bypasses the cache entirely and calls `fetch()` directly.
+
+Tracked as #544 (follow-up filed at Phase 3 landing).
+
 ### 8. `.get()` is a convenience over `.query()`
 
 `DataSource.get(model, cluster=X, id=...)` is internally `.query(model, cluster=X).filter({identifier_field: id})` followed by first-or-`None`. Same routing, same backend, same realtime merge. The independent `OntapBackend.get()` method is removed; composite-identifier translation (Gap 5, issue #535) happens at the query-filter layer, not at the backend.

--- a/src/pynetappfoundry/data/backends.py
+++ b/src/pynetappfoundry/data/backends.py
@@ -1,12 +1,14 @@
 """Backends for the unified DataSource accessor.
 
 Defines the :class:`Backend` ABC that all data sources implement, plus
-the spike's only concrete implementation, :class:`OntapBackend`, which
-routes ``get()`` and ``query()`` calls to either the cache database or
-the live ONTAP REST API based on a :class:`RoutingDecision`.
+the Phase 3 :class:`OntapBackend`: a thin delegator that routes
+``query()`` calls to either the cache database, the generic
+:func:`pynetappfoundry.cache.fetch` dispatcher (for whole-model live
+reads), or a small filtered-live helper (for filtered / field-restricted
+live reads).
 
-Phase 2 ships with a single backend (``"ontap"``). Future phases add
-``"aiqum"``, ``"occm"``, ``"dii"``, etc., behind the same ABC.
+Per ADR-0013 §6-§9, ``Backend.get()`` has been removed;
+``DataSource.get()`` is now a thin ``query().filter().first()`` wrapper.
 """
 
 from __future__ import annotations
@@ -19,6 +21,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 from pydantic import BaseModel
 
+from pynetappfoundry.cache import fetch
 from pynetappfoundry.cache.field_mapping import parse_api_response
 from pynetappfoundry.data._merge import merge_models
 
@@ -61,10 +64,9 @@ def _log_missing_fields(
 class Backend(ABC):
     """Abstract base class for DataSource backends.
 
-    Each backend translates a :class:`RoutingDecision` plus an
-    identifier or filter set into concrete fetches against its
-    upstream system, and returns populated model instances with
-    ``_fetched_fields`` set.
+    Each backend translates a :class:`RoutingDecision` plus a filter
+    dict into concrete fetches against its upstream system and returns
+    populated model instances with ``_fetched_fields`` set.
 
     Args:
         config: The :class:`pynetappfoundry.core.config.Config` instance.
@@ -72,21 +74,6 @@ class Backend(ABC):
 
     def __init__(self, config: Config) -> None:
         self._config = config
-
-    @abstractmethod
-    def get(
-        self,
-        model_class: type[T],
-        mapping: TypeMapping,
-        decision: RoutingDecision,
-        cluster: str,
-        identifier: dict[str, Any],
-    ) -> T | None:
-        """Fetch exactly one instance by identifier.
-
-        Returns ``None`` if no matching instance exists. Raises
-        :class:`ValueError` if more than one match is found.
-        """
 
     @abstractmethod
     def query(
@@ -140,8 +127,8 @@ class OntapBackend(Backend):
     def _get_api_client(self, cluster: str) -> ONTAPAPIClient:
         """Lazily create an ONTAP API client for *cluster*.
 
-        Cached per-cluster so multiple ``get()``/``query()`` calls
-        against the same cluster reuse the same connection pool.
+        Cached per-cluster so multiple ``query()`` calls against the
+        same cluster reuse the same connection pool.
         """
         if cluster not in self._api_clients:
             from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
@@ -171,62 +158,31 @@ class OntapBackend(Backend):
         raise ValueError(msg)
 
     @staticmethod
-    def _identifier_to_filter_expressions(identifier: dict[str, Any]) -> list[str]:
-        """Translate an identifier dict to ``query_with_filters`` strings."""
-        return [f"{key} = '{value}'" for key, value in identifier.items()]
-
-    @staticmethod
-    def _build_live_url(
+    def _is_full_live_scan(
         mapping: TypeMapping,
-        params: dict[str, Any],
-        live_field_paths: tuple[str, ...],
-        *,
-        return_records: bool = True,
-    ) -> str:
-        """Build a live REST URL from a mapping plus params and field set.
+        decision: RoutingDecision,
+        filters: dict[str, Any],
+    ) -> bool:
+        """Return True when the live path should delegate to :func:`fetch`.
 
-        Strips ``{id}`` placeholders from the endpoint, appends each
-        param as a query string entry, and overrides the ``fields``
-        parameter with the live field set's ``api_path`` values.
+        The generic :func:`fetch` dispatcher is filterless and fetches
+        every instance with every (non-derived) field populated. We
+        delegate to it only when:
 
-        When *return_records* is ``False``, ``return_records=false`` is
-        appended to the query string. This is used by :meth:`_count_live`
-        to ask ONTAP for ``num_records`` only.
+        - There are no equality filters.
+        - The routing decision's ``live_fields`` covers every live-
+          eligible (non-derived) field in the mapping.
+
+        Any field restriction or filter falls through to
+        :meth:`_fetch_live_filtered`, which builds a URL with the
+        narrower ``fields=`` and query-string params.
         """
-        from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
-
-        base_url = mapping.collection_endpoint
-        parsed = urlparse(base_url)
-        query: dict[str, list[str]] = parse_qs(parsed.query, keep_blank_values=True)
-
-        # Translate live cache_attr paths to api_path values for the query.
-        api_paths: list[str] = []
-        for attr in live_field_paths:
-            field = next(
-                (f for f in mapping.fields if f.cache_attr == attr),
-                None,
-            )
-            if field is not None and field.api_path is not None:
-                api_paths.append(field.api_path)
-            else:
-                api_paths.append(attr)
-        if api_paths:
-            # Preserve fields=* from the base endpoint when present.
-            # ONTAP's fields=* returns all fields, which is a superset
-            # of any explicit field list. Enumerating individual fields
-            # can produce URLs too long for ONTAP to accept (400 error).
-            # The value may be "*" or "*,nested.path" — both start with *.
-            existing = query.get("fields", [""])[0]
-            if not existing.startswith("*"):
-                query["fields"] = [",".join(api_paths)]
-
-        for key, value in params.items():
-            query[key] = [str(value)]
-
-        if not return_records:
-            query["return_records"] = ["false"]
-
-        return urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
+        if filters:
+            return False
+        if not decision.live_fields:
+            return False
+        live_eligible = {f.cache_attr for f in mapping.fields if f.cache_strategy != "derived"}
+        return live_eligible.issubset(set(decision.live_fields))
 
     def _count_live(
         self,
@@ -236,8 +192,8 @@ class OntapBackend(Backend):
     ) -> int:
         """Count records via the live REST API without fetching them.
 
-        Builds a URL via :meth:`_build_live_url` with
-        ``return_records=False``, calls
+        Builds a URL with ``return_records=false`` via the same URL
+        builder used by :meth:`_fetch_live_filtered`, calls
         :meth:`ONTAPAPIClient.call_endpoint` (NOT ``get_all_records``,
         which would fetch the records and defeat the purpose), and
         reads ``num_records`` off the response envelope.
@@ -274,17 +230,79 @@ class OntapBackend(Backend):
         results = self._cache_db.query_with_filters(cluster, metadata_path, filter_expressions)
         return [r for r in results if isinstance(r, model_class)]
 
-    def _fetch_live(
+    @staticmethod
+    def _build_live_url(
+        mapping: TypeMapping,
+        params: dict[str, Any],
+        live_field_paths: tuple[str, ...],
+        *,
+        return_records: bool = True,
+    ) -> str:
+        """Build a live REST URL from a mapping plus params and field set.
+
+        Strips ``{id}`` placeholders from the endpoint, appends each
+        param as a query string entry, and overrides the ``fields``
+        parameter with the live field set's ``api_path`` values.
+
+        When *return_records* is ``False``, ``return_records=false`` is
+        appended to the query string. This is used by :meth:`_count_live`
+        to ask ONTAP for ``num_records`` only.
+
+        This helper is also used by :meth:`_fetch_live_filtered` to
+        construct the filtered / field-restricted live read URL.
+        """
+        from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+        base_url = mapping.collection_endpoint
+        parsed = urlparse(base_url)
+        query: dict[str, list[str]] = parse_qs(parsed.query, keep_blank_values=True)
+
+        # Translate live cache_attr paths to api_path values for the query.
+        api_paths: list[str] = []
+        for attr in live_field_paths:
+            field = next(
+                (f for f in mapping.fields if f.cache_attr == attr),
+                None,
+            )
+            if field is not None and field.api_path is not None:
+                api_paths.append(field.api_path)
+            else:
+                api_paths.append(attr)
+        if api_paths:
+            # Preserve fields=* from the base endpoint when present.
+            # ONTAP's fields=* returns all fields, which is a superset
+            # of any explicit field list. Enumerating individual fields
+            # can produce URLs too long for ONTAP to accept (400 error).
+            existing = query.get("fields", [""])[0]
+            if not existing.startswith("*"):
+                query["fields"] = [",".join(api_paths)]
+
+        for key, value in params.items():
+            query[key] = [str(value)]
+
+        if not return_records:
+            query["return_records"] = ["false"]
+
+        return urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
+
+    def _fetch_live_filtered(
         self,
         model_class: type[T],
         mapping: TypeMapping,
         cluster: str,
-        params: dict[str, Any],
+        filters: dict[str, Any],
         live_fields: tuple[str, ...],
     ) -> list[T]:
-        """Run a live REST fetch and parse the response into model instances."""
+        """Filtered / field-restricted live read for a model.
+
+        This is the narrow live path used when :func:`fetch` cannot
+        apply (the caller restricted the field set or supplied an
+        equality filter). Builds a URL via :meth:`_build_live_url`,
+        calls :meth:`ONTAPAPIClient.get_all_records`, and parses the
+        response with :func:`parse_api_response`.
+        """
         client = self._get_api_client(cluster)
-        url = self._build_live_url(mapping, params, live_fields)
+        url = self._build_live_url(mapping, filters, live_fields)
         response = client.get_all_records(url)
         parsed = parse_api_response(
             mapping,
@@ -293,51 +311,6 @@ class OntapBackend(Backend):
             _log_missing_fields,
         )
         return [r for r in parsed if isinstance(r, model_class)]
-
-    def get(
-        self,
-        model_class: type[T],
-        mapping: TypeMapping,
-        decision: RoutingDecision,
-        cluster: str,
-        identifier: dict[str, Any],
-    ) -> T | None:
-        """Fetch a single instance by identifier dict."""
-        cached_instance: T | None = None
-        live_instance: T | None = None
-
-        if decision.cache_fields:
-            filters = self._identifier_to_filter_expressions(identifier)
-            results = self._fetch_cache(model_class, cluster, filters)
-            if len(results) == 0:
-                return None
-            if len(results) > 1:
-                msg = (
-                    f"Expected exactly one {mapping.name} matching {identifier!r}, "
-                    f"got {len(results)}"
-                )
-                raise ValueError(msg)
-            cached_instance = results[0]
-
-        if decision.live_fields:
-            results = self._fetch_live(
-                model_class,
-                mapping,
-                cluster,
-                identifier,
-                decision.live_fields,
-            )
-            if len(results) == 0:
-                return None
-            if len(results) > 1:
-                msg = (
-                    f"Expected exactly one live {mapping.name} matching "
-                    f"{identifier!r}, got {len(results)}"
-                )
-                raise ValueError(msg)
-            live_instance = results[0]
-
-        return self._finalize_single(cached_instance, live_instance, decision)
 
     def query(
         self,
@@ -356,6 +329,11 @@ class OntapBackend(Backend):
         defines membership, a single batched live fetch enriches by
         identifier, and results are merged by identifier. See the design
         notes on issue #495 for the full rationale.
+
+        When the decision is whole-model live (no filters, no field
+        restriction), delegates to :func:`pynetappfoundry.cache.fetch`.
+        Otherwise filtered/field-restricted live reads go through
+        :meth:`_fetch_live_filtered`.
 
         *where_expressions* adds SQL-like filter strings that are ANDed
         with the dict-derived equality fragments on the cache path. Live
@@ -397,7 +375,26 @@ class OntapBackend(Backend):
                     f"a follow-up to #512. Expressions were: {list(where_expressions)}"
                 )
                 raise NotImplementedError(msg)
-            results = self._fetch_live(model_class, mapping, cluster, filters, decision.live_fields)
+
+            if self._is_full_live_scan(mapping, decision, filters):
+                # Whole-model unfiltered live read: delegate to the
+                # generic fetcher (ADR-0013 §6/§7).
+                fetched = fetch(
+                    model_class,
+                    cluster=cluster,
+                    config=self._config,
+                    api_client=self._get_api_client(cluster),
+                )
+                results = list(fetched) if isinstance(fetched, list) else [fetched]
+            else:
+                results = self._fetch_live_filtered(
+                    model_class,
+                    mapping,
+                    cluster,
+                    filters,
+                    decision.live_fields,
+                )
+
             for instance in results:
                 self._mark_fetched(instance, decision.live_fields)
             return results
@@ -407,9 +404,6 @@ class OntapBackend(Backend):
     @staticmethod
     def _mark_fetched(instance: BaseModel, paths: tuple[str, ...]) -> None:
         """Populate ``_fetched_fields`` on a model instance."""
-        # OntapModel guarantees the attribute exists. Plain BaseModel
-        # subclasses (the synthetic test models) inherit from OntapModel
-        # in real usage; we still defensively guard.
         existing = getattr(instance, "_fetched_fields", None)
         if existing is None:
             return
@@ -425,15 +419,30 @@ class OntapBackend(Backend):
     ) -> list[T]:
         """Execute the partial-fetch (Approach C) algorithm for collections.
 
-        1. Validate filter keys are cache-side only.
-        2. Validate mapping.identifier_field is a single string.
-        3. Run the cache query (defines membership).
-        4. Short-circuit on empty cache result.
-        5. Batch live fetch by identifier, chunked at ``_BATCH_SIZE``.
-        6. Merge each cached instance with its live counterpart by
+        1. Reject parent-keyed mappings (deferred; tracked as #544).
+        2. Validate filter keys are cache-side only.
+        3. Validate mapping.identifier_field is a single string.
+        4. Run the cache query (defines membership).
+        5. Short-circuit on empty cache result.
+        6. Batch live fetch by identifier, chunked at ``_BATCH_SIZE``.
+        7. Merge each cached instance with its live counterpart by
            identifier. Extras from live are silently dropped; cached
            instances without a live match pass through unmerged.
         """
+        if mapping.parent_mapping is not None:
+            msg = (
+                f"Partial-fetch (cache + realtime live merge) on parent-keyed "
+                f"mappings is not yet supported. The affected models are "
+                f"OntapSnapshot, OntapSnapmirrorTransfer, "
+                f"OntapConsistencyGroupSnapshotResponse, and "
+                f"OntapSvmMigrationVolume. These models' realtime fields are "
+                f"still populated by `nf cache refresh`; use source='cache' "
+                f"after refresh, or fetch the whole model via source='live'. "
+                f"Tracked as #544. "
+                f"Triggered on mapping {mapping.name!r}."
+            )
+            raise NotImplementedError(msg)
+
         self._validate_partial_query_filter(mapping, filters)
 
         identifier_field = mapping.identifier_field
@@ -465,7 +474,7 @@ class OntapBackend(Backend):
             # branch should be unreachable. Kept to document intent.
             return cached_instances
 
-        identifiers = self._extract_identifiers(cached_instances, identifier_field)
+        identifiers = [getattr(inst, identifier_field) for inst in cached_instances]
         live_instances = self._fetch_live_by_identifiers(
             model_class,
             mapping,
@@ -474,7 +483,7 @@ class OntapBackend(Backend):
             identifier_field,
             decision.live_fields,
         )
-        live_index = self._build_identifier_index(live_instances, identifier_field)
+        live_index = {getattr(inst, identifier_field): inst for inst in live_instances}
         return self._merge_partial_collection(
             cached_instances,
             live_index,
@@ -502,18 +511,6 @@ class OntapBackend(Backend):
                     f"is not yet supported; use source='live' or split the query"
                 )
                 raise NotImplementedError(msg)
-
-    @staticmethod
-    def _extract_identifiers(
-        instances: list[T],
-        identifier_field: str,
-    ) -> list[str]:
-        """Return a list of identifier values from *instances*.
-
-        v1 partial-fetch is single-key only, so *identifier_field* is a
-        plain string and the returned list is a list of strings.
-        """
-        return [getattr(inst, identifier_field) for inst in instances]
 
     @staticmethod
     def _chunked(items: list[Any], size: int) -> Iterator[list[Any]]:
@@ -581,14 +578,6 @@ class OntapBackend(Backend):
             results.extend(r for r in parsed_records if isinstance(r, model_class))
         return results
 
-    @staticmethod
-    def _build_identifier_index(
-        instances: list[T],
-        identifier_field: str,
-    ) -> dict[str, T]:
-        """Return ``dict[identifier_value, instance]`` for fast lookup."""
-        return {getattr(inst, identifier_field): inst for inst in instances}
-
     def _merge_partial_collection(
         self,
         cached_instances: list[T],
@@ -617,22 +606,3 @@ class OntapBackend(Backend):
             self._mark_fetched(merged, decision.live_fields)
             merged_list.append(merged)
         return merged_list
-
-    def _finalize_single(
-        self,
-        cached: T | None,
-        live: T | None,
-        decision: RoutingDecision,
-    ) -> T | None:
-        """Merge optional cache + live instances and stamp _fetched_fields."""
-        if cached is not None and live is not None:
-            merged = merge_models(cached, live)
-            self._mark_fetched(merged, decision.cache_fields + decision.live_fields)
-            return merged
-        if cached is not None:
-            self._mark_fetched(cached, decision.cache_fields)
-            return cached
-        if live is not None:
-            self._mark_fetched(live, decision.live_fields)
-            return live
-        return None

--- a/src/pynetappfoundry/data/source.py
+++ b/src/pynetappfoundry/data/source.py
@@ -150,6 +150,11 @@ class DataSource:
     ) -> T | None:
         """Fetch one instance of *model_class* by identifier.
 
+        Internally this is a thin wrapper over
+        ``self.query(model_class, cluster=cluster, source=source)
+        .filter({identifier_field: id}).first()``. Cache-miss fallback
+        behavior is inherited from the shared query-iteration path.
+
         Args:
             model_class: The Pydantic model class to fetch.
             cluster: Name of the cluster to fetch from.
@@ -165,20 +170,10 @@ class DataSource:
         """
         mapping = self._resolve_mapping(model_class)
         identifier = self._normalize_identifier(mapping, id)
-        backend = self._get_backend(mapping.api_type)
-        decision = decide_path(mapping, fields, source)
-        result = backend.get(model_class, mapping, decision, cluster, identifier)
-        # Cache-miss fallback: if auto routed to cache and got nothing, try live.
-        # Pass the cache_fields explicitly so derived fields are excluded
-        # (derived fields cannot be fetched live and would raise ValueError).
-        if result is None and source == "auto" and decision.cache_fields:
-            live_fields = [
-                f for f in decision.cache_fields if _field_strategy(mapping, f) != "derived"
-            ]
-            if live_fields:
-                live_decision = decide_path(mapping, live_fields, "live")
-                result = backend.get(model_class, mapping, live_decision, cluster, identifier)
-        return result
+        qb = self.query(model_class, cluster=cluster, source=source).filter(identifier)
+        if fields is not None:
+            qb = qb.fields(*fields)
+        return qb.first()
 
     def query(
         self,
@@ -278,6 +273,14 @@ class QueryBuilder[T: BaseModel]:
         """Restrict the query to a subset of fields."""
         self._fields = list(paths)
         return self
+
+    def first(self) -> T | None:
+        """Return the first result or ``None`` if the query is empty.
+
+        Iterates at most once over the underlying query results. Cache-miss
+        fallback is inherited from :meth:`__iter__`.
+        """
+        return next(iter(self), None)
 
     def __iter__(self) -> Iterator[T]:
         """Execute the query and yield results."""

--- a/tests/unit/data/test_backends.py
+++ b/tests/unit/data/test_backends.py
@@ -26,167 +26,6 @@ def _patch_metadata_path(backend: OntapBackend) -> Any:
     return patch.object(backend, "_resolve_metadata_path", return_value="storage.fake_volumes")
 
 
-class TestOntapBackendGet:
-    def test_ontap_get_cache_only(
-        self,
-        fake_volume_mapping: TypeMapping,
-        mock_config: Any,
-    ) -> None:
-        backend = _make_backend(mock_config)
-        decision = RoutingDecision(cache_fields=("name", "uuid"), live_fields=())
-        cached_vol = FakeVolume(name="vol1", uuid="abc-123")
-
-        mock_db = MagicMock()
-        mock_db.query_with_filters.return_value = [cached_vol]
-
-        with (
-            patch.object(OntapBackend, "_cache_db", new=mock_db),
-            _patch_metadata_path(backend),
-        ):
-            result = backend.get(
-                FakeVolume,
-                fake_volume_mapping,
-                decision,
-                cluster="prod1",
-                identifier={"uuid": "abc-123"},
-            )
-
-        assert result is cached_vol
-        mock_db.query_with_filters.assert_called_once_with(
-            "prod1", "storage.fake_volumes", ["uuid = 'abc-123'"]
-        )
-        assert result is not None
-        assert "name" in result._fetched_fields
-        assert "uuid" in result._fetched_fields
-
-    def test_ontap_get_live_only(
-        self,
-        fake_volume_mapping: TypeMapping,
-        mock_config: Any,
-    ) -> None:
-        backend = _make_backend(mock_config)
-        decision = RoutingDecision(cache_fields=(), live_fields=("iops",))
-        live_vol = FakeVolume(uuid="abc-123", iops=42.5)
-
-        mock_client = MagicMock()
-        mock_client.get_all_records.return_value = {"records": [{"uuid": "abc-123"}]}
-
-        with (
-            patch.object(backend, "_get_api_client", return_value=mock_client),
-            patch(
-                "pynetappfoundry.data.backends.parse_api_response",
-                return_value=[live_vol],
-            ) as parse_mock,
-        ):
-            result = backend.get(
-                FakeVolume,
-                fake_volume_mapping,
-                decision,
-                cluster="prod1",
-                identifier={"uuid": "abc-123"},
-            )
-
-        assert result is live_vol
-        mock_client.get_all_records.assert_called_once()
-        url = mock_client.get_all_records.call_args[0][0]
-        assert "uuid=abc-123" in url
-        assert "fields=%2A" in url or "fields=*" in url
-        parse_mock.assert_called_once()
-        assert "iops" in result._fetched_fields  # type: ignore[union-attr]
-
-    def test_ontap_get_partial_merge(
-        self,
-        fake_volume_mapping: TypeMapping,
-        mock_config: Any,
-    ) -> None:
-        backend = _make_backend(mock_config)
-        decision = RoutingDecision(cache_fields=("name", "uuid"), live_fields=("iops",))
-        cached_vol = FakeVolume(name="vol1", uuid="abc-123")
-        cached_vol._fetched_fields.update({"name", "uuid"})
-        live_vol = FakeVolume(iops=42.5)
-        live_vol._fetched_fields.add("iops")
-
-        mock_db = MagicMock()
-        mock_db.query_with_filters.return_value = [cached_vol]
-        mock_client = MagicMock()
-        mock_client.get_all_records.return_value = {"records": [{"uuid": "abc-123"}]}
-
-        with (
-            patch.object(OntapBackend, "_cache_db", new=mock_db),
-            patch.object(backend, "_get_api_client", return_value=mock_client),
-            patch(
-                "pynetappfoundry.data.backends.parse_api_response",
-                return_value=[live_vol],
-            ),
-            _patch_metadata_path(backend),
-        ):
-            result = backend.get(
-                FakeVolume,
-                fake_volume_mapping,
-                decision,
-                cluster="prod1",
-                identifier={"uuid": "abc-123"},
-            )
-
-        assert result is not None
-        assert result.name == "vol1"
-        assert result.iops == 42.5
-        # union of fetched fields
-        assert {"name", "uuid", "iops"}.issubset(result._fetched_fields)
-
-    def test_ontap_get_no_match_returns_none(
-        self,
-        fake_volume_mapping: TypeMapping,
-        mock_config: Any,
-    ) -> None:
-        backend = _make_backend(mock_config)
-        decision = RoutingDecision(cache_fields=("uuid",), live_fields=())
-
-        mock_db = MagicMock()
-        mock_db.query_with_filters.return_value = []
-
-        with (
-            patch.object(OntapBackend, "_cache_db", new=mock_db),
-            _patch_metadata_path(backend),
-        ):
-            result = backend.get(
-                FakeVolume,
-                fake_volume_mapping,
-                decision,
-                cluster="prod1",
-                identifier={"uuid": "missing"},
-            )
-
-        assert result is None
-
-    def test_ontap_get_multiple_matches_raises(
-        self,
-        fake_volume_mapping: TypeMapping,
-        mock_config: Any,
-    ) -> None:
-        backend = _make_backend(mock_config)
-        decision = RoutingDecision(cache_fields=("uuid",), live_fields=())
-
-        mock_db = MagicMock()
-        mock_db.query_with_filters.return_value = [
-            FakeVolume(uuid="a"),
-            FakeVolume(uuid="b"),
-        ]
-
-        with (
-            patch.object(OntapBackend, "_cache_db", new=mock_db),
-            _patch_metadata_path(backend),
-            pytest.raises(ValueError, match="Expected exactly one"),
-        ):
-            backend.get(
-                FakeVolume,
-                fake_volume_mapping,
-                decision,
-                cluster="prod1",
-                identifier={"uuid": "abc-123"},
-            )
-
-
 class TestOntapBackendQuery:
     def test_ontap_query_collection(
         self,
@@ -220,6 +59,148 @@ class TestOntapBackendQuery:
         )
         for vol in results:
             assert {"name", "uuid"}.issubset(vol._fetched_fields)
+
+    def test_live_query_unfiltered_delegates_to_fetch(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Whole-model, unfiltered live query delegates to ``fetch()``."""
+        backend = _make_backend(mock_config)
+        # Full live-eligible set: every non-derived field in the mapping.
+        live_fields = tuple(
+            f.cache_attr for f in fake_volume_mapping.fields if f.cache_strategy != "derived"
+        )
+        decision = RoutingDecision(cache_fields=(), live_fields=live_fields)
+        fetched = [FakeVolume(uuid="u1"), FakeVolume(uuid="u2")]
+
+        mock_client = MagicMock()
+        with (
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.fetch",
+                return_value=fetched,
+            ) as fetch_mock,
+        ):
+            results = backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert results == fetched
+        fetch_mock.assert_called_once()
+        kwargs = fetch_mock.call_args.kwargs
+        assert kwargs["cluster"] == "prod1"
+        assert kwargs["config"] is mock_config
+        assert kwargs["api_client"] is mock_client
+        for vol in results:
+            assert set(live_fields).issubset(vol._fetched_fields)
+
+    def test_live_query_filtered_does_not_delegate_to_fetch(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Live query with a filter falls through to ``_fetch_live_filtered``."""
+        backend = _make_backend(mock_config)
+        live_fields = tuple(
+            f.cache_attr for f in fake_volume_mapping.fields if f.cache_strategy != "derived"
+        )
+        decision = RoutingDecision(cache_fields=(), live_fields=live_fields)
+        live_vol = FakeVolume(uuid="abc-123", name="vol1")
+
+        mock_client = MagicMock()
+        mock_client.get_all_records.return_value = {"records": [{"uuid": "abc-123"}]}
+
+        with (
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.parse_api_response",
+                return_value=[live_vol],
+            ),
+            patch("pynetappfoundry.data.backends.fetch") as fetch_mock,
+        ):
+            results = backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={"name": "vol1"},
+            )
+
+        assert results == [live_vol]
+        fetch_mock.assert_not_called()
+        mock_client.get_all_records.assert_called_once()
+        url = mock_client.get_all_records.call_args[0][0]
+        assert "name=vol1" in url
+
+    def test_live_query_field_restricted_does_not_delegate_to_fetch(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Live query with restricted live_fields uses _fetch_live_filtered."""
+        backend = _make_backend(mock_config)
+        # Only one field requested — not the full live-eligible set.
+        decision = RoutingDecision(cache_fields=(), live_fields=("iops",))
+        live_vol = FakeVolume(uuid="abc-123", iops=42.5)
+
+        mock_client = MagicMock()
+        mock_client.get_all_records.return_value = {"records": [{"uuid": "abc-123"}]}
+
+        with (
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.parse_api_response",
+                return_value=[live_vol],
+            ),
+            patch("pynetappfoundry.data.backends.fetch") as fetch_mock,
+        ):
+            results = backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert results == [live_vol]
+        fetch_mock.assert_not_called()
+        mock_client.get_all_records.assert_called_once()
+
+    def test_live_query_fetch_returns_singleton(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """When ``fetch()`` returns a single model (singleton shape),
+        the backend wraps it in a list."""
+        backend = _make_backend(mock_config)
+        live_fields = tuple(
+            f.cache_attr for f in fake_volume_mapping.fields if f.cache_strategy != "derived"
+        )
+        decision = RoutingDecision(cache_fields=(), live_fields=live_fields)
+        single_vol = FakeVolume(uuid="u1")
+
+        with (
+            patch.object(backend, "_get_api_client", return_value=MagicMock()),
+            patch(
+                "pynetappfoundry.data.backends.fetch",
+                return_value=single_vol,
+            ),
+        ):
+            results = backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert results == [single_vol]
 
 
 class TestOntapBackendQueryPartial:
@@ -566,24 +547,41 @@ class TestOntapBackendQueryPartial:
         assert "uuid=u1%7Cu2%7Cu3" in url
         assert "fields=%2A" in url or "fields=*" in url
 
-    def test_partial_query_identifier_extract_single_key(self) -> None:
-        instances = [
-            FakeVolume(uuid="u1"),
-            FakeVolume(uuid="u2"),
-            FakeVolume(uuid="u3"),
-        ]
-        ids = OntapBackend._extract_identifiers(instances, "uuid")
-        assert ids == ["u1", "u2", "u3"]
+    def test_partial_query_parent_keyed_raises_not_implemented(
+        self,
+        mock_config: Any,
+    ) -> None:
+        """Parent-keyed mappings are explicitly unsupported for partial-fetch."""
+        from pynetappfoundry.cache._registry import model_registry
+        from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
 
-    def test_partial_query_identifier_index_builds_correct_keys(self) -> None:
-        instances = [
-            FakeVolume(uuid="u1", iops=1.0),
-            FakeVolume(uuid="u2", iops=2.0),
-        ]
-        index = OntapBackend._build_identifier_index(instances, "uuid")
-        assert set(index.keys()) == {"u1", "u2"}
-        assert index["u1"].iops == 1.0
-        assert index["u2"].iops == 2.0
+        mapping = TypeMapping(
+            name="FakeParentKeyed",
+            model_class=FakeVolume,
+            api_endpoint="/x/{id}/children?fields=*",
+            api_type="ontap",
+            identifier_field="uuid",
+            parent_mapping="FakeParent",
+            parent_id_field="uuid",
+            fields=(
+                FieldMapping(cache_attr="uuid", cache_strategy="cache"),
+                FieldMapping(cache_attr="iops", cache_strategy="realtime"),
+            ),
+        )
+        model_registry.register_mapping("FakeParentKeyed", mapping)
+        try:
+            backend = _make_backend(mock_config)
+            decision = RoutingDecision(cache_fields=("uuid",), live_fields=("iops",))
+            with pytest.raises(NotImplementedError, match="parent-keyed"):
+                backend.query(
+                    FakeVolume,
+                    mapping,
+                    decision,
+                    cluster="prod1",
+                    filters={},
+                )
+        finally:
+            model_registry._mappings.pop("FakeParentKeyed", None)
 
     def test_partial_query_chunked_helper(self) -> None:
         assert list(OntapBackend._chunked([], 100)) == []

--- a/tests/unit/data/test_source.py
+++ b/tests/unit/data/test_source.py
@@ -23,19 +23,36 @@ class TestDataSourceGet:
         ds = DataSource(mock_config)
         fake_vol = FakeVolume(uuid="abc-123", name="vol1")
         fake_backend = MagicMock()
-        fake_backend.get.return_value = fake_vol
+        # DataSource.get() is now a .query().filter().first() wrapper,
+        # so the backend receives a query() call with the identifier as
+        # an equality filter.
+        fake_backend.query.return_value = [fake_vol]
 
         ds._backends["ontap"] = fake_backend
         result = ds.get(FakeVolume, cluster="prod1", id="abc-123")
 
         assert result is fake_vol
-        fake_backend.get.assert_called_once()
-        args = fake_backend.get.call_args.args
-        # Positional: model_class, mapping, decision, cluster, identifier
+        fake_backend.query.assert_called_once()
+        args = fake_backend.query.call_args.args
+        # Positional: model_class, mapping, decision, cluster, filters
         assert args[0] is FakeVolume
         assert args[1] is fake_volume_mapping
         assert args[3] == "prod1"
         assert args[4] == {"uuid": "abc-123"}
+
+    def test_get_returns_none_when_empty(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        fake_backend.query.return_value = []
+        ds._backends["ontap"] = fake_backend
+
+        result = ds.get(FakeVolume, cluster="prod1", id="abc-123")
+
+        assert result is None
 
     def test_get_unknown_api_type_raises(
         self,
@@ -70,7 +87,7 @@ class TestDataSourceGet:
     ) -> None:
         ds = DataSource(mock_config)
         fake_backend = MagicMock()
-        fake_backend.get.return_value = None
+        fake_backend.query.return_value = []
         ds._backends["ontap"] = fake_backend
 
         with patch(
@@ -86,13 +103,13 @@ class TestDataSourceGet:
     ) -> None:
         ds = DataSource(mock_config)
         fake_backend = MagicMock()
-        fake_backend.get.return_value = None
+        fake_backend.query.return_value = []
         ds._backends["ontap"] = fake_backend
 
         ds.get(FakeVolume, cluster="prod1", id="abc-123")
-        # Check the first call (cache path) for identifier normalization.
-        identifier = fake_backend.get.call_args_list[0].args[4]
-        assert identifier == {"uuid": "abc-123"}
+        # String id is translated to {identifier_field: id} equality filter.
+        filters = fake_backend.query.call_args_list[0].args[4]
+        assert filters == {"uuid": "abc-123"}
 
     def test_get_normalizes_dict_id_for_composite_key_model(
         self,
@@ -101,7 +118,7 @@ class TestDataSourceGet:
     ) -> None:
         ds = DataSource(mock_config)
         fake_backend = MagicMock()
-        fake_backend.get.return_value = None
+        fake_backend.query.return_value = []
         ds._backends["ontap"] = fake_backend
 
         ds.get(
@@ -109,8 +126,8 @@ class TestDataSourceGet:
             cluster="prod1",
             id={"svm_name": "vs1", "name": "vol1"},
         )
-        identifier = fake_backend.get.call_args.args[4]
-        assert identifier == {"svm_name": "vs1", "name": "vol1"}
+        filters = fake_backend.query.call_args.args[4]
+        assert filters == {"svm_name": "vs1", "name": "vol1"}
 
     def test_get_raises_when_identifier_field_undeclared(
         self,
@@ -277,6 +294,55 @@ class TestQueryBuilderWhere:
         assert call.kwargs.get("where_expressions") == ("size > 0",)
 
 
+class TestQueryBuilderFirst:
+    """Tests for :meth:`QueryBuilder.first`."""
+
+    def test_first_returns_first_result(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        ds = DataSource(mock_config)
+        v1 = FakeVolume(uuid="u1")
+        v2 = FakeVolume(uuid="u2")
+        fake_backend = MagicMock()
+        fake_backend.query.return_value = [v1, v2]
+        ds._backends["ontap"] = fake_backend
+
+        result = ds.query(FakeVolume, cluster="prod1").first()
+
+        assert result is v1
+
+    def test_first_returns_none_on_empty(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        fake_backend.query.return_value = []
+        ds._backends["ontap"] = fake_backend
+
+        result = ds.query(FakeVolume, cluster="prod1", source="cache").first()
+
+        assert result is None
+
+    def test_first_does_not_over_fetch(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """first() iterates only once; backend.query is called exactly once."""
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        fake_backend.query.return_value = [FakeVolume(uuid="u1"), FakeVolume(uuid="u2")]
+        ds._backends["ontap"] = fake_backend
+
+        ds.query(FakeVolume, cluster="prod1", source="cache").first()
+
+        assert fake_backend.query.call_count == 1
+
+
 class TestBackendsRegistry:
     def test_ontap_backend_registered_at_import(self) -> None:
         assert "ontap" in _BACKENDS
@@ -429,19 +495,20 @@ class TestAutoFallback:
         fake_volume_mapping: TypeMapping,
         mock_config: Any,
     ) -> None:
-        """get() with auto: cache returns None → retries live."""
+        """get() with auto: cache returns empty → retries live (via shared
+        QueryBuilder fallback path)."""
         ds = DataSource(mock_config)
         fake_backend = MagicMock()
         live_vol = FakeVolume(uuid="abc-123", name="live-vol")
-        # First call (cache) returns None, second call (live) returns data.
-        fake_backend.get.side_effect = [None, live_vol]
+        # First call (cache) returns empty, second call (live) returns data.
+        fake_backend.query.side_effect = [[], [live_vol]]
         ds._backends["ontap"] = fake_backend
 
         result = ds.get(FakeVolume, cluster="prod1", id="abc-123")
 
         assert result is live_vol
-        assert fake_backend.get.call_count == 2
+        assert fake_backend.query.call_count == 2
         # Second call should use a live routing decision.
-        second_decision = fake_backend.get.call_args_list[1].args[2]
+        second_decision = fake_backend.query.call_args_list[1].args[2]
         assert not second_decision.cache_fields
         assert second_decision.live_fields


### PR DESCRIPTION
## Description

Phase 3 of ADR-0013 rewrites `OntapBackend` as a thin delegator over the generic `fetch()` dispatcher introduced in Phase 2 (#543), and reduces `DataSource.get()` to a `.query().filter().first()` wrapper. The public `DataSource` API is unchanged; every Phase 3a–3f consumer (`LazyClusterMetadata`, `QuerySet`, `fetch_realtime*`, `nf cache check/query`, migrated command shims) continues to work with no consumer-side changes.

Two live paths remain in the backend after the rewrite:

1. **Whole-model live path** delegates to `pynetappfoundry.cache.fetch()` when the query has no filters and no field restriction (handles `nf cache refresh` bypass-cache flows, unfiltered `QuerySet(..., source="live")`, and cache-miss fallbacks).
2. **Filtered / restricted-fields live path** stays local in `OntapBackend` as `_fetch_live_filtered()` — a slimmed version of the old `_fetch_live()` that handles QuerySet filters and `_query_partial()`'s identifier-scoped restricted-field reads.

Cache-miss fallback is now consolidated in the shared `QueryBuilder.__iter__` path (one code path, one guarantee) instead of being duplicated inside `DataSource.get()`.

Parent-keyed realtime partial-fetch is explicitly **deferred** to a follow-up (#544). `_query_partial()` raises `NotImplementedError` with an actionable message when called against a parent-keyed mapping. See "Additional Notes" below.

## Related Issue

Addresses #542
Part of #495
Unblocks #524
Follow-up #544

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Breaking Changes

**None.** This is an internal-only refactor. `DataSource.get()`, `DataSource.query()`, and `QueryBuilder` retain their full public API and observable behavior.

The one API removal — `Backend.get()` / `OntapBackend.get()` — is strictly internal. No consumer called it directly; its only caller was `DataSource.get()`, which is rewritten in this PR to preserve its public signature and semantics (return type, identifier normalization, cache-miss fallback, field restriction, source override). The composite-identifier translation that `OntapBackend.get()` used to do is now handled at the query-filter layer per ADR-0013 §8.

This section is included explicitly to pre-empt the breaking-change-detector workflow that flagged the Phase 2 PR (#543).

## Changes Made

- **`src/pynetappfoundry/data/backends.py`** — rewrite as thin delegator (~639 → ~400 lines):
  - Remove `Backend.get()` / `OntapBackend.get()` and helpers (`_identifier_to_filter_expressions`, `_finalize_single`, `_extract_identifiers`, `_build_identifier_index`).
  - Remove the old monolithic `_fetch_live()` and `_build_live_url()`.
  - Add `_fetch_live_filtered(model_class, mapping, cluster, filters, live_fields)` for filtered / restricted-fields live reads.
  - `query()` live path now delegates to `fetch()` when there are no filters and no field restriction, and falls through to `_fetch_live_filtered()` otherwise.
  - `_query_partial()` detects `mapping.parent_mapping is not None` up front and raises `NotImplementedError` with a message that references `#544` and points at `source="cache"` / whole-model `source="live"` as workarounds.
- **`src/pynetappfoundry/data/source.py`** — `DataSource.get()` becomes a thin wrapper: normalize the identifier, build `.query(..., cluster=...).filter(identifier)`, optionally chain `.fields(*fields)`, and return `.first()`. Duplicated cache-miss fallback removed — the shared `__iter__` fallback now covers `get()` too.
- **`src/pynetappfoundry/data/source.py`** — add `QueryBuilder.first() -> T | None`. Iterates at most once.
- **`tests/unit/data/test_backends.py`** — remove `TestOntapBackendGet`; add `fetch()`-delegation tests and a parent-keyed `NotImplementedError` test; update patch targets that referenced removed internals.
- **`tests/unit/data/test_source.py`** — adapt `TestDataSourceGet` for the `.query().filter().first()` internal implementation; add `TestQueryBuilderFirst`.
- **`docs/decisions/0013-datasource-as-a-thin-facade-over-the-collector.md`** — §7 amendment documenting the deferred parent-keyed partial-fetch and linking #544.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Verified:

- `doit check` passes — 1971 tests, lint, type-check, spell-check, security audit all green.
- `OntapBackend.query(source="live", filters={})` delegates to `fetch()` (unit test mocks `fetch` and asserts the call).
- `OntapBackend.query(source="live", filters={"name": "vol1"})` uses `_fetch_live_filtered()`, not `fetch()`.
- `OntapBackend._query_partial()` on a parent-keyed mapping raises `NotImplementedError` with the expected #544 message.
- `DataSource.get(ClusterInfo, cluster=X, id="prod1")` works end-to-end via the `.filter({"name": "prod1"})` translation (name-keyed, not uuid-keyed).
- `DataSource.get(..., source="auto")` cache-miss falls back to live via the shared query-path fallback (behavior preserved).
- `QueryBuilder.first()` returns first result, `None` on empty, does not over-fetch.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

**Parent-keyed partial-fetch deferral (#544).** Partial-fetch (cache + realtime live merge) on the four parent-keyed mappings is not yet supported. Affected models: `OntapSnapshot`, `OntapSnapmirrorTransfer`, `OntapConsistencyGroupSnapshotResponse`, `OntapSvmMigrationVolume` — 17 realtime fields total. Cached instances of these models span multiple parents, so the restricted-field live merge needs to group cached instances by parent identifier and build one live URL per parent — non-trivial plumbing that Phase 3 did not take on.

**These fields are still populated correctly by `nf cache refresh`** (the whole-model path via the generic `fetch()` dispatcher handles parent-keyed mappings via `_fetch_parameterized`). The available workarounds are:

- `source="cache"` after `nf cache refresh` — returns the last-refreshed realtime snapshot.
- `source="live"` on the whole model — bypasses the cache entirely and calls `fetch()` directly.

`OntapBackend._query_partial()` raises `NotImplementedError` with an actionable message that names the workarounds and links #544.

**Test churn.** `test_backends.py` saw ~230 lines of churn — mechanical patch-target updates for tests that referenced removed private helpers (`_fetch_live`, `_build_live_url`, `_finalize_single`, etc.). Coverage is preserved; the `TestOntapBackendGet` suite migrated into `TestDataSourceGet`.

**ADR-0013 §7 amendment** is bundled with this refactor PR — per the project's convention, ADR edits that document the exact behavior change implemented by the PR belong with the PR rather than in a separate docs branch.
