### PR TITLE
fix: skip clusters with empty query results in cache query

### DIFF
--- a/src/pynetappfoundry/cli/commands/cache/query.py
+++ b/src/pynetappfoundry/cli/commands/cache/query.py
@@ -457,6 +457,8 @@ def query(
             value, error = _get_field_value(data, field)
             if error:
                 errors.append(f"{name}: {error}")
+            elif isinstance(value, list) and not value:
+                continue
             else:
                 cluster_results[field] = value
 

--- a/tests/unit/cli/commands/cache/test_query.py
+++ b/tests/unit/cli/commands/cache/test_query.py
@@ -1169,3 +1169,208 @@ base_api_path = "/api"
 
         assert result.exit_code == 0
         assert result.output.strip() == "9.14.1"
+
+
+class TestEmptyResultSkipping:
+    """Empty list results (no filter matches, empty wildcard arrays) are skipped."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_config_dir(self, tmp_path: Path) -> Path:
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.toml").write_text(
+            """
+[ontapapi]
+[ontapapi.general]
+base_api_path = "/api"
+"""
+        )
+        return config_dir
+
+    def _metadata(self, name: str, node_names: list[str]) -> CachedClusterMetadata:
+        return CachedClusterMetadata(
+            cluster_name=name,
+            cached_at=datetime(2024, 1, 15, tzinfo=UTC),
+            nodes=[OntapNodeResponse(name=n, serial_number=f"SN-{n}") for n in node_names],
+        )
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_filter_no_match_single_cluster_errors(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Single cluster with no filter matches yields 'No results found.'"""
+        mock_db = MagicMock()
+        mock_db.get_lazy.return_value = _make_lazy_mock(self._metadata("c1", ["node-01"]))
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "c1",
+                'nodes["name=does-not-exist"].serial_number',
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "No results found" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_filter_no_match_all_clusters_skipped(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """--all skips clusters whose filter result is empty, shows only matching ones."""
+        mock_db = MagicMock()
+        mock_db.list_clusters.return_value = [
+            {"cluster_name": "c1"},
+            {"cluster_name": "c2"},
+        ]
+        meta1 = self._metadata("c1", ["node-01", "node-02"])
+        meta2 = self._metadata("c2", ["other-99"])
+        mock_db.get_lazy.side_effect = lambda n: (
+            _make_lazy_mock(meta1) if n == "c1" else _make_lazy_mock(meta2)
+        )
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "--all",
+                'nodes["name=node-01"].serial_number',
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "c1:" in result.output
+        assert "c2:" not in result.output
+        assert "[]" not in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_filter_no_match_all_clusters_json(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """--all --json omits clusters with empty filter results entirely."""
+        mock_db = MagicMock()
+        mock_db.list_clusters.return_value = [
+            {"cluster_name": "c1"},
+            {"cluster_name": "c2"},
+        ]
+        meta1 = self._metadata("c1", ["node-01"])
+        meta2 = self._metadata("c2", ["other-99"])
+        mock_db.get_lazy.side_effect = lambda n: (
+            _make_lazy_mock(meta1) if n == "c1" else _make_lazy_mock(meta2)
+        )
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "--all",
+                'nodes["name=node-01"].serial_number',
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output == {"c1": {'nodes["name=node-01"].serial_number': ["SN-node-01"]}}
+        assert "c2" not in output
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_filter_no_match_all_clusters_csv(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """--all --csv omits rows for clusters with empty filter results."""
+        mock_db = MagicMock()
+        mock_db.list_clusters.return_value = [
+            {"cluster_name": "c1"},
+            {"cluster_name": "c2"},
+        ]
+        meta1 = self._metadata("c1", ["node-01"])
+        meta2 = self._metadata("c2", ["other-99"])
+        mock_db.get_lazy.side_effect = lambda n: (
+            _make_lazy_mock(meta1) if n == "c1" else _make_lazy_mock(meta2)
+        )
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "--all",
+                'nodes["name=node-01"].serial_number',
+                "--csv",
+            ],
+        )
+
+        assert result.exit_code == 0
+        lines = [ln for ln in result.output.strip().split("\n") if ln]
+        assert lines[0] == 'cluster,"nodes[""name=node-01""].serial_number"'
+        assert any(ln.startswith("c1,") for ln in lines[1:])
+        assert not any(ln.startswith("c2,") for ln in lines[1:])
+
+    @patch("pynetappfoundry.cli.commands.cache.query.ClusterMetadataDB")
+    def test_empty_wildcard_array_skipped(
+        self,
+        mock_db_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir: Path,
+    ) -> None:
+        """Wildcard over an empty array is treated as no match and skipped."""
+        mock_db = MagicMock()
+        mock_db.list_clusters.return_value = [
+            {"cluster_name": "c1"},
+            {"cluster_name": "c2"},
+        ]
+        meta1 = self._metadata("c1", ["node-01"])
+        meta2 = self._metadata("c2", [])
+        mock_db.get_lazy.side_effect = lambda n: (
+            _make_lazy_mock(meta1) if n == "c1" else _make_lazy_mock(meta2)
+        )
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir),
+                "cache",
+                "query",
+                "--all",
+                "nodes[*].name",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "c1:" in result.output
+        assert "c2:" not in result.output


### PR DESCRIPTION
## Description

When a cache query field resolves to an empty list (filter predicate with no matches, or wildcard over an empty array), omit that field from the cluster's results. Clusters with no remaining fields are dropped, so `nf cache query --all` no longer shows clusters with spurious `field: []` entries.

## Related Issue

Addresses #592

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/pynetappfoundry/cli/commands/cache/query.py`: skip empty-list field values in the per-cluster result loop; clusters whose entire result set ends up empty are excluded from output.
- `tests/unit/cli/commands/cache/test_query.py`: new `TestEmptyResultSkipping` class covering single-cluster (errors with "No results found"), `--all` default output, `--all --json`, `--all --csv`, and an empty-array wildcard.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes (`doit check` green)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Replaces #593 (closed) which proposed an equivalent fix without test coverage.
