### PR TITLE
feat: add filter predicates to cache query syntax

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -621,9 +621,16 @@ cached snapshot.
 
 `nf cache query` retrieves a specific set of field paths from cached
 snapshots, across one or many clusters, with CSV/JSON/table output.
+Filter predicates select array items by field value using bracket syntax.
 
 ```bash
 nf cache query --all storage.volumes -F name,svm.name,size
+
+# Filter predicate — select items matching a field value
+nf cache query cluster1 'volumes["name=vol1"].size'
+
+# OR filter — match multiple values
+nf cache query cluster1 'volumes["name=vol1 || name=vol2"].size'
 ```
 
 ### Raw cache views (`nf cache show` and `nf cache inspect`)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -460,6 +460,15 @@ nf cache query --all cloud.provider cloud.region --csv
 # CSV with wildcards (expands to multiple rows)
 nf cache query cluster1 nodes[*].name nodes[*].serial_number --csv
 
+# Filter predicate (select items by field value)
+nf cache query cluster1 'volumes["name=vol1"].size'
+
+# OR filter (match multiple values)
+nf cache query cluster1 'volumes["name=vol1 || name=vol2"].size'
+
+# Single-quoted predicate (alternative syntax)
+nf cache query cluster1 "volumes['state=online'].name"
+
 # View cache schema as tree
 nf cache schema
 

--- a/src/pynetappfoundry/cli/commands/cache/query.py
+++ b/src/pynetappfoundry/cli/commands/cache/query.py
@@ -348,6 +348,15 @@ def query(
 
         # CSV with wildcards (expands to multiple rows)
         nf cache query cluster1 nodes[*].name nodes[*].serial_number --csv
+
+        # Filter predicate (select items by field value)
+        nf cache query cluster1 'volumes["name=vol1"].size'
+
+        # OR filter (match multiple values)
+        nf cache query cluster1 'volumes["name=vol1 || name=vol2"].size'
+
+        # Single-quoted predicate (alternative syntax)
+        nf cache query cluster1 "volumes['state=online'].name"
     """
     config_dir = ctx.obj.get("config_dir", "config")
 

--- a/src/pynetappfoundry/utils/dict_path.py
+++ b/src/pynetappfoundry/utils/dict_path.py
@@ -22,6 +22,9 @@ _ARRAY_INDEX_PATTERN = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\[(\d+)\]$")
 # Pattern to match wildcard array access like "nodes[*]"
 _ARRAY_WILDCARD_PATTERN = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\[\*\]$")
 
+# Pattern to match filter predicate access like nodes["name=vol1"] or nodes['name=vol1']
+_ARRAY_FILTER_PATTERN = re.compile(r"""^([a-zA-Z_][a-zA-Z0-9_]*)\[["'](.+?)["']\]$""")
+
 
 class PathNotFoundError(Exception):
     """Raised when a path cannot be resolved in a nested structure.
@@ -46,21 +49,71 @@ class PathNotFoundError(Exception):
         super().__init__(f"Path '{path}' not found at '{position}': {reason}")
 
 
+def _parse_filter_predicate(predicate: str) -> list[tuple[str, str]]:
+    """Parse a filter predicate string into field-value pairs.
+
+    Supports OR conditions separated by ``||``.
+
+    Args:
+        predicate: Filter string like ``"name=vol1"`` or ``"name=A || name=B"``.
+
+    Returns:
+        List of ``(field, value)`` tuples (values are lowercased for comparison).
+
+    Raises:
+        ValueError: If any clause is malformed (missing ``=`` or empty field name).
+    """
+    clauses = predicate.split("||")
+    conditions: list[tuple[str, str]] = []
+    for clause in clauses:
+        clause = clause.strip()
+        if "=" not in clause:
+            raise ValueError(f"Invalid filter clause (missing '='): {clause!r}")
+        field, value = clause.split("=", 1)
+        field = field.strip()
+        value = value.strip()
+        if not field:
+            raise ValueError(f"Invalid filter clause (empty field name): {clause!r}")
+        conditions.append((field, value.lower()))
+    return conditions
+
+
+def _matches_filter(item: dict[str, Any], conditions: list[tuple[str, str]]) -> bool:
+    """Check whether *item* matches any of the OR *conditions*.
+
+    Comparison is case-insensitive on the stringified value.
+
+    Args:
+        item: Dictionary to test.
+        conditions: List of ``(field, expected_value_lower)`` pairs (OR logic).
+
+    Returns:
+        True if *item* matches at least one condition.
+    """
+    for field, expected in conditions:
+        actual = item.get(field)
+        if actual is not None and str(actual).lower() == expected:
+            return True
+    return False
+
+
 def get_nested_value(data: dict[str, Any], path: str) -> Any:
     """Retrieve a value from a nested dictionary using dot notation.
 
     Supports accessing nested dictionaries and lists. Array indices can be
     specified using bracket notation (e.g., "nodes[0].name"). Wildcard syntax
-    [*] can be used to access all items in an array.
+    [*] can be used to access all items in an array. Filter predicates can be
+    used to select items matching field values (e.g., ``nodes["name=node-01"]``).
 
     Args:
         data: The dictionary to traverse.
         path: Dot-notation path (e.g., "cloud.instance_type", "nodes[0].name",
-              "nodes[*].name" for wildcard access).
+              "nodes[*].name" for wildcard access,
+              ``nodes["name=node-01"].uptime`` for filter predicate access).
 
     Returns:
-        The value at the specified path. For wildcard paths, returns a list
-        of values from all array items.
+        The value at the specified path. For wildcard and filter predicate
+        paths, returns a list of values from matching array items.
 
     Raises:
         PathNotFoundError: If the path cannot be resolved.
@@ -77,6 +130,13 @@ def get_nested_value(data: dict[str, Any], path: str) -> Any:
         >>> data = {"nodes": [{"name": "node-01"}, {"name": "node-02"}]}
         >>> get_nested_value(data, "nodes[*].name")
         ['node-01', 'node-02']
+
+        >>> data = {"vols": [{"name": "v1", "size": 100}, {"name": "v2", "size": 200}]}
+        >>> get_nested_value(data, 'vols["name=v1"].size')
+        [100]
+
+        >>> get_nested_value(data, 'vols["name=v1 || name=v2"].size')
+        [100, 200]
     """
     if not path:
         raise PathNotFoundError(path, "", "empty path")
@@ -137,6 +197,52 @@ def get_nested_value(data: dict[str, Any], path: str) -> Any:
             else:
                 # No remaining path, return all items
                 return list(array)
+
+        # Check for filter predicate pattern like nodes["name=vol1"]
+        filter_match = _ARRAY_FILTER_PATTERN.match(part)
+        if filter_match:
+            key = filter_match.group(1)
+            predicate = filter_match.group(2)
+
+            # First access the key
+            if not isinstance(current, dict):
+                raise PathNotFoundError(
+                    path,
+                    ".".join(traversed) or "(root)",
+                    f"expected dict, got {type(current).__name__}",
+                )
+            if key not in current:
+                raise PathNotFoundError(
+                    path,
+                    ".".join([*traversed, key]) if traversed else key,
+                    "key not found",
+                )
+
+            array = current[key]
+            if not isinstance(array, list):
+                raise PathNotFoundError(
+                    path,
+                    ".".join([*traversed, key]) if traversed else key,
+                    f"expected list for filter access, got {type(array).__name__}",
+                )
+
+            conditions = _parse_filter_predicate(predicate)
+            filtered = [
+                item
+                for item in array
+                if isinstance(item, dict) and _matches_filter(item, conditions)
+            ]
+
+            # Get remaining path after the filter
+            remaining_parts = parts[i + 1 :]
+            if remaining_parts:
+                remaining_path = ".".join(remaining_parts)
+                results = []
+                for item in filtered:
+                    results.append(get_nested_value({"_": item}, f"_.{remaining_path}"))
+                return results
+            else:
+                return filtered
 
         # Check for array index pattern like "nodes[0]"
         match = _ARRAY_INDEX_PATTERN.match(part)

--- a/tests/benchmarks/test_bench_dict_path.py
+++ b/tests/benchmarks/test_bench_dict_path.py
@@ -75,3 +75,9 @@ def test_bench_multi_field_extraction(benchmark: Any, nested_api_response: dict[
         return [get_nested_value(nested_api_response, p) for p in paths]
 
     benchmark(extract_all)
+
+
+@pytest.mark.benchmark(group="dict_path")
+def test_bench_filter_predicate(benchmark: Any, nested_api_response: dict[str, Any]) -> None:
+    """Filter predicate access: nodes["name=node-01"].uptime (4 items, 1 match)."""
+    benchmark(get_nested_value, nested_api_response, 'nodes["name=node-01"].uptime')

--- a/tests/unit/utils/test_dict_path.py
+++ b/tests/unit/utils/test_dict_path.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from pynetappfoundry.utils.dict_path import PathNotFoundError, get_nested_value
+from pynetappfoundry.utils.dict_path import (
+    PathNotFoundError,
+    _parse_filter_predicate,
+    get_nested_value,
+)
 
 
 class TestGetNestedValue:
@@ -315,3 +319,140 @@ class TestEdgeCases:
         assert get_nested_value(data, "clusters[0].name") == "cluster-1"
         assert get_nested_value(data, "clusters[0].nodes[1].cpus") == 8
         assert get_nested_value(data, "clusters[1].nodes[0].name") == "node-c"
+
+
+class TestParseFilterPredicate:
+    """Tests for _parse_filter_predicate helper."""
+
+    def test_simple_predicate(self) -> None:
+        """Single field=value clause."""
+        assert _parse_filter_predicate("name=vol1") == [("name", "vol1")]
+
+    def test_or_predicate(self) -> None:
+        """Multiple clauses joined by ||."""
+        result = _parse_filter_predicate("name=A || name=B")
+        assert result == [("name", "a"), ("name", "b")]
+
+    def test_whitespace_variations(self) -> None:
+        """Whitespace around || should not matter."""
+        assert _parse_filter_predicate("name=A||name=B") == [("name", "a"), ("name", "b")]
+        assert _parse_filter_predicate("name=A  ||  name=B") == [("name", "a"), ("name", "b")]
+
+    def test_value_with_spaces(self) -> None:
+        """Value may contain spaces."""
+        assert _parse_filter_predicate("name=my volume") == [("name", "my volume")]
+
+    def test_value_with_equals(self) -> None:
+        """Split on first = only; value may contain =."""
+        assert _parse_filter_predicate("desc=a=b") == [("desc", "a=b")]
+
+    def test_empty_field_raises(self) -> None:
+        """Empty field name before = is invalid."""
+        with pytest.raises(ValueError, match="empty field name"):
+            _parse_filter_predicate("=value")
+
+    def test_no_equals_raises(self) -> None:
+        """Clause without = is invalid."""
+        with pytest.raises(ValueError, match="missing '='"):
+            _parse_filter_predicate("justtext")
+
+
+class TestFilterPredicateAccess:
+    """Tests for filter predicate access via get_nested_value."""
+
+    @pytest.fixture
+    def volumes_data(self) -> dict[str, list[dict[str, object]]]:
+        """Sample data with a volumes list."""
+        return {
+            "volumes": [
+                {"name": "vol1", "size": 100, "state": "online"},
+                {"name": "vol2", "size": 200, "state": "online"},
+                {"name": "vol3", "size": 300, "state": "offline"},
+            ]
+        }
+
+    def test_single_match(self, volumes_data: dict[str, object]) -> None:
+        """Filter matching one item returns single-element list."""
+        assert get_nested_value(volumes_data, 'volumes["name=vol1"].size') == [100]
+
+    def test_multiple_matches(self, volumes_data: dict[str, object]) -> None:
+        """Filter matching multiple items returns all matching values."""
+        result = get_nested_value(volumes_data, 'volumes["state=online"].name')
+        assert result == ["vol1", "vol2"]
+
+    def test_no_matches(self, volumes_data: dict[str, object]) -> None:
+        """Filter with no matches returns empty list."""
+        assert get_nested_value(volumes_data, 'volumes["name=nonexistent"].size') == []
+
+    def test_or_filter(self, volumes_data: dict[str, object]) -> None:
+        """OR filter matches multiple named items."""
+        result = get_nested_value(volumes_data, 'volumes["name=vol1 || name=vol2"].size')
+        assert result == [100, 200]
+
+    def test_case_insensitive(self, volumes_data: dict[str, object]) -> None:
+        """Filter comparison is case-insensitive."""
+        assert get_nested_value(volumes_data, 'volumes["name=VOL1"].size') == [100]
+
+    def test_no_remaining_path(self, volumes_data: dict[str, object]) -> None:
+        """Filter without remaining path returns full matching dicts."""
+        result = get_nested_value(volumes_data, 'volumes["name=vol1"]')
+        assert result == [{"name": "vol1", "size": 100, "state": "online"}]
+
+    def test_nested_prefix(self, volumes_data: dict[str, object]) -> None:
+        """Filter works with nested dict prefix."""
+        data = {"storage": volumes_data}
+        assert get_nested_value(data, 'storage.volumes["name=vol1"].size') == [100]
+
+    def test_single_quoted_predicate(self, volumes_data: dict[str, object]) -> None:
+        """Single-quoted predicate syntax works."""
+        assert get_nested_value(volumes_data, "volumes['name=vol1'].size") == [100]
+
+    def test_empty_array(self) -> None:
+        """Filter on empty array returns empty list."""
+        data: dict[str, list[object]] = {"volumes": []}
+        assert get_nested_value(data, 'volumes["name=vol1"]') == []
+
+    def test_non_dict_items_skipped(self) -> None:
+        """Non-dict items in the array are silently skipped."""
+        data: dict[str, list[object]] = {
+            "items": [
+                "not-a-dict",
+                {"name": "vol1", "size": 100},
+                42,
+            ]
+        }
+        assert get_nested_value(data, 'items["name=vol1"].size') == [100]
+
+    def test_missing_filter_field_excludes_item(self) -> None:
+        """Items without the filter field are excluded."""
+        data = {
+            "volumes": [
+                {"name": "vol1", "size": 100},
+                {"size": 200},  # no 'name' field
+            ]
+        }
+        assert get_nested_value(data, 'volumes["name=vol1"].size') == [100]
+
+    def test_filter_on_non_list_raises(self) -> None:
+        """Filter on non-list value raises PathNotFoundError."""
+        data = {"config": {"name": "test"}}
+        with pytest.raises(PathNotFoundError, match="expected list for filter access"):
+            get_nested_value(data, 'config["name=test"]')
+
+    def test_missing_key_raises(self) -> None:
+        """Filter on missing key raises PathNotFoundError."""
+        data = {"volumes": [{"name": "vol1"}]}
+        with pytest.raises(PathNotFoundError, match="key not found"):
+            get_nested_value(data, 'missing["name=vol1"]')
+
+    def test_index_still_works(self, volumes_data: dict[str, object]) -> None:
+        """Index access [0] still works alongside filter predicates."""
+        assert get_nested_value(volumes_data, "volumes[0].name") == "vol1"
+
+    def test_wildcard_still_works(self, volumes_data: dict[str, object]) -> None:
+        """Wildcard [*] still works alongside filter predicates."""
+        assert get_nested_value(volumes_data, "volumes[*].name") == [
+            "vol1",
+            "vol2",
+            "vol3",
+        ]


### PR DESCRIPTION
## Description

Add filter predicate syntax to `get_nested_value` so that `nf cache query`
(and any other caller) can select array items by field value. The new
bracket syntax supports equality matching and OR conditions:

- `nodes["name=node-01"].uptime` -- select by field value
- `volumes["name=v1 || name=v2"].size` -- OR across multiple values
- Both single- and double-quoted predicates are accepted

Comparison is case-insensitive on the stringified value.

## Related Issue

Addresses #190

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `_ARRAY_FILTER_PATTERN` regex and `_parse_filter_predicate` / `_matches_filter` helpers to `utils/dict_path.py`
- Integrated filter predicate resolution into `get_nested_value` traversal loop
- Added filter predicate examples to `nf cache query` CLI help text
- Updated `docs/reference/cli.md` with filter predicate query examples
- Updated `docs/reference/cache.md` with filter predicate syntax and examples
- Added 22 unit tests covering equality, OR, case-insensitivity, nested paths, error cases, and edge cases
- Added filter predicate benchmark to `test_bench_dict_path.py`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
