### PR TITLE
feat: add DataSource SSH/CLI backend (merges PR, addresses #532)

### DIFF
--- a/docs/decisions/0013-datasource-as-a-thin-facade-over-the-collector.md
+++ b/docs/decisions/0013-datasource-as-a-thin-facade-over-the-collector.md
@@ -132,7 +132,7 @@ The snapshot-consistency requirement (§3/§4) is not a new constraint — it's 
 
 This ADR is **Phase 1** of a three-phase plan. A new parent issue supersedes #495's Phase 3/4 plans.
 
-- **Phase 1 — ADR (this PR).** Pure docs. Locks in the design points above. Mark ADR-0012 as Superseded. Close #531, #535, #536, #537 as "absorbed into ADR-0013"; close #530 once the new parent issue is filed. Keep #532 and #533 open as deferred (SSH and non-ONTAP backends are still Phase 4+ work, but they plug into the collector, not into `OntapBackend`).
+- **Phase 1 — ADR (this PR).** Pure docs. Locks in the design points above. Mark ADR-0012 as Superseded. Close #531, #535, #536, #537 as "absorbed into ADR-0013"; close #530 once the new parent issue is filed. Keep #533 open as deferred (non-ONTAP backends are still Phase 4+ work, but they plug into the collector, not into `OntapBackend`). #532 (SSH/CLI backend) has been resolved — CLI dispatch is wired into ``fetch()``.
 - **Phase 2 — Collector fetch/persist split.** Refactor `MetadataCollector` so every `collect_<type>` method splits into a pure `fetch_<type>` and a `persist_<type>`. `nf cache refresh` chains them; `DataSource` live reads call `fetch_<type>` only. Hook invocation (`compute_is_ha` and siblings) moves to the fetch layer. No `DataSource` consumer changes.
 - **Phase 3 — `OntapBackend` rewrite.** Rewrite `OntapBackend` as a thin delegator over the collector's fetch layer, with a dedicated realtime live-fetch path for the partial-fetch merge case (§7). Remove `OntapBackend.get()`. Update `DataSource.get()` to be a `.query()` convenience wrapper. Verify every Phase 3 shim (from ADR-0012 Phase 3a–3f) still passes its tests — no consumer changes expected.
 - **Phase 4 — `nf reports html` home_node fix (#524).** Unblocked by Phase 3. Migrates the last non-shim `QuerySet(...)` call sites through the new backend, including `ClusterInfo` via the collector's singleton-aware fetch.
@@ -150,7 +150,7 @@ This ADR is **Phase 1** of a three-phase plan. A new parent issue supersedes #49
 - Issue #535: feat: DataSource composite and non-UUID identifiers — closed, absorbed into ADR-0013
 - Issue #536: feat: DataSource path-parameter endpoints — closed, absorbed into ADR-0013
 - Issue #537: feat: DataSource post-query hooks for derived fields — closed, absorbed into ADR-0013
-- Issue #532: feat: DataSource SSH/CLI backend — deferred, retargeted to plug into collector
+- Issue #532: feat: DataSource SSH/CLI backend — resolved; CLI dispatch wired into ``fetch()`` via ``_fetch_cli()``, ``OntapBackend`` constructs CLI clients lazily with ``is_cloud`` gate
 - Issue #533: feat: DataSource non-ONTAP backends — deferred, retargeted to plug into collector
 - Issue #534: feat: audit Pydantic models without TypeMappings — unchanged
 - Issue #538: feat: DataSource pagination/chunking edge cases — re-scoped to the realtime live-fetch path only

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -9,7 +9,6 @@ are API-only and must succeed.
 from __future__ import annotations
 
 import logging
-import re
 import threading
 import time
 from collections.abc import Callable, Sequence
@@ -28,6 +27,7 @@ from pynetappfoundry.cache._metadata import (
 )
 from pynetappfoundry.cache._registry import model_registry
 from pynetappfoundry.cache.fetchers import fetch as _fetch
+from pynetappfoundry.cache.fetchers import normalize_cli_key, parse_vm_instance_output
 from pynetappfoundry.cache.field_mapping import (
     TypeMapping,
     parse_cli_records,
@@ -801,7 +801,7 @@ class MetadataCollector:
         output = self.cli_client.run_command("virtual-machine instance show")
         logger.debug("%s CLI response: %d lines", self._log_prefix, len(output))
 
-        records = self._parse_vm_instance_output(output)
+        records = parse_vm_instance_output(output)
         items = parse_cli_records(
             CLOUD_METADATA_MAPPING,
             records,
@@ -837,8 +837,7 @@ class MetadataCollector:
     def _parse_vm_instance_output(self, output: list[str]) -> list[dict[str, str]]:
         """Parse virtual-machine instance show output into raw records.
 
-        The CLI output contains entries for each node, separated by blank lines
-        or new "Node:" entries. Each node has its own cloud metadata.
+        Delegates to :func:`pynetappfoundry.cache.fetchers.parse_vm_instance_output`.
 
         Args:
             output: Lines of CLI output.
@@ -846,50 +845,7 @@ class MetadataCollector:
         Returns:
             List of raw record dicts (one per node) with normalized keys.
         """
-        results: list[dict[str, str]] = []
-        current_data: dict[str, str] = {}
-        current_node: str = ""
-
-        for line in output:
-            line = line.strip()
-            if not line:
-                # Empty line may indicate end of a node's data
-                continue
-
-            if ":" not in line:
-                continue
-
-            parts = line.split(":", 1)
-            if len(parts) != 2:
-                continue
-
-            key = parts[0].strip()
-            value = parts[1].strip()
-            key_normalized = self._normalize_cli_key(key)
-
-            # Check if this is a new node entry
-            if key_normalized == "node":
-                # Save previous node's data if we have any
-                if current_node and current_data:
-                    current_data["node"] = current_node
-                    results.append(current_data)
-                # Start new node
-                current_node = value
-                current_data = {}
-            else:
-                current_data[key_normalized] = value
-
-        # Don't forget the last node
-        if current_node and current_data:
-            current_data["node"] = current_node
-            results.append(current_data)
-
-        # If no node field was found but we have data, create single entry
-        if not results and current_data:
-            current_data["node"] = ""
-            results.append(current_data)
-
-        return results
+        return parse_vm_instance_output(output)
 
     def _update_azure_cloud_links(
         self,
@@ -968,17 +924,15 @@ class MetadataCollector:
     def _normalize_cli_key(key: str) -> str:
         """Normalize CLI output key to snake_case.
 
+        Delegates to :func:`pynetappfoundry.cache.fetchers.normalize_cli_key`.
+
         Args:
             key: Original key from CLI output.
 
         Returns:
             Normalized key name.
         """
-        # Replace spaces with underscores, lowercase
-        normalized = key.lower().replace(" ", "_").replace("-", "_")
-        # Remove any non-alphanumeric chars except underscore
-        normalized = re.sub(r"[^a-z0-9_]", "", normalized)
-        return normalized
+        return normalize_cli_key(key)
 
     # -------------------------------------------------------------------------
     # Cluster Info Collection

--- a/src/pynetappfoundry/cache/fetchers.py
+++ b/src/pynetappfoundry/cache/fetchers.py
@@ -7,8 +7,10 @@ model class, resolves its :class:`TypeMapping` via
 :meth:`ModelRegistry.get_mapping_by_model_class`, and dispatches entirely
 on declared metadata:
 
-- ``mapping.cli_command`` non-empty → CLI path (raises
-  :class:`NotImplementedError` pointing at #532 until Phase 4+).
+- ``mapping.cli_command`` non-empty → CLI path via :func:`_fetch_cli`.
+  The CLI client executes the command, raw output is parsed into dicts
+  by :func:`parse_vm_instance_output`, and records are fed through
+  :func:`parse_cli_records`.
 - ``mapping.parent_mapping`` non-None → parameterized endpoint; parent
   objects are themselves fetched via a recursive :func:`fetch` call and
   each parent's ``parent_id_field`` is substituted into the endpoint URL.
@@ -31,6 +33,7 @@ missing from the shared ``results_cache``, recursively calls
 from __future__ import annotations
 
 import logging
+import re
 from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 
@@ -39,6 +42,7 @@ from pydantic import BaseModel
 from pynetappfoundry.cache._registry import model_registry
 from pynetappfoundry.cache.field_mapping import (
     TypeMapping,
+    parse_cli_records,
 )
 from pynetappfoundry.cache.field_mapping import (
     parse_api_record as _parse_api_record_raw,
@@ -118,6 +122,109 @@ def _run_post_collection_hooks(
             )
             raise
     return items
+
+
+def normalize_cli_key(key: str) -> str:
+    """Normalize a CLI output key to snake_case.
+
+    Converts spaces and hyphens to underscores, lowercases the string,
+    and strips non-alphanumeric characters (except underscores).
+
+    This is extracted from ``MetadataCollector._normalize_cli_key``
+    so both the collector and :func:`_fetch_cli` share the same logic.
+
+    Args:
+        key: Original key from CLI output.
+
+    Returns:
+        Normalized key name.
+    """
+    normalized = key.lower().replace(" ", "_").replace("-", "_")
+    normalized = re.sub(r"[^a-z0-9_]", "", normalized)
+    return normalized
+
+
+def parse_vm_instance_output(output: list[str]) -> list[dict[str, str]]:
+    """Parse ``virtual-machine instance show`` CLI output into raw records.
+
+    The CLI output contains key-value pairs (``Key: Value``) for each
+    node, separated by new ``Node:`` entries.  Each node's data becomes
+    one dict with :func:`normalize_cli_key`-normalised keys.
+
+    This is extracted from ``MetadataCollector._parse_vm_instance_output``
+    so both the collector and :func:`_fetch_cli` share the same logic.
+
+    Args:
+        output: Lines of CLI output.
+
+    Returns:
+        List of raw record dicts (one per node) with normalized keys.
+    """
+    results: list[dict[str, str]] = []
+    current_data: dict[str, str] = {}
+    current_node: str = ""
+
+    for line in output:
+        line = line.strip()
+        if not line:
+            continue
+
+        if ":" not in line:
+            continue
+
+        parts = line.split(":", 1)
+        if len(parts) != 2:
+            continue
+
+        key = parts[0].strip()
+        value = parts[1].strip()
+        key_normalized = normalize_cli_key(key)
+
+        if key_normalized == "node":
+            if current_node and current_data:
+                current_data["node"] = current_node
+                results.append(current_data)
+            current_node = value
+            current_data = {}
+        else:
+            current_data[key_normalized] = value
+
+    if current_node and current_data:
+        current_data["node"] = current_node
+        results.append(current_data)
+
+    if not results and current_data:
+        current_data["node"] = ""
+        results.append(current_data)
+
+    return results
+
+
+def _fetch_cli(
+    mapping: TypeMapping,
+    cli_client: ONTAPCLI,
+    log_prefix: str,
+) -> list[BaseModel]:
+    """Fetch records via CLI command execution and parsing.
+
+    Runs the mapping's ``cli_command`` through *cli_client*, parses
+    the raw text output into dict records via
+    :func:`parse_vm_instance_output`, and feeds them through
+    :func:`parse_cli_records`.
+
+    Args:
+        mapping: TypeMapping with a non-empty ``cli_command``.
+        cli_client: SSH/CLI client to run the command on.
+        log_prefix: Prefix for log messages.
+
+    Returns:
+        List of parsed model instances.
+    """
+    logger.debug("%s CLI command: %s", log_prefix, mapping.cli_command)
+    output = cli_client.run_command(mapping.cli_command)
+    logger.debug("%s CLI response: %d lines", log_prefix, len(output))
+    records = parse_vm_instance_output(output)
+    return parse_cli_records(mapping, records, log_prefix, _noop_log_missing)
 
 
 def _fetch_flat(
@@ -267,26 +374,17 @@ def fetch[T: BaseModel](
         mappings, a list of model instances.
 
     Raises:
-        NotImplementedError: If the mapping's ``cli_command`` is set
-            (CLI dispatch is deferred to #532).
-        ValueError: If no TypeMapping is registered for ``model_class``.
+        ValueError: If no TypeMapping is registered for ``model_class``,
+            or if a CLI-only mapping is invoked without a ``cli_client``.
     """
     del cluster  # reserved for logging / future use
     del config
-    del cli_client  # reserved for CLI dispatch (#532)
 
     mapping = model_registry.get_mapping_by_model_class(model_class)
     if mapping is None:
         raise ValueError(
             f"fetch(): no TypeMapping registered for model class "
             f"{model_class.__module__}.{model_class.__name__}"
-        )
-
-    if mapping.cli_command:
-        raise NotImplementedError(
-            f"fetch(): CLI dispatch for {mapping.name} (cli_command="
-            f"{mapping.cli_command!r}) is not yet supported; tracked in "
-            f"https://github.com/endavis/pynetappfoundry/issues/532"
         )
 
     # Prepare results_cache used by post-collection hooks.
@@ -314,8 +412,14 @@ def fetch[T: BaseModel](
             )
             local_cache[dep_key] = dep_result if isinstance(dep_result, list) else [dep_result]
 
-    # Fetch instances.
-    if mapping.parent_mapping:
+    # Fetch instances — dispatch on CLI vs API path.
+    if mapping.cli_command:
+        if cli_client is None:
+            raise ValueError(
+                f"fetch(): {mapping.name} requires cli_client (cli_command={mapping.cli_command!r})"
+            )
+        items = _fetch_cli(mapping, cli_client, log_prefix)
+    elif mapping.parent_mapping:
         # Parent objects must already be in results_cache. The collector
         # threads this via `_collect_svm_top_metrics_users` and composite
         # assembly; tests may pass a synthetic results_cache.
@@ -350,4 +454,4 @@ def _results_key_for_parent(parent_mapping_name: str) -> str:
     return parent_mapping_name
 
 
-__all__ = ["fetch"]
+__all__ = ["fetch", "normalize_cli_key", "parse_vm_instance_output"]

--- a/src/pynetappfoundry/cache/ontap/cloud/metadata/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cloud/metadata/mapping.py
@@ -4,17 +4,50 @@ Defines CLOUD_METADATA_MAPPING which maps ONTAP CLI virtual-machine instance
 data to CloudMetadata cache model attributes. CloudMetadata is CLI-only —
 there is no REST API endpoint for this data.
 
-The computed link fields (instance_link, instance_sso_link,
-resource_group_link) are not part of the mapping; they are built as
-post-processing in the collector using collector state (aws_sso_config)
-and cross-field logic.
+The computed link fields (``instance_link``, ``resource_group_link``) are
+derived via ``post_collection`` hooks so that :func:`fetch` populates them
+automatically. ``instance_sso_link`` depends on collector-only state
+(``aws_sso_config``) and is therefore left to the collector's post-
+processing; the DataSource path returns it as an empty string.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 from pynetappfoundry.cache._registry import model_registry
 from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
 from pynetappfoundry.models.ontap.cloud.metadata.model import CloudMetadata
+from pynetappfoundry.utils.cloud import (
+    build_cloud_instance_link,
+    build_cloud_resource_group_link,
+)
+
+
+def _compute_instance_link(instance: CloudMetadata, _results: dict[str, Any]) -> CloudMetadata:
+    """Derive ``instance_link`` from the instance's own fields."""
+    region = instance.region or instance.availability_zone
+    link = build_cloud_instance_link(
+        provider=instance.provider,
+        instance_id=instance.instance_id,
+        region=region,
+        account_id=instance.account_id,
+        resource_group=instance.resource_group_name,
+    )
+    return instance.model_copy(update={"instance_link": link})
+
+
+def _compute_resource_group_link(
+    instance: CloudMetadata, _results: dict[str, Any]
+) -> CloudMetadata:
+    """Derive ``resource_group_link`` from the instance's own fields."""
+    link = build_cloud_resource_group_link(
+        provider=instance.provider,
+        account_id=instance.account_id,
+        resource_group=instance.resource_group_name,
+    )
+    return instance.model_copy(update={"resource_group_link": link})
+
 
 CLOUD_METADATA_MAPPING = TypeMapping(
     name="CloudMetadata",
@@ -100,6 +133,17 @@ CLOUD_METADATA_MAPPING = TypeMapping(
         FieldMapping(
             cache_attr="sku_version",
             cli_field="sku_version",
+        ),
+        # Derived link fields — populated by post_collection hooks.
+        FieldMapping(
+            cache_attr="instance_link",
+            cache_strategy="derived",
+            post_collection=_compute_instance_link,
+        ),
+        FieldMapping(
+            cache_attr="resource_group_link",
+            cache_strategy="derived",
+            post_collection=_compute_resource_group_link,
         ),
     ),
 )

--- a/src/pynetappfoundry/data/backends.py
+++ b/src/pynetappfoundry/data/backends.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from pynetappfoundry.cache.db import ClusterMetadataDB
     from pynetappfoundry.cache.field_mapping import TypeMapping
     from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
+    from pynetappfoundry.clients.ontap.cli import ONTAPCLI
     from pynetappfoundry.core.config import Config
     from pynetappfoundry.data._routing import RoutingDecision
 
@@ -116,6 +117,7 @@ class OntapBackend(Backend):
     def __init__(self, config: Config) -> None:
         super().__init__(config)
         self._api_clients: dict[str, ONTAPAPIClient] = {}
+        self._cli_clients: dict[str, ONTAPCLI] = {}
 
     @cached_property
     def _cache_db(self) -> ClusterMetadataDB:
@@ -137,6 +139,52 @@ class OntapBackend(Backend):
             cluster_obj = ClusterConfig(name=cluster, ip=cluster)
             self._api_clients[cluster] = ONTAPAPIClient(cluster=cluster_obj, config=self._config)
         return self._api_clients[cluster]
+
+    def _get_cli_client(self, cluster: str) -> ONTAPCLI:
+        """Lazily create an ONTAP CLI (SSH) client for *cluster*.
+
+        Cached per-cluster so multiple ``query()`` calls against the
+        same cluster reuse the same connection.
+
+        Credentials are resolved via ``Config.get_user`` and the
+        cluster's ``ip`` from the configuration data, mirroring
+        the pattern used by the ``cache refresh`` CLI command.
+        """
+        if cluster not in self._cli_clients:
+            from pynetappfoundry.clients.ontap.cli import ONTAPCLI
+
+            cluster_data = self._config.data.get("clusters", {}).get(cluster, {})
+            user, password = self._config.get_user("clusters", cluster)
+            self._cli_clients[cluster] = ONTAPCLI(
+                name=cluster,
+                host_or_ip=cluster_data.get("ip", cluster),
+                username=user,
+                password=password,
+            )
+        return self._cli_clients[cluster]
+
+    def _is_cloud_cluster(self, cluster: str) -> bool:
+        """Return ``True`` if *cluster* is a cloud (CVO) cluster.
+
+        Queries ``ClusterInfo`` from the cache DB and checks the
+        ``is_cloud`` flag. If the cache has no data for the cluster
+        (e.g. never refreshed), defaults to ``False`` to avoid SSH
+        timeouts on unknown clusters.
+        """
+        from pynetappfoundry.models.ontap.cluster.model import ClusterInfo
+
+        try:
+            metadata_path = self._resolve_metadata_path(ClusterInfo)
+            results = self._cache_db.query_with_filters(cluster, metadata_path, [])
+            for item in results:
+                if isinstance(item, ClusterInfo):
+                    return item.is_cloud
+        except (ValueError, Exception):
+            logger.debug(
+                "OntapBackend: cannot determine is_cloud for %s, defaulting to False",
+                cluster,
+            )
+        return False
 
     def _resolve_metadata_path(self, model_class: type[BaseModel]) -> str:
         """Find the cache table's metadata_path for *model_class*.
@@ -376,7 +424,25 @@ class OntapBackend(Backend):
                 )
                 raise NotImplementedError(msg)
 
-            if self._is_full_live_scan(mapping, decision, filters):
+            if mapping.cli_command:
+                # CLI-only mapping (e.g. CloudMetadata). Skip non-cloud
+                # clusters to avoid SSH timeouts on on-prem hardware.
+                if not self._is_cloud_cluster(cluster):
+                    logger.debug(
+                        "OntapBackend: skipping CLI-only %s for non-cloud cluster %s",
+                        mapping.name,
+                        cluster,
+                    )
+                    return []
+                fetched = fetch(
+                    model_class,
+                    cluster=cluster,
+                    config=self._config,
+                    api_client=self._get_api_client(cluster),
+                    cli_client=self._get_cli_client(cluster),
+                )
+                results = list(fetched) if isinstance(fetched, list) else [fetched]
+            elif self._is_full_live_scan(mapping, decision, filters):
                 # Whole-model unfiltered live read: delegate to the
                 # generic fetcher (ADR-0013 §6/§7).
                 fetched = fetch(

--- a/tests/unit/cache/test_fetchers.py
+++ b/tests/unit/cache/test_fetchers.py
@@ -9,11 +9,16 @@ import pytest
 from pydantic import BaseModel
 
 from pynetappfoundry.cache._registry import model_registry
-from pynetappfoundry.cache.fetchers import fetch
+from pynetappfoundry.cache.fetchers import (
+    fetch,
+    normalize_cli_key,
+    parse_vm_instance_output,
+)
 from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
 from pynetappfoundry.cache.ontap.cluster.mapping import CLUSTER_MAPPING
 from pynetappfoundry.cache.ontap.cluster.nodes.mapping import ONTAPNODERESPONSE_MAPPING
 from pynetappfoundry.cache.ontap.storage.volumes.mapping import ONTAPVOLUME_MAPPING
+from pynetappfoundry.models.ontap.cloud.metadata.model import CloudMetadata
 from pynetappfoundry.models.ontap.cluster.model import ClusterInfo
 from pynetappfoundry.models.ontap.cluster.nodes.model import OntapNodeResponse
 from pynetappfoundry.models.ontap.storage.volumes.model import OntapVolume
@@ -465,7 +470,79 @@ class TestFetchParameterized:
 
 
 # ---------------------------------------------------------------------------
-# CLI dispatch (NotImplementedError)
+# CLI parsing helpers (extracted from collector, issue #532)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeCliKey:
+    """normalize_cli_key() converts CLI keys to snake_case."""
+
+    def test_spaces_to_underscores(self) -> None:
+        assert normalize_cli_key("Instance ID") == "instance_id"
+
+    def test_hyphens_to_underscores(self) -> None:
+        assert normalize_cli_key("cpu-platform") == "cpu_platform"
+
+    def test_strips_special_chars(self) -> None:
+        assert normalize_cli_key("Region (AWS)") == "region_aws"
+
+    def test_lowercase(self) -> None:
+        assert normalize_cli_key("Node") == "node"
+
+
+class TestParseVmInstanceOutput:
+    """parse_vm_instance_output() parses CLI key-value lines into records."""
+
+    def test_two_nodes(self) -> None:
+        output = [
+            "Node: node-01",
+            "Instance ID: i-abc",
+            "Provider: AWS",
+            "",
+            "Node: node-02",
+            "Instance ID: i-def",
+            "Provider: AWS",
+        ]
+        records = parse_vm_instance_output(output)
+        assert len(records) == 2
+        assert records[0]["node"] == "node-01"
+        assert records[0]["instance_id"] == "i-abc"
+        assert records[1]["node"] == "node-02"
+        assert records[1]["instance_id"] == "i-def"
+
+    def test_single_node(self) -> None:
+        output = [
+            "Node: solo",
+            "Region: us-east-1",
+        ]
+        records = parse_vm_instance_output(output)
+        assert len(records) == 1
+        assert records[0]["node"] == "solo"
+        assert records[0]["region"] == "us-east-1"
+
+    def test_empty_output(self) -> None:
+        assert parse_vm_instance_output([]) == []
+
+    def test_no_node_field_creates_single_entry(self) -> None:
+        output = ["Region: us-east-1", "Provider: AWS"]
+        records = parse_vm_instance_output(output)
+        assert len(records) == 1
+        assert records[0]["node"] == ""
+
+    def test_skips_blank_and_no_colon_lines(self) -> None:
+        output = [
+            "Node: n1",
+            "",
+            "---separator---",
+            "Region: eu-west-1",
+        ]
+        records = parse_vm_instance_output(output)
+        assert len(records) == 1
+        assert records[0]["region"] == "eu-west-1"
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch (issue #532)
 # ---------------------------------------------------------------------------
 
 
@@ -478,12 +555,12 @@ _CLI_MAPPING = TypeMapping(
     model_class=_CliModel,
     api_endpoint="/never",
     cli_command="something show",
-    fields=(FieldMapping(cache_attr="name"),),
+    fields=(FieldMapping(cache_attr="name", cli_field="name"),),
 )
 
 
 class TestFetchCliDispatch:
-    """CLI dispatch raises NotImplementedError until #532 lands."""
+    """CLI dispatch via _fetch_cli (#532)."""
 
     def setup_method(self) -> None:
         model_registry.register_mapping("CliMapping", _CLI_MAPPING)
@@ -492,16 +569,75 @@ class TestFetchCliDispatch:
         model_registry._mappings.pop("CliMapping", None)
         model_registry._mappings_by_class.pop(_CliModel, None)
 
-    def test_cli_branch_raises_with_issue_reference(self) -> None:
-        """NotImplementedError message references issue #532."""
+    def test_cli_without_client_raises_value_error(self) -> None:
+        """fetch() with cli_command but no cli_client raises ValueError."""
         client = MagicMock()
-        with pytest.raises(NotImplementedError, match="532"):
+        with pytest.raises(ValueError, match="requires cli_client"):
             fetch(
                 _CliModel,
                 cluster="c1",
                 config=None,
                 api_client=client,
             )
+
+    def test_cli_dispatch_parses_output(self) -> None:
+        """fetch() dispatches to CLI path and returns parsed instances."""
+        api_client = MagicMock()
+        cli_client = MagicMock()
+        cli_client.run_command.return_value = [
+            "Node: n1",
+            "Name: alpha",
+            "",
+            "Node: n2",
+            "Name: beta",
+        ]
+        result = fetch(
+            _CliModel,
+            cluster="c1",
+            config=None,
+            api_client=api_client,
+            cli_client=cli_client,
+        )
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0].name == "alpha"
+        assert result[1].name == "beta"
+        cli_client.run_command.assert_called_once_with("something show")
+        # API client should not be called for CLI-only mappings.
+        api_client.call_endpoint.assert_not_called()
+        api_client.get_all_records.assert_not_called()
+
+
+class TestFetchCloudMetadataViaFetch:
+    """Integration test: fetch(CloudMetadata) with a mock CLI client."""
+
+    def test_cloud_metadata_fetch_returns_instances(self) -> None:
+        """fetch(CloudMetadata, ...) returns CloudMetadata with link fields."""
+        api_client = MagicMock()
+        cli_client = MagicMock()
+        cli_client.run_command.return_value = [
+            "Node: cvo-node-01",
+            "Instance ID: i-0123456789abcdef0",
+            "Account ID: 123456789012",
+            "Provider: AWS",
+            "Region: us-east-1",
+        ]
+        result = fetch(
+            CloudMetadata,
+            cluster="c1",
+            config=None,
+            api_client=api_client,
+            cli_client=cli_client,
+        )
+        assert isinstance(result, list)
+        assert len(result) == 1
+        cm = result[0]
+        assert isinstance(cm, CloudMetadata)
+        assert cm.node == "cvo-node-01"
+        assert cm.instance_id == "i-0123456789abcdef0"
+        assert cm.provider == "AWS"
+        # instance_link should be populated by the post_collection hook.
+        assert "i-0123456789abcdef0" in cm.instance_link
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/data/test_backends.py
+++ b/tests/unit/data/test_backends.py
@@ -1250,3 +1250,72 @@ class TestBuildLiveUrlFieldsStar:
         )
         assert "fields=%2A" in url or "fields=*" in url
         assert "return_records=false" in url
+
+
+# ---------------------------------------------------------------------------
+# CLI backend dispatch (#532)
+# ---------------------------------------------------------------------------
+
+
+class TestOntapBackendCliDispatch:
+    """Tests for CLI-only mapping dispatch through ``OntapBackend.query()``."""
+
+    def test_cli_mapping_dispatches_to_fetch_with_cli_client(
+        self,
+        mock_config: Any,
+    ) -> None:
+        """Cloud cluster + CLI-only mapping delegates to ``fetch()`` with cli_client."""
+        from pynetappfoundry.cache.ontap.cloud.metadata.mapping import CLOUD_METADATA_MAPPING
+        from pynetappfoundry.models.ontap.cloud.metadata.model import CloudMetadata
+
+        backend = _make_backend(mock_config)
+        live_fields = tuple(
+            f.cache_attr for f in CLOUD_METADATA_MAPPING.fields if f.cache_strategy != "derived"
+        )
+        decision = RoutingDecision(cache_fields=(), live_fields=live_fields)
+
+        mock_cli = MagicMock()
+        fetched = [CloudMetadata(node="n1", provider="AWS")]
+
+        with (
+            patch.object(backend, "_is_cloud_cluster", return_value=True),
+            patch.object(backend, "_get_cli_client", return_value=mock_cli),
+            patch.object(backend, "_get_api_client", return_value=MagicMock()),
+            patch("pynetappfoundry.data.backends.fetch", return_value=fetched) as fetch_mock,
+        ):
+            results = backend.query(
+                CloudMetadata,
+                CLOUD_METADATA_MAPPING,
+                decision,
+                cluster="cloud1",
+                filters={},
+            )
+
+        assert results == fetched
+        fetch_mock.assert_called_once()
+        assert fetch_mock.call_args.kwargs["cli_client"] is mock_cli
+
+    def test_cli_mapping_skips_non_cloud_cluster(
+        self,
+        mock_config: Any,
+    ) -> None:
+        """Non-cloud cluster returns empty list for CLI-only mappings."""
+        from pynetappfoundry.cache.ontap.cloud.metadata.mapping import CLOUD_METADATA_MAPPING
+        from pynetappfoundry.models.ontap.cloud.metadata.model import CloudMetadata
+
+        backend = _make_backend(mock_config)
+        live_fields = tuple(
+            f.cache_attr for f in CLOUD_METADATA_MAPPING.fields if f.cache_strategy != "derived"
+        )
+        decision = RoutingDecision(cache_fields=(), live_fields=live_fields)
+
+        with patch.object(backend, "_is_cloud_cluster", return_value=False):
+            results = backend.query(
+                CloudMetadata,
+                CLOUD_METADATA_MAPPING,
+                decision,
+                cluster="onprem1",
+                filters={},
+            )
+
+        assert results == []


### PR DESCRIPTION
## Description

Add SSH/CLI backend support to the DataSource fetch pipeline (ADR-0013 Gap 2). CLI-mapped types (e.g. cloud metadata) now dispatch through `_fetch_cli()` in fetchers and `OntapBackend`, with lazy CLI client construction gated by `is_cloud` to avoid SSH timeouts on on-prem clusters.

Addresses #532

## Related Issue

Addresses #532

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- **`src/pynetappfoundry/cache/fetchers.py`** -- Added `_fetch_cli()` dispatch path, extracted `normalize_cli_key()` and `parse_vm_instance_output()` from collector so both collector and fetchers share the same parsing logic.
- **`src/pynetappfoundry/cache/collector.py`** -- Removed inlined CLI parsing methods now extracted to fetchers.
- **`src/pynetappfoundry/data/backends.py`** -- Added `_get_cli_client()` for lazy per-cluster ONTAPCLI construction, `_is_cloud_cluster()` gate to skip CLI on on-prem clusters, and CLI dispatch branch in `fetch()`.
- **`src/pynetappfoundry/cache/ontap/cloud/metadata/mapping.py`** -- Added `post_collection` hooks for cloud metadata types.
- **`docs/decisions/0013-datasource-as-a-thin-facade-over-the-collector.md`** -- Updated #532 status from "deferred" to "resolved" in the phase plan and issue tracker sections.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

New tests added:
- **`tests/unit/cache/test_fetchers.py`** -- CLI dispatch tests covering `normalize_cli_key`, `parse_vm_instance_output`, and `_fetch_cli` integration.
- **`tests/unit/data/test_backends.py`** -- Backend CLI dispatch tests covering `_get_cli_client`, `_is_cloud_cluster`, and the CLI branch in `OntapBackend.fetch()`.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
