### PR TITLE
docs: document cache DB schema migration requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,16 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 - **Mutable Defaults**: Never use `def foo(items=[])`
 - **String Concatenation for Paths**: Use `Path` objects
 
+### Cache Schema Pitfalls
+- **Adding fields to cache models requires a DB migration**: If you add a field to any model stored in `CachedClusterMetadata` (e.g., `CloudMetadata`, `ClusterInfo`, `OntapNodeResponse`), existing SQLite databases won't have the column. You **must**:
+  1. Bump `SCHEMA_VERSION` in `src/pynetappfoundry/cache/db.py`
+  2. Add an `_upgrade_to_vN()` method that runs `ALTER TABLE <table> ADD COLUMN "<field>" <type>`
+  3. Make the migration idempotent (check `PRAGMA table_info` first) since earlier migration chains may recreate tables with the current DDL
+  4. Add a test for the migration in `tests/unit/cache/test_db.py`
+  5. Update any existing migration tests that assert the schema version number
+- **Table names**: Table names are the lowercased model class name (e.g., `CloudMetadata` → `cloudmetadata`)
+- **DDL is auto-generated**: `db_schema.py:generate_table_ddl()` generates CREATE TABLE from Pydantic model fields — new databases get the column automatically, but existing databases need the migration
+
 ### Security Pitfalls
 - **Never log secrets**: Scrub sensitive data before logging
 - **Command Injection**: Always use subprocess with list args, not shell=True

--- a/docs/development/cache-models.md
+++ b/docs/development/cache-models.md
@@ -480,20 +480,29 @@ remove its column — it just stops populating it during collection.
 3. **Requirement**: You must add a `post_collection` callable to the
    `FieldMapping` in `mapping.py`.
 
-#### Adding or removing a field from the model
+#### Adding a field to a cache model
 
-If you add or remove a field from the Pydantic model:
+If you add a field to a Pydantic model stored in `CachedClusterMetadata`:
 
-1. **Adding**: The new column won't exist in existing databases. SQLite's
-   `extra="allow"` on `CacheModel` means old rows won't break, but the
-   column won't exist until the database is recreated. Currently, a full
-   cache clear and refresh is needed: `nf cache clear`.
-2. **Removing**: The column remains in the SQL table (SQLite doesn't support
-   `DROP COLUMN` before 3.35). The column is ignored on read since
-   `_row_to_model()` only reads fields defined on the model.
+1. **New databases**: Get the column automatically — `generate_table_ddl()`
+   reads fields from the Pydantic model at import time.
+2. **Existing databases**: The column won't exist. You **must** add a schema
+   migration:
+   - Bump `SCHEMA_VERSION` in `src/pynetappfoundry/cache/db.py`
+   - Add an `_upgrade_to_vN()` method with
+     `ALTER TABLE <table> ADD COLUMN "<field>" <type>`
+   - Make it idempotent (check `PRAGMA table_info` first) — earlier
+     migration chains may recreate tables with the current DDL
+   - Add a test in `tests/unit/cache/test_db.py`
+   - Update any existing migration tests that assert the schema version
+3. **Table names**: Lowercased model class name (e.g., `CloudMetadata` →
+   `cloudmetadata`)
 
-**Future**: Schema migration support (ADR-0009) will handle adding columns
-via `ALTER TABLE ADD COLUMN` when model fields are added.
+#### Removing a field from a cache model
+
+The column remains in the SQL table (SQLite doesn't support `DROP COLUMN`
+before 3.35). The column is ignored on read since `_row_to_model()` only
+reads fields defined on the model. No migration is needed.
 
 ---
 


### PR DESCRIPTION
## Description

Document the requirement that adding fields to cache models requires a
DB schema migration, so this doesn't get missed again (as happened with
PR #582 / #584).

Addresses #586

## Related Issue

Addresses #586

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- **`AGENTS.md`**: Added "Cache Schema Pitfalls" subsection under Common Pitfalls with the full migration checklist (bump version, add migration method, make idempotent, add test, update assertions)
- **`docs/development/cache-models.md`**: Replaced outdated "full cache clear needed" / "Future: migration support" text with the actual migration procedure

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings