### PR TITLE
feat: add glob matching to filter predicate values

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -631,6 +631,9 @@ nf cache query cluster1 'volumes["name=vol1"].size'
 
 # OR filter — match multiple values
 nf cache query cluster1 'volumes["name=vol1 || name=vol2"].size'
+
+# Glob pattern — match by substring or pattern (* and ? supported)
+nf cache query cluster1 'volumes["name=*PROD*"].size'
 ```
 
 ### Raw cache views (`nf cache show` and `nf cache inspect`)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -466,6 +466,9 @@ nf cache query cluster1 'volumes["name=vol1"].size'
 # OR filter (match multiple values)
 nf cache query cluster1 'volumes["name=vol1 || name=vol2"].size'
 
+# Glob pattern (match by substring or pattern, * and ? supported)
+nf cache query cluster1 'volumes["name=*PROD*"].size'
+
 # Single-quoted predicate (alternative syntax)
 nf cache query cluster1 "volumes['state=online'].name"
 

--- a/src/pynetappfoundry/utils/dict_path.py
+++ b/src/pynetappfoundry/utils/dict_path.py
@@ -13,6 +13,7 @@ Example:
 
 from __future__ import annotations
 
+import fnmatch
 import re
 from typing import Any
 
@@ -81,7 +82,10 @@ def _parse_filter_predicate(predicate: str) -> list[tuple[str, str]]:
 def _matches_filter(item: dict[str, Any], conditions: list[tuple[str, str]]) -> bool:
     """Check whether *item* matches any of the OR *conditions*.
 
-    Comparison is case-insensitive on the stringified value.
+    Comparison is case-insensitive on the stringified value.  If *expected*
+    contains ``*`` or ``?`` glob characters, matching is performed with
+    :func:`fnmatch.fnmatchcase` (against the lowercased actual value);
+    otherwise an exact ``==`` comparison is used.
 
     Args:
         item: Dictionary to test.
@@ -92,8 +96,13 @@ def _matches_filter(item: dict[str, Any], conditions: list[tuple[str, str]]) -> 
     """
     for field, expected in conditions:
         actual = item.get(field)
-        if actual is not None and str(actual).lower() == expected:
-            return True
+        if actual is not None:
+            actual_lower = str(actual).lower()
+            if "*" in expected or "?" in expected:
+                if fnmatch.fnmatchcase(actual_lower, expected):
+                    return True
+            elif actual_lower == expected:
+                return True
     return False
 
 
@@ -104,6 +113,8 @@ def get_nested_value(data: dict[str, Any], path: str) -> Any:
     specified using bracket notation (e.g., "nodes[0].name"). Wildcard syntax
     [*] can be used to access all items in an array. Filter predicates can be
     used to select items matching field values (e.g., ``nodes["name=node-01"]``).
+    Filter values may contain glob patterns (``*`` and ``?``) for pattern
+    matching (e.g., ``volumes["name=*Store*"]``).
 
     Args:
         data: The dictionary to traverse.
@@ -136,6 +147,9 @@ def get_nested_value(data: dict[str, Any], path: str) -> Any:
         [100]
 
         >>> get_nested_value(data, 'vols["name=v1 || name=v2"].size')
+        [100, 200]
+
+        >>> get_nested_value(data, 'vols["name=v*"].size')
         [100, 200]
     """
     if not path:

--- a/tests/unit/utils/test_dict_path.py
+++ b/tests/unit/utils/test_dict_path.py
@@ -456,3 +456,26 @@ class TestFilterPredicateAccess:
             "vol2",
             "vol3",
         ]
+
+    def test_glob_star_wildcard(self, volumes_data: dict[str, object]) -> None:
+        """Glob * pattern matches substring."""
+        assert get_nested_value(volumes_data, 'volumes["name=*ol1"].size') == [100]
+
+    def test_glob_question_mark(self, volumes_data: dict[str, object]) -> None:
+        """Glob ? pattern matches single character."""
+        result = get_nested_value(volumes_data, 'volumes["state=onlin?"].name')
+        assert result == ["vol1", "vol2"]
+
+    def test_glob_contains_pattern(self, volumes_data: dict[str, object]) -> None:
+        """Glob *substring* matches multiple items."""
+        result = get_nested_value(volumes_data, 'volumes["name=*ol*"].name')
+        assert result == ["vol1", "vol2", "vol3"]
+
+    def test_glob_case_insensitive(self, volumes_data: dict[str, object]) -> None:
+        """Glob matching is case-insensitive."""
+        assert get_nested_value(volumes_data, 'volumes["name=*OL1"].size') == [100]
+
+    def test_glob_or_filter(self, volumes_data: dict[str, object]) -> None:
+        """OR filter with glob patterns."""
+        result = get_nested_value(volumes_data, 'volumes["name=vol1* || state=offline"].name')
+        assert result == ["vol1", "vol3"]


### PR DESCRIPTION
## Description

Add glob pattern matching (`*`, `?`) to filter predicate values in
`get_nested_value()`. Values containing `*` or `?` use `fnmatch.fnmatchcase()`
for matching; values without glob characters use exact equality as before.

```bash
nf cache query --all 'storage.volumes["name=*Name*"].autosize.mode'
nf cache query --all 'storage.volumes["name=PROD*"].size'
```

Addresses #589

## Related Issue

Addresses #589

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `fnmatch` import and glob-aware comparison in `_matches_filter()` in `dict_path.py`
- Added 5 glob tests to `TestFilterPredicateAccess` (star, question mark, contains, case-insensitive, OR with glob)
- Added glob examples to `docs/reference/cache.md` and `docs/reference/cli.md`

## Testing

- [x] All existing tests pass
- [x] Added new tests for glob functionality
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings