### PR TITLE
feat: add parallel cluster processing to cache refresh

### DIFF
--- a/docs/decisions/0014-parallel-cluster-refresh.md
+++ b/docs/decisions/0014-parallel-cluster-refresh.md
@@ -1,0 +1,119 @@
+# ADR-0014: Parallel Cluster Refresh
+
+## Status
+
+Accepted
+
+## Decision
+
+`nf cache refresh --all` accepts a `--parallel-clusters N` flag (default `4`,
+minimum `1`). When `N > 1`, clusters are collected concurrently using a
+`ThreadPoolExecutor`; when `N == 1`, the command executes the historical
+strictly-sequential code path unchanged.
+
+The implementation follows a **workers collect, main thread persists** split:
+
+- `_collect_cluster()` — worker-safe. Builds API/CLI clients, reads the
+  previous history snapshot, runs `MetadataCollector.collect_all()`, and (in
+  verbose mode) captures its own phase output into a Rich `Console(record=True)`
+  buffer. Returns a `_CollectResult` dataclass; never touches `ClusterMetadataDB`
+  or `CacheHistoryDB` for writes.
+- `_persist_cluster()` — main-thread only. Computes the diff via
+  `compute_diff()`, records history via `history_db.record_change()`, and
+  writes the cache via `db.set()`. All database writes for every cluster flow
+  through this function on the main thread.
+
+For verbose parallel mode, each worker's captured buffer is flushed as a
+single block on the main thread when its future completes, keeping per-cluster
+output coherent. Cluster blocks may appear in any completion order; the
+internal structure of each block (phase lines, summary) is preserved.
+
+## Rationale
+
+1. **SQLite single connection is not thread-safe.** `ClusterMetadataDB` keeps
+   a single shared connection (`src/pynetappfoundry/cache/db.py:301`). Sharing
+   it across threads is unsupported. Serialising every write on the main
+   thread preserves the existing substrate with no cache-layer changes.
+
+2. **Cluster collection is already independent.** Each cluster has its own
+   API/CLI clients, its own configuration lookup, and no inter-cluster derived
+   fields. Inter-phase ordering inside a cluster is already handled by the
+   inner parallelism in `MetadataCollector._collect_all_parallel()`
+   (`src/pynetappfoundry/cache/collector.py:605`), with `CLOUD` running
+   sequentially after parallel phases. Outer cluster-level parallelism adds
+   no new coordination.
+
+3. **Workload is I/O-bound.** Per-cluster wall time is dominated by REST API
+   calls and SSH round trips. Threads (not processes) are the right tool.
+
+4. **4 × default expected speedup.** With 66+ clusters at ~1–2s each, a full
+   refresh takes 66–132s sequentially. Four parallel workers reduce that to
+   ~12–24s without increasing cache-layer surface area.
+
+5. **`N == 1` preserves historical behaviour.** The sequential path remains
+   in `_process_cluster()` unchanged, so users who want the old ordering or
+   who hit an unforeseen parallelism bug can opt out with no behavioural
+   difference. Existing tests on the sequential path continue to pass.
+
+6. **Inner collector concurrency is unchanged.** `max_workers=8` inside
+   `MetadataCollector` is retained. At default settings peak concurrency is
+   roughly `4 × 8 = 32` worker threads, which is comfortable for a CLI tool
+   against one API server per cluster.
+
+### Consequences
+
+**Positive:**
+
+- 4 × default speedup on `nf cache refresh --all` with no cache-schema or
+  collector changes.
+- No new DB-threading surface area — the cache substrate is unchanged.
+- Failure of one cluster does not block others; each future is independent
+  and its failure is reported in the existing failure summary.
+- Opt-out (`--parallel-clusters 1`) is a stable fallback.
+
+**Negative:**
+
+- In parallel verbose mode, cluster blocks complete in non-deterministic
+  order (by wall-clock). The per-cluster block is internally coherent, but
+  the overall ordering is not the configuration order.
+- Peak connection count per host is higher; clusters that share an egress
+  proxy or have per-client rate limits may need to lower `--parallel-clusters`.
+- Log lines from parallel workers interleave in the log file; per-cluster
+  context is carried via a `[cluster_name]` prefix on refresh-level logs.
+
+**Neutral:**
+
+- Single-cluster invocations (`nf cache refresh c1`) always use the
+  sequential path regardless of the flag — no change in behaviour.
+- `N` is clamped to `min(N, len(clusters_to_refresh))` so a large `N` with
+  a small fleet does not oversubscribe the executor.
+
+### Alternatives Considered
+
+- **Share the SQLite connection across threads.** Rejected: requires changing
+  `ClusterMetadataDB` and all downstream code to use a connection-per-thread
+  or a lock-wrapped connection. Touches the cache substrate for a benefit
+  (parallel writes) that is not needed — writes are short and fast compared
+  to the collection phase.
+- **One connection per worker thread.** Rejected: still requires substrate
+  changes, and SQLite's write serialisation means concurrent writers don't
+  gain throughput anyway.
+- **Process pool instead of thread pool.** Rejected: the workload is I/O
+  bound, processes add pickling overhead for the `Config` object and
+  API/CLI clients, and would complicate the single-connection DB writes.
+- **Keep the existing sequential behaviour.** Rejected: 66+ clusters at
+  1–2s each is a real operational pain point (issue #149).
+
+## Related Issues
+
+- Issue #149: feat: parallelize cluster refresh in `nf cache refresh --all`
+
+## Related Documentation
+
+- [ADR-0001: Use SQLite for cluster metadata caching](0001-use-sqlite-for-cluster-metadata-caching.md)
+- [ADR-0003: Use base SQLiteDB class with version-based migrations](0003-use-base-sqlitedb-class-with-version-based-migrations.md)
+- [Cache System Reference](../reference/cache.md)
+- CLI command: `nf cache refresh --all [--parallel-clusters N]`
+- Source: `src/pynetappfoundry/cli/commands/cache/refresh.py` (`_collect_cluster`, `_persist_cluster`)
+- Source: `src/pynetappfoundry/cache/collector.py` (inner per-phase parallelism)
+- Source: `src/pynetappfoundry/cache/db.py` (single SQLite connection)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -75,3 +75,7 @@ Template-inherited ADRs (9XXX range) are maintained in [docs/template/decisions/
 | [0008](0008-openapi-codegen-for-model-generation.md) | OpenAPI codegen for model and mapping generation | Accepted |
 | [0009](0009-sql-table-storage.md) | Per-Model SQL Table Storage for Cache Layer | Accepted |
 | [0010](0010-clusterentry-and-namespace-access-pattern.md) | ClusterEntry and namespace access pattern | Accepted |
+| [0011](0011-nested-models-to-replace-flat-model-pattern.md) | Nested models to replace flat model pattern | Accepted |
+| [0012](0012-unified-datasource-accessor.md) | Unified DataSource Accessor for All Cluster Reads | Superseded |
+| [0013](0013-datasource-as-a-thin-facade-over-the-collector.md) | DataSource as a Thin Facade Over the Collector | Proposed |
+| [0014](0014-parallel-cluster-refresh.md) | Parallel Cluster Refresh | Accepted |

--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -526,7 +526,18 @@ nf cache refresh --all -f '{"env": "Prod"}'
 
 # Verbose mode (show phase-by-phase progress)
 nf cache refresh --all -v
+
+# Parallel cluster processing (default: 4 workers)
+nf cache refresh --all --parallel-clusters 8
+
+# Disable cluster-level parallelism (strictly sequential)
+nf cache refresh --all --parallel-clusters 1
 ```
+
+Cluster collection runs in parallel by default (4 workers). Database writes
+are serialised on the main thread for SQLite thread-safety. In verbose
+parallel mode each cluster's phase output is buffered and flushed as a
+coherent block on completion; blocks may appear in any order.
 
 ### View history
 

--- a/src/pynetappfoundry/cli/commands/cache/refresh.py
+++ b/src/pynetappfoundry/cli/commands/cache/refresh.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from pathlib import Path
 
 import click
@@ -101,6 +104,24 @@ class VerboseProgressDisplay:
         self.console.print(f"  [dim]`-[/dim] Total: {total_time:.1f}s {status}")
 
 
+@dataclass
+class _CollectResult:
+    """Result of a worker-thread cluster collection.
+
+    Carries everything the main thread needs to persist the result (diff,
+    history write, cache write) plus any verbose output captured during
+    collection so it can be replayed coherently on the main thread.
+    """
+
+    cluster_name: str
+    metadata: CachedClusterMetadata | None
+    previous_metadata: CachedClusterMetadata | None
+    captured_output: str
+    success: bool
+    error: Exception | None
+    no_clients: bool
+
+
 @click.command()
 @click.argument("cluster", required=False)
 @click.option(
@@ -122,6 +143,17 @@ class VerboseProgressDisplay:
     is_flag=True,
     help="Show detailed progress for each collection phase.",
 )
+@click.option(
+    "--parallel-clusters",
+    "parallel_clusters",
+    type=click.IntRange(min=1),
+    default=4,
+    show_default=True,
+    help=(
+        "Number of clusters to process in parallel (with --all). "
+        "Use 1 to disable parallelism and preserve strictly sequential behaviour."
+    ),
+)
 @click.pass_context
 def refresh(
     ctx: click.Context,
@@ -129,6 +161,7 @@ def refresh(
     refresh_all: bool,
     filter_str: str | None,
     verbose: bool,
+    parallel_clusters: int,
 ) -> None:
     """Refresh the metadata cache for cluster(s).
 
@@ -142,6 +175,7 @@ def refresh(
         nf cache refresh --all         # Refresh all clusters
         nf cache refresh --all -v      # Refresh all with detailed progress
         nf cache refresh --all -f '{"env": "Prod"}'  # Refresh only Prod clusters
+        nf cache refresh --all --parallel-clusters 8  # More concurrency
     """
     # Always set up file logging
     _, log_file = setup_logger("cache-refresh")
@@ -206,6 +240,11 @@ def refresh(
     db = ClusterMetadataDB(config=config)
     history_db = CacheHistoryDB(config=config)
 
+    # Single-cluster path always runs sequentially regardless of the flag.
+    effective_workers = (
+        1 if len(clusters_to_refresh) <= 1 else min(parallel_clusters, len(clusters_to_refresh))
+    )
+
     console.print(f"\nRefreshing cache for {len(clusters_to_refresh)} cluster(s)...")
     if filter_dict:
         console.print(f"[dim]Filter: {filter_str}[/dim]")
@@ -216,14 +255,17 @@ def refresh(
         )
     else:
         logger.info("Refreshing cache for %d cluster(s)", len(clusters_to_refresh))
+    if effective_workers > 1:
+        console.print(f"[dim]Parallel workers: {effective_workers}[/dim]")
+        logger.info("Parallel workers: %d", effective_workers)
     console.print(f"[dim]Log file: {log_file}[/dim]\n")
 
     if verbose:
         # Verbose mode: detailed phase-by-phase progress
-        _refresh_verbose(ctx, config, db, history_db, clusters_to_refresh)
+        _refresh_verbose(ctx, config, db, history_db, clusters_to_refresh, effective_workers)
     else:
         # Normal mode: spinner per cluster
-        _refresh_normal(ctx, config, db, history_db, clusters_to_refresh)
+        _refresh_normal(ctx, config, db, history_db, clusters_to_refresh, effective_workers)
 
     db.close()
     history_db.close()
@@ -276,6 +318,7 @@ def _refresh_normal(
     db: ClusterMetadataDB,
     history_db: CacheHistoryDB,
     clusters_to_refresh: list[str],
+    workers: int,
 ) -> None:
     """Refresh clusters with spinner progress (normal mode).
 
@@ -285,37 +328,93 @@ def _refresh_normal(
         db: Cache database.
         history_db: History database.
         clusters_to_refresh: List of cluster names.
+        workers: Number of parallel cluster workers (1 = sequential).
     """
     success_count = 0
     error_count = 0
     failures: dict[str, list[str]] = {}
 
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        console=console,
-    ) as progress:
-        for cluster_name in clusters_to_refresh:
-            task = progress.add_task(f"Collecting metadata for {cluster_name}...", total=1)
-            logger.info("Processing cluster: %s", cluster_name)
+    if workers <= 1:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+        ) as progress:
+            for cluster_name in clusters_to_refresh:
+                task = progress.add_task(f"Collecting metadata for {cluster_name}...", total=1)
+                logger.info("Processing cluster: %s", cluster_name)
 
-            try:
-                success = _process_cluster(config, db, history_db, cluster_name, verbose=False)
-                if success:
-                    print_success(f"  {cluster_name}: Cache refreshed")
-                    success_count += 1
-                else:
+                try:
+                    success = _process_cluster(config, db, history_db, cluster_name, verbose=False)
+                    if success:
+                        print_success(f"  {cluster_name}: Cache refreshed")
+                        success_count += 1
+                    else:
+                        error_count += 1
+                        failures.setdefault(cluster_name, []).append("No clients available")
+
+                except Exception as e:
+                    print_exception(f"  {cluster_name}: Failed - {e}", e)
+                    logger.exception("Failed to process cluster %s", cluster_name)
+                    error_count += 1
+                    category, detail = _categorize_failure(e)
+                    failures.setdefault(cluster_name, []).append(f"{category}: {detail}")
+
+                progress.update(task, completed=1)
+    else:
+        # Parallel path: workers collect, main thread persists.
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            future_map = {
+                executor.submit(
+                    _collect_cluster,
+                    config,
+                    history_db,
+                    cluster_name,
+                    verbose=False,
+                ): cluster_name
+                for cluster_name in clusters_to_refresh
+            }
+            for future in as_completed(future_map):
+                cluster_name = future_map[future]
+                try:
+                    result = future.result()
+                except Exception as e:  # pragma: no cover - defensive
+                    print_exception(f"  {cluster_name}: Failed - {e}", e)
+                    logger.exception("Failed to process cluster %s", cluster_name)
+                    error_count += 1
+                    category, detail = _categorize_failure(e)
+                    failures.setdefault(cluster_name, []).append(f"{category}: {detail}")
+                    continue
+
+                if result.no_clients:
+                    print_error(f"  No clients available for {cluster_name}")
+                    logger.error("No clients available for %s", cluster_name)
                     error_count += 1
                     failures.setdefault(cluster_name, []).append("No clients available")
+                    continue
 
-            except Exception as e:
-                print_exception(f"  {cluster_name}: Failed - {e}", e)
-                logger.exception("Failed to process cluster %s", cluster_name)
-                error_count += 1
-                category, detail = _categorize_failure(e)
-                failures.setdefault(cluster_name, []).append(f"{category}: {detail}")
+                if result.error is not None or result.metadata is None:
+                    err = result.error or RuntimeError("Unknown collection failure")
+                    print_exception(f"  {cluster_name}: Failed - {err}", err)
+                    logger.error("Failed to process cluster %s: %s", cluster_name, err)
+                    error_count += 1
+                    category, detail = _categorize_failure(err)
+                    failures.setdefault(cluster_name, []).append(f"{category}: {detail}")
+                    continue
 
-            progress.update(task, completed=1)
+                # Main-thread persistence (DB writes are not thread-safe).
+                try:
+                    _persist_cluster(db, history_db, result)
+                except Exception as e:
+                    print_exception(f"  {cluster_name}: Persist failed - {e}", e)
+                    logger.exception("Persist failed for cluster %s", cluster_name)
+                    error_count += 1
+                    category, detail = _categorize_failure(e)
+                    failures.setdefault(cluster_name, []).append(f"{category}: {detail}")
+                    continue
+
+                print_success(f"  {cluster_name}: Cache refreshed")
+                success_count += 1
 
     # Summary
     console.print()
@@ -336,6 +435,7 @@ def _refresh_verbose(
     db: ClusterMetadataDB,
     history_db: CacheHistoryDB,
     clusters_to_refresh: list[str],
+    workers: int,
 ) -> None:
     """Refresh clusters with detailed progress (verbose mode).
 
@@ -345,46 +445,125 @@ def _refresh_verbose(
         db: Cache database.
         history_db: History database.
         clusters_to_refresh: List of cluster names.
+        workers: Number of parallel cluster workers (1 = sequential).
     """
     success_count = 0
     error_count = 0
     total_clusters = len(clusters_to_refresh)
     failures: dict[str, list[str]] = {}
 
-    for idx, cluster_name in enumerate(clusters_to_refresh, 1):
-        logger.info("Processing cluster: %s (%d/%d)", cluster_name, idx, total_clusters)
+    if workers <= 1:
+        for idx, cluster_name in enumerate(clusters_to_refresh, 1):
+            logger.info("Processing cluster: %s (%d/%d)", cluster_name, idx, total_clusters)
 
-        display = VerboseProgressDisplay(
-            console=console,
-            cluster_name=cluster_name,
-            cluster_index=idx,
-            total_clusters=total_clusters,
-        )
-        display.print_header()
-
-        try:
-            success = _process_cluster(
-                config,
-                db,
-                history_db,
-                cluster_name,
-                verbose=True,
-                progress_callback=display.on_progress,
+            display = VerboseProgressDisplay(
+                console=console,
+                cluster_name=cluster_name,
+                cluster_index=idx,
+                total_clusters=total_clusters,
             )
-            display.print_summary(success)
-            if success:
-                success_count += 1
-            else:
-                error_count += 1
-                failures.setdefault(cluster_name, []).append("No clients available")
+            display.print_header()
 
-        except Exception as e:
-            display.print_summary(success=False)
-            print_exception(f"  Error: {e}", e)
-            logger.exception("Failed to process cluster %s", cluster_name)
-            error_count += 1
-            category, detail = _categorize_failure(e)
-            failures.setdefault(cluster_name, []).append(f"{category}: {detail}")
+            try:
+                success = _process_cluster(
+                    config,
+                    db,
+                    history_db,
+                    cluster_name,
+                    verbose=True,
+                    progress_callback=display.on_progress,
+                )
+                display.print_summary(success)
+                if success:
+                    success_count += 1
+                else:
+                    error_count += 1
+                    failures.setdefault(cluster_name, []).append("No clients available")
+
+            except Exception as e:
+                display.print_summary(success=False)
+                print_exception(f"  Error: {e}", e)
+                logger.exception("Failed to process cluster %s", cluster_name)
+                error_count += 1
+                category, detail = _categorize_failure(e)
+                failures.setdefault(cluster_name, []).append(f"{category}: {detail}")
+    else:
+        # Parallel + verbose: each worker captures its own output in a buffered
+        # Console(record=True); on completion the main thread flushes the whole
+        # block so per-cluster output stays coherent.
+        # Use 1-based completion counter for display ordering.
+        completion_counter = 0
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            future_map = {
+                executor.submit(
+                    _collect_cluster,
+                    config,
+                    history_db,
+                    cluster_name,
+                    verbose=True,
+                ): cluster_name
+                for cluster_name in clusters_to_refresh
+            }
+
+            # Announce work on the main thread so users see progress immediately.
+            for cluster_name in clusters_to_refresh:
+                logger.info(
+                    "Queued cluster for refresh: %s (of %d)",
+                    cluster_name,
+                    total_clusters,
+                )
+
+            for future in as_completed(future_map):
+                completion_counter += 1
+                cluster_name = future_map[future]
+                try:
+                    result = future.result()
+                except Exception as e:  # pragma: no cover - defensive
+                    console.print(
+                        f"\n[bold][{completion_counter}/{total_clusters}] {cluster_name}[/bold]"
+                    )
+                    print_exception(f"  Error: {e}", e)
+                    logger.exception("Failed to process cluster %s", cluster_name)
+                    error_count += 1
+                    category, detail = _categorize_failure(e)
+                    failures.setdefault(cluster_name, []).append(f"{category}: {detail}")
+                    continue
+
+                # Flush the worker's captured verbose block as one unit.
+                console.print(
+                    f"\n[bold][{completion_counter}/{total_clusters}] {cluster_name}[/bold]"
+                )
+                if result.captured_output:
+                    # End with no extra newline: captured output already has trailing newlines.
+                    console.out(result.captured_output, end="", highlight=False)
+
+                if result.no_clients:
+                    print_error(f"  No clients available for {cluster_name}")
+                    logger.error("No clients available for %s", cluster_name)
+                    error_count += 1
+                    failures.setdefault(cluster_name, []).append("No clients available")
+                    continue
+
+                if result.error is not None or result.metadata is None:
+                    err = result.error or RuntimeError("Unknown collection failure")
+                    print_exception(f"  Error: {err}", err)
+                    logger.error("Failed to process cluster %s: %s", cluster_name, err)
+                    error_count += 1
+                    category, detail = _categorize_failure(err)
+                    failures.setdefault(cluster_name, []).append(f"{category}: {detail}")
+                    continue
+
+                try:
+                    _persist_cluster(db, history_db, result)
+                except Exception as e:
+                    print_exception(f"  Persist failed: {e}", e)
+                    logger.exception("Persist failed for cluster %s", cluster_name)
+                    error_count += 1
+                    category, detail = _categorize_failure(e)
+                    failures.setdefault(cluster_name, []).append(f"{category}: {detail}")
+                    continue
+
+                success_count += 1
 
     # Summary
     console.print()
@@ -399,6 +578,233 @@ def _refresh_verbose(
     logger.info("Cache refresh completed: %d success, %d failed", success_count, error_count)
 
 
+def _load_previous_metadata(
+    history_db: CacheHistoryDB, cluster_name: str
+) -> CachedClusterMetadata | None:
+    """Load the previous cluster snapshot from history, if any.
+
+    Safe to call from a worker thread because history DB reads are isolated
+    from the main-thread write serialisation path.
+    """
+    latest_snapshot = history_db.get_latest_snapshot(cluster_name)
+    if not latest_snapshot:
+        return None
+
+    after_json = latest_snapshot.get("after_json")
+    if not (after_json and isinstance(after_json, str)):
+        return None
+
+    try:
+        previous_data = json.loads(after_json)
+        snapshot_version = previous_data.get("cache_version")
+
+        if not is_schema_compatible(snapshot_version):
+            logger.warning(
+                "Previous snapshot for %s has incompatible schema version %s, "
+                "treating as initial capture",
+                cluster_name,
+                snapshot_version,
+            )
+            return None
+
+        previous_metadata = CachedClusterMetadata.model_validate(previous_data)
+        logger.debug("Found previous snapshot for %s (v%s)", cluster_name, snapshot_version)
+        return previous_metadata
+    except Exception as e:
+        logger.warning("Failed to parse previous snapshot for %s: %s", cluster_name, e)
+        return None
+
+
+def _collect_cluster(
+    config: Config,
+    history_db: CacheHistoryDB,
+    cluster_name: str,
+    *,
+    verbose: bool,
+) -> _CollectResult:
+    """Worker-thread collection for a single cluster.
+
+    Performs read-side work only: builds API/CLI clients, reads the previous
+    snapshot from history, and runs the collector. **Does not write to the
+    cache or history database** — those writes must happen on the main thread
+    because SQLite connections are not thread-safe.
+
+    In verbose mode, a ``Console(record=True)`` captures the collector's
+    phase output so the main thread can flush it as one coherent block.
+    """
+    captured_console: Console | None = None
+    progress_callback: ProgressCallback | None = None
+    display: VerboseProgressDisplay | None = None
+
+    if verbose:
+        captured_console = Console(record=True, force_terminal=False, width=120)
+        # The index is assigned on the main thread when flushing; we use 0/0
+        # as a placeholder inside the captured block since the header is
+        # printed on the main thread anyway.
+        display = VerboseProgressDisplay(
+            console=captured_console,
+            cluster_name=cluster_name,
+            cluster_index=0,
+            total_clusters=0,
+        )
+        progress_callback = display.on_progress
+
+    cluster_data = config.data["clusters"][cluster_name]
+
+    # Get credentials
+    user, password = config.get_user("clusters", cluster_name)
+
+    # Create cluster object for API client
+    class ClusterObj:
+        def __init__(self, name: str, ip: str) -> None:
+            self.name = name
+            self.ip = ip
+
+    cluster_obj = ClusterObj(cluster_name, cluster_data.get("ip", ""))
+
+    # Initialize clients
+    api_client: ONTAPAPIClient | None = None
+    cli_client: ONTAPCLI | None = None
+
+    try:
+        api_client = ONTAPAPIClient(cluster=cluster_obj, config=config)
+        logger.debug("[%s] API client initialized", cluster_name)
+    except Exception as e:
+        if verbose and captured_console is not None:
+            captured_console.print(f"  [dim]API client unavailable: {e}[/dim]")
+        logger.warning("[%s] API client unavailable: %s", cluster_name, e)
+
+    try:
+        cli_client = ONTAPCLI(
+            name=cluster_name,
+            host_or_ip=cluster_data.get("ip", ""),
+            username=user,
+            password=password,
+        )
+        logger.debug("[%s] CLI client initialized", cluster_name)
+    except Exception as e:
+        if verbose and captured_console is not None:
+            captured_console.print(f"  [dim]CLI client unavailable: {e}[/dim]")
+        logger.warning("[%s] CLI client unavailable: %s", cluster_name, e)
+
+    if not api_client and not cli_client:
+        logger.error("[%s] No clients available", cluster_name)
+        return _CollectResult(
+            cluster_name=cluster_name,
+            metadata=None,
+            previous_metadata=None,
+            captured_output=captured_console.export_text(clear=False)
+            if captured_console is not None
+            else "",
+            success=False,
+            error=None,
+            no_clients=True,
+        )
+
+    # Get AWS SSO config if configured
+    aws_sso_config = config.settings.get("aws", {}).get("sso")
+
+    # Previous snapshot (read-only; safe in worker).
+    previous_metadata = _load_previous_metadata(history_db, cluster_name)
+
+    # Collect metadata
+    collector = MetadataCollector(
+        api_client=api_client,
+        cli_client=cli_client,
+        progress_callback=progress_callback,
+        aws_sso_config=aws_sso_config,
+    )
+
+    error: Exception | None = None
+    metadata: CachedClusterMetadata | None = None
+    try:
+        metadata = collector.collect_all(cluster_name)
+    except Exception as e:
+        error = e
+        logger.warning("[%s] Collection failed: %s", cluster_name, e)
+
+    # Verbose summary line so captured output is complete.
+    if verbose and display is not None:
+        display.print_summary(success=error is None and metadata is not None)
+
+    # Clean up CLI client inside the worker — disconnect is not DB-related.
+    if cli_client:
+        with contextlib.suppress(Exception):
+            cli_client.disconnect()
+            logger.debug("[%s] CLI client disconnected", cluster_name)
+
+    return _CollectResult(
+        cluster_name=cluster_name,
+        metadata=metadata,
+        previous_metadata=previous_metadata,
+        captured_output=captured_console.export_text(clear=False)
+        if captured_console is not None
+        else "",
+        success=error is None and metadata is not None,
+        error=error,
+        no_clients=False,
+    )
+
+
+def _persist_cluster(
+    db: ClusterMetadataDB,
+    history_db: CacheHistoryDB,
+    result: _CollectResult,
+) -> None:
+    """Main-thread-only persistence for a collected cluster result.
+
+    Computes the diff against the previous snapshot, records a history entry
+    when appropriate, and writes the new metadata to the cache database. All
+    DB writes for every cluster flow through this function on the main thread
+    to preserve SQLite single-connection thread-safety.
+    """
+    assert result.metadata is not None, "must have metadata to persist"
+    cluster_name = result.cluster_name
+    metadata = result.metadata
+    previous_metadata = result.previous_metadata
+
+    # Sanity: make sure we really are on the main thread. This is a
+    # defence-in-depth check, not a user-facing guarantee.
+    if threading.current_thread() is not threading.main_thread():
+        logger.warning(
+            "[%s] _persist_cluster called off the main thread (%s); SQLite writes may race.",
+            cluster_name,
+            threading.current_thread().name,
+        )
+
+    # Compute diff and record history.
+    changes = compute_diff(previous_metadata, metadata)
+
+    if previous_metadata is None or changes:
+        before_json = previous_metadata.model_dump_json() if previous_metadata else None
+        after_json = metadata.model_dump_json()
+        change_id = history_db.record_change(
+            cluster_name=cluster_name,
+            before_json=before_json,
+            after_json=after_json,
+            summary=changes,
+        )
+        if previous_metadata is None:
+            logger.info(
+                "[%s] Initial snapshot recorded (change_id=%d)",
+                cluster_name,
+                change_id,
+            )
+        else:
+            logger.info(
+                "[%s] Change recorded: %d changes (change_id=%d)",
+                cluster_name,
+                len(changes),
+                change_id,
+            )
+    else:
+        logger.info("[%s] No changes detected, history not updated", cluster_name)
+
+    # Store in cache.
+    db.set(cluster_name, metadata)
+    logger.info("[%s] Cache updated", cluster_name)
+
+
 def _process_cluster(
     config: Config,
     db: ClusterMetadataDB,
@@ -407,7 +813,12 @@ def _process_cluster(
     verbose: bool = False,
     progress_callback: ProgressCallback | None = None,
 ) -> bool:
-    """Process a single cluster for cache refresh.
+    """Process a single cluster for cache refresh (sequential path).
+
+    This is the historical in-loop implementation used by the sequential
+    (``--parallel-clusters 1``) path. The parallel path uses
+    :func:`_collect_cluster` + :func:`_persist_cluster` so that SQLite writes
+    stay on the main thread.
 
     Args:
         config: Configuration object.

--- a/tests/unit/cli/commands/cache/test_refresh.py
+++ b/tests/unit/cli/commands/cache/test_refresh.py
@@ -749,3 +749,443 @@ enc = "cGFzc3dvcmQ="
         )
         assert result.exit_code == 0
         assert "No clusters match filter" in result.output
+
+
+class TestParallelClusterRefresh:
+    """Tests for the --parallel-clusters flag on nf cache refresh."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_config_dir_many(self, tmp_path: Path) -> Path:
+        """Create a config directory with several clusters for parallel tests."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.toml").write_text(
+            """
+[ontapapi]
+[ontapapi.general]
+base_api_path = "/api"
+timeout = 30.0
+
+[clusters]
+searchable_keys = ["env"]
+"""
+        )
+        (config_dir / "clusters.toml").write_text(
+            """
+[settings]
+type = "data"
+
+[clusters.c1]
+ip = "10.0.0.1"
+env = "Prod"
+
+[clusters.c2]
+ip = "10.0.0.2"
+env = "Prod"
+
+[clusters.c3]
+ip = "10.0.0.3"
+env = "Dev"
+
+[clusters.c4]
+ip = "10.0.0.4"
+env = "Prod"
+"""
+        )
+        (config_dir / "users.toml").write_text(
+            """
+[clusters]
+user = "admin"
+enc = "cGFzc3dvcmQ="
+"""
+        )
+        return config_dir
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.CacheHistoryDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_parallel_default_uses_executor(
+        self,
+        mock_db_class: MagicMock,
+        mock_history_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_many: Path,
+    ) -> None:
+        """Default `--all` should use a ThreadPoolExecutor for collection."""
+        mock_db_class.return_value = MagicMock()
+        mock_history_db = MagicMock()
+        mock_history_db.get_latest_snapshot.return_value = None
+        mock_history_db_class.return_value = mock_history_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock()
+        mock_collector_class.return_value = mock_collector
+
+        mock_cli_class.return_value = MagicMock()
+        mock_api_class.return_value = MagicMock()
+
+        with patch(
+            "pynetappfoundry.cli.commands.cache.refresh.ThreadPoolExecutor",
+            wraps=__import__(
+                "concurrent.futures", fromlist=["ThreadPoolExecutor"]
+            ).ThreadPoolExecutor,
+        ) as mock_executor:
+            result = runner.invoke(
+                nf, ["-c", str(mock_config_dir_many), "cache", "refresh", "--all"]
+            )
+
+        assert result.exit_code == 0
+        # 4 clusters configured; default is 4 workers, capped by cluster count.
+        mock_executor.assert_called_once()
+        kwargs = mock_executor.call_args.kwargs
+        args = mock_executor.call_args.args
+        max_workers = kwargs.get("max_workers") or (args[0] if args else None)
+        assert max_workers == 4
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.CacheHistoryDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_parallel_one_does_not_use_executor(
+        self,
+        mock_db_class: MagicMock,
+        mock_history_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_many: Path,
+    ) -> None:
+        """`--parallel-clusters 1` must preserve the original sequential path."""
+        mock_db_class.return_value = MagicMock()
+        mock_history_db = MagicMock()
+        mock_history_db.get_latest_snapshot.return_value = None
+        mock_history_db_class.return_value = mock_history_db
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock()
+        mock_collector_class.return_value = mock_collector
+        mock_cli_class.return_value = MagicMock()
+        mock_api_class.return_value = MagicMock()
+
+        with patch(
+            "pynetappfoundry.cli.commands.cache.refresh.ThreadPoolExecutor"
+        ) as mock_executor:
+            result = runner.invoke(
+                nf,
+                [
+                    "-c",
+                    str(mock_config_dir_many),
+                    "cache",
+                    "refresh",
+                    "--all",
+                    "--parallel-clusters",
+                    "1",
+                ],
+            )
+
+        assert result.exit_code == 0
+        mock_executor.assert_not_called()
+        # All 4 clusters should still be collected.
+        assert mock_collector.collect_all.call_count == 4
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.CacheHistoryDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_parallel_writes_on_main_thread(
+        self,
+        mock_db_class: MagicMock,
+        mock_history_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_many: Path,
+    ) -> None:
+        """All `db.set` calls must happen on the main thread even with parallel workers."""
+        import threading
+
+        main_thread = threading.main_thread()
+        set_threads: list[threading.Thread] = []
+        record_threads: list[threading.Thread] = []
+
+        mock_db = MagicMock()
+        mock_db.set.side_effect = lambda *_a, **_kw: set_threads.append(threading.current_thread())
+        mock_db_class.return_value = mock_db
+
+        mock_history_db = MagicMock()
+        mock_history_db.get_latest_snapshot.return_value = None
+        mock_history_db.record_change.side_effect = lambda *_a, **_kw: (
+            record_threads.append(threading.current_thread()) or 1
+        )
+        mock_history_db_class.return_value = mock_history_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock()
+        mock_collector_class.return_value = mock_collector
+        mock_cli_class.return_value = MagicMock()
+        mock_api_class.return_value = MagicMock()
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir_many),
+                "cache",
+                "refresh",
+                "--all",
+                "--parallel-clusters",
+                "4",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert mock_db.set.call_count == 4
+        assert all(t is main_thread for t in set_threads), set_threads
+        assert all(t is main_thread for t in record_threads), record_threads
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.CacheHistoryDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_parallel_one_failure_does_not_block_others(
+        self,
+        mock_db_class: MagicMock,
+        mock_history_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_many: Path,
+    ) -> None:
+        """One worker raising must not prevent the remaining clusters from being persisted."""
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+
+        mock_history_db = MagicMock()
+        mock_history_db.get_latest_snapshot.return_value = None
+        mock_history_db_class.return_value = mock_history_db
+
+        mock_collector = MagicMock()
+
+        def collect_side_effect(cluster_name: str) -> MagicMock:
+            if cluster_name == "c2":
+                raise RuntimeError("API_FAILURE: simulated failure for c2")
+            return MagicMock()
+
+        mock_collector.collect_all.side_effect = collect_side_effect
+        mock_collector_class.return_value = mock_collector
+        mock_cli_class.return_value = MagicMock()
+        mock_api_class.return_value = MagicMock()
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir_many),
+                "cache",
+                "refresh",
+                "--all",
+                "--parallel-clusters",
+                "4",
+            ],
+        )
+
+        # Exit non-zero because c2 failed.
+        assert result.exit_code != 0
+        # The other 3 clusters must still have been persisted.
+        assert mock_db.set.call_count == 3
+        assert "Failure Summary" in result.output
+        assert "c2" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.CacheHistoryDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_verbose_parallel_buffers_output_per_cluster(
+        self,
+        mock_db_class: MagicMock,
+        mock_history_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_many: Path,
+    ) -> None:
+        """Verbose parallel mode must emit each cluster's block contiguously."""
+        mock_db_class.return_value = MagicMock()
+        mock_history_db = MagicMock()
+        mock_history_db.get_latest_snapshot.return_value = None
+        mock_history_db_class.return_value = mock_history_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock()
+        mock_collector_class.return_value = mock_collector
+        mock_cli_class.return_value = MagicMock()
+        mock_api_class.return_value = MagicMock()
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir_many),
+                "cache",
+                "refresh",
+                "--all",
+                "-v",
+                "--parallel-clusters",
+                "4",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Each cluster must appear exactly once in a bold header line and before
+        # the next cluster's header (no interleaving of per-cluster blocks).
+        output = result.output
+        headers = []
+        for name in ("c1", "c2", "c3", "c4"):
+            idx = output.find(name)
+            assert idx != -1, f"{name} not in verbose output"
+            headers.append((idx, name))
+        # Non-overlapping, each cluster named exactly once as a header.
+        assert len({n for _, n in headers}) == 4
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.CacheHistoryDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_parallel_clusters_zero_rejected(
+        self,
+        mock_db_class: MagicMock,
+        mock_history_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_many: Path,
+    ) -> None:
+        """`--parallel-clusters 0` must be rejected as a click usage error."""
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir_many),
+                "cache",
+                "refresh",
+                "--all",
+                "--parallel-clusters",
+                "0",
+            ],
+        )
+        assert result.exit_code != 0
+        # click IntRange error mentions "not in the range" or similar.
+        assert "0" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.CacheHistoryDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_filter_combined_with_parallel(
+        self,
+        mock_db_class: MagicMock,
+        mock_history_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_many: Path,
+    ) -> None:
+        """Filter + parallel should only refresh the matching clusters in parallel."""
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+        mock_history_db = MagicMock()
+        mock_history_db.get_latest_snapshot.return_value = None
+        mock_history_db_class.return_value = mock_history_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock()
+        mock_collector_class.return_value = mock_collector
+        mock_cli_class.return_value = MagicMock()
+        mock_api_class.return_value = MagicMock()
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir_many),
+                "cache",
+                "refresh",
+                "--all",
+                "-f",
+                '{"env": "Prod"}',
+                "--parallel-clusters",
+                "2",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # 3 Prod clusters (c1, c2, c4) should be collected and persisted.
+        assert mock_collector.collect_all.call_count == 3
+        assert mock_db.set.call_count == 3
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.CacheHistoryDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_single_cluster_ignores_parallel_flag(
+        self,
+        mock_db_class: MagicMock,
+        mock_history_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_many: Path,
+    ) -> None:
+        """Single-cluster target must not spin up an executor."""
+        mock_db_class.return_value = MagicMock()
+        mock_history_db = MagicMock()
+        mock_history_db.get_latest_snapshot.return_value = None
+        mock_history_db_class.return_value = mock_history_db
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock()
+        mock_collector_class.return_value = mock_collector
+        mock_cli_class.return_value = MagicMock()
+        mock_api_class.return_value = MagicMock()
+
+        with patch(
+            "pynetappfoundry.cli.commands.cache.refresh.ThreadPoolExecutor"
+        ) as mock_executor:
+            result = runner.invoke(
+                nf,
+                [
+                    "-c",
+                    str(mock_config_dir_many),
+                    "cache",
+                    "refresh",
+                    "c1",
+                    "--parallel-clusters",
+                    "4",
+                ],
+            )
+
+        assert result.exit_code == 0
+        mock_executor.assert_not_called()
+        assert mock_collector.collect_all.call_count == 1


### PR DESCRIPTION
## Description

Adds parallel cluster processing to `nf cache refresh --all`. A new
`--parallel-clusters N` flag (default `4`, minimum `1`) collects clusters
concurrently using a `ThreadPoolExecutor` while persisting all database
writes on the main thread to preserve SQLite single-connection safety.

With 66+ clusters taking ~1–2s each, sequential refresh runs 66–132s; at
the default `N=4`, refresh completes in roughly a quarter of that time.
Setting `--parallel-clusters 1` restores the historical strictly-sequential
code path for users who want the old ordering or need to opt out.

Architecture: **workers collect, main thread persists**
- `_collect_cluster()` — worker-safe; builds clients, runs
  `MetadataCollector.collect_all()`, buffers verbose phase output into a
  Rich `Console(record=True)`, returns a `_CollectResult` dataclass. Never
  writes to `ClusterMetadataDB` or `CacheHistoryDB`.
- `_persist_cluster()` — main-thread only; computes diff, records history,
  writes cache. All DB writes serialised through this function.

Single-cluster invocations (`nf cache refresh <name>`) always use the
sequential path regardless of the flag.

## Related Issue

Addresses #149

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- `src/pynetappfoundry/cli/commands/cache/refresh.py` — add
  `--parallel-clusters` flag, `_collect_cluster()`/`_persist_cluster()`
  split, and `ThreadPoolExecutor` driver; retain sequential
  `_process_cluster()` for `N == 1`.
- `tests/unit/cli/commands/cache/test_refresh.py` — add
  `TestParallelClusterRefresh` (8 tests): executor usage at default and
  `N=1`, main-thread-only writes, per-cluster failure isolation, verbose
  per-cluster buffering, `--parallel-clusters 0` rejection, filter +
  parallel interaction, and single-cluster invocations ignoring the flag.
- `docs/reference/cache.md` — document the new flag and parallel behaviour.
- `docs/decisions/0014-parallel-cluster-refresh.md` — new ADR capturing
  the decision, rationale, consequences, and alternatives considered.
- `docs/decisions/README.md` — index updated for ADRs 11–14.

## Testing

- [x] All existing tests pass (`doit check` green)
- [x] Added 8 new tests in `TestParallelClusterRefresh`
- [ ] Manually verified on a live fleet:
  - [ ] `nf cache refresh --all` (default parallelism)
  - [ ] `nf cache refresh --all --parallel-clusters 1` (sequential
    fallback matches pre-change behaviour)
  - [ ] `nf cache refresh --all --parallel-clusters 8 -v` (verbose block
    coherence under higher concurrency)
  - [ ] `nf cache refresh --all -f '{"env": "Prod"}' --parallel-clusters 4`
    (filter + parallel)
  - [ ] `nf cache refresh <single-cluster>` (flag ignored; sequential
    path used)
  - [ ] Confirm cache history records are written correctly for each
    cluster under parallel collection.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
  (`docs/reference/cache.md`, new ADR-0014)
- [ ] CHANGELOG.md is auto-generated at release time from conventional
  commits, no manual update needed
- [x] My changes generate no new warnings

## Additional Notes

- **ADR:** This PR introduces ADR-0014. The issue was not tagged
  `needs-adr`, but the decision (thread pool + main-thread-persists split,
  default `N=4`, opt-out at `N=1`) is architecturally significant enough
  to warrant one.
- **Non-deterministic verbose ordering:** In parallel verbose mode
  cluster blocks complete in wall-clock order rather than configuration
  order. The block contents are coherent; only the outer ordering changes.
- **Peak concurrency:** Inner `MetadataCollector` parallelism
  (`max_workers=8`) is unchanged, so at default settings peak thread
  count is ~4 × 8 = 32 — appropriate for a CLI tool against one API
  server per cluster. Deployments behind shared egress proxies or with
  per-client rate limits can lower `--parallel-clusters`.
