### PR TITLE
feat: add per-mapping batch_size override and chunking edge-case tests (merges PR, addresses #538)

### DIFF
--- a/docs/decisions/0012-unified-datasource-accessor.md
+++ b/docs/decisions/0012-unified-datasource-accessor.md
@@ -150,6 +150,16 @@ This ADR is Phase 1 of a four-phase plan. The full plan is in issue #495.
 
   See [ADR-0013](0013-datasource-as-a-thin-facade-over-the-collector.md) for the superseding design decisions that informed the Phase 4 cleanup.
 
+### Chunking / batch-size behavior
+
+`OntapBackend` chunks identifier-filtered live queries at `_BATCH_SIZE` (default 100). Each chunk produces one ONTAP REST call using pipe-OR syntax (`?uuid=id1|id2|id3`). Chunk failures propagate atomically — no partial results.
+
+Per-mapping override: `TypeMapping(batch_size=50)` overrides the default for endpoints with narrower URL limits.
+
+Known limitations:
+- Pipe-OR syntax is ONTAP-specific. Non-ONTAP backends (#533) will need different batching strategies.
+- Single identifier field only. Composite identifiers (#535) are not supported in the batched path.
+
 ### Links to Documentation
 
 - [DataSource User Guide](../usage/data-source.md) — comprehensive guide covering `DataSource.query()`, `DataSource.get()`, source modes, `QueryBuilder` chaining (`.filter()`, `.where()`, `.fields()`), and common patterns.

--- a/src/pynetappfoundry/cache/field_mapping.py
+++ b/src/pynetappfoundry/cache/field_mapping.py
@@ -132,6 +132,11 @@ class TypeMapping:
     parent_id_field: str | None = None
     identifier_field: str | tuple[str, ...] | None = None
     response_shape: Literal["envelope", "singleton"] = "envelope"
+    batch_size: int | None = None
+    """Per-mapping override for the default chunk size used by
+    ``_fetch_live_by_identifiers`` and ``_fetch_live_by_parent``.
+    When ``None``, the module-level ``_BATCH_SIZE`` constant in
+    ``backends.py`` (100) is used."""
 
     def api_expected_fields(self) -> list[str]:
         """Derive top-level API keys expected in a response record.

--- a/src/pynetappfoundry/data/backends.py
+++ b/src/pynetappfoundry/data/backends.py
@@ -39,7 +39,17 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
 _BATCH_SIZE = 100
-"""Hardcoded chunk size for batch live fetches in partial-fetch query.
+"""Default chunk size for identifier-filtered live fetches.
+
+``_fetch_live_by_identifiers`` and ``_fetch_live_by_parent`` split
+identifier lists into chunks of this size.  Each chunk produces one
+ONTAP REST call using pipe-OR syntax (``?uuid=id1|id2|id3``).  The
+value balances ONTAP URL-length limits (approx 8 KiB for most
+controllers) against the number of round-trips.
+
+Per-mapping override: set ``TypeMapping(batch_size=N)`` to override
+for endpoints with narrower URL limits.  When ``batch_size`` is
+``None`` (the default), this constant is used.
 
 Per design notes on issue #495, this is intentionally a constant for v1.
 Promote to a config knob only if a real workload hits the limit.
@@ -663,8 +673,20 @@ class OntapBackend(Backend):
         For each parent UUID and its children, builds a resolved URL via
         :meth:`TypeMapping.build_parameterized_url`, overrides ``fields=``
         with the live field paths (preserving ``fields=*`` when present),
-        adds pipe-OR identifier filters chunked at ``_BATCH_SIZE``, and
+        adds pipe-OR identifier filters chunked by batch size, and
         fetches via :meth:`ONTAPAPIClient.get_all_records`.
+
+        Assumptions:
+
+        - **Pipe-OR filter syntax** is ONTAP-specific.  Non-ONTAP
+          backends (#533) will need a different batching strategy.
+        - **Single identifier field only.**  Composite identifiers
+          (#535) are not supported in the batched path.
+        - **``mapping.batch_size`` override** — when set, overrides the
+          module-level ``_BATCH_SIZE`` constant (100) for this mapping.
+
+        Chunk failures propagate atomically — if any chunk's call raises,
+        the whole fetch raises. There is no partial result.
 
         Returns:
             Aggregated list of parsed model instances across all parents
@@ -686,6 +708,7 @@ class OntapBackend(Backend):
             else:
                 api_paths.append(attr)
 
+        chunk_size = mapping.batch_size or _BATCH_SIZE
         results: list[T] = []
         for parent_uuid, children in parent_groups.items():
             base_url = mapping.build_parameterized_url(parent_uuid)
@@ -701,7 +724,7 @@ class OntapBackend(Backend):
             if not child_ids:
                 continue
 
-            for chunk in self._chunked(child_ids, _BATCH_SIZE):
+            for chunk in self._chunked(child_ids, chunk_size):
                 query = {k: list(v) for k, v in base_query.items()}
                 if api_paths:
                     existing = query.get("fields", [""])[0]
@@ -755,13 +778,22 @@ class OntapBackend(Backend):
         identifier_field: str,
         live_field_paths: tuple[str, ...],
     ) -> list[T]:
-        """Batch-fetch live data for *identifiers*, chunked at ``_BATCH_SIZE``.
+        """Batch-fetch live data for *identifiers*, chunked by batch size.
 
         For each chunk, builds one URL using ONTAP REST pipe-OR syntax
         on the identifier filter (``?{identifier_field}=id1|id2|id3``)
         with the ``fields=`` query parameter restricted to the
         ``api_path`` values of *live_field_paths*. Results across all
         chunks are concatenated into a single list.
+
+        Assumptions:
+
+        - **Pipe-OR filter syntax** is ONTAP-specific.  Non-ONTAP
+          backends (#533) will need a different batching strategy.
+        - **Single identifier field only.**  Composite identifiers
+          (#535) are not supported in the batched path.
+        - **``mapping.batch_size`` override** — when set, overrides the
+          module-level ``_BATCH_SIZE`` constant (100) for this mapping.
 
         Chunk failures propagate atomically — if any chunk's call raises
         (network error, REST 5xx, parser failure), the whole fetch
@@ -786,8 +818,9 @@ class OntapBackend(Backend):
             else:
                 api_paths.append(attr)
 
+        chunk_size = mapping.batch_size or _BATCH_SIZE
         results: list[T] = []
-        for chunk in self._chunked(list(identifiers), _BATCH_SIZE):
+        for chunk in self._chunked(list(identifiers), chunk_size):
             query = {k: list(v) for k, v in base_query.items()}
             if api_paths:
                 # Preserve fields=* from the base endpoint when present.

--- a/tests/unit/data/test_backends.py
+++ b/tests/unit/data/test_backends.py
@@ -611,6 +611,139 @@ class TestOntapBackendQueryPartial:
             list(range(200, 250)),
         ]
 
+    def test_partial_query_exactly_batch_size(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Exactly 100 cached records should produce 1 API call (no split)."""
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("uuid",), live_fields=("iops",))
+        cached = [FakeVolume(uuid=f"u{i}") for i in range(100)]
+        live_all = [FakeVolume(uuid=f"u{i}", iops=float(i)) for i in range(100)]
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = cached
+        mock_client = MagicMock()
+        mock_client.get_all_records.return_value = {"records": []}
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.parse_api_response",
+                return_value=live_all,
+            ),
+            _patch_metadata_path(backend),
+        ):
+            results = backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert len(results) == 100
+        assert mock_client.get_all_records.call_count == 1
+
+    def test_partial_query_batch_size_plus_one(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """101 cached records should produce exactly 2 API calls (100 + 1)."""
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("uuid",), live_fields=("iops",))
+        cached = [FakeVolume(uuid=f"u{i}") for i in range(101)]
+        live_chunk1 = [FakeVolume(uuid=f"u{i}", iops=float(i)) for i in range(100)]
+        live_chunk2 = [FakeVolume(uuid="u100", iops=100.0)]
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = cached
+        mock_client = MagicMock()
+        mock_client.get_all_records.return_value = {"records": []}
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.parse_api_response",
+                side_effect=[live_chunk1, live_chunk2],
+            ),
+            _patch_metadata_path(backend),
+        ):
+            results = backend.query(
+                FakeVolume,
+                fake_volume_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert len(results) == 101
+        assert mock_client.get_all_records.call_count == 2
+
+    def test_partial_query_custom_batch_size(
+        self,
+        mock_config: Any,
+    ) -> None:
+        """Mapping with batch_size=50 and 250 records produces 5 API calls."""
+        from pynetappfoundry.cache._registry import model_registry
+        from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
+
+        mapping = TypeMapping(
+            name="SmallBatchVolume",
+            model_class=FakeVolume,
+            api_endpoint="/storage/small-batch?fields=*",
+            api_type="ontap",
+            identifier_field="uuid",
+            batch_size=50,
+            fields=(
+                FieldMapping(cache_attr="name", cache_strategy="cache"),
+                FieldMapping(cache_attr="uuid", cache_strategy="cache"),
+                FieldMapping(cache_attr="size", cache_strategy="cache"),
+                FieldMapping(cache_attr="iops", cache_strategy="realtime"),
+                FieldMapping(cache_attr="is_root", cache_strategy="derived"),
+            ),
+        )
+        model_registry.register_mapping("SmallBatchVolume", mapping)
+        try:
+            backend = _make_backend(mock_config)
+            decision = RoutingDecision(cache_fields=("uuid",), live_fields=("iops",))
+            cached = [FakeVolume(uuid=f"u{i}") for i in range(250)]
+            live_chunks = [
+                [FakeVolume(uuid=f"u{i}", iops=float(i)) for i in range(j, j + 50)]
+                for j in range(0, 250, 50)
+            ]
+
+            mock_db = MagicMock()
+            mock_db.query_with_filters.return_value = cached
+            mock_client = MagicMock()
+            mock_client.get_all_records.return_value = {"records": []}
+
+            with (
+                patch.object(OntapBackend, "_cache_db", new=mock_db),
+                patch.object(backend, "_get_api_client", return_value=mock_client),
+                patch(
+                    "pynetappfoundry.data.backends.parse_api_response",
+                    side_effect=live_chunks,
+                ),
+                patch.object(backend, "_resolve_metadata_path", return_value="storage.small_batch"),
+            ):
+                results = backend.query(
+                    FakeVolume,
+                    mapping,
+                    decision,
+                    cluster="prod1",
+                    filters={},
+                )
+
+            assert len(results) == 250
+            assert mock_client.get_all_records.call_count == 5
+        finally:
+            model_registry._mappings.pop("SmallBatchVolume", None)
+
 
 class TestOntapBackendQueryPartialParentKeyed:
     """Tests for parent-keyed partial-fetch in ``_query_partial``."""
@@ -880,6 +1013,48 @@ class TestOntapBackendQueryPartialParentKeyed:
 
         assert results == []
         mock_client.get_all_records.assert_not_called()
+
+    def test_parent_keyed_chunking_large_child_set(
+        self,
+        fake_child_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """1 parent with 150 children should produce 2 API calls (100 + 50)."""
+        backend = _make_backend(mock_config)
+        decision = RoutingDecision(cache_fields=("uuid", "volume.uuid"), live_fields=("metric",))
+        cached = [
+            FakeChildWithDottedRef(uuid=f"c{i}", volume=FakeChildVolume(uuid="vol-1"), metric=0.0)
+            for i in range(150)
+        ]
+        live_chunk1 = [FakeChildWithDottedRef(uuid=f"c{i}", metric=float(i)) for i in range(100)]
+        live_chunk2 = [
+            FakeChildWithDottedRef(uuid=f"c{i}", metric=float(i)) for i in range(100, 150)
+        ]
+
+        mock_db = MagicMock()
+        mock_db.query_with_filters.return_value = cached
+        mock_client = MagicMock()
+        mock_client.get_all_records.return_value = {"records": []}
+
+        with (
+            patch.object(OntapBackend, "_cache_db", new=mock_db),
+            patch.object(backend, "_get_api_client", return_value=mock_client),
+            patch(
+                "pynetappfoundry.data.backends.parse_api_response",
+                side_effect=[live_chunk1, live_chunk2],
+            ),
+            patch.object(backend, "_resolve_metadata_path", return_value="storage.fake_children"),
+        ):
+            results = backend.query(
+                FakeChildWithDottedRef,
+                fake_child_mapping,
+                decision,
+                cluster="prod1",
+                filters={},
+            )
+
+        assert len(results) == 150
+        assert mock_client.get_all_records.call_count == 2
 
     def test_extract_parent_ref_field(self) -> None:
         """Unit test for _extract_parent_ref_field with various URL patterns."""


### PR DESCRIPTION
## Description

Add `TypeMapping.batch_size` optional field that overrides the default `_BATCH_SIZE` (100) for endpoints with narrower URL limits. Update `_fetch_live_by_identifiers` and `_fetch_live_by_parent` to use `mapping.batch_size or _BATCH_SIZE`. Document chunking assumptions (pipe-OR syntax, single identifier field, chunk failure atomicity) in method docstrings. Add ADR-0012 chunking behavior section.

Addresses #538

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test improvement

## Changes Made

- `src/pynetappfoundry/cache/field_mapping.py` — added `batch_size: int | None = None` to TypeMapping
- `src/pynetappfoundry/data/backends.py` — use `mapping.batch_size or _BATCH_SIZE` in both batching methods; expanded docstrings
- `tests/unit/data/test_backends.py` — 4 new tests: exact boundary (100), boundary+1 (101), custom batch_size (50x5), parent-keyed large child set (150→2 chunks)
- `docs/decisions/0012-unified-datasource-accessor.md` — chunking behavior section

## Testing

- [x] `doit check` passes
- [x] All existing tests pass
- [x] 4 new edge-case tests added
