### PR TITLE
chore: add nested field audit task and compliance baseline (merges PR, addresses #525)

### DIFF
--- a/tests/unit/compliance/test_nested_fields.py
+++ b/tests/unit/compliance/test_nested_fields.py
@@ -1,0 +1,73 @@
+"""Compliance guard: deeply nested mapping fields must be tracked.
+
+When a mapping gains (or loses) fields with ``cache_attr`` having 3+ dots
+(nesting depth 4+), this test fails so the change is reviewed for
+``requires_explicit_fetch`` applicability.  Update ``EXPECTED_COUNTS``
+after reviewing the new fields.
+"""
+
+from __future__ import annotations
+
+import pynetappfoundry.cache  # noqa: F401 — triggers registry bootstrap
+from pynetappfoundry.cache._registry import model_registry
+
+# Baseline counts of fields with cache_attr containing 3+ dots per mapping.
+# Update these after reviewing new deeply nested fields for explicit-fetch risk.
+EXPECTED_COUNTS: dict[str, int] = {
+    "OntapApplication": 34,
+    "OntapApplicationTemplate": 34,
+    "OntapAudit": 5,
+    "OntapBgpPeerGroup": 2,
+    "OntapFcInterface": 2,
+    "OntapFileInfo": 8,
+    "OntapIgroup": 6,
+    "OntapIpInterface": 2,
+    "OntapLun": 12,
+    "OntapNfsService": 66,
+    "OntapNodeResponse": 14,
+    "OntapNvmeInterface": 4,
+    "OntapNvmeService": 44,
+    "OntapPort": 7,
+    "OntapS3Audit": 5,
+    "OntapSnapmirrorTransfer": 6,
+    "OntapSoftwareReference": 4,
+    "OntapSwitchPort": 5,
+    "OntapVolume": 172,
+}
+
+
+def _collect_deeply_nested_counts() -> dict[str, int]:
+    """Return mapping-name -> count of fields with 3+ dots in cache_attr."""
+    counts: dict[str, int] = {}
+    for name, mapping in sorted(model_registry.mappings.items()):
+        n = sum(1 for f in mapping.fields if f.cache_attr.count(".") >= 3)
+        if n > 0:
+            counts[name] = n
+    return counts
+
+
+def test_deeply_nested_field_counts_stable() -> None:
+    """Flag new or changed deeply nested fields for review."""
+    actual = _collect_deeply_nested_counts()
+
+    # Mappings that gained deeply nested fields (not in baseline).
+    new_mappings = set(actual) - set(EXPECTED_COUNTS)
+    assert new_mappings == set(), (
+        f"New mappings with deeply nested fields (review for requires_explicit_fetch): "
+        f"{sorted(new_mappings)}. After reviewing, add them to EXPECTED_COUNTS."
+    )
+
+    # Mappings whose count changed.
+    changed: dict[str, tuple[int, int]] = {}
+    for name, expected in EXPECTED_COUNTS.items():
+        actual_count = actual.get(name, 0)
+        if actual_count != expected:
+            changed[name] = (expected, actual_count)
+
+    assert changed == {}, (
+        "Deeply nested field counts changed (review for requires_explicit_fetch):\n"
+        + "\n".join(
+            f"  {name}: expected {exp}, got {act}" for name, (exp, act) in sorted(changed.items())
+        )
+        + "\nAfter reviewing, update EXPECTED_COUNTS."
+    )

--- a/tools/doit/audit_nested.py
+++ b/tools/doit/audit_nested.py
@@ -1,0 +1,88 @@
+"""Audit doit task for deeply nested mapping fields."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+
+
+def _run_nested_audit() -> bool:
+    """Walk all mappings, report fields with 3+ dot depth, return success."""
+    import pynetappfoundry.cache  # noqa: F401 — triggers registry bootstrap
+    from pynetappfoundry.cache._registry import model_registry
+
+    console = Console()
+    mappings = model_registry.mappings
+
+    table = Table(title="Deeply Nested Field Audit (cache_attr depth >= 4)", show_lines=True)
+    table.add_column("Mapping", style="bold")
+    table.add_column("Total Deep", justify="right")
+    table.add_column("Already Explicit", justify="right")
+    table.add_column("Needs Review", justify="right")
+
+    total_deep = 0
+    total_explicit = 0
+    total_needs_review = 0
+
+    for name, mapping in sorted(mappings.items()):
+        deep_fields: list[str] = []
+        explicit_fields: list[str] = []
+
+        for field in mapping.fields:
+            if field.cache_attr.count(".") >= 3:
+                deep_fields.append(field.cache_attr)
+                if field.requires_explicit_fetch:
+                    explicit_fields.append(field.cache_attr)
+
+        if not deep_fields:
+            continue
+
+        needs_review = len(deep_fields) - len(explicit_fields)
+        total_deep += len(deep_fields)
+        total_explicit += len(explicit_fields)
+        total_needs_review += needs_review
+
+        review_style = "[red]" if needs_review > 0 else "[green]"
+        table.add_row(
+            name,
+            str(len(deep_fields)),
+            str(len(explicit_fields)),
+            f"{review_style}{needs_review}[/]",
+        )
+
+    # Summary row
+    table.add_section()
+    review_style = "[red]" if total_needs_review > 0 else "[green]"
+    table.add_row(
+        "[bold]TOTAL[/bold]",
+        f"[bold]{total_deep}[/bold]",
+        f"[bold]{total_explicit}[/bold]",
+        f"[bold]{review_style}{total_needs_review}[/]",
+    )
+
+    console.print()
+    console.print(table)
+    console.print()
+
+    if total_needs_review > 0:
+        console.print(
+            f"[yellow]{total_needs_review} deeply nested field(s) "
+            "lack requires_explicit_fetch — review recommended.[/yellow]"
+        )
+    else:
+        console.print(
+            "[bold green]All deeply nested fields have requires_explicit_fetch set.[/bold green]"
+        )
+
+    # Informational — always succeeds.
+    return True
+
+
+def task_mapping_nested_audit() -> dict[str, Any]:
+    """Audit mappings for deeply nested fields (cache_attr depth >= 4)."""
+    return {
+        "actions": [_run_nested_audit],
+        "verbosity": 2,
+    }


### PR DESCRIPTION
## Description

Add `doit mapping_nested_audit` task that reports deeply nested fields (3+ dots in `cache_attr`) across all TypeMappings. Currently finds 432 fields across 19 mappings — 294 already marked with `requires_explicit_fetch`, 138 needing review against real ONTAP responses.

Add compliance test with count-based baseline that fails when new deeply nested fields are added without updating the expected counts.

No mapping files modified — the high-risk candidates from the issue body describe API response summary truncation, not `cache_attr` nesting depth. Each confirmed case needs a dedicated endpoint fetch (like #524's fix), not `requires_explicit_fetch`.

Addresses #525

## Type of Change

- [x] Code refactoring
- [x] Test improvement

## Testing

- [x] `doit check` passes
- [x] `doit mapping_nested_audit` produces correct output
- [x] Compliance test passes with current baseline
