### PR TITLE
fix: HTML report node management IP and VServer title formatting (merges PR, addresses #562)

### DIFF
--- a/src/pynetappfoundry/cli/commands/reports/html.py
+++ b/src/pynetappfoundry/cli/commands/reports/html.py
@@ -993,7 +993,7 @@ class ClusterData:
             with tag("li"):
                 with tag("details"):
                     with tag("summary"):
-                        text(f"vserver {svm.name}{state_text}")
+                        text(f"VServer: {svm.name}{state_text}")
                     with tag("ul"):
                         self._format_netapp_vserver_interfaces_info(svm)
                         self._format_netapp_vserver_dns_info(svm)
@@ -1190,7 +1190,7 @@ class ClusterData:
         fmt = self.app_instance.format_table_row_text
         fmt_link = self.app_instance.format_table_row_link
 
-        mgmt_ip = node.management_interface.ip.address
+        mgmt_ip = node.management_interfaces[0].ip.address if node.management_interfaces else ""
         management_link = f"https://{mgmt_ip}" if mgmt_ip else ""
 
         with tag("li"):


### PR DESCRIPTION
## Description

Fix node management IP display and VServer title formatting in the HTML report.

- **Node management IP/links missing:** Used `management_interfaces[0].ip.address` (plural, populated via transform) instead of `management_interface.ip.address` (singular, empty from `fields=*`). Restores Node Management IP, System Manager link, and SPI link.
- **VServer title formatting:** Changed "vserver svm1" to "VServer: svm1" matching the "Node: ontapcl-01" pattern.

Addresses #562

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `doit check` passes
