### PR TITLE
fix: skip empty list results in cache query --all

### DIFF
--- a/src/pynetappfoundry/cli/commands/cache/query.py
+++ b/src/pynetappfoundry/cli/commands/cache/query.py
@@ -458,6 +458,9 @@ def query(
             if error:
                 errors.append(f"{name}: {error}")
             else:
+                # Skip empty lists (no filter/wildcard matches)
+                if isinstance(value, list) and len(value) == 0:
+                    continue
                 cluster_results[field] = value
 
         if cluster_results:
@@ -472,8 +475,8 @@ def query(
         ctx.exit(1)
 
     if not results:
-        print_error("No results found.")
-        ctx.exit(1)
+        print_warning("No results found.")
+        ctx.exit(0)
 
     # Print warnings for any errors that occurred but we still have some results
     for err in errors:


### PR DESCRIPTION
Fixes #592

When using `nf cache query --all` with filter predicates or wildcards that match no items, empty `[]` results were treated as valid values — causing every cluster to appear in output with `field: []`.

**Changes:**
1. Skip empty list results in the result collection loop — if a field resolves to `[]`, it is omitted from that cluster results
2. Skip clusters with no meaningful field values remaining
3. Change "No results found" from error exit(1) to warning exit(0) — no matches is a normal condition, not an error