### PR TITLE
fix(codegen): resolve parent_id_field and schema_lookup for child endpoints on regen

### DIFF
--- a/tests/unit/codegen/test_roundtrip.py
+++ b/tests/unit/codegen/test_roundtrip.py
@@ -29,6 +29,10 @@ ONTAP endpoints (issue #601):
   ``cache_strategy`` mirroring, ``identifier_field`` inference.
 * ``/svm/peers`` — simple flat mapping with only
   ``identifier_field`` inference, no transforms or TOML overrides.
+* ``/network/fc/fabrics/{fabric.name}/zones`` — child endpoint whose
+  parent (``/network/fc/fabrics``) uses ``identifier_field="name"``
+  instead of the ONTAP default ``"uuid"``.  Exercises
+  ``parent_id_field`` derivation from the identifier map (issue #606).
 
 DII endpoints (issue #603):
 
@@ -71,29 +75,42 @@ ROUNDTRIP_ENDPOINTS = [
     ("ontap", "/storage/volumes", ("storage", "volumes"), "volumes"),
     ("ontap", "/storage/aggregates", ("storage", "aggregates"), "aggregates"),
     ("ontap", "/svm/peers", ("svm", "peers"), "peers"),
+    # Child endpoint whose parent uses ``identifier_field="name"`` (#606).
+    (
+        "ontap",
+        "/network/fc/fabrics/{fabric.name}/zones",
+        ("network", "fc", "fabrics", "zones"),
+        "zones",
+    ),
     ("dii", "/assets/storages", ("assets", "storages"), "storages"),
     ("dii", "/assets/storages/count", ("assets", "storages", "count"), "count"),
 ]
 
 
 @pytest.fixture(scope="module")
-def parsed_endpoints_by_api() -> dict[str, tuple[list, set[str]]]:
-    """Parse each spec once per module and return (endpoints, shared_schemas).
+def parsed_endpoints_by_api() -> dict[str, tuple[list, set[str], list]]:
+    """Parse each spec once per module and return (endpoints, shared_schemas, full_endpoints).
 
     Mirrors the production pipeline in :mod:`tools.codegen.openapi_codegen`:
     deduplicates same-module-path endpoints BEFORE detecting shared
     schemas.  ONTAP's collection+item pairs reference the same schema
     but only one survives dedup, so the schema is not truly shared
     across distinct module paths.
+
+    Also returns the full (pre-dedup) endpoint list so the test can
+    build ``schema_lookup`` and ``identifier_map`` from all endpoints —
+    mirroring the production code which builds these from the full list
+    so child endpoints can always find their parent's schema and
+    identifier field (issue #606).
     """
-    result: dict[str, tuple[list, set[str]]] = {}
+    result: dict[str, tuple[list, set[str], list]] = {}
     for api_type, spec_path in [("ontap", ONTAP_SPEC_PATH), ("dii", DII_SPEC_PATH)]:
         if not spec_path.exists():
             continue
-        endpoints = parse_openapi_spec(spec_path, api_type)
-        endpoints = _deduplicate_endpoints(endpoints)
+        full_endpoints = parse_openapi_spec(spec_path, api_type)
+        endpoints = _deduplicate_endpoints(full_endpoints)
         shared = detect_shared_schemas(endpoints)
-        result[api_type] = (endpoints, shared)
+        result[api_type] = (endpoints, shared, full_endpoints)
     return result
 
 
@@ -122,13 +139,13 @@ def test_codegen_round_trip(
     api_path: str,
     module_parts: tuple[str, ...],
     toml_stem: str,
-    parsed_endpoints_by_api: dict[str, tuple[list, set[str]]],
+    parsed_endpoints_by_api: dict[str, tuple[list, set[str], list]],
     tmp_path: Path,
 ) -> None:
     """Regenerating an on-disk endpoint must reproduce it byte-identically."""
     if api_type not in parsed_endpoints_by_api:
         pytest.skip(f"{api_type} spec not available")
-    endpoints, shared_schemas = parsed_endpoints_by_api[api_type]
+    endpoints, shared_schemas, full_endpoints = parsed_endpoints_by_api[api_type]
     endpoint = next((e for e in endpoints if e.path == api_path), None)
     assert endpoint is not None, f"endpoint {api_path} not found in parsed {api_type} spec"
 
@@ -152,8 +169,12 @@ def test_codegen_round_trip(
     seed_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(ondisk_toml, seed_dir / f"{toml_stem}.toml")
 
-    # Run the codegen pipeline into the temp tree.
-    schema_lookup = {e.path: e.schema_name for e in endpoints}
+    # Build schema_lookup and identifier_map from the full (pre-dedup)
+    # endpoint list — mirrors production code in openapi_codegen.py so
+    # child endpoints can always resolve their parent's schema and
+    # identifier field even when the parent was collapsed by dedup (#606).
+    schema_lookup = {e.path: e.schema_name for e in full_endpoints}
+    identifier_map = {e.path: e.identifier_field for e in full_endpoints if e.identifier_field}
     write_endpoint_files(
         endpoint,
         temp_cache_dir,
@@ -162,6 +183,7 @@ def test_codegen_round_trip(
         schema_lookup,
         models_dir=temp_models_dir,
         shared_schemas=shared_schemas,
+        identifier_map=identifier_map,
     )
 
     generated_mapping = temp_cache_dir / api_type / Path(*module_parts) / "mapping.py"

--- a/tools/codegen/generators.py
+++ b/tools/codegen/generators.py
@@ -738,6 +738,7 @@ def generate_mapping(
     existing_toml_path: Path | None = None,
     *,
     shared_schemas: frozenset[str] | set[str] = frozenset(),
+    identifier_map: dict[str, str] | None = None,
 ) -> str:
     """Generate a TypeMapping/FieldMapping module for an endpoint.
 
@@ -771,6 +772,11 @@ def generate_mapping(
             :func:`_path_to_class_name` so the class name is
             URL-path-derived for shared schemas (avoids registry
             collisions across endpoints that share a schema).
+        identifier_map: Optional mapping of API path → identifier_field
+            name (e.g. ``{"/network/fc/fabrics": "name"}``).  Used to
+            look up the parent endpoint's actual identifier when emitting
+            ``parent_id_field``.  Falls back to the API-default dispatch
+            table when the parent path is absent from the map.
 
     Returns:
         Python source code for the mapping module.
@@ -951,10 +957,14 @@ def generate_mapping(
                 break
     if parent_resolvable:
         lines.append(f'    parent_mapping="{parent_class}",')
-        # Dispatch ``parent_id_field`` by API.  ONTAP uses ``uuid``;
-        # DII uses ``id``.  Fall back to ``uuid`` for any API not in
-        # the dispatch table (legacy behavior).
-        parent_id_field = _PARENT_ID_FIELD_BY_API.get(api_type, "uuid")
+        # Look up the parent endpoint's actual ``identifier_field`` from
+        # the pre-built map.  This correctly handles parents that use
+        # non-default identifiers (e.g. ``"name"`` instead of ``"uuid"``).
+        # Fall back to the API-default dispatch table when the parent
+        # path is absent from the map (legacy behavior).
+        parent_id_field = (identifier_map or {}).get(
+            endpoint.parent_path
+        ) or _PARENT_ID_FIELD_BY_API.get(api_type, "uuid")
         lines.append(f'    parent_id_field="{parent_id_field}",')
 
     lines.append("    fields=(")
@@ -1164,6 +1174,7 @@ def write_endpoint_files(
     models_dir: Path | None = None,
     *,
     shared_schemas: frozenset[str] | set[str] = frozenset(),
+    identifier_map: dict[str, str] | None = None,
 ) -> list[Path]:
     """Write all generated files for an endpoint.
 
@@ -1187,6 +1198,9 @@ def write_endpoint_files(
         shared_schemas: Set of schema names referenced by >1 endpoint
             in the current spec.  Threaded through the model, mapping,
             init, and TOML generators so class names stay consistent.
+        identifier_map: Optional mapping of API path → identifier_field
+            name.  Threaded through to :func:`generate_mapping` for
+            resolving the parent's ``parent_id_field``.
 
     Returns:
         List of paths to all files written.
@@ -1243,6 +1257,7 @@ def write_endpoint_files(
             schema_lookup,
             existing_toml_path=existing_toml,
             shared_schemas=shared_schemas,
+            identifier_map=identifier_map,
         )
     )
     written.append(mapping_path)

--- a/tools/codegen/openapi_codegen.py
+++ b/tools/codegen/openapi_codegen.py
@@ -160,12 +160,20 @@ def run(
         print("No endpoints to generate.", file=sys.stderr)
         return []
 
-    # Preserve the reference to the full (pre-filter) spec endpoints so
-    # future enhancements can reason about schemas outside the filter.
-    del full_spec_endpoints
+    # Build schema lookup from the full (pre-dedup) endpoint list so that
+    # child endpoints can always resolve their parent's schema name — even
+    # when the parent collection endpoint was collapsed by dedup with its
+    # sibling item endpoint.
+    schema_lookup: dict[str, str] = {ep.path: ep.schema_name for ep in full_spec_endpoints}
 
-    # Build schema lookup for parent path resolution in mappings
-    schema_lookup: dict[str, str] = {ep.path: ep.schema_name for ep in endpoints}
+    # Build identifier map from the full endpoint list so that
+    # ``generate_mapping`` can look up the parent's actual
+    # ``identifier_field`` (e.g. ``"name"`` instead of assuming ``"uuid"``).
+    identifier_map: dict[str, str] = {
+        ep.path: ep.identifier_field for ep in full_spec_endpoints if ep.identifier_field
+    }
+
+    del full_spec_endpoints
 
     all_written: list[Path] = []
 
@@ -184,6 +192,7 @@ def run(
             overlay_dir,
             schema_lookup,
             shared_schemas=shared_schemas,
+            identifier_map=identifier_map,
         )
         all_written.extend(written)
         field_count = len([f for f in ep.fields if not f.is_object or f.is_list])


### PR DESCRIPTION
## Description

Fix two related bugs in the codegen pipeline that caused `parent_id_field` and `parent_mapping` to be clobbered when regenerating child endpoints whose parent uses a non-default identifier field.

## Related Issue

Addresses #606

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **`tools/codegen/generators.py`** -- Accept an `identifier_map` parameter in `generate_mapping()` and `write_endpoint_files()`. Use it to look up the parent endpoint's actual `identifier_field` (e.g. `"name"`) instead of hardcoding the API-default (`"uuid"` for ONTAP). Falls back to the existing `_PARENT_ID_FIELD_BY_API` dispatch table when the parent is absent from the map.
- **`tools/codegen/openapi_codegen.py`** -- Build `schema_lookup` and `identifier_map` from the full (pre-dedup) endpoint list so child endpoints can always resolve their parent's schema and identifier field, even when the parent collection endpoint was collapsed during deduplication.
- **`tests/unit/codegen/test_roundtrip.py`** -- Add `/network/fc/fabrics/{fabric.name}/zones` as a round-trip test case. This child endpoint's parent (`/network/fc/fabrics`) uses `identifier_field="name"`, exercising the `parent_id_field` derivation fix.

## Root Causes

1. **Hardcoded `parent_id_field`**: `generate_mapping()` dispatched `parent_id_field` solely by API type (ONTAP -> `"uuid"`, DII -> `"id"`), ignoring cases where the parent endpoint uses a different identifier (e.g. `"name"`).
2. **`schema_lookup` built from deduped list**: The schema lookup dict was built from the deduplicated endpoint list. When a parent collection endpoint was collapsed during dedup (merged with its sibling item endpoint), child endpoints could no longer resolve `parent_mapping` because the parent path was missing from the lookup.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This fix unblocks #605 (full ONTAP regen), which was producing incorrect `parent_id_field` values for child endpoints like `/network/fc/fabrics/{fabric.name}/zones`.
