### PR TITLE
feat: add vm_name derived field to CloudMetadata

### DIFF
--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -887,6 +887,9 @@ class MetadataCollector:
                 account_id=cm.account_id,
                 resource_group=cm.resource_group_name,
             )
+            # Set vm_name without cluster context; for Azure this is
+            # overwritten by _update_azure_cloud_links() which has
+            # cluster_name and node info for the proper derivation.
             cm.vm_name = build_vm_name(
                 provider=cm.provider,
                 instance_id=cm.instance_id,

--- a/src/pynetappfoundry/cache/collector.py
+++ b/src/pynetappfoundry/cache/collector.py
@@ -85,6 +85,7 @@ from pynetappfoundry.utils.cloud import (
     build_cloud_instance_link,
     build_cloud_instance_sso_link,
     build_cloud_resource_group_link,
+    build_vm_name,
 )
 
 # Cache collector skips realtime fields (volatile metrics not persisted).
@@ -886,6 +887,10 @@ class MetadataCollector:
                 account_id=cm.account_id,
                 resource_group=cm.resource_group_name,
             )
+            cm.vm_name = build_vm_name(
+                provider=cm.provider,
+                instance_id=cm.instance_id,
+            )
 
         return results
 
@@ -946,6 +951,14 @@ class MetadataCollector:
                 sso_config=self.aws_sso_config,
             )
 
+            vm_name = build_vm_name(
+                provider=meta.provider,
+                cluster_name=cluster_name,
+                node_name=meta.node,
+                instance_id=meta.instance_id,
+                is_ha=is_ha,
+            )
+
             # Create updated CloudMetadata with new links
             updated.append(
                 CloudMetadata(
@@ -971,6 +984,7 @@ class MetadataCollector:
                     instance_link=instance_link,
                     instance_sso_link=instance_sso_link,
                     resource_group_link=meta.resource_group_link,
+                    vm_name=vm_name,
                 )
             )
         return updated

--- a/src/pynetappfoundry/cache/ontap/cloud/metadata/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cloud/metadata/mapping.py
@@ -21,6 +21,7 @@ from pynetappfoundry.models.ontap.cloud.metadata.model import CloudMetadata
 from pynetappfoundry.utils.cloud import (
     build_cloud_instance_link,
     build_cloud_resource_group_link,
+    build_vm_name,
 )
 
 
@@ -47,6 +48,20 @@ def _compute_resource_group_link(
         resource_group=instance.resource_group_name,
     )
     return instance.model_copy(update={"resource_group_link": link})
+
+
+def _compute_vm_name(instance: CloudMetadata, _results: dict[str, Any]) -> CloudMetadata:
+    """Derive ``vm_name`` from the instance's own fields.
+
+    For AWS and other providers the instance_id is used as the VM identifier.
+    Azure vm_name requires cluster/node context and is updated by the collector's
+    ``_update_azure_cloud_links`` pass; this hook provides the AWS/fallback value.
+    """
+    name = build_vm_name(
+        provider=instance.provider,
+        instance_id=instance.instance_id,
+    )
+    return instance.model_copy(update={"vm_name": name})
 
 
 CLOUD_METADATA_MAPPING = TypeMapping(
@@ -144,6 +159,11 @@ CLOUD_METADATA_MAPPING = TypeMapping(
             cache_attr="resource_group_link",
             cache_strategy="derived",
             post_collection=_compute_resource_group_link,
+        ),
+        FieldMapping(
+            cache_attr="vm_name",
+            cache_strategy="derived",
+            post_collection=_compute_vm_name,
         ),
     ),
 )

--- a/src/pynetappfoundry/cli/commands/reports/html.py
+++ b/src/pynetappfoundry/cli/commands/reports/html.py
@@ -28,7 +28,7 @@ from pynetappfoundry.models.ontap.svm.svms.model import OntapSvm
 from pynetappfoundry.utils.cloud import (
     build_azure_id,
     build_azure_portal_link,
-    build_azure_vm_name,
+    build_vm_name,
     get_cloud_account_name,
 )
 
