### PR TITLE
fix: thread config and honor shim connection lifetime in ClusterEntry cache

### DIFF
--- a/src/pynetappfoundry/core/cluster_entry.py
+++ b/src/pynetappfoundry/core/cluster_entry.py
@@ -195,25 +195,32 @@ class ClusterEntry(MutableMapping[str, Any]):
         fetcher = self._build_fetcher()
 
         if self._cache_db_path.exists():
-            try:
-                from pynetappfoundry.cache.db import ClusterMetadataDB
+            from pynetappfoundry.cache.db import ClusterMetadataDB
 
-                db = ClusterMetadataDB(db_path=self._cache_db_path)
-                try:
-                    result = db.get_lazy(self._name)
-                    logging.debug(
-                        f"{_file_name} : loaded cache for {self._name}: "
-                        f"{'found' if result else 'not found'}"
-                    )
-                    # Attach fetcher so missing groups can be fetched live.
-                    if result is not None and fetcher is not None:
-                        result._fetcher = fetcher
-                    return result
-                finally:
-                    db.close()
+            db: ClusterMetadataDB | None = None
+            result: LazyClusterMetadata | None = None
+            try:
+                db = ClusterMetadataDB(db_path=self._cache_db_path, config=self._config)
+                result = db.get_lazy(self._name)
             except Exception as e:
+                if db is not None:
+                    db.close()
                 logging.debug(f"{_file_name} : could not load cache for {self._name}: {e}")
-                # Fall through to fetcher-only path below.
+                result = None
+            else:
+                logging.debug(
+                    f"{_file_name} : loaded cache for {self._name}: "
+                    f"{'found' if result else 'not found'}"
+                )
+            if result is not None:
+                # Attach fetcher so missing groups can be fetched live.
+                if fetcher is not None:
+                    result._fetcher = fetcher
+                return result  # caller owns the db via the shim
+            # No shim — close the db before falling through.
+            if db is not None:
+                db.close()
+            # Fall through to fetcher-only path below.
 
         # No cache DB (or DB load failed) — try fetcher-only mode.
         live = self._build_live_metadata(fetcher=fetcher)

--- a/tests/unit/core/test_cluster_entry.py
+++ b/tests/unit/core/test_cluster_entry.py
@@ -147,7 +147,39 @@ class TestLazyLoading:
             result = entry.ontap
             assert result is mock_metadata
             mock_db_instance.get_lazy.assert_called_once_with("test-cluster")
