### PR TITLE
fix: add "Node:" prefix to HTML report node titles (merges PR, addresses #440)

### DIFF
--- a/src/pynetappfoundry/cli/commands/reports/html.py
+++ b/src/pynetappfoundry/cli/commands/reports/html.py
@@ -1196,11 +1196,12 @@ class ClusterData:
         with tag("li"):
             with tag("details"):
                 with tag("summary"):
+                    node_label = f"Node: {node.name}" if node.name else "Node: Unknown"
                     if management_link:
                         with tag("a", ("href", management_link)):
-                            text(node.name or "Unknown")
+                            text(node_label)
                     else:
-                        text(node.name or "Unknown")
+                        text(node_label)
                 with tag("ul"):
                     with tag("li"):
                         with tag("table", ("class", "custom-table")):


### PR DESCRIPTION
## Description

Add "Node: " prefix to HTML report node dropdown headers, matching the existing "vserver svm1" pattern. Previously rendered as just the node name (e.g. "ontapcl-01"), now shows "Node: ontapcl-01".

The other three bugs in #440 were already fixed by subsequent PRs:
- Node management IP — fixed by PR #439 (nested model access)
- SVM interface "Unknown" — fixed by PR #524 (DataSource + LIF lookup)
- Cloud section placement — fixed by PR #442 (cluster + per-node sections)

Addresses #440

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `doit check` passes
- [x] No test regressions
