### PR TITLE
feat: add mapping audit task and unmapped-model regression guard (merges PR, addresses #534)

### DIFF
--- a/src/pynetappfoundry/models/ontap/network/model.py
+++ b/src/pynetappfoundry/models/ontap/network/model.py
@@ -12,6 +12,8 @@ from pynetappfoundry.models.ontap.network.ethernet.broadcast_domains.model impor
 from pynetappfoundry.models.ontap.network.ip.interfaces.model import OntapIpInterface
 from pynetappfoundry.models.ontap.network.ip.subnets.model import OntapIpSubnet
 
+_UNMAPPED_REASON = "Aggregate container model — not an ONTAP REST endpoint"
+
 
 class NetworkInfo(OntapModel):
     """Network configuration information.

--- a/src/pynetappfoundry/models/ontap/protocols/model.py
+++ b/src/pynetappfoundry/models/ontap/protocols/model.py
@@ -11,6 +11,8 @@ from pynetappfoundry.models.ontap.protocols.nfs.export_policies.model import Ont
 from pynetappfoundry.models.ontap.protocols.nfs.services.model import OntapNfsService
 from pynetappfoundry.models.ontap.protocols.s3.buckets.model import OntapS3Bucket
 
+_UNMAPPED_REASON = "Aggregate container model — not an ONTAP REST endpoint"
+
 
 class ProtocolsInfo(OntapModel):
     """Protocol configuration information.

--- a/src/pynetappfoundry/models/ontap/storage/model.py
+++ b/src/pynetappfoundry/models/ontap/storage/model.py
@@ -18,6 +18,8 @@ from pynetappfoundry.models.ontap.storage.volumes.model import OntapVolume
 from pynetappfoundry.models.ontap.svm.svms.model import OntapSvm
 from pynetappfoundry.models.ontap.svm.svms.top_metrics.users.model import OntapTopMetricsSvmUser
 
+_UNMAPPED_REASON = "Aggregate container model — not an ONTAP REST endpoint"
+
 
 class StorageInfo(OntapModel):
     """Storage topology information.

--- a/tests/unit/compliance/test_mapping_coverage.py
+++ b/tests/unit/compliance/test_mapping_coverage.py
@@ -1,0 +1,33 @@
+"""Regression guard: every model directory must have a mapping or be excluded."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+# TODO(#533): hardcoded to ontap only — when aiqum/occm/dii models land,
+# generalize to walk all subdirectories of models/ and cache/.
+_MODELS_ROOT = _PROJECT_ROOT / "src" / "pynetappfoundry" / "models" / "ontap"
+_CACHE_ROOT = _PROJECT_ROOT / "src" / "pynetappfoundry" / "cache" / "ontap"
+
+# Model directories that are intentionally unmapped (aggregate containers).
+EXCLUDED: frozenset[str] = frozenset({"network", "protocols", "storage"})
+
+
+def _dirs_with_file(root: Path, filename: str) -> set[str]:
+    """Return relative POSIX paths of directories under *root* containing *filename*."""
+    return {p.parent.relative_to(root).as_posix() for p in root.rglob(filename)}
+
+
+def test_every_model_directory_has_mapping_or_exclusion() -> None:
+    """New model directories must have a mapping.py or be explicitly excluded."""
+    model_dirs = _dirs_with_file(_MODELS_ROOT, "model.py")
+    mapping_dirs = _dirs_with_file(_CACHE_ROOT, "mapping.py")
+
+    unmapped = model_dirs - mapping_dirs
+    gaps = unmapped - EXCLUDED
+
+    assert gaps == set(), (
+        f"Model directories without a mapping.py or EXCLUDED entry: {sorted(gaps)}. "
+        "Add a mapping.py in cache/ontap/<path>/ or add the path to EXCLUDED in this test."
+    )

--- a/tools/doit/audit_models.py
+++ b/tools/doit/audit_models.py
@@ -1,0 +1,109 @@
+"""Audit doit tasks for model-to-mapping coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+
+# Project root (tools/doit/ -> project root)
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+# TODO(#533): hardcoded to ontap only — when aiqum/occm/dii models land,
+# generalize to walk all subdirectories of models/ and cache/.
+_MODELS_ROOT = _PROJECT_ROOT / "src" / "pynetappfoundry" / "models" / "ontap"
+_CACHE_ROOT = _PROJECT_ROOT / "src" / "pynetappfoundry" / "cache" / "ontap"
+
+
+def _find_dirs_with_file(root: Path, filename: str) -> set[str]:
+    """Find all directories under *root* containing *filename*.
+
+    Returns relative POSIX paths (e.g. ``storage/volumes``).
+    """
+    dirs: set[str] = set()
+    for path in root.rglob(filename):
+        rel = path.parent.relative_to(root)
+        dirs.add(rel.as_posix())
+    return dirs
+
+
+def _check_unmapped_reason(model_rel: str) -> str | None:
+    """Return the ``_UNMAPPED_REASON`` value from a model.py, or ``None``."""
+    model_file = _MODELS_ROOT / model_rel / "model.py"
+    if not model_file.exists():
+        return None
+    text = model_file.read_text()
+    for line in text.splitlines():
+        if line.startswith("_UNMAPPED_REASON"):
+            # Extract the string value after '='
+            _, _, value = line.partition("=")
+            return value.strip().strip("\"'")
+    return None
+
+
+def _run_mapping_audit() -> bool:
+    """Walk model and mapping directories, report coverage, return success."""
+    console = Console()
+
+    model_dirs = _find_dirs_with_file(_MODELS_ROOT, "model.py")
+    mapping_dirs = _find_dirs_with_file(_CACHE_ROOT, "mapping.py")
+
+    mapped = model_dirs & mapping_dirs
+    unmapped = model_dirs - mapping_dirs
+
+    intentional: dict[str, str] = {}
+    gaps: set[str] = set()
+
+    for rel in sorted(unmapped):
+        reason = _check_unmapped_reason(rel)
+        if reason:
+            intentional[rel] = reason
+        else:
+            gaps.add(rel)
+
+    # Summary table
+    table = Table(title="Model-to-Mapping Audit", show_lines=True)
+    table.add_column("Category", style="bold")
+    table.add_column("Count", justify="right")
+    table.add_column("Details")
+
+    table.add_row("Mapped", str(len(mapped)), "")
+    table.add_row(
+        "Intentionally unmapped",
+        str(len(intentional)),
+        "\n".join(f"{k}: {v}" for k, v in sorted(intentional.items())),
+    )
+
+    if gaps:
+        table.add_row(
+            "[red]Gaps (missing mapping)[/red]",
+            f"[red]{len(gaps)}[/red]",
+            "\n".join(sorted(gaps)),
+        )
+    else:
+        table.add_row("Gaps", "0", "[green]None[/green]")
+
+    console.print()
+    console.print(table)
+    console.print()
+
+    if gaps:
+        console.print(
+            f"[bold red]FAIL:[/bold red] {len(gaps)} model director(ies) "
+            "lack a mapping.py and have no _UNMAPPED_REASON.",
+        )
+        return False
+
+    console.print(
+        "[bold green]All model directories are mapped or explicitly excluded.[/bold green]"
+    )
+    return True
+
+
+def task_mapping_audit() -> dict[str, Any]:
+    """Audit model directories for missing cache mappings."""
+    return {
+        "actions": [_run_mapping_audit],
+        "verbosity": 2,
+    }


### PR DESCRIPTION
## Description

Add a `doit mapping_audit` task and a regression-guard test that ensure every Pydantic model directory under `models/ontap/` either has a corresponding `mapping.py` in `cache/ontap/` or is explicitly marked with a `_UNMAPPED_REASON` constant.

Three aggregate container models (`network`, `protocols`, `storage`) are intentionally unmapped and now carry that annotation.

Addresses #534

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `_UNMAPPED_REASON` constant to `network/model.py`, `protocols/model.py`, and `storage/model.py` to document why these aggregate containers have no mapping
- Created `tools/doit/audit_models.py` with a `doit mapping_audit` task that walks model and cache directories and reports mapped, intentionally-unmapped, and gap buckets via a Rich table
- Created `tests/unit/compliance/test_mapping_coverage.py` as a regression guard that fails when a new model directory lacks both a mapping and an EXCLUDED entry

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (format, lint, type-check, security, spell, tests)
