### PR TITLE
feat: HTML report cloud VM sub-sections, service processor, and node details (merges PR, addresses #562)

### DIFF
--- a/src/pynetappfoundry/cli/commands/reports/html.py
+++ b/src/pynetappfoundry/cli/commands/reports/html.py
@@ -866,9 +866,8 @@ class ClusterData:
     def _format_netapp_cloud_info(self) -> None:
         """Format cluster-level cloud provider information.
 
-        Shows provider, account/subscription ID, resource group, and region.
-        Per-node fields (instance_id, instance_type, etc.) are rendered
-        in _format_netapp_node() instead.
+        Shows provider, account/subscription ID, resource group, and region,
+        followed by a collapsible sub-section per node with VM details.
         """
         tag = self.app_instance.tag
         text = self.app_instance.text
@@ -902,6 +901,44 @@ class ClusterData:
                                     fmt("Resource Group", self.cloud_resource_group_name)
                             if self.cloud_region:
                                 fmt("Region", self.cloud_region)
+
+                    for node in self.nodes:
+                        cloud_meta = self.cloud_metadata_by_node.get(node.name)
+                        if not cloud_meta:
+                            continue
+                        if provider_lower == "azure":
+                            vm_name = build_azure_vm_name(
+                                self.name, node.name, is_ha=len(self.nodes) > 1
+                            )
+                            vm_link = cloud_meta.instance_link
+                        else:
+                            vm_name = node.name
+                            vm_link = cloud_meta.instance_sso_link or cloud_meta.instance_link
+                        with tag("li"):
+                            with tag("details"):
+                                with tag("summary"):
+                                    label = vm_name or node.name or "VM"
+                                    if vm_link:
+                                        with tag("a", ("href", vm_link)):
+                                            text(label)
+                                    else:
+                                        text(label)
+                                with tag("ul"):
+                                    with tag("li"):
+                                        with tag("table", ("class", "custom-table")):
+                                            if vm_name and vm_link:
+                                                fmt_link("VM Name", vm_name, vm_link)
+                                            elif vm_name:
+                                                fmt("VM Name", vm_name)
+                                            if cloud_meta.instance_id:
+                                                fmt("Instance ID", cloud_meta.instance_id)
+                                            if cloud_meta.instance_type:
+                                                fmt("Instance Type", cloud_meta.instance_type)
+                                            if cloud_meta.availability_zone:
+                                                fmt(
+                                                    "Availability Zone",
+                                                    cloud_meta.availability_zone,
+                                                )
 
     def _format_netapp_cluster_info(self) -> None:
         """Format cluster-level information (version, management IPs, DNS, NTP)."""
@@ -1182,6 +1219,10 @@ class ClusterData:
     def _format_netapp_node(self, node: OntapNodeResponse) -> None:
         """Format a single node's information.
 
+        Node identity and management links are rendered in a flat table.
+        The Service Processor gets its own collapsible sub-section below
+        the table.
+
         Args:
             node: OntapNodeResponse model instance.
         """
@@ -1190,7 +1231,10 @@ class ClusterData:
         fmt = self.app_instance.format_table_row_text
         fmt_link = self.app_instance.format_table_row_link
 
-        mgmt_ip = node.management_interfaces[0].ip.address if node.management_interfaces else ""
+        mgmt_ip = node.management_interface.ip.address or next(
+            (iface.ip.address for iface in node.management_interfaces if iface.ip.address),
+            "",
+        )
         management_link = f"https://{mgmt_ip}" if mgmt_ip else ""
 
         with tag("li"):
@@ -1207,68 +1251,58 @@ class ClusterData:
                         with tag("table", ("class", "custom-table")):
                             if mgmt_ip:
                                 fmt("Node Management IP", mgmt_ip)
-                            serial = node.serial_number or "Unknown"
-                            fmt("Serial Number", serial)
+                            if node.serial_number:
+                                fmt("Serial Number", node.serial_number)
+                            if node.model_:
+                                fmt("Model", node.model_)
+                            if node.location:
+                                fmt("Location", node.location)
                             if management_link:
                                 fmt_link("System Manager", "Link", management_link)
                                 fmt_link("SPI", "Link", f"{management_link}/spi")
 
-                    # Per-node cloud section
-                    cloud_meta = self.cloud_metadata_by_node.get(node.name)
-                    if cloud_meta:
-                        self._format_node_cloud_section(node, cloud_meta)
+                    # Service Processor sub-section (separate device with its own IP)
+                    if node.service_processor.ipv4_interface.address:
+                        self._format_node_service_processor(node)
 
-    def _format_node_cloud_section(
-        self,
-        node: OntapNodeResponse,
-        cloud_meta: CloudMetadata,
-    ) -> None:
-        """Format per-node cloud provider information.
+    def _format_node_service_processor(self, node: OntapNodeResponse) -> None:
+        """Format the Service Processor (BMC) sub-section for a node.
 
-        Shows VM name, instance ID, instance type, availability zone,
-        and cloud console links for the given node.
+        The SP is a separate management device with its own IP, so it is
+        rendered as a collapsible sub-section rather than inline rows.
 
         Args:
             node: OntapNodeResponse model instance.
-            cloud_meta: CloudMetadata for this node.
         """
         tag = self.app_instance.tag
         text = self.app_instance.text
         fmt = self.app_instance.format_table_row_text
         fmt_link = self.app_instance.format_table_row_link
 
-        provider = cloud_meta.provider
-        provider_lower = provider.lower()
-
-        # Derive VM name
-        if provider_lower == "azure":
-            vm_name = build_azure_vm_name(self.name, node.name, is_ha=len(self.nodes) > 1)
-        else:
-            vm_name = node.name
+        sp = node.service_processor
+        sp_ip = sp.ipv4_interface.address
+        sp_link = f"https://{sp_ip}" if sp_ip else ""
 
         with tag("li"):
             with tag("details"):
                 with tag("summary"):
-                    text(f"Cloud - {provider}")
+                    if sp_link:
+                        with tag("a", ("href", sp_link)):
+                            text("Service Processor")
+                    else:
+                        text("Service Processor")
                 with tag("ul"):
                     with tag("li"):
                         with tag("table", ("class", "custom-table")):
-                            if vm_name:
-                                fmt("VM Name", vm_name)
-                            if cloud_meta.instance_id:
-                                fmt("Instance ID", cloud_meta.instance_id)
-                            if cloud_meta.instance_type:
-                                fmt("Instance Type", cloud_meta.instance_type)
-                            if cloud_meta.availability_zone:
-                                fmt("Availability Zone", cloud_meta.availability_zone)
-                            if cloud_meta.instance_link:
-                                fmt_link("Cloud Console", "Link", cloud_meta.instance_link)
-                            if cloud_meta.instance_sso_link:
-                                fmt_link(
-                                    "Cloud Console (SSO)",
-                                    "Link",
-                                    cloud_meta.instance_sso_link,
-                                )
+                            if sp_ip:
+                                fmt("SP IP", sp_ip)
+                            if sp.state:
+                                fmt("State", sp.state)
+                            if sp.firmware_version:
+                                fmt("Firmware Version", sp.firmware_version)
+                            if sp_link:
+                                fmt_link("System Manager", "Link", sp_link)
+                                fmt_link("SPI", "Link", f"{sp_link}/spi")
 
 
 @click.command()

--- a/tests/unit/cli/commands/reports/test_html.py
+++ b/tests/unit/cli/commands/reports/test_html.py
@@ -1612,9 +1612,11 @@ class TestCloudSections:
         assert "https://portal.azure.com/#resource/rg-test" in html
         assert "Region" in html
         assert "eastus" in html
-        # Instance-level fields should NOT appear at cluster level
-        assert "Instance ID" not in html
-        assert "Instance Type" not in html
+        # Instance-level fields now appear in per-node sub-sections
+        # within the cluster cloud section.
+        assert "Instance ID" in html
+        assert "i-123" in html
+        assert "Instance Type" in html
 
     def test_cluster_cloud_section_aws(self, mock_builder: MagicMock) -> None:
         """Test cluster-level cloud section for AWS uses Account ID label."""
@@ -1645,8 +1647,8 @@ class TestCloudSections:
         # No resource group for AWS
         assert "Resource Group" not in html
 
-    def test_node_cloud_section_azure(self, mock_builder: MagicMock) -> None:
-        """Test per-node cloud section for Azure with VM name and links."""
+    def test_cloud_vm_subsection_azure(self, mock_builder: MagicMock) -> None:
+        """Test per-node VM sub-section under cluster cloud for Azure."""
         cluster = self._make_cluster(
             mock_builder,
             [
@@ -1663,26 +1665,11 @@ class TestCloudSections:
                     "instance_link": "https://portal.azure.com/#resource/vm1",
                     "instance_sso_link": "",
                 },
-                {
-                    "node": "test-cluster-02",
-                    "provider": "Azure",
-                    "region": "eastus",
-                    "account_id": "sub-123",
-                    "resource_group_name": "rg-test",
-                    "resource_group_link": "",
-                    "instance_id": "i-456",
-                    "instance_type": "Standard_DS4_v2",
-                    "availability_zone": "eastus-2",
-                    "instance_link": "https://portal.azure.com/#resource/vm2",
-                    "instance_sso_link": "",
-                },
             ],
         )
-        node = cluster.nodes[0]
-        cluster._format_netapp_node(node)
+        cluster._format_netapp_cloud_info()
         html = mock_builder.doc.getvalue()
 
-        assert "Cloud - Azure" in html
         assert "VM Name" in html
         assert "test-cluster-vm1" in html
         assert "Instance ID" in html
@@ -1691,11 +1678,11 @@ class TestCloudSections:
         assert "Standard_DS4_v2" in html
         assert "Availability Zone" in html
         assert "eastus-1" in html
-        assert "Cloud Console" in html
+        # Azure uses instance_link on the VM name
         assert "https://portal.azure.com/#resource/vm1" in html
 
-    def test_node_cloud_section_aws(self, mock_builder: MagicMock) -> None:
-        """Test per-node cloud section for AWS with console link."""
+    def test_cloud_vm_subsection_aws(self, mock_builder: MagicMock) -> None:
+        """Test per-node VM sub-section under cluster cloud for AWS uses SSO link."""
         cluster = self._make_cluster(
             mock_builder,
             [
@@ -1714,18 +1701,16 @@ class TestCloudSections:
                 },
             ],
         )
-        node = cluster.nodes[0]
-        cluster._format_netapp_node(node)
+        cluster._format_netapp_cloud_info()
         html = mock_builder.doc.getvalue()
 
-        assert "Cloud - AWS" in html
         assert "VM Name" in html
         assert "test-cluster-01" in html
         assert "Instance ID" in html
         assert "i-0abc123" in html
-        assert "Cloud Console" in html
-        assert "https://us-east-1.console.aws.amazon.com/ec2" in html
-        assert "Cloud Console (SSO)" in html
+        assert "Instance Type" in html
+        assert "m5.xlarge" in html
+        # AWS uses SSO link (falls back to instance_link)
         assert "https://sso.awsapps.com/start/#/console" in html
 
     def test_no_cloud_section_when_no_data(self, mock_builder: MagicMock) -> None:


### PR DESCRIPTION
## Description

Restructure HTML report node and cloud sections per the changes from `feat/html-report-node-cloud-links`:

- **Cloud VM sub-sections:** Per-node VM details (instance ID, type, AZ) moved into collapsible sub-sections under the cluster-level Cloud section. Azure uses `instance_link`, AWS uses `instance_sso_link` with `instance_link` fallback. Removes the separate "Cloud Console (SSO)" row — SSO link is now on the VM name itself.
- **Service Processor:** New collapsible sub-section per node showing SP IP, state, firmware version, and System Manager/SPI links via the SP IP.
- **Node details:** Added Model and Location fields. Serial number now conditional. Management IP tries `management_interface.ip.address` first, falls back to `management_interfaces[0]`.

Addresses #562

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] `doit check` passes
- [x] Cloud section tests updated for new structure
