### PR TITLE
fix: add v4→v5 cache DB migration for vm_name column

### DIFF
--- a/src/pynetappfoundry/cache/db.py
+++ b/src/pynetappfoundry/cache/db.py
@@ -269,7 +269,7 @@ class ClusterMetadataDB(SQLiteDB):
     for data safety and isolation.
     """
 
-    SCHEMA_VERSION: ClassVar[int] = 4
+    SCHEMA_VERSION: ClassVar[int] = 5
     TABLE_NAME: ClassVar[str] = "cluster_metadata"
 
     def __init__(
@@ -400,6 +400,24 @@ class ClusterMetadataDB(SQLiteDB):
 
         # Clear envelope so callers detect stale/missing cache
         self.conn.execute("DELETE FROM cluster_metadata")
+
+    # ------------------------------------------------------------------
+    # Migration v4 → v5
+    # ------------------------------------------------------------------
+
+    def _upgrade_to_v5(self) -> None:
+        """Add ``vm_name`` column to the cloudmetadata table.
+
+        PR #582 added ``vm_name`` as a derived field on ``CloudMetadata``.
+        Existing v4 databases lack this column, causing INSERT failures
+        on cache refresh.  The column check is idempotent: earlier
+        migrations may have recreated the table with the current DDL
+        (which already includes ``vm_name``).
+        """
+        cursor = self.conn.execute("PRAGMA table_info(cloudmetadata)")
+        existing_cols = {row[1] for row in cursor.fetchall()}
+        if "vm_name" not in existing_cols:
+            self.conn.execute('ALTER TABLE cloudmetadata ADD COLUMN "vm_name" TEXT')
 
     # ------------------------------------------------------------------
     # Internal: decompose metadata into tables

--- a/tests/unit/cache/test_db.py
+++ b/tests/unit/cache/test_db.py
@@ -860,13 +860,81 @@ class TestClusterMetadataDBMigrationV3:
         )
         assert cursor.fetchone() is None
 
-        # Verify schema version is 4 (v4 drops/recreates tables)
+        # Verify schema version is 5 (v4 drops/recreates, v5 adds vm_name)
         cursor = db.conn.execute("SELECT version FROM _schema_version")
-        assert cursor.fetchone()[0] == 4
+        assert cursor.fetchone()[0] == 5
 
         # v4 clears envelope data (nested model refactoring)
         got = db.get("test-cluster")
         assert got is None
+
+        db.close()
+
+    def test_upgrade_v4_to_v5_adds_vm_name_column(self, tmp_path: Path) -> None:
+        """v4→v5 migration adds vm_name column to cloudmetadata table."""
+        db_path = tmp_path / "v4.db"
+        conn = sqlite3.connect(db_path)
+
+        # Create a v4 schema: envelope + per-model tables
+        conn.execute(
+            "CREATE TABLE cluster_metadata ("
+            "    cluster_name TEXT PRIMARY KEY,"
+            "    cached_at TEXT NOT NULL,"
+            "    cache_version TEXT NOT NULL"
+            ")"
+        )
+        conn.execute("CREATE TABLE _schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO _schema_version (version) VALUES (4)")
+
+        # Create cloudmetadata table WITHOUT vm_name (simulates pre-#582 state)
+        conn.execute(
+            "CREATE TABLE cloudmetadata ("
+            "    cluster_name TEXT NOT NULL,"
+            "    _row_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            '    "node" TEXT,'
+            '    "instance_id" TEXT,'
+            '    "provider" TEXT,'
+            '    "region" TEXT,'
+            '    "account_id" TEXT,'
+            '    "instance_link" TEXT,'
+            '    "resource_group_link" TEXT,'
+            '    "instance_sso_link" TEXT,'
+            "    _extra_json TEXT DEFAULT NULL"
+            ")"
+        )
+
+        # Create remaining model tables so _init_db doesn't fail
+        from pynetappfoundry.cache.db_schema import (
+            _ensure_registry,
+            generate_cluster_name_index_ddl,
+            generate_table_ddl,
+            generate_uuid_column_index_ddl,
+        )
+
+        registry = _ensure_registry()
+        for spec in registry.values():
+            if spec.table_name == "cloudmetadata":
+                continue  # already created above (without vm_name)
+            ddl = generate_table_ddl(spec.table_name, spec.model_class)
+            conn.execute(ddl)
+            conn.execute(generate_cluster_name_index_ddl(spec.table_name))
+            if spec.has_uuid:
+                conn.execute(generate_uuid_column_index_ddl(spec.table_name))
+
+        conn.commit()
+        conn.close()
+
+        # Open with current code — should trigger v4→v5 migration
+        db = ClusterMetadataDB(db_path=db_path)
+
+        # Verify schema version is 5
+        cursor = db.conn.execute("SELECT version FROM _schema_version")
+        assert cursor.fetchone()[0] == 5
+
+        # Verify vm_name column exists
+        cursor = db.conn.execute("PRAGMA table_info(cloudmetadata)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "vm_name" in columns
 
         db.close()
 


### PR DESCRIPTION
## Description

Add schema migration v4→v5 that adds the `vm_name` column to the
`cloudmetadata` table. Existing v4 databases fail on cache refresh
with "table cloudmetadata has no column named vm_name" after PR #582
added `vm_name` to `CloudMetadata`.

The migration is idempotent — it checks `PRAGMA table_info` before
adding the column, so it safely handles tables already created with
the current DDL (e.g., from earlier migration chains that recreate
tables from scratch).

Addresses #584

## Related Issue

Addresses #584

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Bumped `SCHEMA_VERSION` from 4 to 5 in `ClusterMetadataDB`
- Added `_upgrade_to_v5()` migration method with idempotent column check
- Added `test_upgrade_v4_to_v5_adds_vm_name_column` test
- Updated existing migration test assertion to expect version 5

## Testing

- [x] All existing tests pass (2065 passed)
- [x] New migration test verifies column is added
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings