### PR TITLE
fix: pre-load cluster snapshots on main thread for parallel refresh

### DIFF
--- a/docs/decisions/0014-parallel-cluster-refresh.md
+++ b/docs/decisions/0014-parallel-cluster-refresh.md
@@ -13,11 +13,13 @@ strictly-sequential code path unchanged.
 
 The implementation follows a **workers collect, main thread persists** split:
 
-- `_collect_cluster()` — worker-safe. Builds API/CLI clients, reads the
-  previous history snapshot, runs `MetadataCollector.collect_all()`, and (in
-  verbose mode) captures its own phase output into a Rich `Console(record=True)`
-  buffer. Returns a `_CollectResult` dataclass; never touches `ClusterMetadataDB`
-  or `CacheHistoryDB` for writes.
+- `_collect_cluster()` — worker-safe. Builds API/CLI clients, runs
+  `MetadataCollector.collect_all()`, and (in verbose mode) captures its own
+  phase output into a Rich `Console(record=True)` buffer. Returns a
+  `_CollectResult` dataclass. **Takes zero DB handles** — neither
+  `ClusterMetadataDB` nor `CacheHistoryDB` is passed into a worker, for reads
+  or writes (see Amendments / issue #596). The previous snapshot is preloaded
+  on the main thread and passed in as a plain `CachedClusterMetadata`.
 - `_persist_cluster()` — main-thread only. Computes the diff via
   `compute_diff()`, records history via `history_db.record_change()`, and
   writes the cache via `db.set()`. All database writes for every cluster flow
@@ -104,9 +106,31 @@ internal structure of each block (phase lines, summary) is preserved.
 - **Keep the existing sequential behaviour.** Rejected: 66+ clusters at
   1–2s each is a real operational pain point (issue #149).
 
+## Amendments
+
+### 2026-04-15 — Issue #596: SQLite thread-safety correction
+
+The original description of `_collect_cluster()` allowed workers to perform
+"read-side" SQLite access against `CacheHistoryDB` (loading the previous
+snapshot via `_load_previous_metadata()`). This was incorrect: SQLite
+connections cannot cross thread boundaries at all — `check_same_thread=True`
+(the default) rejects *any* use of the connection from a thread other than
+the one that created it, including reads. This produced random per-cluster
+failures in parallel mode with the error `SQLite objects created in a thread
+can only be used in that same thread`.
+
+**Corrected rule: no DB handle crosses thread boundaries, for reads or
+writes.** `_collect_cluster()` now takes zero DB handles. The main thread
+preloads previous snapshots for every cluster before submitting futures and
+passes each snapshot into its worker call as a plain value. Workers remain
+purely network/CPU.
+
+See issue #596 and the corresponding PR for the implementation.
+
 ## Related Issues
 
 - Issue #149: feat: parallelize cluster refresh in `nf cache refresh --all`
+- Issue #596: fix: SQLite thread-safety regression in parallel cache refresh
 
 ## Related Documentation
 

--- a/src/pynetappfoundry/cli/commands/cache/refresh.py
+++ b/src/pynetappfoundry/cli/commands/cache/refresh.py
@@ -363,13 +363,18 @@ def _refresh_normal(
                 progress.update(task, completed=1)
     else:
         # Parallel path: workers collect, main thread persists.
+        # Preload previous snapshots on the main thread — SQLite connections
+        # can't cross threads, so workers must not touch history_db.
+        previous_by_cluster: dict[str, CachedClusterMetadata | None] = {
+            name: _load_previous_metadata(history_db, name) for name in clusters_to_refresh
+        }
         with ThreadPoolExecutor(max_workers=workers) as executor:
             future_map = {
                 executor.submit(
                     _collect_cluster,
                     config,
-                    history_db,
                     cluster_name,
+                    previous_by_cluster[cluster_name],
                     verbose=False,
                 ): cluster_name
                 for cluster_name in clusters_to_refresh
@@ -493,13 +498,18 @@ def _refresh_verbose(
         # block so per-cluster output stays coherent.
         # Use 1-based completion counter for display ordering.
         completion_counter = 0
+        # Preload previous snapshots on the main thread — SQLite connections
+        # can't cross threads, so workers must not touch history_db.
+        previous_by_cluster: dict[str, CachedClusterMetadata | None] = {
+            name: _load_previous_metadata(history_db, name) for name in clusters_to_refresh
+        }
         with ThreadPoolExecutor(max_workers=workers) as executor:
             future_map = {
                 executor.submit(
                     _collect_cluster,
                     config,
-                    history_db,
                     cluster_name,
+                    previous_by_cluster[cluster_name],
                     verbose=True,
                 ): cluster_name
                 for cluster_name in clusters_to_refresh
@@ -583,8 +593,7 @@ def _load_previous_metadata(
 ) -> CachedClusterMetadata | None:
     """Load the previous cluster snapshot from history, if any.
 
-    Safe to call from a worker thread because history DB reads are isolated
-    from the main-thread write serialisation path.
+    Must be called on the main thread — SQLite connections can't cross threads.
     """
     latest_snapshot = history_db.get_latest_snapshot(cluster_name)
     if not latest_snapshot:
@@ -617,17 +626,18 @@ def _load_previous_metadata(
 
 def _collect_cluster(
     config: Config,
-    history_db: CacheHistoryDB,
     cluster_name: str,
+    previous_metadata: CachedClusterMetadata | None,
     *,
     verbose: bool,
 ) -> _CollectResult:
     """Worker-thread collection for a single cluster.
 
-    Performs read-side work only: builds API/CLI clients, reads the previous
-    snapshot from history, and runs the collector. **Does not write to the
-    cache or history database** — those writes must happen on the main thread
-    because SQLite connections are not thread-safe.
+    Takes **zero DB handles**. Builds API/CLI clients and runs the collector,
+    using the caller-supplied ``previous_metadata`` (loaded on the main thread).
+    **Does not read from or write to the cache or history database** — all DB
+    access happens on the main thread because SQLite connections can't cross
+    threads.
 
     In verbose mode, a ``Console(record=True)`` captures the collector's
     phase output so the main thread can flush it as one coherent block.
@@ -703,9 +713,6 @@ def _collect_cluster(
 
     # Get AWS SSO config if configured
     aws_sso_config = config.settings.get("aws", {}).get("sso")
-
-    # Previous snapshot (read-only; safe in worker).
-    previous_metadata = _load_previous_metadata(history_db, cluster_name)
 
     # Collect metadata
     collector = MetadataCollector(

--- a/tests/unit/cli/commands/cache/test_refresh.py
+++ b/tests/unit/cli/commands/cache/test_refresh.py
@@ -927,9 +927,12 @@ enc = "cGFzc3dvcmQ="
 
         mock_history_db = MagicMock()
         mock_history_db.get_latest_snapshot.return_value = None
-        mock_history_db.record_change.side_effect = lambda *_a, **_kw: (
-            record_threads.append(threading.current_thread()) or 1
-        )
+
+        def _record_change(*_a: object, **_kw: object) -> int:
+            record_threads.append(threading.current_thread())
+            return 1
+
+        mock_history_db.record_change.side_effect = _record_change
         mock_history_db_class.return_value = mock_history_db
 
         mock_collector = MagicMock()
@@ -1010,6 +1013,127 @@ enc = "cGFzc3dvcmQ="
         assert mock_db.set.call_count == 3
         assert "Failure Summary" in result.output
         assert "c2" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.CacheHistoryDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_parallel_does_not_pass_db_to_workers(
+        self,
+        mock_db_class: MagicMock,
+        mock_history_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_many: Path,
+    ) -> None:
+        """Worker `_collect_cluster` must not receive any DB handle (see #596)."""
+        from pynetappfoundry.cache.db import ClusterMetadataDB
+        from pynetappfoundry.cache.history_db import CacheHistoryDB
+
+        mock_db = MagicMock(spec=ClusterMetadataDB)
+        mock_db_class.return_value = mock_db
+        mock_history_db = MagicMock(spec=CacheHistoryDB)
+        mock_history_db.get_latest_snapshot.return_value = None
+        mock_history_db_class.return_value = mock_history_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock()
+        mock_collector_class.return_value = mock_collector
+        mock_cli_class.return_value = MagicMock()
+        mock_api_class.return_value = MagicMock()
+
+        with patch("pynetappfoundry.cli.commands.cache.refresh._collect_cluster") as mock_collect:
+            mock_collect.return_value = MagicMock(
+                cluster_name="c1",
+                metadata=None,
+                previous_metadata=None,
+                captured_output="",
+                success=False,
+                error=None,
+                no_clients=True,
+            )
+            runner.invoke(
+                nf,
+                [
+                    "-c",
+                    str(mock_config_dir_many),
+                    "cache",
+                    "refresh",
+                    "--all",
+                    "--parallel-clusters",
+                    "4",
+                ],
+            )
+
+        assert mock_collect.call_count == 4
+        # spec'd MagicMocks pass isinstance() checks for the spec class, so this
+        # catches both real instances and spec'd mocks of either DB type.
+        for call in mock_collect.call_args_list:
+            for arg in (*call.args, *call.kwargs.values()):
+                assert not isinstance(arg, (CacheHistoryDB, ClusterMetadataDB)), (
+                    f"DB handle leaked into worker: {arg!r}"
+                )
+
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.MetadataCollector")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.CacheHistoryDB")
+    @patch("pynetappfoundry.cli.commands.cache.refresh.ClusterMetadataDB")
+    def test_parallel_preloads_previous_metadata_on_main_thread(
+        self,
+        mock_db_class: MagicMock,
+        mock_history_db_class: MagicMock,
+        mock_collector_class: MagicMock,
+        mock_cli_class: MagicMock,
+        mock_api_class: MagicMock,
+        runner: CliRunner,
+        mock_config_dir_many: Path,
+    ) -> None:
+        """`get_latest_snapshot` must be called once per cluster on the main thread (see #596)."""
+        import threading
+
+        main_thread = threading.main_thread()
+        snapshot_threads: list[threading.Thread] = []
+        snapshot_clusters: list[str] = []
+
+        def record_snapshot(cluster_name: str) -> None:
+            snapshot_threads.append(threading.current_thread())
+            snapshot_clusters.append(cluster_name)
+            return None
+
+        mock_db_class.return_value = MagicMock()
+        mock_history_db = MagicMock()
+        mock_history_db.get_latest_snapshot.side_effect = record_snapshot
+        mock_history_db_class.return_value = mock_history_db
+
+        mock_collector = MagicMock()
+        mock_collector.collect_all.return_value = MagicMock()
+        mock_collector_class.return_value = mock_collector
+        mock_cli_class.return_value = MagicMock()
+        mock_api_class.return_value = MagicMock()
+
+        result = runner.invoke(
+            nf,
+            [
+                "-c",
+                str(mock_config_dir_many),
+                "cache",
+                "refresh",
+                "--all",
+                "--parallel-clusters",
+                "4",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Exactly one snapshot load per cluster.
+        assert mock_history_db.get_latest_snapshot.call_count == 4
+        assert sorted(snapshot_clusters) == ["c1", "c2", "c3", "c4"]
+        # Every load must happen on the main thread.
+        assert all(t is main_thread for t in snapshot_threads), snapshot_threads
 
     @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPAPIClient")
     @patch("pynetappfoundry.cli.commands.cache.refresh.ONTAPCLI")


### PR DESCRIPTION
## Description

Workers in the parallel cache refresh path were calling `_load_previous_metadata()` with the shared `CacheHistoryDB` connection, triggering SQLite's cross-thread guard and producing random per-cluster failures after PR #595.

This PR pre-loads all previous cluster snapshots on the main thread before submitting futures, then passes each cluster's snapshot into `_collect_cluster` as an argument. No DB handle ever crosses a thread boundary — reads or writes.

## Related Issue

Addresses #596

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Remove `history_db` parameter from `_collect_cluster`; add `previous_metadata` parameter instead
- Parallel branches in `_refresh_normal` and `_refresh_verbose` pre-load snapshots into a `previous_by_cluster` dict on the main thread before dispatching workers
- Correct docstring on `_load_previous_metadata` (must be main-thread-only)
- Amend ADR-0014 with the corrected rule: no DB handle crosses thread boundaries

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

New tests in `TestParallelClusterRefresh`:

- `test_parallel_does_not_pass_db_to_workers` — asserts no `CacheHistoryDB`/`ClusterMetadataDB` instance appears in `_collect_cluster` call arguments
- `test_parallel_preloads_previous_metadata_on_main_thread` — asserts `get_latest_snapshot` is called exactly once per cluster and every call is from the main thread

Manual validation pending on real config that reproduces the bug.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (ADR-0014 amended)
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Amends ADR-0014. No new ADR needed — this is a correction to the same architectural decision.