-            mock_db_instance.close.assert_called_once()
+            # After fix: success path does NOT close db; shim owns the connection.
+            mock_db_instance.close.assert_not_called()
+
+    def test_cache_db_constructed_with_config(
+        self, sample_data: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """ClusterMetadataDB is constructed with config= so get_lazy() works.
+
+        Regression for #548: previously the db was constructed without
+        ``config=``, causing ``get_lazy()`` to raise ``ValueError``. Also
+        verifies the db is NOT closed when a shim is returned, since the
+        shim shares the open connection.
+        """
+        cache_path = tmp_path / ".cache" / "cluster_metadata.db"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.touch()
+
+        mock_metadata = MagicMock()
+        mock_db_instance = MagicMock()
+        mock_db_instance.get_lazy.return_value = mock_metadata
+        mock_config = MagicMock()
+
+        with patch(
+            "pynetappfoundry.cache.db.ClusterMetadataDB",
+            return_value=mock_db_instance,
+        ) as mock_db:
+            entry = ClusterEntry("test-cluster", sample_data, cache_path, config=mock_config)
+            result = entry.ontap
+            assert result is mock_metadata
+            # Key assertion: BOTH db_path and config must be passed.
+            mock_db.assert_called_once_with(db_path=cache_path, config=mock_config)
+            # Db must NOT be closed: the shim owns the connection.
+            mock_db_instance.close.assert_not_called()
 
     def test_ontap_cached_on_second_access(
         self, sample_data: dict[str, Any], tmp_path: Path
@@ -302,6 +334,7 @@ class TestConfigAwareFetcher:
             entry = ClusterEntry("test-cluster", sample_data, cache_path, config=mock_config)
             result = entry.ontap
 
+            assert result is not None
             assert result is mock_metadata
             assert result._fetcher is mock_fetcher
 
@@ -363,6 +396,7 @@ class TestNoCacheBypass:
             result = entry.ontap
 
             mock_db_cls.assert_not_called()
+            assert result is not None
             assert isinstance(result, LazyClusterMetadata)
             assert result._db_path is None
             assert result._fetcher is mock_fetcher


### PR DESCRIPTION
## Description

`ClusterEntry._load_cached_metadata()` had two latent bugs in the same code
path that together caused every cache read to silently fall through to the
live ONTAP fetcher. The original issue (#548) identified one of them as a
one-line fix; implementation exposed a second lifecycle bug that the first
was masking. Both are fixed here.

**Bug 1 — `config=` was never threaded through to `ClusterMetadataDB`.**
Since ADR-0012 Phase 3b (#502), `ClusterMetadataDB.get_lazy()` requires a
`Config` instance to build the `LazyClusterMetadata` shim (see
`cache/db.py:532-539`). `_load_cached_metadata` constructed the db as
`ClusterMetadataDB(db_path=self._cache_db_path)` — no `config=` — so
`get_lazy()` raised `ValueError`, the outer `try/except` swallowed it, and
every caller silently bypassed the cache.

**Bug 2 — the db was closed before the returned shim could use it.**
`ClusterMetadataDB.get_lazy()` at `cache/db.py:540-552` deliberately
pre-populates `backend._cache_db = self` with the comment "shares THIS open
connection for cache reads". The design intent is that the caller keeps the
db open for the shim's lifetime. `_load_cached_metadata` closed it
immediately in a `finally` block. Bug 1 masked this because `get_lazy()`
always raised before returning a shim — so the premature close was
unreachable in practice. With Bug 1 fixed, accessing any field group on the
returned shim would raise `sqlite3.ProgrammingError: Cannot operate on a
closed database`.

Both bugs have to land together. `cache/db.py` is intentionally untouched:
the sharing-connection contract at `get_lazy:540-552` is the source of
truth and still correct.

## Related Issue

Addresses #548

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Breaking Changes

**None.**

- `ClusterEntry.__init__` signature is unchanged.
- `_load_cached_metadata` is private (leading underscore).
- The only public-visible change is that cache reads now actually succeed
  on the path they always claimed to. Output shape is unchanged; callers
  that were incidentally hitting the live fetcher will now hit the cache
  and return the same data faster.

## Changes Made

- `src/pynetappfoundry/core/cluster_entry.py` — two edits in
  `_load_cached_metadata()`:
  - Pass `config=self._config` into the `ClusterMetadataDB(...)`
    constructor so `get_lazy()` can build the `LazyClusterMetadata` shim.
  - Restructure the `try/finally` into `try/except/else`: on the success
    path (shim returned) the db is **not** closed — the shim owns it.
    On the exception path and on the `result is None` path, the db is
    closed before falling through to the live fetcher.
  - Wrap the `ClusterMetadataDB(...)` construction inside the `try` so
    test doubles that raise from the constructor (`side_effect=Exception`)
    are still caught; `db` is initialized to `None` beforehand and the
    `except` branch guards `db is not None` before calling `close()`.
- `tests/unit/core/test_cluster_entry.py`:
  - New regression test `test_cache_db_constructed_with_config` in
    `TestLazyLoading` asserting the db is built with both `db_path=` and
    `config=` kwargs and is **not** closed when a shim is returned.
  - Updated existing `test_ontap_opens_db_on_first_access` — replaced
    `mock_db_instance.close.assert_called_once()` with
    `assert_not_called()` to match the new lifecycle (success path keeps
    the connection open for the shim).
  - Added `assert result is not None` type guards in two unrelated
    tests where the new optional return type tripped Pyright's
    `reportOptionalMemberAccess`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Verified:

- New unit test `test_cache_db_constructed_with_config` passes.
- Updated `test_ontap_opens_db_on_first_access` passes with
  `close.assert_not_called()`.
- **Regression:** `tests/unit/test_config.py::TestClusterEntryWrapping::test_cluster_entry_lazy_cache_access`
  was previously passing by falling through to the live fetcher. With
  both bugs fixed, it now exercises the cache path it always claimed to
  test (writes a real cluster to SQLite, reads it back through
  `ClusterEntry`, asserts Azure cloud values round-trip).
- `doit check` — green, 2005 tests pass.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

(No user-facing docs or CHANGELOG entry are required for this bug fix —
behavior-visible change is "cache reads work correctly", no API change.)

## Additional Notes

**The v1 plan was wrong.** The original #548 body described this as a
one-line fix: add `config=self._config` to the `ClusterMetadataDB(...)`
call. That fix alone would have revealed Bug 2 (premature close) and
crashed every cache read at the first field-group access. The v2 plan
comment on #548 addresses both bugs together; the diff is ~8 lines of
production code instead of 1, entirely contained in
`_load_cached_metadata()`.

**Why `close.assert_not_called()` is correct, not a regression.** The old
`finally: db.close()` was wrong given `get_lazy()`'s documented contract
("shares THIS open connection for cache reads"). The shim now owns the
connection for its lifetime. `ClusterEntry` instances are short-lived per
command invocation and SQLite connections close on Python garbage
collection, so the connection is cleaned up naturally. This matches the
design intent documented inline at `cache/db.py:540-552`.

**Small implementation deviation from the v2 plan.** The plan showed
`ClusterMetadataDB(...)` constructed outside the `try`. Implementation
wraps it inside the `try` so test doubles using `side_effect=Exception`
on the constructor itself are caught by the existing
`test_ontap_returns_none_on_db_error` test. A `db: ClusterMetadataDB | None`
is declared beforehand and the `except` branch guards `db is not None`
before closing. Functionally equivalent; strictly more defensive.

**`db.py` intentionally untouched.** The sharing machinery
(`object.__setattr__(backend, "_cache_db", self)` at `get_lazy:540-552`)
is the source of truth for the connection lifetime contract. Fixing this
in `cluster_entry.py` honors that contract rather than working around it.
