### PR TITLE
fix(codegen): preserve identifier_field and TOML strategy overrides on regen

### DIFF
--- a/docs/decisions/0008-openapi-codegen-for-model-generation.md
+++ b/docs/decisions/0008-openapi-codegen-for-model-generation.md
@@ -76,14 +76,53 @@ Mapping files (`mapping.py`, `__init__.py`, TOML overlays) remain under `cache/o
 Generated models inherit from `OntapModel` (defined in `models._base`) instead of
 `CacheModel`.
 
+### Round-trip invariant and TOML-as-authority (Issue #601)
+
+**Regeneration is a no-op for existing endpoints.**  Running
+`doit generate_models --api=<api>` against an endpoint whose output
+already exists on disk must produce byte-identical `mapping.py` and
+`model.py` files (after `ruff format`).  This invariant is enforced by
+`tests/unit/codegen/test_roundtrip.py` for three representative ONTAP
+endpoints (`/storage/volumes`, `/storage/aggregates`, `/svm/peers`).  A
+failure there means either the generator has drifted or the on-disk
+file contains an un-mirrored hand edit — both must be resolved before
+codegen is safe to run against the full tree.
+
+**TOML is authoritative for per-field strategy.**  The sibling
+`<name>.toml` overlay owns `cache_strategy` and `requires_explicit_fetch`
+at runtime — the runtime overlay loader
+(`src/pynetappfoundry/cache/overlay_loader.py`) re-applies these values
+from the TOML at registry-load time and takes precedence over anything
+written into the emitted Python.  The generator mirrors those values
+into `mapping.py` so the file is self-describing and round-trippable;
+to change the strategy for a field, edit the TOML — the Python will
+pick it up on the next regen.
+
+**`identifier_field` is auto-inferred; nested cases need a manual
+edit.**  The generator infers `TypeMapping.identifier_field` from a
+collection endpoint's sibling item endpoint path parameter
+(e.g. `/storage/volumes` + `/storage/volumes/{uuid}` →
+`identifier_field="uuid"`).  Multi-param item endpoints are left as
+`None` — composite identifiers are not auto-inferred.  One ONTAP
+endpoint (`/svm/migrations/volumes`) uses a nested response-field
+identifier (`"volume.uuid"`) that cannot be derived from the spec; the
+`mapping.py` for that endpoint must be hand-edited after regen.
+Regeneration will wipe the manual override, so the edit must be
+re-applied (or mirrored into the generator if more nested identifiers
+appear in future specs).
+
+Issue: #601
+
 ## Related Issues
 
 - Issue #301: feat: field annotations, OpenAPI codegen, and SQL cache storage
 - Issue #402: refactor: move ONTAP API models from cache/ to models/ package
 - Issue #444: refactor: evaluate nested models to replace flat model pattern (see ADR-0011)
+- Issue #601: bug(codegen): pipeline drops identifier_field and cache_strategy=realtime on regen
 
 ## Related Documentation
 
 - [ADR-0004: Declarative field mapping framework](0004-declarative-field-mapping-framework.md)
 - [ADR-0007: URL-tree model registry](0007-url-tree-model-registry.md)
 - [Cache Model Architecture](../development/cache-models.md)
+- [Adding Backends](../development/adding-backends.md)

--- a/docs/development/adding-backends.md
+++ b/docs/development/adding-backends.md
@@ -112,7 +112,11 @@ as existing ONTAP models. Every field that the `DataSource` might return
 should have a default value so that partially-populated instances are valid.
 
 See [Cache Models](cache-models.md) for the full model creation workflow,
-including codegen from OpenAPI specs.
+including codegen from OpenAPI specs.  See
+[ADR-0008](../decisions/0008-openapi-codegen-for-model-generation.md) for
+the codegen pipeline's round-trip invariant (regeneration must be a
+no-op for existing endpoints) and the TOML-as-authority rule for
+`cache_strategy` / `requires_explicit_fetch`.
 
 ### 3. Create field mappings
 

--- a/src/pynetappfoundry/cache/ontap/storage/aggregates/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/aggregates/mapping.py
@@ -76,6 +76,7 @@ ONTAPAGGREGATE_MAPPING = TypeMapping(
     model_class=OntapAggregate,
     api_endpoint="/storage/aggregates?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="block_storage.hybrid_cache.disk_count",

--- a/src/pynetappfoundry/cache/ontap/svm/peers/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/svm/peers/mapping.py
@@ -11,6 +11,7 @@ ONTAPSVMPEER_MAPPING = TypeMapping(
     model_class=OntapSvmPeer,
     api_endpoint="/svm/peers?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="applications",

--- a/tests/unit/codegen/test_adapters.py
+++ b/tests/unit/codegen/test_adapters.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from tools.codegen.adapters import (
+    _build_identifier_map,
     _detect_parent_path,
     _detect_records_path,
     _flatten_schema,
@@ -434,3 +435,143 @@ class TestParseOpenAPISpec:
         assert vol is not None
         assert len(vol.fields) > 50
         assert len(vol.expensive_patterns) > 5
+
+
+# ---------------------------------------------------------------------------
+# _build_identifier_map tests (issue #601 — identifier_field inference)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildIdentifierMap:
+    def test_uuid_param(self):
+        """A `/foo` + `/foo/{uuid}` pair yields identifier_field='uuid'."""
+        paths = ["/storage/volumes", "/storage/volumes/{uuid}"]
+        assert _build_identifier_map(paths) == {"/storage/volumes": "uuid"}
+
+    def test_custom_param_name(self):
+        """The inferred identifier uses whatever name the spec declares."""
+        paths = ["/foo", "/foo/{id}"]
+        assert _build_identifier_map(paths) == {"/foo": "id"}
+
+        paths = ["/bar", "/bar/{key}"]
+        assert _build_identifier_map(paths) == {"/bar": "key"}
+
+    def test_no_sibling_item_endpoint(self):
+        """Collection without a sibling item endpoint is absent from the map."""
+        paths = ["/storage/volumes"]
+        assert _build_identifier_map(paths) == {}
+
+    def test_multi_param_item_skipped(self):
+        """Item endpoints with >1 path parameter are skipped (composite keys)."""
+        paths = [
+            "/a/b",
+            "/a/b/{x}/c/{y}",  # multi-param -- skip
+        ]
+        assert _build_identifier_map(paths) == {}
+
+    def test_nested_parent_not_confused_with_collection(self):
+        """Item endpoint under a parameterized parent (two params total) is skipped."""
+        paths = [
+            "/svm/svms/{svm.uuid}/web",
+            "/svm/svms/{svm.uuid}/web/{uuid}",
+        ]
+        # The latter has two `{...}` segments, so it's skipped.
+        # The former is not an item endpoint, so it's skipped too.
+        assert _build_identifier_map(paths) == {}
+
+    def test_item_without_collection(self):
+        """An item endpoint whose collection path doesn't exist is ignored."""
+        paths = ["/solo/{uuid}"]
+        assert _build_identifier_map(paths) == {}
+
+
+class TestParseOpenAPISpecIdentifierField:
+    def _spec_with_paths(self, paths: dict) -> dict:
+        return {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": paths,
+            "components": {
+                "schemas": {
+                    "volume": {
+                        "type": "object",
+                        "properties": {
+                            "uuid": {"type": "string", "format": "uuid"},
+                            "name": {"type": "string"},
+                        },
+                    }
+                }
+            },
+        }
+
+    def _collection_get(self) -> dict:
+        """Returns a GET op that parses into a ParsedEndpoint."""
+        return {
+            "get": {
+                "description": "List volumes.",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "records": {
+                                            "type": "array",
+                                            "items": {"$ref": "#/components/schemas/volume"},
+                                        }
+                                    },
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        }
+
+    def _item_get(self) -> dict:
+        """Returns a GET op for an item endpoint (doesn't need to parse)."""
+        return {"get": {"description": "Get one volume.", "responses": {}}}
+
+    def test_uuid_inferred(self, tmp_path):
+        spec = self._spec_with_paths(
+            {
+                "/storage/volumes": self._collection_get(),
+                "/storage/volumes/{uuid}": self._item_get(),
+            }
+        )
+        spec_path = _write_spec(spec, tmp_path)
+        endpoints = parse_openapi_spec(spec_path, "ontap")
+        assert len(endpoints) == 1
+        assert endpoints[0].identifier_field == "uuid"
+
+    def test_alternative_param_name_inferred(self, tmp_path):
+        spec = self._spec_with_paths(
+            {
+                "/foo": self._collection_get(),
+                "/foo/{id}": self._item_get(),
+            }
+        )
+        spec_path = _write_spec(spec, tmp_path)
+        endpoints = parse_openapi_spec(spec_path, "ontap")
+        assert len(endpoints) == 1
+        assert endpoints[0].identifier_field == "id"
+
+    def test_none_when_no_sibling(self, tmp_path):
+        spec = self._spec_with_paths({"/storage/volumes": self._collection_get()})
+        spec_path = _write_spec(spec, tmp_path)
+        endpoints = parse_openapi_spec(spec_path, "ontap")
+        assert len(endpoints) == 1
+        assert endpoints[0].identifier_field is None
+
+    def test_none_when_item_has_multi_params(self, tmp_path):
+        spec = self._spec_with_paths(
+            {
+                "/a/b": self._collection_get(),
+                "/a/b/{x}/c/{y}": self._item_get(),
+            }
+        )
+        spec_path = _write_spec(spec, tmp_path)
+        endpoints = parse_openapi_spec(spec_path, "ontap")
+        assert len(endpoints) == 1
+        assert endpoints[0].identifier_field is None

--- a/tests/unit/codegen/test_generators.py
+++ b/tests/unit/codegen/test_generators.py
@@ -424,6 +424,142 @@ class TestGenerateMapping:
         code = generate_mapping(ep)
         assert 'model_registry.register_mapping("OntapVolume"' in code
 
+    def test_identifier_field_emitted_when_set(self):
+        """identifier_field on the endpoint emits a line in TypeMapping."""
+        ep = _make_endpoint()
+        ep.identifier_field = "uuid"
+        code = generate_mapping(ep)
+        assert 'identifier_field="uuid"' in code
+        # Line should sit right after api_type
+        api_type_pos = code.index('api_type="ontap",')
+        ident_pos = code.index('identifier_field="uuid",')
+        fields_pos = code.index("fields=(")
+        assert api_type_pos < ident_pos < fields_pos
+
+    def test_identifier_field_omitted_when_none(self):
+        """identifier_field=None leaves the line out entirely."""
+        ep = _make_endpoint()
+        ep.identifier_field = None
+        code = generate_mapping(ep)
+        assert "identifier_field" not in code
+
+    def test_custom_identifier_field_name(self):
+        """identifier_field preserves the exact parameter name."""
+        ep = _make_endpoint()
+        ep.identifier_field = "id"
+        code = generate_mapping(ep)
+        assert 'identifier_field="id"' in code
+
+
+class TestGenerateMappingTomlMirroring:
+    """Tests for the ``existing_toml_path`` TOML-mirroring behavior."""
+
+    def test_mirrors_cache_strategy_realtime(self, tmp_path):
+        fields = [
+            ParsedField(name="foo", api_path="foo", python_type="int", default=0),
+        ]
+        ep = _make_endpoint(fields=fields)
+
+        toml = tmp_path / "volumes.toml"
+        toml.write_text(
+            '[endpoint]\npath = "/storage/volumes"\n\n[fields.foo]\ncache_strategy = "realtime"\n'
+        )
+
+        code = generate_mapping(ep, existing_toml_path=toml)
+        assert 'cache_strategy="realtime"' in code
+
+    def test_mirrors_requires_explicit_fetch(self, tmp_path):
+        fields = [
+            ParsedField(name="foo", api_path="foo", python_type="int", default=0),
+        ]
+        ep = _make_endpoint(fields=fields)
+
+        toml = tmp_path / "volumes.toml"
+        toml.write_text(
+            '[endpoint]\npath = "/storage/volumes"\n\n'
+            "[fields.foo]\nrequires_explicit_fetch = true\n"
+        )
+
+        code = generate_mapping(ep, existing_toml_path=toml)
+        assert "requires_explicit_fetch=True" in code
+
+    def test_default_cache_strategy_omitted(self, tmp_path):
+        """cache_strategy='cache' (the default) is NOT emitted."""
+        fields = [
+            ParsedField(name="foo", api_path="foo", python_type="int", default=0),
+        ]
+        ep = _make_endpoint(fields=fields)
+
+        toml = tmp_path / "volumes.toml"
+        toml.write_text(
+            '[endpoint]\npath = "/storage/volumes"\n\n[fields.foo]\ncache_strategy = "cache"\n'
+        )
+
+        code = generate_mapping(ep, existing_toml_path=toml)
+        assert "cache_strategy=" not in code
+
+    def test_no_toml_emits_defaults(self):
+        """No existing_toml_path → behavior matches the old code path."""
+        fields = [
+            ParsedField(name="foo", api_path="foo", python_type="int", default=0),
+        ]
+        ep = _make_endpoint(fields=fields)
+        code = generate_mapping(ep, existing_toml_path=None)
+        assert "cache_strategy=" not in code
+        assert "requires_explicit_fetch=" not in code
+
+    def test_missing_toml_file_emits_defaults(self, tmp_path):
+        """Non-existent path → silent fallback to defaults (no error)."""
+        fields = [
+            ParsedField(name="foo", api_path="foo", python_type="int", default=0),
+        ]
+        ep = _make_endpoint(fields=fields)
+        bogus = tmp_path / "does-not-exist.toml"
+        code = generate_mapping(ep, existing_toml_path=bogus)
+        assert "cache_strategy=" not in code
+
+    def test_missing_fields_table_emits_defaults(self, tmp_path):
+        """TOML present but no [fields] table → defaults emitted silently."""
+        fields = [
+            ParsedField(name="foo", api_path="foo", python_type="int", default=0),
+        ]
+        ep = _make_endpoint(fields=fields)
+        toml = tmp_path / "volumes.toml"
+        toml.write_text('[endpoint]\npath = "/storage/volumes"\n')
+        code = generate_mapping(ep, existing_toml_path=toml)
+        assert "cache_strategy=" not in code
+
+    def test_malformed_toml_silent_fallback(self, tmp_path):
+        """Malformed TOML falls back to defaults silently (no raise)."""
+        fields = [
+            ParsedField(name="foo", api_path="foo", python_type="int", default=0),
+        ]
+        ep = _make_endpoint(fields=fields)
+        toml = tmp_path / "volumes.toml"
+        toml.write_text("this is not = valid = toml [[[[")
+        code = generate_mapping(ep, existing_toml_path=toml)
+        # Must not raise — and emits defaults
+        assert "cache_strategy=" not in code
+
+    def test_toml_only_one_of_two_fields(self, tmp_path):
+        """TOML declares a custom strategy for one field; others stay default."""
+        fields = [
+            ParsedField(name="foo", api_path="foo", python_type="int", default=0),
+            ParsedField(name="bar", api_path="bar", python_type="int", default=0),
+        ]
+        ep = _make_endpoint(fields=fields)
+        toml = tmp_path / "volumes.toml"
+        toml.write_text(
+            '[endpoint]\npath = "/storage/volumes"\n\n'
+            '[fields.foo]\ncache_strategy = "realtime"\n\n'
+            '[fields.bar]\ncache_strategy = "cache"\n'
+        )
+        code = generate_mapping(ep, existing_toml_path=toml)
+        # foo gets realtime; bar stays default (omitted)
+        assert 'cache_strategy="realtime"' in code
+        # Only one emission
+        assert code.count("cache_strategy=") == 1
+
 
 # ---------------------------------------------------------------------------
 # Init generation

--- a/tests/unit/codegen/test_roundtrip.py
+++ b/tests/unit/codegen/test_roundtrip.py
@@ -1,0 +1,157 @@
+"""Round-trip regression test for the OpenAPI codegen pipeline (issue #601).
+
+The codegen pipeline must be a no-op against the current on-disk output.
+For each of three representative ONTAP endpoints the test:
+
+1. Seeds a temp directory with a copy of the on-disk ``<name>.toml``
+   overlay (so :func:`generate_mapping` can mirror any
+   ``cache_strategy`` / ``requires_explicit_fetch`` values the TOML
+   declares).
+2. Runs :func:`write_endpoint_files` into the temp directory.
+3. Runs ``ruff format`` (via ``subprocess.run``) over the generated
+   ``mapping.py`` and ``model.py`` — the on-disk files are formatted
+   the same way, so any ordering differences surface here.
+4. Diffs the produced files against the on-disk files and asserts
+   byte-identical equality.
+
+If any diff is found, the generator has drifted from the on-disk
+expectation — either the generator has a bug or the on-disk file has
+an un-mirrored hand edit.  Both are fail cases the maintainer must fix
+before the codegen is safe to run across the full ONTAP tree.
+
+Endpoints chosen:
+
+* ``/storage/volumes`` — biggest on-disk mapping, exercises
+  ``cache_strategy="realtime"`` + ``requires_explicit_fetch`` mirroring,
+  array-of-objects transforms, and ``identifier_field`` inference.
+* ``/storage/aggregates`` — array-of-objects transforms plus
+  ``cache_strategy`` mirroring, ``identifier_field`` inference.
+* ``/svm/peers`` — simple flat mapping with only
+  ``identifier_field`` inference, no transforms or TOML overrides.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tools.codegen.adapters import parse_openapi_spec
+from tools.codegen.generators import write_endpoint_files
+
+# Resolve the repo root so the test is robust to pytest being invoked
+# from any working directory.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SPEC_PATH = REPO_ROOT / "docs" / "example-config" / "apis" / "ontap" / "openapi3.json"
+CACHE_ROOT = REPO_ROOT / "src" / "pynetappfoundry" / "cache"
+MODELS_ROOT = REPO_ROOT / "src" / "pynetappfoundry" / "models"
+
+
+# (api_path, module_parts, toml_stem) — module_parts mirrors the
+# on-disk directory layout.
+ROUNDTRIP_ENDPOINTS = [
+    ("/storage/volumes", ("storage", "volumes"), "volumes"),
+    ("/storage/aggregates", ("storage", "aggregates"), "aggregates"),
+    ("/svm/peers", ("svm", "peers"), "peers"),
+]
+
+
+@pytest.fixture(scope="module")
+def parsed_endpoints():
+    """Parse the ONTAP spec once per module."""
+    if not SPEC_PATH.exists():
+        pytest.skip(f"ONTAP spec not available at {SPEC_PATH}")
+    endpoints = parse_openapi_spec(SPEC_PATH, "ontap")
+    return endpoints
+
+
+def _ruff_format(*paths: Path) -> None:
+    """Run ``ruff format`` on the given paths.
+
+    The round-trip test is validated against ruff-formatted files on
+    disk, so the generated output has to go through the same formatter
+    before comparison.
+    """
+    subprocess.run(
+        ["uv", "run", "ruff", "format", *[str(p) for p in paths]],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("api_path", "module_parts", "toml_stem"),
+    ROUNDTRIP_ENDPOINTS,
+    ids=[ep[0] for ep in ROUNDTRIP_ENDPOINTS],
+)
+def test_codegen_round_trip(
+    api_path: str,
+    module_parts: tuple[str, ...],
+    toml_stem: str,
+    parsed_endpoints,
+    tmp_path: Path,
+) -> None:
+    """Regenerating an on-disk endpoint must reproduce it byte-identically."""
+    endpoint = next((e for e in parsed_endpoints if e.path == api_path), None)
+    assert endpoint is not None, f"endpoint {api_path} not found in parsed spec"
+
+    # On-disk targets
+    ondisk_cache_dir = CACHE_ROOT / "ontap" / Path(*module_parts)
+    ondisk_models_dir = MODELS_ROOT / "ontap" / Path(*module_parts)
+    ondisk_mapping = ondisk_cache_dir / "mapping.py"
+    ondisk_model = ondisk_models_dir / "model.py"
+    ondisk_toml = ondisk_cache_dir / f"{toml_stem}.toml"
+
+    assert ondisk_mapping.exists(), f"missing on-disk mapping: {ondisk_mapping}"
+    assert ondisk_model.exists(), f"missing on-disk model: {ondisk_model}"
+    assert ondisk_toml.exists(), f"missing on-disk TOML: {ondisk_toml}"
+
+    # Seed the temp tree with a copy of the on-disk TOML so
+    # ``generate_mapping`` can read its ``cache_strategy`` /
+    # ``requires_explicit_fetch`` overrides when emitting Python.
+    temp_cache_dir = tmp_path / "cache"
+    temp_models_dir = tmp_path / "models"
+    seed_dir = temp_cache_dir / "ontap" / Path(*module_parts)
+    seed_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(ondisk_toml, seed_dir / f"{toml_stem}.toml")
+
+    # Run the codegen pipeline into the temp tree.
+    schema_lookup = {e.path: e.schema_name for e in parsed_endpoints}
+    write_endpoint_files(
+        endpoint,
+        temp_cache_dir,
+        "ontap",
+        None,
+        schema_lookup,
+        models_dir=temp_models_dir,
+    )
+
+    generated_mapping = temp_cache_dir / "ontap" / Path(*module_parts) / "mapping.py"
+    generated_model = temp_models_dir / "ontap" / Path(*module_parts) / "model.py"
+
+    assert generated_mapping.exists(), "codegen did not produce mapping.py"
+    assert generated_model.exists(), "codegen did not produce model.py"
+
+    # Format the generated files the same way the on-disk ones are.
+    _ruff_format(generated_mapping, generated_model)
+
+    # Byte-identical assertion: any drift is a generator bug or an
+    # un-mirrored on-disk hand edit.
+    ondisk_mapping_bytes = ondisk_mapping.read_bytes()
+    generated_mapping_bytes = generated_mapping.read_bytes()
+    assert generated_mapping_bytes == ondisk_mapping_bytes, (
+        f"mapping.py drift for {api_path}:\n"
+        f"  on-disk:   {ondisk_mapping}\n"
+        f"  generated: {generated_mapping}\n"
+    )
+
+    ondisk_model_bytes = ondisk_model.read_bytes()
+    generated_model_bytes = generated_model.read_bytes()
+    assert generated_model_bytes == ondisk_model_bytes, (
+        f"model.py drift for {api_path}:\n"
+        f"  on-disk:   {ondisk_model}\n"
+        f"  generated: {generated_model}\n"
+    )

--- a/tools/codegen/adapters.py
+++ b/tools/codegen/adapters.py
@@ -71,6 +71,13 @@ class ParsedEndpoint:
             ``/svm/svms/{svm.uuid}/...``).
         parent_path: The parent resource path segment if parameterized.
         tags: API tags for grouping.
+        identifier_field: Inferred single-field identifier used to address
+            a collection item (e.g. ``"uuid"`` for ``/storage/volumes``
+            whose sibling item endpoint is ``/storage/volumes/{uuid}``).
+            ``None`` when no sibling item endpoint exists or when the item
+            endpoint has multiple path parameters.  Composite identifiers
+            are not inferred; nested response-field identifiers (e.g.
+            ``"volume.uuid"``) must be set via a manual edit after codegen.
     """
 
     path: str
@@ -83,6 +90,7 @@ class ParsedEndpoint:
     has_parent: bool = False
     parent_path: str = ""
     tags: list[str] = field(default_factory=list)
+    identifier_field: str | None = None
 
 
 # OpenAPI type → (python_type, default_value)
@@ -371,6 +379,56 @@ def _detect_parent_path(path: str) -> tuple[bool, str]:
     return False, ""
 
 
+def _build_identifier_map(all_paths: list[str]) -> dict[str, str]:
+    """Build a ``{collection_path: identifier_param_name}`` lookup.
+
+    Scans every path in the spec for item endpoints of the form
+    ``/foo/bar/{param}`` and pairs them with their collection path
+    ``/foo/bar``.  Only item endpoints with **exactly one** path
+    parameter qualify — composite identifiers and deeply-parameterized
+    paths are skipped so the caller can fall back to manual editing for
+    those edge cases.
+
+    The inner name of ``{param}`` is returned, e.g. ``/storage/volumes``
+    paired with ``/storage/volumes/{uuid}`` yields ``"uuid"``.
+
+    Args:
+        all_paths: Every path string defined in the OpenAPI spec.
+
+    Returns:
+        Mapping from collection path to single identifier parameter name.
+        Collections without a qualifying sibling item endpoint are absent
+        from the returned dict.
+    """
+    identifiers: dict[str, str] = {}
+    path_set = set(all_paths)
+    for path in all_paths:
+        # We're looking for paths of the form `/foo/bar/{param}`
+        # whose parent `/foo/bar` also exists and has no other params.
+        segments = path.strip("/").split("/")
+        if not segments or "{" not in segments[-1] or "}" not in segments[-1]:
+            continue
+        # Count path parameters in the whole path.  Multi-param item
+        # endpoints are skipped — those imply composite identifiers
+        # (which we don't auto-infer) or parameterized parents (already
+        # handled by `has_parent`).
+        total_params = sum(1 for s in segments if "{" in s)
+        if total_params != 1:
+            continue
+        param_name = segments[-1].strip("{}")
+        collection_segments = segments[:-1]
+        if not collection_segments:
+            continue
+        collection_path = "/" + "/".join(collection_segments)
+        if collection_path not in path_set:
+            continue
+        # If multiple item endpoints somehow map to the same collection
+        # (shouldn't happen in well-formed specs), first one wins and
+        # subsequent candidates are ignored.
+        identifiers.setdefault(collection_path, param_name)
+    return identifiers
+
+
 def parse_openapi_spec(
     spec_path: Path,
     api_type: str = "ontap",
@@ -462,6 +520,17 @@ def parse_openapi_spec(
                 tags=tags,
             )
         )
+
+    # Second pass: infer ``identifier_field`` for collection endpoints by
+    # matching them against sibling item endpoints (``/foo`` + ``/foo/{x}``).
+    # The spec contains many item endpoints that are never generated (they
+    # don't have list response schemas), so we scan *all* paths from the
+    # spec — not just the parsed endpoints — when building the lookup.
+    identifier_map = _build_identifier_map(list(paths.keys()))
+    for ep in endpoints:
+        param = identifier_map.get(ep.path)
+        if param is not None:
+            ep.identifier_field = param
 
     return endpoints
 

--- a/tools/codegen/generators.py
+++ b/tools/codegen/generators.py
@@ -654,10 +654,50 @@ def generate_model(endpoint: ParsedEndpoint, api_type: str = "ontap") -> str:
     return result
 
 
+def _load_toml_field_overrides(
+    existing_toml_path: Path | None,
+) -> dict[str, dict[str, Any]]:
+    """Load per-field overrides from a sibling ``<name>.toml`` overlay.
+
+    Used by :func:`generate_mapping` to mirror any ``cache_strategy`` or
+    ``requires_explicit_fetch`` values that the user (or a prior
+    hand-edit) has set in the TOML into the emitted Python source.  The
+    runtime overlay loader (``cache/overlay_loader.py``) already treats
+    the TOML as authoritative; mirroring into Python keeps the two in
+    sync for readability and round-trip stability.
+
+    A missing path or malformed TOML returns an empty mapping — callers
+    fall back to dataclass defaults.  This mirrors the silent-fallback
+    behavior of :func:`generate_toml_overlay`.
+
+    Args:
+        existing_toml_path: Path to the sibling TOML overlay, or
+            ``None`` if no overlay exists on disk.
+
+    Returns:
+        ``{cache_attr: {config_key: value}}`` extracted from the
+        ``[fields.*]`` tables.  Empty when no TOML, no ``fields`` table,
+        or the TOML can't be parsed.
+    """
+    if existing_toml_path is None or not existing_toml_path.exists():
+        return {}
+    try:
+        with open(existing_toml_path, "rb") as f:
+            data = tomllib.load(f)
+    except (tomllib.TOMLDecodeError, OSError):
+        # Malformed TOML or filesystem error: fall back to defaults.
+        return {}
+    fields_table = data.get("fields")
+    if not isinstance(fields_table, dict):
+        return {}
+    return {k: v for k, v in fields_table.items() if isinstance(v, dict)}
+
+
 def generate_mapping(
     endpoint: ParsedEndpoint,
     api_type: str = "ontap",
     schema_lookup: dict[str, str] | None = None,
+    existing_toml_path: Path | None = None,
 ) -> str:
     """Generate a TypeMapping/FieldMapping module for an endpoint.
 
@@ -668,11 +708,24 @@ def generate_mapping(
     Array-of-objects fields with typed sub-models get transform functions
     that construct sub-model instances using ``get_nested_value()``.
 
+    When ``existing_toml_path`` points at a sibling ``<name>.toml``
+    overlay, per-field ``cache_strategy`` and ``requires_explicit_fetch``
+    values are mirrored from the overlay into the emitted Python
+    ``FieldMapping(...)`` calls.  The TOML remains the authoritative
+    runtime source; the Python-level mirror only exists so that the file
+    is self-describing and so regeneration is a byte-identical round
+    trip against the on-disk output.
+
     Args:
         endpoint: Parsed endpoint with fields (tree structure).
         api_type: API type tag.
         schema_lookup: Optional mapping of API path → schema name for
             resolving parent class names.
+        existing_toml_path: Optional path to an existing sibling TOML
+            overlay.  When present, per-field ``cache_strategy`` and
+            ``requires_explicit_fetch`` values are mirrored into the
+            emitted Python.  Missing or malformed overlays fall back
+            silently to dataclass defaults.
 
     Returns:
         Python source code for the mapping module.
@@ -683,6 +736,10 @@ def generate_mapping(
 
     # Collect all leaf fields from the tree
     leaves = _collect_all_leaves(endpoint.fields)
+
+    # Load the sibling TOML overlay (if any) so we can mirror user-set
+    # cache_strategy / requires_explicit_fetch into the emitted Python.
+    toml_field_overrides = _load_toml_field_overrides(existing_toml_path)
 
     # Identify sub-model fields for array-of-objects transforms
     # Build the same sub_model_map as generate_model to get consistent names
@@ -726,12 +783,11 @@ def generate_mapping(
         ]
     )
 
-    # Add get_nested_value import if we have nested transforms
-    has_nested_transforms = any("." in ap for ap in array_sub_models)
-    if has_nested_transforms:
-        lines.append("from pynetappfoundry.utils.dict_path import get_nested_value")
-
-    # Split long model import across multiple lines
+    # Split long model import across multiple lines.  Emitted before the
+    # ``utils.dict_path`` import so the resulting order matches ruff's
+    # isort convention (alphabetical: ``cache.*``, ``models.*``,
+    # ``utils.*``) — this keeps codegen output in sync with the on-disk
+    # files and lets round-trip regeneration stay byte-identical.
     model_import_line = f"from {model_import} import {', '.join(model_classes)}"
     if len(model_import_line) > 100:
         lines.append(f"from {model_import} import (")
@@ -740,6 +796,11 @@ def generate_mapping(
         lines.append(")")
     else:
         lines.append(model_import_line)
+
+    # Add get_nested_value import if we have nested transforms
+    has_nested_transforms = any("." in ap for ap in array_sub_models)
+    if has_nested_transforms:
+        lines.append("from pynetappfoundry.utils.dict_path import get_nested_value")
 
     # Generate transform functions for array sub-model fields
     if array_sub_models:
@@ -782,14 +843,23 @@ def generate_mapping(
             else:
                 lines.append(ret_line)
 
+    # Separate the TypeMapping from the preceding block.  PEP 8 calls for
+    # two blank lines before a top-level class/function, but a single
+    # blank line is conventional when the preceding block is only
+    # imports.  We detect which by whether transform helpers were
+    # emitted.
     lines.append("")
-    lines.append("")
+    if array_sub_models:
+        lines.append("")
     lines.append(f"{mapping_name} = TypeMapping(")
     lines.append(f'    name="{class_name}",')
     lines.append(f"    model_class={class_name},")
     lines.append(f'    api_endpoint="{endpoint.path}?fields=*",')
 
     lines.append(f'    api_type="{api_type}",')
+
+    if endpoint.identifier_field is not None:
+        lines.append(f'    identifier_field="{endpoint.identifier_field}",')
 
     if endpoint.records_path != "records":
         lines.append(f'    records_path="{endpoint.records_path}",')
@@ -811,8 +881,24 @@ def generate_mapping(
         seen_attrs.add(cache_attr)
         default_repr = _python_default_repr(field, for_mapping=True)
 
+        # Mirror the sibling TOML's per-field config (if any).  TOML is
+        # authoritative at runtime; this only keeps the emitted Python
+        # in sync for readability and round-trip stability.
+        toml_field_cfg = toml_field_overrides.get(cache_attr, {})
+        toml_cache_strategy = toml_field_cfg.get("cache_strategy")
+        toml_requires_explicit_fetch = bool(toml_field_cfg.get("requires_explicit_fetch", False))
+        # Emit ``requires_explicit_fetch`` when the parser flagged it OR
+        # when the sibling TOML declares it.  This keeps the Python and
+        # TOML in sync on regen even if the TOML has hand-edited the
+        # flag for a field the parser didn't detect as expensive.
+        emit_explicit_fetch = field.requires_explicit_fetch or toml_requires_explicit_fetch
+
         field_args = [f'        cache_attr="{cache_attr}"']
 
+        # Ordering matches the on-disk ONTAP mappings:
+        # cache_attr, api_path, transform, cache_strategy, default,
+        # requires_explicit_fetch.  When api_path equals cache_attr it's
+        # omitted (FieldMapping.__post_init__ fills it in).
         if field.api_path in array_sub_models:
             func_name = f"_transform_{field.api_path.replace('.', '_')}"
             if field.api_path != cache_attr:
@@ -821,10 +907,13 @@ def generate_mapping(
         elif field.api_path != cache_attr:
             field_args.append(f'        api_path="{field.api_path}"')
 
+        if isinstance(toml_cache_strategy, str) and toml_cache_strategy != "cache":
+            field_args.append(f'        cache_strategy="{toml_cache_strategy}"')
+
         if field.default != "" or field.is_list:
             field_args.append(f"        default={default_repr}")
 
-        if field.requires_explicit_fetch:
+        if emit_explicit_fetch:
             field_args.append("        requires_explicit_fetch=True")
 
         lines.append("        FieldMapping(")
@@ -1002,6 +1091,17 @@ def write_endpoint_files(
     _ensure_init_files(models_dir / api_type, module_parts, pkg_type="models")
     _ensure_init_files(output_dir / api_type, module_parts, pkg_type="cache")
 
+    # Resolve the sibling TOML path up-front so ``generate_mapping``
+    # can read any existing overlay before it's regenerated.  The TOML
+    # is authoritative for ``cache_strategy`` / ``requires_explicit_fetch``
+    # at runtime; mirroring it into the emitted Python keeps the file
+    # self-describing and regeneration byte-identical (round-trip
+    # invariant — see ADR-0008).
+    toml_dir = overlay_dir or cache_pkg_dir
+    toml_dir.mkdir(parents=True, exist_ok=True)
+    toml_path = toml_dir / f"{module_parts[-1]}.toml"
+    existing_toml = toml_path if toml_path.exists() else None
+
     # model.py (in models/)
     model_path = model_pkg_dir / "model.py"
     model_path.write_text(generate_model(endpoint, api_type))
@@ -1012,17 +1112,20 @@ def write_endpoint_files(
     init_path.write_text(generate_init(endpoint, api_type))
     written.append(init_path)
 
-    # mapping.py (in cache/)
+    # mapping.py (in cache/) — reads the current on-disk TOML if any
     mapping_path = cache_pkg_dir / "mapping.py"
-    mapping_path.write_text(generate_mapping(endpoint, api_type, schema_lookup))
+    mapping_path.write_text(
+        generate_mapping(
+            endpoint,
+            api_type,
+            schema_lookup,
+            existing_toml_path=existing_toml,
+        )
+    )
     written.append(mapping_path)
 
-    # TOML overlay (in cache/ or overlay_dir)
-    toml_dir = overlay_dir or cache_pkg_dir
-    toml_dir.mkdir(parents=True, exist_ok=True)
-    toml_path = toml_dir / f"{module_parts[-1]}.toml"
-    existing = toml_path if toml_path.exists() else None
-    toml_path.write_text(generate_toml_overlay(endpoint, existing, api_type))
+    # TOML overlay (in cache/ or overlay_dir) — regenerated after mapping
+    toml_path.write_text(generate_toml_overlay(endpoint, existing_toml, api_type))
     written.append(toml_path)
 
     return written


### PR DESCRIPTION
## Description

Make the OpenAPI codegen pipeline round-trip-safe. Before this change, running `doit generate_models --api=ontap` against the current spec silently dropped 968 customizations across 124 on-disk ONTAP mapping files — two categories specifically:

1. **`TypeMapping(identifier_field=...)`** — required for `DataSource.get(id=...)` lookups. Not emitted by the generator.
2. **`FieldMapping(cache_strategy="realtime")` and `requires_explicit_fetch=True`** — present in Python `mapping.py` and mirrored in the sibling `<name>.toml`. The runtime overlay loader already applies these from TOML at registry-load time (TOML is authoritative); the Python-level values are a documentation mirror. Regen wiped them from Python anyway.

## Related Issue

Addresses #601

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

**Generator:**
- `tools/codegen/adapters.py` — `ParsedEndpoint` gains `identifier_field: str | None`. New `_build_identifier_map()` pairs `/foo` collection endpoints with `/foo/{param}` single-param item siblings and populates `identifier_field` during `parse_openapi_spec()`.
- `tools/codegen/generators.py` — `generate_mapping()` takes an optional `existing_toml_path`. When present, it loads the TOML and mirrors per-field `cache_strategy` (when non-default) and `requires_explicit_fetch=True` into the emitted Python. Emits `identifier_field=...` on `TypeMapping` when the parsed endpoint carries one. `write_endpoint_files()` computes the TOML path up front and passes it in before regenerating mapping.py, so the merge is one-pass.
- Two pre-existing generator bugs also fixed (surfaced by the round-trip test): blank-line count before `TypeMapping` when no transform helpers exist; `get_nested_value` import now sorts alphabetically.

**Latent correctness improvement:**
- Added `identifier_field="uuid"` to `src/pynetappfoundry/cache/ontap/storage/aggregates/mapping.py` and `src/pynetappfoundry/cache/ontap/svm/peers/mapping.py`. Both were silently missing this field — `DataSource.get(OntapAggregate, id=...)` and `DataSource.get(OntapSvmPeer, id=...)` would not have filtered correctly. Surfaced during round-trip test development; included here since the generator now emits `identifier_field` for these endpoints and without the change the round-trip would fail. The remaining ~120 ONTAP mappings without `identifier_field` are out of scope for this PR (document-only follow-up).

**Docs:**
- `docs/decisions/0008-openapi-codegen-for-model-generation.md` — new amendment section documenting (a) the round-trip invariant enforced by the new test, (b) TOML as authoritative source for `cache_strategy` / `requires_explicit_fetch`, (c) the manual-edit escape hatch for the one known `identifier_field` edge case (`svm/migrations/volumes` → `"volume.uuid"` — a nested response field, not a path param).
- `docs/development/adding-backends.md` — cross-reference to ADR-0008.

## Testing

- [x] All existing tests pass (`doit check` green).
- [x] Added 10 new tests for `identifier_field` inference (`tests/unit/codegen/test_adapters.py`).
- [x] Added 11 new tests for `generate_mapping` identifier emission and TOML strategy mirroring (`tests/unit/codegen/test_generators.py`, including silent-fallback on missing/malformed TOML).
- [x] Added `tests/unit/codegen/test_roundtrip.py` — parametrized regression test over `/storage/volumes`, `/storage/aggregates`, `/svm/peers`. Runs `write_endpoint_files()` into a temp dir pre-seeded with the on-disk TOML, runs `ruff format` over the produced `mapping.py` and `model.py`, asserts byte-identical against on-disk. All 3 pass.

## Checklist

- [x] Code follows project style (`doit format` clean).
- [x] `doit lint`, `doit type_check`, `doit test` all pass.
- [x] New tests prove the fix is effective (round-trip regression test locks the contract).
- [x] Documentation updated (ADR-0008, adding-backends.md).

## Additional Notes

- **Scope not expanded**: did not regenerate the other ~120 ONTAP mappings to add `identifier_field` — the plan explicitly scoped that out. The round-trip test only covers the three named endpoints; future PRs can expand it.
- **Double-truth at rest, single-truth at runtime**: `cache_strategy` now appears in both Python and TOML for fields that override the default. This is cosmetic — the runtime overlay loader (`cache/overlay_loader.py`) always re-reads TOML and patches each `FieldMapping` at registry-load time, so TOML still wins. The Python mirror is for readability.
- **Unblocks #600** (DII backend): DII models can now be generated via `doit generate_models --api=dii` and the output will be round-trip-safe.
