### PR TITLE
refactor: auto-register TypeMappings via _ensure_bootstrapped guard

### DIFF
--- a/docs/usage/query-layer.md
+++ b/docs/usage/query-layer.md
@@ -45,8 +45,8 @@ The layer ships five public surfaces:
 | Express "fetch related X for this Y" intent | `related` / `related_one` |
 | Read fields excluded from the cache (IOPS, latency, ...) | `fetch_realtime` family |
 
-!!! note "Prerequisite: TypeMapping must be registered"
-    Every entry point in this module looks the model class up in the model registry. If you see `ValueError: No TypeMapping registered for 'OntapXxx'`, import the matching mapping module (e.g. `import pynetappfoundry.cache.ontap.storage.volumes.mapping`) before constructing the `QuerySet` / `Mutation`. Importing the cache subpackage is usually enough — most CLI entry points already trigger this transitively.
+!!! note "TypeMappings are auto-registered"
+    Every entry point in this module looks the model class up in the model registry. Mappings are auto-registered: the first registry lookup triggers the `cache` package import, which walks `cache/ontap/**/mapping.py` and registers every `TypeMapping`. If you see `ValueError: No TypeMapping registered for 'OntapXxx'`, verify that a `mapping.py` module exists under `cache/ontap/` for the model in question.
 
 For the wider context of when to use the query layer instead of `ClusterEntry.ontap`, see the [decision section](#combining-with-clusterentryontap) below and the [ONTAP Access Patterns](ontap-access-patterns.md) guide.
 

--- a/src/pynetappfoundry/cache/_registry.py
+++ b/src/pynetappfoundry/cache/_registry.py
@@ -7,13 +7,15 @@ calls ``model_registry.register_mapping()`` to register its mapping.
 Two parallel indexes are maintained: a name-keyed ``_mappings`` dict
 (the original API) and a class-keyed ``_mappings_by_class`` dict used by
 :func:`pynetappfoundry.cache.fetchers.fetch` for model-class lookups.
-Both are populated at ``register_mapping()`` time, so mapping modules
-must be imported before any lookup fires — same import-order rule as
-the original name-keyed registry.
+Both are populated at ``register_mapping()`` time.  A defensive
+:func:`_ensure_bootstrapped` guard triggers the ``cache`` package
+import (which walks ``cache/ontap/**/mapping.py``) on first lookup,
+so callers no longer need manual mapping imports.
 """
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -22,11 +24,32 @@ if TYPE_CHECKING:
     from pynetappfoundry.cache.field_mapping import TypeMapping
 
 
+def _ensure_bootstrapped() -> None:
+    """Import the cache package if it hasn't been loaded yet.
+
+    The ``cache/__init__.py`` module walks ``cache.ontap`` and imports
+    every ``mapping.py``, which registers all :class:`TypeMapping`
+    instances on :data:`model_registry`.  Most code paths already
+    trigger this import transitively, but registry look-ups that run
+    before the cache package is loaded would see an empty registry.
+
+    This guard makes the registration self-healing: callers no longer
+    need manual ``import pynetappfoundry.cache.ontap.<...>.mapping``
+    lines.
+
+    Cost: a single ``dict.__contains__`` on the common (already-loaded)
+    path.
+    """
+    if "pynetappfoundry.cache" not in sys.modules:
+        import pynetappfoundry.cache  # noqa: F401
+
+
 class ModelRegistry:
     """Registry of cache field mappings.
 
     Mappings are registered explicitly by each ``mapping.py`` module
-    at import time.
+    at import time.  Look-up methods call :func:`_ensure_bootstrapped`
+    so callers do not need manual mapping imports.
     """
 
     def __init__(self) -> None:
@@ -52,6 +75,7 @@ class ModelRegistry:
         Returns:
             The TypeMapping instance, or None if not registered.
         """
+        _ensure_bootstrapped()
         return self._mappings.get(name)
 
     def get_mapping_by_model_class(self, model_class: type[BaseModel]) -> TypeMapping | None:
@@ -64,6 +88,7 @@ class ModelRegistry:
             The TypeMapping instance, or None if no mapping registers that
             class.
         """
+        _ensure_bootstrapped()
         return self._mappings_by_class.get(model_class)
 
     @property

--- a/src/pynetappfoundry/cache/fetchers.py
+++ b/src/pynetappfoundry/cache/fetchers.py
@@ -384,7 +384,9 @@ def fetch[T: BaseModel](
     if mapping is None:
         raise ValueError(
             f"fetch(): no TypeMapping registered for model class "
-            f"{model_class.__module__}.{model_class.__name__}"
+            f"{model_class.__module__}.{model_class.__name__}. "
+            f"Mappings are auto-registered; verify a mapping.py module "
+            f"exists under cache/ontap/ for this model."
         )
 
     # Prepare results_cache used by post-collection hooks.

--- a/src/pynetappfoundry/cli/commands/licenses/check.py
+++ b/src/pynetappfoundry/cli/commands/licenses/check.py
@@ -7,8 +7,6 @@ from typing import Any
 
 import click
 
-import pynetappfoundry.cache.ontap.cluster.licensing.licenses.mapping
-import pynetappfoundry.cache.ontap.cluster.nodes.mapping  # noqa: F401 - register TypeMapping
 from pynetappfoundry.cli.decorators import with_config
 from pynetappfoundry.cli.utils import print_error, print_info, print_warning
 from pynetappfoundry.clients.ontap.api import ONTAPAPIClient

--- a/src/pynetappfoundry/cli/commands/licenses/savings.py
+++ b/src/pynetappfoundry/cli/commands/licenses/savings.py
@@ -7,7 +7,6 @@ from typing import Any
 import click
 from rich.table import Table
 
-import pynetappfoundry.cache.ontap.cluster.licensing.licenses.mapping  # noqa: F401
 from pynetappfoundry.cli.decorators import with_config
 from pynetappfoundry.cli.utils import console, print_error, print_info
 from pynetappfoundry.clients.ontap.api import ONTAPAPIClient

--- a/src/pynetappfoundry/cli/commands/reports/html.py
+++ b/src/pynetappfoundry/cli/commands/reports/html.py
@@ -17,11 +17,6 @@ from typing import TYPE_CHECKING, Any
 import click
 from yattag import Doc, indent
 
-import pynetappfoundry.cache.ontap.cluster.mapping
-import pynetappfoundry.cache.ontap.cluster.nodes.mapping
-import pynetappfoundry.cache.ontap.network.ip.interfaces.mapping
-import pynetappfoundry.cache.ontap.protocols.cifs.services.mapping
-import pynetappfoundry.cache.ontap.svm.svms.mapping  # noqa: F401
 from pynetappfoundry.cli.decorators import with_config
 from pynetappfoundry.cli.utils import print_debug, print_error, print_info, print_success
 from pynetappfoundry.data.source import DataSource

--- a/src/pynetappfoundry/cli/commands/reports/locks.py
+++ b/src/pynetappfoundry/cli/commands/reports/locks.py
@@ -8,7 +8,6 @@ from typing import Any
 import click
 from openpyxl import Workbook
 
-import pynetappfoundry.cache.ontap.protocols.locks.mapping  # noqa: F401 - register TypeMapping
 from pynetappfoundry.cli.decorators import with_config
 from pynetappfoundry.cli.utils import print_debug, print_error, print_info, print_success
 from pynetappfoundry.clients.ontap.api import ONTAPAPIClient

--- a/src/pynetappfoundry/cli/commands/reports/space_usage.py
+++ b/src/pynetappfoundry/cli/commands/reports/space_usage.py
@@ -16,8 +16,6 @@ import click
 import xlsxwriter
 import xlsxwriter.utility
 
-import pynetappfoundry.cache.ontap.cluster.nodes.mapping
-import pynetappfoundry.cache.ontap.storage.volumes.mapping  # noqa: F401 - register TypeMapping
 from pynetappfoundry.cli.decorators import with_config
 from pynetappfoundry.cli.utils import print_error, print_info, print_success
 from pynetappfoundry.clients.ontap.api import ONTAPAPIClient

--- a/src/pynetappfoundry/cli/commands/utils/validate.py
+++ b/src/pynetappfoundry/cli/commands/utils/validate.py
@@ -6,8 +6,6 @@ from typing import Any
 
 import click
 
-import pynetappfoundry.cache.ontap.cluster.nodes.mapping  # register TypeMapping
-import pynetappfoundry.cache.ontap.storage.volumes.mapping  # noqa: F401 - register TypeMapping
 from pynetappfoundry.cli.decorators import with_config
 from pynetappfoundry.cli.utils import (
     print_debug,

--- a/src/pynetappfoundry/data/source.py
+++ b/src/pynetappfoundry/data/source.py
@@ -91,7 +91,8 @@ class DataSource:
         if mapping is None:
             msg = (
                 f"No TypeMapping registered for {model_class.__name__!r}. "
-                f"Ensure the model's mapping module has been imported."
+                f"Mappings are auto-registered; verify a mapping.py module "
+                f"exists under cache/ontap/ for this model."
             )
             raise ValueError(msg)
         return mapping

--- a/src/pynetappfoundry/query/mutation.py
+++ b/src/pynetappfoundry/query/mutation.py
@@ -76,7 +76,8 @@ class Mutation:
         if mapping is None:
             msg = (
                 f"No TypeMapping registered for '{model_class.__name__}'. "
-                f"Ensure the model's mapping module has been imported."
+                f"Mappings are auto-registered; verify a mapping.py module "
+                f"exists under cache/ontap/ for this model."
             )
             raise ValueError(msg)
         return mapping

--- a/src/pynetappfoundry/query/queryset.py
+++ b/src/pynetappfoundry/query/queryset.py
@@ -79,7 +79,8 @@ class QuerySet:
         if mapping is None:
             msg = (
                 f"No TypeMapping registered for '{model_class.__name__}'. "
-                f"Ensure the model's mapping module has been imported."
+                f"Mappings are auto-registered; verify a mapping.py module "
+                f"exists under cache/ontap/ for this model."
             )
             raise ValueError(msg)
         return mapping

--- a/src/pynetappfoundry/query/realtime.py
+++ b/src/pynetappfoundry/query/realtime.py
@@ -54,7 +54,8 @@ def _resolve_realtime(
     if mapping is None:
         msg = (
             f"No TypeMapping registered for '{model_class.__name__}'. "
-            f"Ensure the model's mapping module has been imported."
+            f"Mappings are auto-registered; verify a mapping.py module "
+            f"exists under cache/ontap/ for this model."
         )
         raise ValueError(msg)
 

--- a/tests/unit/cache/test_db.py
+++ b/tests/unit/cache/test_db.py
@@ -962,8 +962,6 @@ class TestRealtimeAttrs:
 
     def test_returns_realtime_cache_attrs_for_mapped_model(self) -> None:
         """realtime_attrs returns correct field names for models with realtime mappings."""
-        # Import the mapping module to trigger register_mapping() calls
-        import pynetappfoundry.cache.ontap.network.fc.ports.mapping  # noqa: F401
         from pynetappfoundry.models.ontap.network.fc.ports.model import OntapFcPort
 
         # Clear cache to ensure fresh lookup

--- a/tests/unit/cache/test_registry.py
+++ b/tests/unit/cache/test_registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
-from pynetappfoundry.cache._registry import ModelRegistry
+from pynetappfoundry.cache._registry import ModelRegistry, _ensure_bootstrapped
 
 
 class TestModelRegistry:
@@ -107,3 +107,22 @@ class TestGlobalRegistryBootstrap:
                 "check cache/__init__.py mapping-import bootstrap."
             )
             assert mapping.model_class is model_class
+
+
+class TestEnsureBootstrapped:
+    """Tests for the ``_ensure_bootstrapped`` guard function."""
+
+    def test_noop_when_cache_already_loaded(self) -> None:
+        """Calling ``_ensure_bootstrapped`` after the cache package is loaded is a no-op."""
+        import pynetappfoundry.cache  # noqa: F401
+        from pynetappfoundry.cache._registry import model_registry
+
+        # Snapshot current registry state
+        before = dict(model_registry._mappings)
+        assert len(before) > 0, "Registry should already be populated"
+
+        # Calling the guard again must not raise or alter the registry
+        _ensure_bootstrapped()
+
+        after = dict(model_registry._mappings)
+        assert before == after

--- a/tests/unit/query/test_job.py
+++ b/tests/unit/query/test_job.py
@@ -43,9 +43,6 @@ FAKE_MAPPING = TypeMapping(
 @pytest.fixture(autouse=True)
 def _register_mappings() -> Any:
     """Register test mappings and ensure OntapJob mapping is available."""
-    # Import to ensure OntapJob mapping is registered
-    import pynetappfoundry.cache.ontap.cluster.jobs.mapping  # noqa: F401
-
     model_registry.register_mapping("FakeVolume", FAKE_MAPPING)
     yield
     model_registry._mappings.pop("FakeVolume", None)


### PR DESCRIPTION
## Description

Add a `_ensure_bootstrapped()` guard to the TypeMapping registry so that all
TypeMappings are auto-registered on first access. This eliminates the need for
consumers (CLI commands, tests) to manually import mapping modules solely for
their registration side effects.

Addresses #578

## Related Issue

Addresses #578

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `_ensure_bootstrapped()` guard in `src/pynetappfoundry/cache/_registry.py` that lazily discovers and imports all TypeMapping modules on first registry access
- Removed manual mapping imports from six CLI command modules (`licenses/check`, `licenses/savings`, `reports/html`, `reports/locks`, `reports/space_usage`, `utils/validate`)
- Removed manual mapping imports from two test modules (`cache/test_db`, `query/test_job`)
- Updated error messages in `cache/fetchers.py`, `data/source.py`, `query/mutation.py`, `query/queryset.py`, and `query/realtime.py` to reference the bootstrapping guard
- Updated `docs/usage/query-layer.md` prerequisite note to reflect auto-registration

## Testing

- [x] All existing tests pass
- [x] Added new test for `_ensure_bootstrapped()` in `tests/unit/cache/test_registry.py`
- [x] Manually verified `doit check` passes (lint, type-check, tests, security, spelling)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

No ADR updates required. ADR-0012 and ADR-0013 discuss TypeMapping at the
architectural/registry level but do not reference the consumer-side manual import
pattern that this PR eliminates.
