### PR TITLE
feat: support parent-keyed mappings in DataSource partial-fetch (merges PR, addresses #544)

### DIFF
--- a/docs/decisions/0013-datasource-as-a-thin-facade-over-the-collector.md
+++ b/docs/decisions/0013-datasource-as-a-thin-facade-over-the-collector.md
@@ -58,19 +58,23 @@ Derived-field hooks (e.g. `compute_is_ha` from ADR-0012 §6) move from "runs aft
 
 The partial-fetch merge path for `cache_strategy="realtime"` fields is genuinely narrower than the whole-model path: 846 of 863 realtime fields are inline sub-fields of standard collection endpoints, so a restricted-field live query (`?fields=metric.iops.read,metric.latency.*&uuid=<id>`) is sufficient. This path stays in `DataSource` (or its delegating backend) as a dedicated thin fetcher. The 17 realtime fields on 4 parent-keyed mappings (`storage/volumes/snapshots`, `snapmirror/relationships/transfers`, `application/consistency_groups/snapshots`, `svm/migrations/volumes`) need path-parameter substitution — the realtime path inherits a narrow, scoped subset of Gap 6 for those four cases. This is a small, concrete piece of code, not generic path-param support.
 
-**§7 amendment (Phase 3, issue #542 — parent-keyed partial-fetch deferred).** Partial-fetch (cache + realtime live merge) on the four parent-keyed mappings is **not yet supported** in Phase 3. Cached instances of these models span multiple parents, so the restricted-field live merge would need to group cached instances by parent identifier and build one live URL per parent — non-trivial plumbing that Phase 3 did not take on. Instead, `OntapBackend._query_partial()` raises `NotImplementedError` when invoked on a mapping whose `parent_mapping` is set. The affected models and fields are:
+**§7 amendment (issue #544 — parent-keyed partial-fetch).** Partial-fetch (cache + realtime live merge) on the four parent-keyed mappings is now supported via a grouped-by-parent algorithm in `OntapBackend._query_partial()`. The implementation:
 
-- `OntapSnapshot` (`storage/volumes/{volume.uuid}/snapshots`) — realtime size/space metrics.
-- `OntapSnapmirrorTransfer` (`snapmirror/relationships/{relationship.uuid}/transfers`) — realtime transfer state and progress.
-- `OntapConsistencyGroupSnapshotResponse` (`application/consistency_groups/{consistency_group.uuid}/snapshots`) — realtime reclaimable/size metrics.
-- `OntapSvmMigrationVolume` (`svm/migrations/{svm_migration.uuid}/volumes`) — realtime migration transfer state.
+1. Parses the `{placeholder}` from `TypeMapping.api_endpoint` (e.g. `{volume.uuid}`) to discover the child→parent reference field.
+2. Groups cached children by parent UUID using `_resolve_dotted_attr` on the parsed reference field.
+3. For each parent group, builds a resolved URL via `TypeMapping.build_parameterized_url`, adds pipe-OR identifier filters chunked at `_BATCH_SIZE`, and fetches live data per parent.
+4. Merges live results into cached instances by `identifier_field`, the same way the non-parent-keyed path does.
 
-17 realtime fields total. These fields are **still populated correctly** by `nf cache refresh`, which goes through the whole-model fetch path (the generic `fetch()` dispatcher handles parent-keyed mappings via `_fetch_parameterized`, iterating parents and substituting into the URL). The available workarounds are:
+For models without a child→parent back-reference (e.g. `OntapSvmMigrationVolume`, whose child records have no attribute pointing back to the parent `svm_migration.uuid`), the algorithm falls back to querying the parent model from cache, then iterates all discovered parents. ONTAP's per-parent endpoint naturally returns only the children belonging to that parent, so identifier-based merge handles deduplication.
 
-- `source="cache"` after a `nf cache refresh` — returns the last-refreshed realtime snapshot.
-- `source="live"` on the whole model — bypasses the cache entirely and calls `fetch()` directly.
+All four affected mappings now declare `identifier_field`:
 
-Tracked as #544 (follow-up filed at Phase 3 landing).
+- `OntapSnapshot` — `identifier_field="uuid"`
+- `OntapSnapmirrorTransfer` — `identifier_field="uuid"`
+- `OntapConsistencyGroupSnapshotResponse` — `identifier_field="uuid"`
+- `OntapSvmMigrationVolume` — `identifier_field="volume.uuid"` (dotted; no top-level uuid)
+
+Resolved by #544.
 
 ### 8. `.get()` is a convenience over `.query()`
 

--- a/src/pynetappfoundry/cache/ontap/application/consistency_groups/snapshots/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/application/consistency_groups/snapshots/mapping.py
@@ -69,6 +69,7 @@ ONTAPCONSISTENCYGROUPSNAPSHOTRESPONSE_MAPPING = TypeMapping(
     api_type="ontap",
     parent_mapping="OntapConsistencyGroupResponse",
     parent_id_field="uuid",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="comment",

--- a/src/pynetappfoundry/cache/ontap/snapmirror/relationships/transfers/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/snapmirror/relationships/transfers/mapping.py
@@ -41,6 +41,7 @@ ONTAPSNAPMIRRORTRANSFER_MAPPING = TypeMapping(
     api_type="ontap",
     parent_mapping="OntapSnapmirrorRelationship",
     parent_id_field="uuid",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="bytes_transferred",

--- a/src/pynetappfoundry/cache/ontap/storage/volumes/snapshots/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/volumes/snapshots/mapping.py
@@ -13,6 +13,7 @@ ONTAPSNAPSHOT_MAPPING = TypeMapping(
     api_type="ontap",
     parent_mapping="OntapVolume",
     parent_id_field="uuid",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="comment",

--- a/src/pynetappfoundry/cache/ontap/svm/migrations/volumes/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/svm/migrations/volumes/mapping.py
@@ -24,6 +24,7 @@ ONTAPSVMMIGRATIONVOLUME_MAPPING = TypeMapping(
     api_type="ontap",
     parent_mapping="OntapSvmMigration",
     parent_id_field="uuid",
+    identifier_field="volume.uuid",
     fields=(
         FieldMapping(
             cache_attr="errors",

--- a/src/pynetappfoundry/data/backends.py
+++ b/src/pynetappfoundry/data/backends.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from pydantic import BaseModel
 
 from pynetappfoundry.cache import fetch
+from pynetappfoundry.cache.fetchers import _resolve_dotted_attr
 from pynetappfoundry.cache.field_mapping import parse_api_response
 from pynetappfoundry.data._merge import merge_models
 
@@ -419,30 +420,17 @@ class OntapBackend(Backend):
     ) -> list[T]:
         """Execute the partial-fetch (Approach C) algorithm for collections.
 
-        1. Reject parent-keyed mappings (deferred; tracked as #544).
-        2. Validate filter keys are cache-side only.
-        3. Validate mapping.identifier_field is a single string.
-        4. Run the cache query (defines membership).
-        5. Short-circuit on empty cache result.
-        6. Batch live fetch by identifier, chunked at ``_BATCH_SIZE``.
-        7. Merge each cached instance with its live counterpart by
+        1. Validate filter keys are cache-side only.
+        2. Validate mapping.identifier_field is a single string.
+        3. Run the cache query (defines membership).
+        4. Short-circuit on empty cache result.
+        5. Branch on parent-keyed vs standard mappings:
+           - Parent-keyed: group by parent, per-parent batched live fetch.
+           - Standard: single batched live fetch by identifier.
+        6. Merge each cached instance with its live counterpart by
            identifier. Extras from live are silently dropped; cached
            instances without a live match pass through unmerged.
         """
-        if mapping.parent_mapping is not None:
-            msg = (
-                f"Partial-fetch (cache + realtime live merge) on parent-keyed "
-                f"mappings is not yet supported. The affected models are "
-                f"OntapSnapshot, OntapSnapmirrorTransfer, "
-                f"OntapConsistencyGroupSnapshotResponse, and "
-                f"OntapSvmMigrationVolume. These models' realtime fields are "
-                f"still populated by `nf cache refresh`; use source='cache' "
-                f"after refresh, or fetch the whole model via source='live'. "
-                f"Tracked as #544. "
-                f"Triggered on mapping {mapping.name!r}."
-            )
-            raise NotImplementedError(msg)
-
         self._validate_partial_query_filter(mapping, filters)
 
         identifier_field = mapping.identifier_field
@@ -474,22 +462,197 @@ class OntapBackend(Backend):
             # branch should be unreachable. Kept to document intent.
             return cached_instances
 
-        identifiers = [getattr(inst, identifier_field) for inst in cached_instances]
-        live_instances = self._fetch_live_by_identifiers(
-            model_class,
-            mapping,
-            cluster,
-            identifiers,
-            identifier_field,
-            decision.live_fields,
-        )
-        live_index = {getattr(inst, identifier_field): inst for inst in live_instances}
+        if mapping.parent_mapping is not None:
+            parent_ref_field = self._extract_parent_ref_field(mapping)
+            parent_groups = self._resolve_parent_uuids(
+                mapping, cached_instances, cluster, parent_ref_field
+            )
+            live_instances = self._fetch_live_by_parent(
+                model_class,
+                mapping,
+                cluster,
+                parent_groups,
+                identifier_field,
+                decision.live_fields,
+            )
+        else:
+            identifiers = [
+                _resolve_dotted_attr(inst, identifier_field) for inst in cached_instances
+            ]
+            live_instances = self._fetch_live_by_identifiers(
+                model_class,
+                mapping,
+                cluster,
+                identifiers,
+                identifier_field,
+                decision.live_fields,
+            )
+
+        live_index: dict[str, T] = {
+            _resolve_dotted_attr(inst, identifier_field): inst for inst in live_instances
+        }
         return self._merge_partial_collection(
             cached_instances,
             live_index,
             identifier_field,
             decision,
         )
+
+    @staticmethod
+    def _extract_parent_ref_field(mapping: TypeMapping) -> str | None:
+        """Parse the ``{placeholder}`` from a parameterized ``api_endpoint``.
+
+        Returns the dotted attribute path inside the first ``{...}``
+        placeholder (e.g. ``"volume.uuid"`` from
+        ``"/storage/volumes/{volume.uuid}/snapshots"``), or ``None`` if no
+        placeholder is found.
+        """
+        import re as _re
+
+        match = _re.search(r"\{([^}]+)\}", mapping.api_endpoint)
+        return match.group(1) if match else None
+
+    def _resolve_parent_uuids(
+        self,
+        mapping: TypeMapping,
+        cached_instances: list[T],
+        cluster: str,
+        parent_ref_field: str | None,
+    ) -> dict[str, list[T]]:
+        """Group *cached_instances* by parent UUID for parent-keyed live fetch.
+
+        For each cached child, resolves *parent_ref_field* via dotted-attr
+        lookup.  Children whose parent ref resolves to ``None`` or empty
+        string are logged as warnings and excluded from the grouped result.
+
+        If **all** children yield ``None`` (the SvmMigrationVolume case,
+        where the child model has no back-reference to the parent), falls
+        back to querying the parent model from cache and returning all
+        children under each parent UUID.
+
+        Returns:
+            ``{parent_uuid: [children]}`` dict suitable for
+            :meth:`_fetch_live_by_parent`.
+        """
+        from collections import defaultdict
+
+        groups: dict[str, list[T]] = defaultdict(list)
+        orphans: list[T] = []
+
+        for child in cached_instances:
+            parent_uuid = (
+                _resolve_dotted_attr(child, parent_ref_field) if parent_ref_field else None
+            )
+            if parent_uuid:
+                groups[str(parent_uuid)].append(child)
+            else:
+                orphans.append(child)
+
+        if groups:
+            # Some children resolved — orphans are logged and excluded.
+            if orphans:
+                logger.warning(
+                    "DataSource %s: %d cached children have no parent ref "
+                    "via %r; they will pass through unmerged",
+                    mapping.name,
+                    len(orphans),
+                    parent_ref_field,
+                )
+            return dict(groups)
+
+        # ALL children yielded None — fall back to parent model cache query.
+        from pynetappfoundry.cache._registry import model_registry
+
+        parent_type_mapping = model_registry.get_mapping(mapping.parent_mapping or "")
+        if parent_type_mapping is None:
+            logger.warning(
+                "DataSource %s: parent mapping %r not found in registry; "
+                "cannot resolve parent UUIDs for cache-fallback path",
+                mapping.name,
+                mapping.parent_mapping,
+            )
+            return {}
+
+        parent_model_class = parent_type_mapping.model_class
+        parent_instances = self._fetch_cache(parent_model_class, cluster, [])
+
+        parent_id_field = mapping.parent_id_field or "uuid"
+        for parent in parent_instances:
+            pid = _resolve_dotted_attr(parent, parent_id_field)
+            if pid:
+                groups[str(pid)] = list(cached_instances)
+
+        return dict(groups)
+
+    def _fetch_live_by_parent(
+        self,
+        model_class: type[T],
+        mapping: TypeMapping,
+        cluster: str,
+        parent_groups: dict[str, list[T]],
+        identifier_field: str,
+        live_field_paths: tuple[str, ...],
+    ) -> list[T]:
+        """Per-parent batched live fetch for parent-keyed mappings.
+
+        For each parent UUID and its children, builds a resolved URL via
+        :meth:`TypeMapping.build_parameterized_url`, overrides ``fields=``
+        with the live field paths (preserving ``fields=*`` when present),
+        adds pipe-OR identifier filters chunked at ``_BATCH_SIZE``, and
+        fetches via :meth:`ONTAPAPIClient.get_all_records`.
+
+        Returns:
+            Aggregated list of parsed model instances across all parents
+            and chunks.
+        """
+        from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+        client = self._get_api_client(cluster)
+
+        # Translate live cache_attr paths to api_path values.
+        api_paths: list[str] = []
+        for attr in live_field_paths:
+            field = next(
+                (f for f in mapping.fields if f.cache_attr == attr),
+                None,
+            )
+            if field is not None and field.api_path is not None:
+                api_paths.append(field.api_path)
+            else:
+                api_paths.append(attr)
+
+        results: list[T] = []
+        for parent_uuid, children in parent_groups.items():
+            base_url = mapping.build_parameterized_url(parent_uuid)
+            parsed = urlparse(base_url)
+            base_query: dict[str, list[str]] = parse_qs(parsed.query, keep_blank_values=True)
+
+            # Extract child identifiers, filtering out None/empty.
+            child_ids = [
+                str(cid)
+                for child in children
+                if (cid := _resolve_dotted_attr(child, identifier_field))
+            ]
+            if not child_ids:
+                continue
+
+            for chunk in self._chunked(child_ids, _BATCH_SIZE):
+                query = {k: list(v) for k, v in base_query.items()}
+                if api_paths:
+                    existing = query.get("fields", [""])[0]
+                    if not existing.startswith("*"):
+                        query["fields"] = [",".join(api_paths)]
+                query[identifier_field] = ["|".join(chunk)]
+                url = urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
+                response = client.get_all_records(url)
+                parsed_records = parse_api_response(
+                    mapping,
+                    response,
+                    f"OntapBackend<{mapping.name}>",
+                    _log_missing_fields,
+                )
+                results.extend(r for r in parsed_records if isinstance(r, model_class))
+        return results
 
     @staticmethod
     def _validate_partial_query_filter(
@@ -595,7 +758,7 @@ class OntapBackend(Backend):
         """
         merged_list: list[T] = []
         for cached in cached_instances:
-            key = getattr(cached, identifier_field)
+            key = _resolve_dotted_attr(cached, identifier_field)
             live = live_index.get(key)
             if live is None:
                 merged_list.append(cached)

--- a/tests/unit/data/_fakes.py
+++ b/tests/unit/data/_fakes.py
@@ -26,3 +26,31 @@ class FakeComposite(OntapModel):
 
     svm_name: str = ""
     name: str = ""
+
+
+class FakeParentModel(OntapModel):
+    """Synthetic parent model for parent-keyed partial-fetch tests."""
+
+    name: str = ""
+    uuid: str = ""
+
+
+class FakeChildVolume(OntapModel):
+    """Nested sub-model providing a parent back-reference via ``uuid``."""
+
+    uuid: str = ""
+
+
+class FakeChildWithDottedRef(OntapModel):
+    """Synthetic child with nested parent ref via ``volume.uuid``."""
+
+    uuid: str = ""
+    volume: FakeChildVolume = FakeChildVolume()
+    metric: float = 0.0
+
+
+class FakeOrphanChild(OntapModel):
+    """Synthetic child with no parent back-reference (SvmMigrationVolume-like)."""
+
+    volume_uuid: str = ""
+    transfer_state: str = ""

--- a/tests/unit/data/conftest.py
+++ b/tests/unit/data/conftest.py
@@ -15,9 +15,21 @@ import pytest
 
 from pynetappfoundry.cache._registry import model_registry
 from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
-from tests.unit.data._fakes import FakeComposite, FakeVolume
+from tests.unit.data._fakes import (
+    FakeChildWithDottedRef,
+    FakeComposite,
+    FakeOrphanChild,
+    FakeParentModel,
+    FakeVolume,
+)
 
-__all__ = ["FakeComposite", "FakeVolume"]
+__all__ = [
+    "FakeChildWithDottedRef",
+    "FakeComposite",
+    "FakeOrphanChild",
+    "FakeParentModel",
+    "FakeVolume",
+]
 
 
 @pytest.fixture
@@ -75,3 +87,74 @@ def fake_composite_mapping() -> Iterator[TypeMapping]:
 def mock_config() -> Any:
     """A bare MagicMock standing in for :class:`Config`."""
     return MagicMock(name="Config")
+
+
+@pytest.fixture
+def fake_parent_mapping() -> Iterator[TypeMapping]:
+    """Register a synthetic FakeParentModel mapping for parent-keyed tests."""
+    mapping = TypeMapping(
+        name="FakeParent",
+        model_class=FakeParentModel,
+        api_endpoint="/storage/fake-parents?fields=*",
+        api_type="ontap",
+        identifier_field="uuid",
+        fields=(
+            FieldMapping(cache_attr="name", cache_strategy="cache"),
+            FieldMapping(cache_attr="uuid", cache_strategy="cache"),
+        ),
+    )
+    model_registry.register_mapping("FakeParent", mapping)
+    try:
+        yield mapping
+    finally:
+        model_registry._mappings.pop("FakeParent", None)
+        model_registry._mappings_by_class.pop(FakeParentModel, None)
+
+
+@pytest.fixture
+def fake_child_mapping(fake_parent_mapping: TypeMapping) -> Iterator[TypeMapping]:
+    """Register a parent-keyed child mapping with dotted parent ref."""
+    mapping = TypeMapping(
+        name="FakeChild",
+        model_class=FakeChildWithDottedRef,
+        api_endpoint="/storage/fakes/{volume.uuid}/children?fields=*",
+        api_type="ontap",
+        parent_mapping="FakeParent",
+        parent_id_field="uuid",
+        identifier_field="uuid",
+        fields=(
+            FieldMapping(cache_attr="uuid", cache_strategy="cache"),
+            FieldMapping(cache_attr="volume.uuid", cache_strategy="cache", api_path="volume.uuid"),
+            FieldMapping(cache_attr="metric", cache_strategy="realtime"),
+        ),
+    )
+    model_registry.register_mapping("FakeChild", mapping)
+    try:
+        yield mapping
+    finally:
+        model_registry._mappings.pop("FakeChild", None)
+        model_registry._mappings_by_class.pop(FakeChildWithDottedRef, None)
+
+
+@pytest.fixture
+def fake_orphan_child_mapping(fake_parent_mapping: TypeMapping) -> Iterator[TypeMapping]:
+    """Register a parent-keyed child with no parent back-reference."""
+    mapping = TypeMapping(
+        name="FakeOrphanChild",
+        model_class=FakeOrphanChild,
+        api_endpoint="/svm/fakes/{fake_parent.uuid}/orphans?fields=*",
+        api_type="ontap",
+        parent_mapping="FakeParent",
+        parent_id_field="uuid",
+        identifier_field="volume_uuid",
+        fields=(
+            FieldMapping(cache_attr="volume_uuid", cache_strategy="cache"),
+            FieldMapping(cache_attr="transfer_state", cache_strategy="realtime"),
+        ),
+    )
+    model_registry.register_mapping("FakeOrphanChild", mapping)
+    try:
+        yield mapping
+    finally:
+        model_registry._mappings.pop("FakeOrphanChild", None)
+        model_registry._mappings_by_class.pop(FakeOrphanChild, None)

--- a/tests/unit/data/test_backends.py
+++ b/tests/unit/data/test_backends.py
@@ -14,7 +14,13 @@ import pytest
 from pynetappfoundry.cache.field_mapping import TypeMapping
 from pynetappfoundry.data._routing import RoutingDecision
 from pynetappfoundry.data.backends import OntapBackend
-from tests.unit.data._fakes import FakeVolume
+from tests.unit.data._fakes import (
+    FakeChildVolume,
+    FakeChildWithDottedRef,
+    FakeOrphanChild,
+    FakeParentModel,
+    FakeVolume,
+)
 
 
 def _make_backend(mock_config: Any) -> OntapBackend:
@@ -547,41 +553,48 @@ class TestOntapBackendQueryPartial:
         assert "uuid=u1%7Cu2%7Cu3" in url
         assert "fields=%2A" in url or "fields=*" in url
 
-    def test_partial_query_parent_keyed_raises_not_implemented(
+    def test_partial_query_parent_keyed_delegates_to_parent_path(
         self,
+        fake_child_mapping: TypeMapping,
         mock_config: Any,
     ) -> None:
-        """Parent-keyed mappings are explicitly unsupported for partial-fetch."""
-        from pynetappfoundry.cache._registry import model_registry
-        from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+        """Parent-keyed mappings now route through the parent-keyed path."""
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("uuid", "volume.uuid"), live_fields=("metric",))
+        cached = [
+            FakeChildWithDottedRef(uuid="c1", volume=FakeChildVolume(uuid="vol-1"), metric=0.0),
+        ]
+        live = [
+            FakeChildWithDottedRef(uuid="c1", metric=99.0),
+        ]
 
-        mapping = TypeMapping(
-            name="FakeParentKeyed",
-            model_class=FakeVolume,
-            api_endpoint="/x/{id}/children?fields=*",
-            api_type="ontap",
-            identifier_field="uuid",
-            parent_mapping="FakeParent",
-            parent_id_field="uuid",
-            fields=(
-                FieldMapping(cache_attr="uuid", cache_strategy="cache"),
-                FieldMapping(cache_attr="iops", cache_strategy="realtime"),
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = cached
+        mock_client = MagicMock()
+        mock_client.get_all_records.return_value = {"records": []}
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.parse_api_response",
+                return_value=live,
             ),
-        )
-        model_registry.register_mapping("FakeParentKeyed", mapping)
-        try:
-            backend = _make_backend(mock_config)
-            decision = RoutingDecision(cache_fields=("uuid",), live_fields=("iops",))
-            with pytest.raises(NotImplementedError, match="parent-keyed"):
-                backend.query(
-                    FakeVolume,
-                    mapping,
-                    decision,
-                    cluster="prod1",
-                    filters={},
-                )
-        finally:
-            model_registry._mappings.pop("FakeParentKeyed", None)
+            patch.object(backend, "_resolve_metadata_path", return_value="storage.fake_children"),
+        ):
+            results = backend.query(
+                FakeChildWithDottedRef,
+                fake_child_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert len(results) == 1
+        assert results[0].metric == 99.0
+        mock_client.get_all_records.assert_called_once()
+        url = mock_client.get_all_records.call_args[0][0]
+        assert "vol-1" in url
 
     def test_partial_query_chunked_helper(self) -> None:
         assert list(OntapBackend._chunked([], 100)) == []
@@ -597,6 +610,312 @@ class TestOntapBackendQueryPartial:
             list(range(100, 200)),
             list(range(200, 250)),
         ]
+
+
+class TestOntapBackendQueryPartialParentKeyed:
+    """Tests for parent-keyed partial-fetch in ``_query_partial``."""
+
+    def test_parent_keyed_single_parent_single_child(
+        self,
+        fake_child_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """One cached child under one parent; API returns updated metric."""
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("uuid", "volume.uuid"), live_fields=("metric",))
+        cached = [
+            FakeChildWithDottedRef(uuid="c1", volume=FakeChildVolume(uuid="vol-1"), metric=0.0),
+        ]
+        live = [
+            FakeChildWithDottedRef(uuid="c1", metric=42.0),
+        ]
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = cached
+        mock_client = MagicMock()
+        mock_client.get_all_records.return_value = {"records": []}
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.parse_api_response",
+                return_value=live,
+            ),
+            patch.object(backend, "_resolve_metadata_path", return_value="storage.fake_children"),
+        ):
+            results = backend.query(
+                FakeChildWithDottedRef,
+                fake_child_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert len(results) == 1
+        assert results[0].metric == 42.0
+        assert results[0].uuid == "c1"
+        mock_client.get_all_records.assert_called_once()
+        url = mock_client.get_all_records.call_args[0][0]
+        assert "vol-1" in url
+        assert "{volume.uuid}" not in url
+
+    def test_parent_keyed_single_parent_multi_child(
+        self,
+        fake_child_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Three children under the same parent; single API call with pipe-OR."""
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("uuid", "volume.uuid"), live_fields=("metric",))
+        cached = [
+            FakeChildWithDottedRef(uuid=f"c{i}", volume=FakeChildVolume(uuid="vol-1"))
+            for i in range(1, 4)
+        ]
+        live = [FakeChildWithDottedRef(uuid=f"c{i}", metric=float(i) * 10) for i in range(1, 4)]
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = cached
+        mock_client = MagicMock()
+        mock_client.get_all_records.return_value = {"records": []}
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.parse_api_response",
+                return_value=live,
+            ),
+            patch.object(backend, "_resolve_metadata_path", return_value="storage.fake_children"),
+        ):
+            results = backend.query(
+                FakeChildWithDottedRef,
+                fake_child_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert len(results) == 3
+        mock_client.get_all_records.assert_called_once()
+        url = mock_client.get_all_records.call_args[0][0]
+        assert "c1" in url
+        assert "c2" in url
+        assert "c3" in url
+
+    def test_parent_keyed_multiple_parents(
+        self,
+        fake_child_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Children spanning two parents; API called once per parent."""
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("uuid", "volume.uuid"), live_fields=("metric",))
+        cached = [
+            FakeChildWithDottedRef(uuid="c1", volume=FakeChildVolume(uuid="vol-1")),
+            FakeChildWithDottedRef(uuid="c2", volume=FakeChildVolume(uuid="vol-2")),
+            FakeChildWithDottedRef(uuid="c3", volume=FakeChildVolume(uuid="vol-1")),
+        ]
+        live_vol1 = [
+            FakeChildWithDottedRef(uuid="c1", metric=10.0),
+            FakeChildWithDottedRef(uuid="c3", metric=30.0),
+        ]
+        live_vol2 = [
+            FakeChildWithDottedRef(uuid="c2", metric=20.0),
+        ]
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = cached
+        mock_client = MagicMock()
+        mock_client.get_all_records.return_value = {"records": []}
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.parse_api_response",
+                side_effect=[live_vol1, live_vol2],
+            ),
+            patch.object(backend, "_resolve_metadata_path", return_value="storage.fake_children"),
+        ):
+            results = backend.query(
+                FakeChildWithDottedRef,
+                fake_child_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert len(results) == 3
+        by_uuid = {r.uuid: r for r in results}
+        assert by_uuid["c1"].metric == 10.0
+        assert by_uuid["c2"].metric == 20.0
+        assert by_uuid["c3"].metric == 30.0
+        assert mock_client.get_all_records.call_count == 2
+        urls = [call.args[0] for call in mock_client.get_all_records.call_args_list]
+        parent_uuids_in_urls = {"vol-1" in u or "vol-2" in u for u in urls}
+        assert all(parent_uuids_in_urls)
+
+    def test_parent_keyed_missing_parent_uuid_warns(
+        self,
+        fake_child_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Children with empty parent ref pass through unmerged; warning logged."""
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("uuid", "volume.uuid"), live_fields=("metric",))
+        cached = [
+            FakeChildWithDottedRef(uuid="c1", volume=FakeChildVolume(uuid="vol-1")),
+            FakeChildWithDottedRef(uuid="c2", volume=FakeChildVolume(uuid="")),
+        ]
+        live = [FakeChildWithDottedRef(uuid="c1", metric=10.0)]
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = cached
+        mock_client = MagicMock()
+        mock_client.get_all_records.return_value = {"records": []}
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.parse_api_response",
+                return_value=live,
+            ),
+            patch.object(backend, "_resolve_metadata_path", return_value="storage.fake_children"),
+            patch("pynetappfoundry.data.backends.logger") as mock_logger,
+        ):
+            results = backend.query(
+                FakeChildWithDottedRef,
+                fake_child_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        # c1 merged, c2 unmerged (no live data for it)
+        assert len(results) == 2
+        by_uuid = {r.uuid: r for r in results}
+        assert by_uuid["c1"].metric == 10.0
+        assert by_uuid["c2"].metric == 0.0
+        mock_logger.warning.assert_called_once()
+        assert "1 cached children" in mock_logger.warning.call_args[0][1] or (
+            mock_logger.warning.call_args[0][2] == 1
+        )
+
+    def test_parent_keyed_cache_fallback_no_child_ref(
+        self,
+        fake_orphan_child_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Orphan children (no parent back-ref) trigger parent cache lookup."""
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("volume_uuid",), live_fields=("transfer_state",))
+        cached = [
+            FakeOrphanChild(volume_uuid="vu1", transfer_state=""),
+            FakeOrphanChild(volume_uuid="vu2", transfer_state=""),
+        ]
+        parents = [
+            FakeParentModel(uuid="p1", name="parent1"),
+            FakeParentModel(uuid="p2", name="parent2"),
+        ]
+        live_p1 = [FakeOrphanChild(volume_uuid="vu1", transfer_state="done")]
+        live_p2 = [FakeOrphanChild(volume_uuid="vu2", transfer_state="running")]
+
+        mock_db = MagicMock()
+        # First call returns children, second returns parents.
+        mock_db.query_with_filters.side_effect = [cached, parents]
+        mock_client = MagicMock()
+        mock_client.get_all_records.return_value = {"records": []}
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.parse_api_response",
+                side_effect=[live_p1, live_p2],
+            ),
+            patch.object(
+                backend,
+                "_resolve_metadata_path",
+                side_effect=["svm.fake_orphans", "storage.fake_parents"],
+            ),
+        ):
+            results = backend.query(
+                FakeOrphanChild,
+                fake_orphan_child_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert len(results) == 2
+        assert mock_client.get_all_records.call_count == 2
+
+    def test_parent_keyed_empty_cache_short_circuits(
+        self,
+        fake_child_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Empty cache result returns [] with no API calls."""
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("uuid", "volume.uuid"), live_fields=("metric",))
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = []
+        mock_client = MagicMock()
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch.object(backend, "_resolve_metadata_path", return_value="storage.fake_children"),
+        ):
+            results = backend.query(
+                FakeChildWithDottedRef,
+                fake_child_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert results == []
+        mock_client.get_all_records.assert_not_called()
+
+    def test_extract_parent_ref_field(self) -> None:
+        """Unit test for _extract_parent_ref_field with various URL patterns."""
+        from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+
+        def _mapping_with_endpoint(endpoint: str) -> TypeMapping:
+            return TypeMapping(
+                name="Test",
+                model_class=FakeVolume,
+                api_endpoint=endpoint,
+                api_type="ontap",
+                fields=(FieldMapping(cache_attr="uuid"),),
+            )
+
+        assert (
+            OntapBackend._extract_parent_ref_field(
+                _mapping_with_endpoint("/storage/volumes/{volume.uuid}/snapshots?fields=*")
+            )
+            == "volume.uuid"
+        )
+        assert (
+            OntapBackend._extract_parent_ref_field(
+                _mapping_with_endpoint("/svm/migrations/{svm_migration.uuid}/volumes?fields=*")
+            )
+            == "svm_migration.uuid"
+        )
+        assert (
+            OntapBackend._extract_parent_ref_field(
+                _mapping_with_endpoint("/snapmirror/relationships/{relationship.uuid}/transfers")
+            )
+            == "relationship.uuid"
+        )
+        assert (
+            OntapBackend._extract_parent_ref_field(_mapping_with_endpoint("/storage/volumes"))
+            is None
+        )
 
 
 class TestQueryWithWhereExpressions:


### PR DESCRIPTION
## Description

Implements parent-keyed partial-fetch support in `OntapBackend`, removing the
`NotImplementedError` guard that blocked four child-resource mappings
(snapshots, snapmirror transfers, consistency-group snapshots, SVM migration
volumes) from using the cache+live merge path.

The algorithm now detects `parent_mapping` on a `TypeMapping` and branches:

- **Parent-keyed**: extracts the parent-ref placeholder from the API endpoint,
  groups cached instances by parent UUID, and issues per-parent batched live
  fetches before merging.
- **Standard** (unchanged): single batched live fetch by identifier.

Adds `identifier_field` to the four affected mapping files so the merge
step can locate each child resource by its unique key.

Amends ADR-0013 section 7 to document the parent-keyed strategy.

Addresses #544

## Related Issue

Addresses #544

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `src/pynetappfoundry/data/backends.py` -- parent-keyed partial-fetch logic: `_extract_parent_ref_field`, `_resolve_parent_uuids`, `_fetch_live_by_parent`, and updated `_partial_fetch_collection`
- Four mapping files -- added `identifier_field` for child resources
- `docs/decisions/0013-...md` -- rewrote section 7 amendment for parent-keyed strategy
- `tests/unit/data/test_backends.py` -- 7 new tests covering parent-keyed happy path, empty cache, missing live, multi-parent, cache-miss fallback, unknown parent ref, and no-placeholder edge case
- `tests/unit/data/_fakes.py` and `conftest.py` -- new fake models and fixtures

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (lint, type-check, security, spell, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