@@ -902,8 +902,13 @@ class ClusterData:
                         if not cloud_meta:
                             continue
                         if provider_lower == "azure":
-                            vm_name = cloud_meta.vm_name or build_azure_vm_name(
-                                self.name, node.name, is_ha=len(self.nodes) > 1
+                            # Fallback for caches built before vm_name field existed
+                            vm_name = cloud_meta.vm_name or build_vm_name(
+                                "azure",
+                                self.name,
+                                node.name,
+                                cloud_meta.instance_id,
+                                is_ha=len(self.nodes) > 1,
                             )
                             vm_link = cloud_meta.instance_link
                         else:

--- a/src/pynetappfoundry/cli/commands/reports/html.py
+++ b/src/pynetappfoundry/cli/commands/reports/html.py
@@ -902,7 +902,7 @@ class ClusterData:
                         if not cloud_meta:
                             continue
                         if provider_lower == "azure":
-                            vm_name = build_azure_vm_name(
+                            vm_name = cloud_meta.vm_name or build_azure_vm_name(
                                 self.name, node.name, is_ha=len(self.nodes) > 1
                             )
                             vm_link = cloud_meta.instance_link

--- a/src/pynetappfoundry/models/ontap/cloud/metadata/model.py
+++ b/src/pynetappfoundry/models/ontap/cloud/metadata/model.py
@@ -37,3 +37,4 @@ class CloudMetadata(OntapModel):
     instance_link: str = ""  # URL to cloud console for this instance
     instance_sso_link: str = ""  # URL to cloud console via AWS SSO (AWS only)
     resource_group_link: str = ""  # URL to cloud console for resource group (Azure)
+    vm_name: str = ""  # Derived VM name (Azure: <cluster>-vm1/vm2, AWS: instance_id)

--- a/src/pynetappfoundry/utils/cloud.py
+++ b/src/pynetappfoundry/utils/cloud.py
@@ -103,6 +103,33 @@ def get_node_number(node_name: str) -> int | None:
     return None
 
 
+def build_vm_name(
+    provider: str,
+    cluster_name: str = "",
+    node_name: str = "",
+    instance_id: str = "",
+    is_ha: bool = True,
+) -> str:
+    """Derive the VM name for a cloud instance.
+
+    For Azure, builds the VM name from cluster/node naming convention.
+    For AWS and other providers, the instance_id is the VM identifier.
+
+    Args:
+        provider: Cloud provider (Azure, AWS, etc.).
+        cluster_name: ONTAP cluster name (Azure).
+        node_name: ONTAP node name (Azure HA).
+        instance_id: Cloud instance ID (AWS fallback).
+        is_ha: Whether the cluster is HA (Azure).
+
+    Returns:
+        VM name string, or empty string if inputs are insufficient.
+    """
+    if provider.lower() == "azure":
+        return build_azure_vm_name(cluster_name, node_name, is_ha)
+    return instance_id
+
+
 def build_azure_vm_name(
     cluster_name: str,
     node_name: str = "",
@@ -186,11 +213,7 @@ def build_cloud_instance_link(
     elif provider_lower == "azure":
         if not account_id or not resource_group:
             return ""
-        # For Azure, derive VM name from cluster/node info if available
-        if cluster_name:
-            vm_name = build_azure_vm_name(cluster_name, node_name, is_ha)
-        else:
-            vm_name = instance_id
+        vm_name = build_vm_name("azure", cluster_name, node_name, instance_id, is_ha)
         if not vm_name:
             return ""
         resource_id = build_azure_id(account_id, resource_group, "vm", vm_name)

--- a/src/pynetappfoundry/utils/cloud.py
+++ b/src/pynetappfoundry/utils/cloud.py
@@ -126,7 +126,8 @@ def build_vm_name(
         VM name string, or empty string if inputs are insufficient.
     """
     if provider.lower() == "azure":
-        return build_azure_vm_name(cluster_name, node_name, is_ha)
+        name = build_azure_vm_name(cluster_name, node_name, is_ha)
+        return name or instance_id
     return instance_id
 
 

--- a/tests/unit/utils/test_cloud.py
+++ b/tests/unit/utils/test_cloud.py
@@ -14,6 +14,7 @@ from pynetappfoundry.utils.cloud import (
     build_cloud_instance_link,
     build_cloud_instance_sso_link,
     build_cloud_resource_group_link,
+    build_vm_name,
     get_cloud_account_name,
     get_cloud_types,
     get_node_number,
@@ -87,6 +88,55 @@ class TestBuildAzureVmName:
         """Test default is_ha is True."""
         result = build_azure_vm_name("mycluster", "mycluster-01")
         assert result == "mycluster-vm1"
+
+
+class TestBuildVmName:
+    """Tests for build_vm_name (provider-dispatch wrapper)."""
+
+    def test_azure_delegates_to_build_azure_vm_name(self) -> None:
+        """Azure dispatches to build_azure_vm_name with cluster/node context."""
+        result = build_vm_name("azure", "mycluster", "mycluster-01", is_ha=True)
+        assert result == "mycluster-vm1"
+
+    def test_azure_falls_back_to_instance_id_when_no_cluster(self) -> None:
+        """Azure returns instance_id when cluster_name is empty."""
+        result = build_vm_name("azure", instance_id="i-abc123")
+        assert result == "i-abc123"
+
+    def test_azure_prefers_derived_name_over_instance_id(self) -> None:
+        """Azure uses derived name when cluster info is available."""
+        result = build_vm_name("azure", "mycluster", "mycluster-02", "i-abc123", is_ha=True)
+        assert result == "mycluster-vm2"
+
+    def test_aws_returns_instance_id(self) -> None:
+        """AWS always returns instance_id regardless of other args."""
+        result = build_vm_name("aws", instance_id="i-0123456789abcdef0")
+        assert result == "i-0123456789abcdef0"
+
+    def test_aws_ignores_cluster_name(self) -> None:
+        """AWS ignores cluster_name even if provided."""
+        result = build_vm_name("aws", "mycluster", "mycluster-01", "i-abc", is_ha=True)
+        assert result == "i-abc"
+
+    def test_unknown_provider_returns_instance_id(self) -> None:
+        """Unknown providers fall back to instance_id."""
+        result = build_vm_name("gcp", instance_id="gcp-instance-1")
+        assert result == "gcp-instance-1"
+
+    def test_case_insensitive_provider(self) -> None:
+        """Provider matching is case-insensitive."""
+        result = build_vm_name("Azure", "mycluster", "mycluster-01", is_ha=True)
+        assert result == "mycluster-vm1"
+
+    def test_empty_provider_returns_instance_id(self) -> None:
+        """Empty provider returns instance_id."""
+        result = build_vm_name("", instance_id="i-fallback")
+        assert result == "i-fallback"
+
+    def test_no_inputs_returns_empty(self) -> None:
+        """No provider, no instance_id returns empty string."""
+        result = build_vm_name("")
+        assert result == ""
 
 
 class TestBuildAzureId:


### PR DESCRIPTION
## Description

Add `vm_name` as a derived field on `CloudMetadata` so consumers can access
`cm.vm_name` directly instead of calling `build_azure_vm_name()` at each use
site. Includes a `post_collection` hook to persist the value to the cache DB
and a `build_vm_name()` helper with Azure/AWS dispatch.

Addresses #580

## Related Issue

Addresses #580

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `vm_name: str` field to `CloudMetadata` model
- Added `build_vm_name()` helper in `utils/cloud.py` with Azure/AWS dispatch (falls back to `instance_id` when `cluster_name` is unavailable)
- Added derived field mapping entry in `cache/ontap/cloud/metadata/mapping.py`
- Added `post_collection` hook in `cache/collector.py` to compute and persist `vm_name` during cache refresh
- Updated HTML report to use `cm.vm_name` instead of `build_azure_vm_name()`

## Testing

- [x] All existing tests pass (2041 passed)
- [x] Fixed `build_vm_name()` Azure fallback to `instance_id` when `cluster_name` is empty
- [x] `doit check` passes (lint, type-check, tests, security, spelling)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings