### PR TITLE
chore: regenerate 106 ONTAP mappings with inferred identifier_field

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"3c53dcc5-24e3-42f3-9d9f-2bd11ac27ac3","pid":2969,"acquiredAt":1775921631520}

--- a/src/pynetappfoundry/cache/ontap/application/applications/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/application/applications/mapping.py
@@ -284,6 +284,7 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
     model_class=OntapApplication,
     api_endpoint="/application/applications?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="svm.uuid",
@@ -341,8 +342,8 @@ ONTAPAPPLICATION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="statistics.components",
-            cache_strategy="realtime",
             transform=_transform_statistics_components,
+            cache_strategy="realtime",
             default=[],
         ),
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/application/consistency_groups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/application/consistency_groups/mapping.py
@@ -70,6 +70,7 @@ ONTAPCONSISTENCYGROUPRESPONSE_MAPPING = TypeMapping(
     model_class=OntapConsistencyGroupResponse,
     api_endpoint="/application/consistency-groups?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="application.component_type",

--- a/src/pynetappfoundry/cache/ontap/application/templates/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/application/templates/mapping.py
@@ -268,6 +268,7 @@ ONTAPAPPLICATIONTEMPLATE_MAPPING = TypeMapping(
     model_class=OntapApplicationTemplate,
     api_endpoint="/application/templates?fields=*",
     api_type="ontap",
+    identifier_field="name",
     fields=(
         FieldMapping(
             cache_attr="name",

--- a/src/pynetappfoundry/cache/ontap/cloud/targets/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cloud/targets/mapping.py
@@ -11,6 +11,7 @@ ONTAPCLOUDTARGET_MAPPING = TypeMapping(
     model_class=OntapCloudTarget,
     api_endpoint="/cloud/targets?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="access_key",

--- a/src/pynetappfoundry/cache/ontap/cluster/chassis/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/chassis/mapping.py
@@ -34,6 +34,7 @@ ONTAPCHASSIS_MAPPING = TypeMapping(
     model_class=OntapChassis,
     api_endpoint="/cluster/chassis?fields=*",
     api_type="ontap",
+    identifier_field="id",
     fields=(
         FieldMapping(
             cache_attr="frus",

--- a/src/pynetappfoundry/cache/ontap/cluster/counter/tables/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/counter/tables/mapping.py
@@ -12,8 +12,8 @@ ONTAPCOUNTERTABLE_MAPPING = TypeMapping(
     api_endpoint="/cluster/counter/tables/{name}?fields=*",
     api_type="ontap",
     records_path="counter_schemas",
-    parent_mapping=None,
-    parent_id_field=None,
+    parent_mapping="OntapCounterTable",
+    parent_id_field="name",
     fields=(
         FieldMapping(
             cache_attr="denominator.name",

--- a/src/pynetappfoundry/cache/ontap/cluster/jobs/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/jobs/mapping.py
@@ -24,6 +24,7 @@ ONTAPJOB_MAPPING = TypeMapping(
     model_class=OntapJob,
     api_endpoint="/cluster/jobs?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="code",

--- a/src/pynetappfoundry/cache/ontap/cluster/licensing/capacity_pools/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/licensing/capacity_pools/mapping.py
@@ -22,6 +22,7 @@ ONTAPCAPACITYPOOLRESPONSE_MAPPING = TypeMapping(
     model_class=OntapCapacityPoolResponse,
     api_endpoint="/cluster/licensing/capacity-pools?fields=*",
     api_type="ontap",
+    identifier_field="serial_number",
     fields=(
         FieldMapping(
             cache_attr="license_manager.uuid",

--- a/src/pynetappfoundry/cache/ontap/cluster/licensing/license_managers/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/licensing/license_managers/mapping.py
@@ -13,6 +13,7 @@ ONTAPLICENSEMANAGERRESPONSE_MAPPING = TypeMapping(
     model_class=OntapLicenseManagerResponse,
     api_endpoint="/cluster/licensing/license-managers?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="default",

--- a/src/pynetappfoundry/cache/ontap/cluster/licensing/licenses/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/licensing/licenses/mapping.py
@@ -22,6 +22,7 @@ ONTAPLICENSEPACKAGERESPONSE_MAPPING = TypeMapping(
     model_class=OntapLicensePackageResponse,
     api_endpoint="/cluster/licensing/licenses?fields=*",
     api_type="ontap",
+    identifier_field="name",
     fields=(
         FieldMapping(
             cache_attr="description",

--- a/src/pynetappfoundry/cache/ontap/cluster/mediators/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/mediators/mapping.py
@@ -11,6 +11,7 @@ ONTAPMEDIATORRESPONSE_MAPPING = TypeMapping(
     model_class=OntapMediatorResponse,
     api_endpoint="/cluster/mediators?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="ca_certificate",

--- a/src/pynetappfoundry/cache/ontap/cluster/metrocluster/dr_groups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/metrocluster/dr_groups/mapping.py
@@ -22,6 +22,7 @@ ONTAPMETROCLUSTERDRGROUP_MAPPING = TypeMapping(
     model_class=OntapMetroclusterDrGroup,
     api_endpoint="/cluster/metrocluster/dr-groups?fields=*",
     api_type="ontap",
+    identifier_field="id",
     fields=(
         FieldMapping(
             cache_attr="dr_pairs",

--- a/src/pynetappfoundry/cache/ontap/cluster/metrocluster/nodes/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/metrocluster/nodes/mapping.py
@@ -11,6 +11,7 @@ ONTAPMETROCLUSTERNODE_MAPPING = TypeMapping(
     model_class=OntapMetroclusterNode,
     api_endpoint="/cluster/metrocluster/nodes?fields=*",
     api_type="ontap",
+    identifier_field="node.uuid",
     fields=(
         FieldMapping(
             cache_attr="automatic_uso",

--- a/src/pynetappfoundry/cache/ontap/cluster/metrocluster/operations/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/metrocluster/operations/mapping.py
@@ -13,6 +13,7 @@ ONTAPMETROCLUSTEROPERATION_MAPPING = TypeMapping(
     model_class=OntapMetroclusterOperation,
     api_endpoint="/cluster/metrocluster/operations?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="additional_info",

--- a/src/pynetappfoundry/cache/ontap/cluster/nodes/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/nodes/mapping.py
@@ -104,6 +104,7 @@ ONTAPNODERESPONSE_MAPPING = TypeMapping(
     model_class=OntapNodeResponse,
     api_endpoint="/cluster/nodes?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="anti_ransomware_version",

--- a/src/pynetappfoundry/cache/ontap/cluster/ntp/keys/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/ntp/keys/mapping.py
@@ -11,6 +11,7 @@ ONTAPNTPKEY_MAPPING = TypeMapping(
     model_class=OntapNtpKey,
     api_endpoint="/cluster/ntp/keys?fields=*",
     api_type="ontap",
+    identifier_field="id",
     fields=(
         FieldMapping(
             cache_attr="digest_type",

--- a/src/pynetappfoundry/cache/ontap/cluster/ntp/servers/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/ntp/servers/mapping.py
@@ -11,6 +11,7 @@ ONTAPNTPSERVER_MAPPING = TypeMapping(
     model_class=OntapNtpServer,
     api_endpoint="/cluster/ntp/servers?fields=*",
     api_type="ontap",
+    identifier_field="server",
     fields=(
         FieldMapping(
             cache_attr="authentication_enabled",

--- a/src/pynetappfoundry/cache/ontap/cluster/peers/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/peers/mapping.py
@@ -26,6 +26,7 @@ ONTAPCLUSTERPEER_MAPPING = TypeMapping(
     model_class=OntapClusterPeer,
     api_endpoint="/cluster/peers?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="authentication.expiry_time",

--- a/src/pynetappfoundry/cache/ontap/cluster/schedules/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/schedules/mapping.py
@@ -11,6 +11,7 @@ ONTAPSCHEDULE_MAPPING = TypeMapping(
     model_class=OntapSchedule,
     api_endpoint="/cluster/schedules?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="cluster.name",

--- a/src/pynetappfoundry/cache/ontap/cluster/software/packages/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/cluster/software/packages/mapping.py
@@ -11,6 +11,7 @@ ONTAPSOFTWAREPACKAGE_MAPPING = TypeMapping(
     model_class=OntapSoftwarePackage,
     api_endpoint="/cluster/software/packages?fields=*",
     api_type="ontap",
+    identifier_field="version",
     fields=(
         FieldMapping(
             cache_attr="create_time",

--- a/src/pynetappfoundry/cache/ontap/name_services/cache/group_membership/settings/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/cache/group_membership/settings/mapping.py
@@ -13,6 +13,7 @@ ONTAPGROUPMEMBERSHIPSETTINGS_MAPPING = TypeMapping(
     model_class=OntapGroupMembershipSettings,
     api_endpoint="/name-services/cache/group-membership/settings?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/name_services/cache/host/settings/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/cache/host/settings/mapping.py
@@ -11,6 +11,7 @@ ONTAPHOSTSSETTINGS_MAPPING = TypeMapping(
     model_class=OntapHostsSettings,
     api_endpoint="/name-services/cache/host/settings?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="dns_ttl_enabled",

--- a/src/pynetappfoundry/cache/ontap/name_services/cache/netgroup/settings/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/cache/netgroup/settings/mapping.py
@@ -13,6 +13,7 @@ ONTAPNETGROUPSSETTINGS_MAPPING = TypeMapping(
     model_class=OntapNetgroupsSettings,
     api_endpoint="/name-services/cache/netgroup/settings?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/name_services/cache/unix_group/settings/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/cache/unix_group/settings/mapping.py
@@ -13,6 +13,7 @@ ONTAPUNIXGROUPSETTINGS_MAPPING = TypeMapping(
     model_class=OntapUnixGroupSettings,
     api_endpoint="/name-services/cache/unix-group/settings?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/name_services/cache/unix_user/settings/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/cache/unix_user/settings/mapping.py
@@ -13,6 +13,7 @@ ONTAPUNIXUSERSETTINGS_MAPPING = TypeMapping(
     model_class=OntapUnixUserSettings,
     api_endpoint="/name-services/cache/unix-user/settings?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/name_services/dns/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/dns/mapping.py
@@ -19,6 +19,7 @@ ONTAPDNS_MAPPING = TypeMapping(
     model_class=OntapDns,
     api_endpoint="/name-services/dns?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="attempts",

--- a/src/pynetappfoundry/cache/ontap/name_services/ldap/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/ldap/mapping.py
@@ -11,6 +11,7 @@ ONTAPLDAPSERVICE_MAPPING = TypeMapping(
     model_class=OntapLdapService,
     api_endpoint="/name-services/ldap?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="ad_domain",

--- a/src/pynetappfoundry/cache/ontap/name_services/netgroup_files/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/netgroup_files/mapping.py
@@ -11,8 +11,6 @@ ONTAPNETGROUPFILE_MAPPING = TypeMapping(
     model_class=OntapNetgroupFile,
     api_endpoint="/name-services/netgroup-files/{svm.uuid}?fields=*",
     api_type="ontap",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="file_size",

--- a/src/pynetappfoundry/cache/ontap/name_services/nis/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/nis/mapping.py
@@ -22,6 +22,7 @@ ONTAPNISSERVICE_MAPPING = TypeMapping(
     model_class=OntapNisService,
     api_endpoint="/name-services/nis?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="binding_details",

--- a/src/pynetappfoundry/cache/ontap/name_services/unix_groups/users/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/name_services/unix_groups/users/mapping.py
@@ -22,8 +22,6 @@ ONTAPUNIXGROUPUSERS_MAPPING = TypeMapping(
     model_class=OntapUnixGroupUsers,
     api_endpoint="/name-services/unix-groups/{svm.uuid}/{unix_group.name}/users?fields=*",
     api_type="ontap",
-    parent_mapping="OntapUnixGroup",
-    parent_id_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="name",

--- a/src/pynetappfoundry/cache/ontap/network/ethernet/broadcast_domains/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ethernet/broadcast_domains/mapping.py
@@ -22,6 +22,7 @@ ONTAPBROADCASTDOMAIN_MAPPING = TypeMapping(
     model_class=OntapBroadcastDomain,
     api_endpoint="/network/ethernet/broadcast-domains?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="ipspace.name",

--- a/src/pynetappfoundry/cache/ontap/network/ethernet/ports/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ethernet/ports/mapping.py
@@ -54,6 +54,7 @@ ONTAPPORT_MAPPING = TypeMapping(
     model_class=OntapPort,
     api_endpoint="/network/ethernet/ports?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="broadcast_domain.ipspace.name",

--- a/src/pynetappfoundry/cache/ontap/network/ethernet/switches/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ethernet/switches/mapping.py
@@ -11,6 +11,7 @@ ONTAPSWITCH_MAPPING = TypeMapping(
     model_class=OntapSwitch,
     api_endpoint="/network/ethernet/switches?fields=*",
     api_type="ontap",
+    identifier_field="name",
     fields=(
         FieldMapping(
             cache_attr="address",

--- a/src/pynetappfoundry/cache/ontap/network/fc/fabrics/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/fc/fabrics/mapping.py
@@ -11,6 +11,7 @@ ONTAPFABRIC_MAPPING = TypeMapping(
     model_class=OntapFabric,
     api_endpoint="/network/fc/fabrics?fields=*",
     api_type="ontap",
+    identifier_field="name",
     fields=(
         FieldMapping(
             cache_attr="cache.age",

--- a/src/pynetappfoundry/cache/ontap/network/fc/interfaces/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/fc/interfaces/mapping.py
@@ -11,6 +11,7 @@ ONTAPFCINTERFACE_MAPPING = TypeMapping(
     model_class=OntapFcInterface,
     api_endpoint="/network/fc/interfaces?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="comment",

--- a/src/pynetappfoundry/cache/ontap/network/fc/ports/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/fc/ports/mapping.py
@@ -11,6 +11,7 @@ ONTAPFCPORT_MAPPING = TypeMapping(
     model_class=OntapFcPort,
     api_endpoint="/network/fc/ports?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="description",

--- a/src/pynetappfoundry/cache/ontap/network/http_proxy/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/http_proxy/mapping.py
@@ -11,6 +11,7 @@ ONTAPNETWORKHTTPPROXY_MAPPING = TypeMapping(
     model_class=OntapNetworkHttpProxy,
     api_endpoint="/network/http-proxy?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="authentication_enabled",

--- a/src/pynetappfoundry/cache/ontap/network/ip/bgp/peer_groups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ip/bgp/peer_groups/mapping.py
@@ -11,6 +11,7 @@ ONTAPBGPPEERGROUP_MAPPING = TypeMapping(
     model_class=OntapBgpPeerGroup,
     api_endpoint="/network/ip/bgp/peer-groups?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="ipspace.name",

--- a/src/pynetappfoundry/cache/ontap/network/ip/interfaces/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ip/interfaces/mapping.py
@@ -11,6 +11,7 @@ ONTAPIPINTERFACE_MAPPING = TypeMapping(
     model_class=OntapIpInterface,
     api_endpoint="/network/ip/interfaces?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="ddns_enabled",

--- a/src/pynetappfoundry/cache/ontap/network/ip/routes/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ip/routes/mapping.py
@@ -22,6 +22,7 @@ ONTAPNETWORKROUTE_MAPPING = TypeMapping(
     model_class=OntapNetworkRoute,
     api_endpoint="/network/ip/routes?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="destination.address",

--- a/src/pynetappfoundry/cache/ontap/network/ip/service_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ip/service_policies/mapping.py
@@ -11,6 +11,7 @@ ONTAPIPSERVICEPOLICY_MAPPING = TypeMapping(
     model_class=OntapIpServicePolicy,
     api_endpoint="/network/ip/service-policies?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="ipspace.name",

--- a/src/pynetappfoundry/cache/ontap/network/ip/subnets/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ip/subnets/mapping.py
@@ -28,6 +28,7 @@ ONTAPIPSUBNET_MAPPING = TypeMapping(
     model_class=OntapIpSubnet,
     api_endpoint="/network/ip/subnets?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="available_count",

--- a/src/pynetappfoundry/cache/ontap/network/ipspaces/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/network/ipspaces/mapping.py
@@ -11,6 +11,7 @@ ONTAPIPSPACE_MAPPING = TypeMapping(
     model_class=OntapIpspace,
     api_endpoint="/network/ipspaces?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="name",

--- a/src/pynetappfoundry/cache/ontap/protocols/active_directory/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/active_directory/mapping.py
@@ -33,6 +33,7 @@ ONTAPACTIVEDIRECTORY_MAPPING = TypeMapping(
     model_class=OntapActiveDirectory,
     api_endpoint="/protocols/active-directory?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="discovered_servers",

--- a/src/pynetappfoundry/cache/ontap/protocols/audit/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/audit/mapping.py
@@ -11,6 +11,7 @@ ONTAPAUDIT_MAPPING = TypeMapping(
     model_class=OntapAudit,
     api_endpoint="/protocols/audit?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="charge_qos",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/connections/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/connections/mapping.py
@@ -49,8 +49,8 @@ ONTAPCIFSCONNECTION_MAPPING = TypeMapping(
         ),
         FieldMapping(
             cache_attr="sessions",
-            cache_strategy="realtime",
             transform=_transform_sessions,
+            cache_strategy="realtime",
             default=[],
         ),
         FieldMapping(

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/domains/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/domains/mapping.py
@@ -40,6 +40,7 @@ ONTAPCIFSDOMAIN_MAPPING = TypeMapping(
     model_class=OntapCifsDomain,
     api_endpoint="/protocols/cifs/domains?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="ad_domain.password",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/group_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/group_policies/mapping.py
@@ -66,6 +66,7 @@ ONTAPPOLICIESANDRULESTOBEAPPLIED_MAPPING = TypeMapping(
     model_class=OntapPoliciesAndRulesToBeApplied,
     api_endpoint="/protocols/cifs/group-policies?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="svm.name",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/local_groups/members/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/local_groups/members/mapping.py
@@ -22,8 +22,6 @@ ONTAPLOCALCIFSGROUPMEMBERS_MAPPING = TypeMapping(
     model_class=OntapLocalCifsGroupMembers,
     api_endpoint="/protocols/cifs/local-groups/{svm.uuid}/{local_cifs_group.sid}/members?fields=*",
     api_type="ontap",
-    parent_mapping="OntapLocalCifsGroup",
-    parent_id_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="local_cifs_group.sid",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/services/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/services/mapping.py
@@ -11,6 +11,7 @@ ONTAPCIFSSERVICE_MAPPING = TypeMapping(
     model_class=OntapCifsService,
     api_endpoint="/protocols/cifs/services?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="ad_domain.default_site",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/shadow_copies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/shadow_copies/mapping.py
@@ -11,6 +11,7 @@ ONTAPSHADOWCOPY_MAPPING = TypeMapping(
     model_class=OntapShadowcopy,
     api_endpoint="/protocols/cifs/shadow-copies?fields=*",
     api_type="ontap",
+    identifier_field="client_uuid",
     fields=(
         FieldMapping(
             cache_attr="client_uuid",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/shadowcopy_sets/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/shadowcopy_sets/mapping.py
@@ -11,6 +11,7 @@ ONTAPSHADOWCOPYSET_MAPPING = TypeMapping(
     model_class=OntapShadowcopySet,
     api_endpoint="/protocols/cifs/shadowcopy-sets?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="keep_snapshots",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/shares/acls/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/shares/acls/mapping.py
@@ -11,8 +11,6 @@ ONTAPCIFSSHAREACL_MAPPING = TypeMapping(
     model_class=OntapCifsShareAcl,
     api_endpoint="/protocols/cifs/shares/{svm.uuid}/{share}/acls?fields=*",
     api_type="ontap",
-    parent_mapping="OntapCifsShare",
-    parent_id_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="permission",

--- a/src/pynetappfoundry/cache/ontap/protocols/cifs/users_and_groups/bulk_import/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/cifs/users_and_groups/bulk_import/mapping.py
@@ -13,8 +13,6 @@ ONTAPLOCALCIFSUSERSANDGROUPSIMPORT_MAPPING = TypeMapping(
     model_class=OntapLocalCifsUsersAndGroupsImport,
     api_endpoint="/protocols/cifs/users-and-groups/bulk-import/{svm.uuid}?fields=*",
     api_type="ontap",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="decryption_password",

--- a/src/pynetappfoundry/cache/ontap/protocols/file_security/permissions/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/file_security/permissions/mapping.py
@@ -14,8 +14,6 @@ ONTAPFILEDIRECTORYSECURITY_MAPPING = TypeMapping(
     api_endpoint="/protocols/file-security/permissions/{svm.uuid}/{path}?fields=*",
     api_type="ontap",
     records_path="acls",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="access",

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/connections/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/connections/mapping.py
@@ -11,8 +11,6 @@ ONTAPFPOLICYCONNECTION_MAPPING = TypeMapping(
     model_class=OntapFpolicyConnection,
     api_endpoint="/protocols/fpolicy/{svm.uuid}/connections?fields=*",
     api_type="ontap",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="disconnected_reason.code",

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/engines/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/engines/mapping.py
@@ -11,8 +11,6 @@ ONTAPFPOLICYENGINE_MAPPING = TypeMapping(
     model_class=OntapFpolicyEngine,
     api_endpoint="/protocols/fpolicy/{svm.uuid}/engines?fields=*",
     api_type="ontap",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="buffer_size.recv_buffer",

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/events/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/events/mapping.py
@@ -11,8 +11,6 @@ ONTAPFPOLICYEVENT_MAPPING = TypeMapping(
     model_class=OntapFpolicyEvent,
     api_endpoint="/protocols/fpolicy/{svm.uuid}/events?fields=*",
     api_type="ontap",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="file_operations.access",

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/mapping.py
@@ -12,8 +12,6 @@ ONTAPFPOLICY_MAPPING = TypeMapping(
     api_endpoint="/protocols/fpolicy/{svm.uuid}?fields=*",
     api_type="ontap",
     records_path="engines",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="buffer_size.recv_buffer",

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/persistent_stores/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/persistent_stores/mapping.py
@@ -13,8 +13,6 @@ ONTAPFPOLICYPERSISTENTSTORE_MAPPING = TypeMapping(
     model_class=OntapFpolicyPersistentStore,
     api_endpoint="/protocols/fpolicy/{svm.uuid}/persistent-stores?fields=*",
     api_type="ontap",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="autosize_mode",

--- a/src/pynetappfoundry/cache/ontap/protocols/fpolicy/policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/fpolicy/policies/mapping.py
@@ -22,8 +22,6 @@ ONTAPFPOLICYPOLICY_MAPPING = TypeMapping(
     model_class=OntapFpolicyPolicy,
     api_endpoint="/protocols/fpolicy/{svm.uuid}/policies?fields=*",
     api_type="ontap",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="allow_privileged_access",

--- a/src/pynetappfoundry/cache/ontap/protocols/locks/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/locks/mapping.py
@@ -11,6 +11,7 @@ ONTAPCLIENTLOCK_MAPPING = TypeMapping(
     model_class=OntapClientLock,
     api_endpoint="/protocols/locks?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="byte_lock.exclusive",

--- a/src/pynetappfoundry/cache/ontap/protocols/ndmp/nodes/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/ndmp/nodes/mapping.py
@@ -11,6 +11,7 @@ ONTAPNDMPNODE_MAPPING = TypeMapping(
     model_class=OntapNdmpNode,
     api_endpoint="/protocols/ndmp/nodes?fields=*",
     api_type="ontap",
+    identifier_field="node.uuid",
     fields=(
         FieldMapping(
             cache_attr="authentication_types",

--- a/src/pynetappfoundry/cache/ontap/protocols/ndmp/svms/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/ndmp/svms/mapping.py
@@ -11,6 +11,7 @@ ONTAPNDMPSVM_MAPPING = TypeMapping(
     model_class=OntapNdmpSvm,
     api_endpoint="/protocols/ndmp/svms?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="authentication_types",

--- a/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/rules/clients/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/rules/clients/mapping.py
@@ -13,8 +13,6 @@ ONTAPEXPORTCLIENT_MAPPING = TypeMapping(
     model_class=OntapExportClient,
     api_endpoint="/protocols/nfs/export-policies/{policy.id}/rules/{index}/clients?fields=*",
     api_type="ontap",
-    parent_mapping=None,
-    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="index",

--- a/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/rules/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nfs/export_policies/rules/mapping.py
@@ -22,8 +22,6 @@ ONTAPEXPORTRULE_MAPPING = TypeMapping(
     model_class=OntapExportRule,
     api_endpoint="/protocols/nfs/export-policies/{policy.id}/rules?fields=*",
     api_type="ontap",
-    parent_mapping=None,
-    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="allow_device_creation",

--- a/src/pynetappfoundry/cache/ontap/protocols/nfs/kerberos/interfaces/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nfs/kerberos/interfaces/mapping.py
@@ -13,6 +13,7 @@ ONTAPKERBEROSINTERFACE_MAPPING = TypeMapping(
     model_class=OntapKerberosInterface,
     api_endpoint="/protocols/nfs/kerberos/interfaces?fields=*",
     api_type="ontap",
+    identifier_field="interface.uuid",
     fields=(
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/protocols/nfs/services/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nfs/services/mapping.py
@@ -11,6 +11,7 @@ ONTAPNFSSERVICE_MAPPING = TypeMapping(
     model_class=OntapNfsService,
     api_endpoint="/protocols/nfs/services?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="access_cache_config.harvest_timeout",

--- a/src/pynetappfoundry/cache/ontap/protocols/nfs/tls/interfaces/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nfs/tls/interfaces/mapping.py
@@ -11,6 +11,7 @@ ONTAPNFSTLSINTERFACE_MAPPING = TypeMapping(
     model_class=OntapNfsTlsInterface,
     api_endpoint="/protocols/nfs/tls/interfaces?fields=*",
     api_type="ontap",
+    identifier_field="interface.uuid",
     fields=(
         FieldMapping(
             cache_attr="certificate.name",

--- a/src/pynetappfoundry/cache/ontap/protocols/nvme/interfaces/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nvme/interfaces/mapping.py
@@ -11,6 +11,7 @@ ONTAPNVMEINTERFACE_MAPPING = TypeMapping(
     model_class=OntapNvmeInterface,
     api_endpoint="/protocols/nvme/interfaces?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/protocols/nvme/services/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nvme/services/mapping.py
@@ -11,6 +11,7 @@ ONTAPNVMESERVICE_MAPPING = TypeMapping(
     model_class=OntapNvmeService,
     api_endpoint="/protocols/nvme/services?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/protocols/nvme/subsystems/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/nvme/subsystems/mapping.py
@@ -28,6 +28,7 @@ ONTAPNVMESUBSYSTEM_MAPPING = TypeMapping(
     model_class=OntapNvmeSubsystem,
     api_endpoint="/protocols/nvme/subsystems?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="comment",

--- a/src/pynetappfoundry/cache/ontap/protocols/s3/services/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/s3/services/mapping.py
@@ -28,6 +28,7 @@ ONTAPS3SERVICE_MAPPING = TypeMapping(
     model_class=OntapS3Service,
     api_endpoint="/protocols/s3/services?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="buckets",

--- a/src/pynetappfoundry/cache/ontap/protocols/san/fcp/services/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/fcp/services/mapping.py
@@ -11,6 +11,7 @@ ONTAPFCPSERVICE_MAPPING = TypeMapping(
     model_class=OntapFcpService,
     api_endpoint="/protocols/san/fcp/services?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/protocols/san/igroups/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/igroups/mapping.py
@@ -66,6 +66,7 @@ ONTAPIGROUP_MAPPING = TypeMapping(
     model_class=OntapIgroup,
     api_endpoint="/protocols/san/igroups?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="comment",

--- a/src/pynetappfoundry/cache/ontap/protocols/san/iscsi/services/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/iscsi/services/mapping.py
@@ -11,6 +11,7 @@ ONTAPISCSISERVICE_MAPPING = TypeMapping(
     model_class=OntapIscsiService,
     api_endpoint="/protocols/san/iscsi/services?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/protocols/san/lun_maps/reporting_nodes/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/lun_maps/reporting_nodes/mapping.py
@@ -13,8 +13,6 @@ ONTAPLUNMAPREPORTINGNODE_MAPPING = TypeMapping(
     model_class=OntapLunMapReportingNode,
     api_endpoint="/protocols/san/lun-maps/{lun.uuid}/{igroup.uuid}/reporting-nodes?fields=*",
     api_type="ontap",
-    parent_mapping="OntapLunMap",
-    parent_id_field="lun.uuid",
     fields=(
         FieldMapping(
             cache_attr="igroup.uuid",

--- a/src/pynetappfoundry/cache/ontap/protocols/san/portsets/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/san/portsets/mapping.py
@@ -28,6 +28,7 @@ ONTAPPORTSET_MAPPING = TypeMapping(
     model_class=OntapPortset,
     api_endpoint="/protocols/san/portsets?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="igroups",

--- a/src/pynetappfoundry/cache/ontap/protocols/vscan/events/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/vscan/events/mapping.py
@@ -11,8 +11,6 @@ ONTAPVSCANEVENT_MAPPING = TypeMapping(
     model_class=OntapVscanEvent,
     api_endpoint="/protocols/vscan/{svm.uuid}/events?fields=*",
     api_type="ontap",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="disconnect_reason",

--- a/src/pynetappfoundry/cache/ontap/protocols/vscan/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/vscan/mapping.py
@@ -12,8 +12,6 @@ ONTAPVSCAN_MAPPING = TypeMapping(
     api_endpoint="/protocols/vscan/{svm.uuid}?fields=*",
     api_type="ontap",
     records_path="on_access_policies",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/protocols/vscan/on_access_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/vscan/on_access_policies/mapping.py
@@ -11,8 +11,6 @@ ONTAPVSCANONACCESS_MAPPING = TypeMapping(
     model_class=OntapVscanOnAccess,
     api_endpoint="/protocols/vscan/{svm.uuid}/on-access-policies?fields=*",
     api_type="ontap",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="enabled",

--- a/src/pynetappfoundry/cache/ontap/protocols/vscan/on_demand_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/vscan/on_demand_policies/mapping.py
@@ -11,8 +11,6 @@ ONTAPVSCANONDEMAND_MAPPING = TypeMapping(
     model_class=OntapVscanOnDemand,
     api_endpoint="/protocols/vscan/{svm.uuid}/on-demand-policies?fields=*",
     api_type="ontap",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="log_path",

--- a/src/pynetappfoundry/cache/ontap/protocols/vscan/scanner_pools/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/protocols/vscan/scanner_pools/mapping.py
@@ -11,8 +11,6 @@ ONTAPVSCANSCANNERPOOL_MAPPING = TypeMapping(
     model_class=OntapVscanScannerPool,
     api_endpoint="/protocols/vscan/{svm.uuid}/scanner-pools?fields=*",
     api_type="ontap",
-    parent_mapping="OntapSvm",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="cluster.name",

--- a/src/pynetappfoundry/cache/ontap/resource_tags/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/resource_tags/mapping.py
@@ -11,6 +11,7 @@ ONTAPRESOURCETAG_MAPPING = TypeMapping(
     model_class=OntapResourceTag,
     api_endpoint="/resource-tags?fields=*",
     api_type="ontap",
+    identifier_field="value",
     fields=(
         FieldMapping(
             cache_attr="num_resources",

--- a/src/pynetappfoundry/cache/ontap/security/anti_ransomware/suspects/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/anti_ransomware/suspects/mapping.py
@@ -13,6 +13,7 @@ ONTAPANTIRANSOMWARESUSPECT_MAPPING = TypeMapping(
     model_class=OntapAntiRansomwareSuspect,
     api_endpoint="/security/anti-ransomware/suspects?fields=*",
     api_type="ontap",
+    identifier_field="volume.uuid",
     fields=(
         FieldMapping(
             cache_attr="file.format",

--- a/src/pynetappfoundry/cache/ontap/security/authentication/cluster/oauth2/clients/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/authentication/cluster/oauth2/clients/mapping.py
@@ -13,6 +13,7 @@ ONTAPSECURITYOAUTH2_MAPPING = TypeMapping(
     model_class=OntapSecurityOauth2,
     api_endpoint="/security/authentication/cluster/oauth2/clients?fields=*",
     api_type="ontap",
+    identifier_field="name",
     fields=(
         FieldMapping(
             cache_attr="application",

--- a/src/pynetappfoundry/cache/ontap/security/authentication/duo/profiles/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/authentication/duo/profiles/mapping.py
@@ -11,6 +11,7 @@ ONTAPDUO_MAPPING = TypeMapping(
     model_class=OntapDuo,
     api_endpoint="/security/authentication/duo/profiles?fields=*",
     api_type="ontap",
+    identifier_field="owner.uuid",
     fields=(
         FieldMapping(
             cache_attr="api_host",

--- a/src/pynetappfoundry/cache/ontap/security/aws_kms/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/aws_kms/mapping.py
@@ -22,6 +22,7 @@ ONTAPAWSKMS_MAPPING = TypeMapping(
     model_class=OntapAwsKms,
     api_endpoint="/security/aws-kms?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="access_key_id",

--- a/src/pynetappfoundry/cache/ontap/security/azure_key_vaults/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/azure_key_vaults/mapping.py
@@ -26,6 +26,7 @@ ONTAPAZUREKEYVAULT_MAPPING = TypeMapping(
     model_class=OntapAzureKeyVault,
     api_endpoint="/security/azure-key-vaults?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="authentication_method",

--- a/src/pynetappfoundry/cache/ontap/security/certificates/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/certificates/mapping.py
@@ -11,6 +11,7 @@ ONTAPSECURITYCERTIFICATE_MAPPING = TypeMapping(
     model_class=OntapSecurityCertificate,
     api_endpoint="/security/certificates?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="authority_key_identifier",

--- a/src/pynetappfoundry/cache/ontap/security/gcp_kms/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/gcp_kms/mapping.py
@@ -22,6 +22,7 @@ ONTAPGCPKMS_MAPPING = TypeMapping(
     model_class=OntapGcpKms,
     api_endpoint="/security/gcp-kms?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="application_credentials",

--- a/src/pynetappfoundry/cache/ontap/security/ipsec/ca_certificates/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/ipsec/ca_certificates/mapping.py
@@ -13,6 +13,7 @@ ONTAPIPSECCACERTIFICATE_MAPPING = TypeMapping(
     model_class=OntapIpsecCaCertificate,
     api_endpoint="/security/ipsec/ca-certificates?fields=*",
     api_type="ontap",
+    identifier_field="certificate.uuid",
     fields=(
         FieldMapping(
             cache_attr="certificate.uuid",

--- a/src/pynetappfoundry/cache/ontap/security/ipsec/policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/ipsec/policies/mapping.py
@@ -11,6 +11,7 @@ ONTAPIPSECPOLICYRESPONSE_MAPPING = TypeMapping(
     model_class=OntapIpsecPolicyResponse,
     api_endpoint="/security/ipsec/policies?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="action",

--- a/src/pynetappfoundry/cache/ontap/security/ipsec/security_associations/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/ipsec/security_associations/mapping.py
@@ -13,6 +13,7 @@ ONTAPSECURITYASSOCIATIONRESPONSE_MAPPING = TypeMapping(
     model_class=OntapSecurityAssociationResponse,
     api_endpoint="/security/ipsec/security-associations?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="cipher_suite",

--- a/src/pynetappfoundry/cache/ontap/security/key_managers/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/key_managers/mapping.py
@@ -42,6 +42,7 @@ ONTAPSECURITYKEYMANAGER_MAPPING = TypeMapping(
     model_class=OntapSecurityKeyManager,
     api_endpoint="/security/key-managers?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="configuration.name",

--- a/src/pynetappfoundry/cache/ontap/security/key_stores/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/key_stores/mapping.py
@@ -11,6 +11,7 @@ ONTAPSECURITYKEYSTORE_MAPPING = TypeMapping(
     model_class=OntapSecurityKeystore,
     api_endpoint="/security/key-stores?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="configuration.name",

--- a/src/pynetappfoundry/cache/ontap/security/login/messages/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/login/messages/mapping.py
@@ -11,6 +11,7 @@ ONTAPLOGINMESSAGES_MAPPING = TypeMapping(
     model_class=OntapLoginMessages,
     api_endpoint="/security/login/messages?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="banner",

--- a/src/pynetappfoundry/cache/ontap/security/multi_admin_verify/requests/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/multi_admin_verify/requests/mapping.py
@@ -13,6 +13,7 @@ ONTAPMULTIADMINVERIFYREQUEST_MAPPING = TypeMapping(
     model_class=OntapMultiAdminVerifyRequest,
     api_endpoint="/security/multi-admin-verify/requests?fields=*",
     api_type="ontap",
+    identifier_field="index",
     fields=(
         FieldMapping(
             cache_attr="approve_expiry_time",

--- a/src/pynetappfoundry/cache/ontap/security/roles/privileges/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/roles/privileges/mapping.py
@@ -11,8 +11,6 @@ ONTAPROLEPRIVILEGE_MAPPING = TypeMapping(
     model_class=OntapRolePrivilege,
     api_endpoint="/security/roles/{owner.uuid}/{name}/privileges?fields=*",
     api_type="ontap",
-    parent_mapping="OntapRole",
-    parent_id_field="owner.uuid",
     fields=(
         FieldMapping(
             cache_attr="access",

--- a/src/pynetappfoundry/cache/ontap/security/ssh/svms/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/ssh/svms/mapping.py
@@ -11,6 +11,7 @@ ONTAPSVMSSHSERVER_MAPPING = TypeMapping(
     model_class=OntapSvmSshServer,
     api_endpoint="/security/ssh/svms?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="ciphers",

--- a/src/pynetappfoundry/cache/ontap/security/webauthn/global_settings/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/security/webauthn/global_settings/mapping.py
@@ -11,6 +11,7 @@ ONTAPWEBAUTHNGLOBAL_MAPPING = TypeMapping(
     model_class=OntapWebauthnGlobal,
     api_endpoint="/security/webauthn/global-settings?fields=*",
     api_type="ontap",
+    identifier_field="owner.uuid",
     fields=(
         FieldMapping(
             cache_attr="attestation",

--- a/src/pynetappfoundry/cache/ontap/snapmirror/policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/snapmirror/policies/mapping.py
@@ -22,6 +22,7 @@ ONTAPSNAPMIRRORPOLICY_MAPPING = TypeMapping(
     model_class=OntapSnapmirrorPolicy,
     api_endpoint="/snapmirror/policies?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="comment",

--- a/src/pynetappfoundry/cache/ontap/snapmirror/relationships/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/snapmirror/relationships/mapping.py
@@ -77,6 +77,7 @@ ONTAPSNAPMIRRORRELATIONSHIP_MAPPING = TypeMapping(
     model_class=OntapSnapmirrorRelationship,
     api_endpoint="/snapmirror/relationships?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="backoff_level",

--- a/src/pynetappfoundry/cache/ontap/storage/bridges/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/bridges/mapping.py
@@ -64,6 +64,7 @@ ONTAPSTORAGEBRIDGE_MAPPING = TypeMapping(
     model_class=OntapStorageBridge,
     api_endpoint="/storage/bridges?fields=*",
     api_type="ontap",
+    identifier_field="wwn",
     fields=(
         FieldMapping(
             cache_attr="chassis_throughput_state",

--- a/src/pynetappfoundry/cache/ontap/storage/disks/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/disks/mapping.py
@@ -47,6 +47,7 @@ ONTAPDISK_MAPPING = TypeMapping(
     model_class=OntapDisk,
     api_endpoint="/storage/disks?fields=*",
     api_type="ontap",
+    identifier_field="name",
     fields=(
         FieldMapping(
             cache_attr="aggregates",

--- a/src/pynetappfoundry/cache/ontap/storage/file/clone/split_loads/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/file/clone/split_loads/mapping.py
@@ -11,6 +11,7 @@ ONTAPSPLITLOAD_MAPPING = TypeMapping(
     model_class=OntapSplitLoad,
     api_endpoint="/storage/file/clone/split-loads?fields=*",
     api_type="ontap",
+    identifier_field="node.uuid",
     fields=(
         FieldMapping(
             cache_attr="load.allowable",

--- a/src/pynetappfoundry/cache/ontap/storage/file/clone/split_status/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/file/clone/split_status/mapping.py
@@ -11,6 +11,7 @@ ONTAPSPLITSTATUS_MAPPING = TypeMapping(
     model_class=OntapSplitStatus,
     api_endpoint="/storage/file/clone/split-status?fields=*",
     api_type="ontap",
+    identifier_field="volume.uuid",
     fields=(
         FieldMapping(
             cache_attr="pending_splits",

--- a/src/pynetappfoundry/cache/ontap/storage/flexcache/flexcaches/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/flexcache/flexcaches/mapping.py
@@ -28,6 +28,7 @@ ONTAPFLEXCACHE_MAPPING = TypeMapping(
     model_class=OntapFlexcache,
     api_endpoint="/storage/flexcache/flexcaches?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="aggregates",

--- a/src/pynetappfoundry/cache/ontap/storage/flexcache/origins/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/flexcache/origins/mapping.py
@@ -12,8 +12,6 @@ ONTAPFLEXCACHEORIGIN_MAPPING = TypeMapping(
     api_endpoint="/storage/flexcache/origins/{uuid}?fields=*",
     api_type="ontap",
     records_path="flexcaches",
-    parent_mapping=None,
-    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="cluster.name",

--- a/src/pynetappfoundry/cache/ontap/storage/luns/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/luns/mapping.py
@@ -86,6 +86,7 @@ ONTAPLUN_MAPPING = TypeMapping(
     model_class=OntapLun,
     api_endpoint="/storage/luns?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="attributes",

--- a/src/pynetappfoundry/cache/ontap/storage/namespaces/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/namespaces/mapping.py
@@ -42,6 +42,7 @@ ONTAPNVMENAMESPACE_MAPPING = TypeMapping(
     model_class=OntapNvmeNamespace,
     api_endpoint="/storage/namespaces?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="auto_delete",

--- a/src/pynetappfoundry/cache/ontap/storage/pools/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/pools/mapping.py
@@ -70,6 +70,7 @@ ONTAPSTORAGEPOOL_MAPPING = TypeMapping(
     model_class=OntapStoragePool,
     api_endpoint="/storage/pools?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="capacity.disk_count",

--- a/src/pynetappfoundry/cache/ontap/storage/qos/policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/qos/policies/mapping.py
@@ -11,6 +11,7 @@ ONTAPQOSPOLICY_MAPPING = TypeMapping(
     model_class=OntapQosPolicy,
     api_endpoint="/storage/qos/policies?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="adaptive.absolute_min_iops",

--- a/src/pynetappfoundry/cache/ontap/storage/qos/workloads/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/qos/workloads/mapping.py
@@ -11,6 +11,7 @@ ONTAPQOSWORKLOAD_MAPPING = TypeMapping(
     model_class=OntapQosWorkload,
     api_endpoint="/storage/qos/workloads?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="file",

--- a/src/pynetappfoundry/cache/ontap/storage/qtrees/metrics/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/qtrees/metrics/mapping.py
@@ -13,8 +13,6 @@ ONTAPPERFORMANCEQTREEMETRICRESPONSE_MAPPING = TypeMapping(
     model_class=OntapPerformanceQtreeMetricResponse,
     api_endpoint="/storage/qtrees/{volume.uuid}/{qtree.id}/metrics?fields=*",
     api_type="ontap",
-    parent_mapping="OntapQtree",
-    parent_id_field="id",
     fields=(
         FieldMapping(
             cache_attr="duration",

--- a/src/pynetappfoundry/cache/ontap/storage/quota/rules/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/quota/rules/mapping.py
@@ -22,6 +22,7 @@ ONTAPQUOTARULE_MAPPING = TypeMapping(
     model_class=OntapQuotaRule,
     api_endpoint="/storage/quota/rules?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="files.hard_limit",

--- a/src/pynetappfoundry/cache/ontap/storage/shelves/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/shelves/mapping.py
@@ -76,6 +76,7 @@ ONTAPSHELF_MAPPING = TypeMapping(
     model_class=OntapShelf,
     api_endpoint="/storage/shelves?fields=*",
     api_type="ontap",
+    identifier_field="uid",
     fields=(
         FieldMapping(
             cache_attr="acps",

--- a/src/pynetappfoundry/cache/ontap/storage/snaplock/audit_logs/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snaplock/audit_logs/mapping.py
@@ -22,6 +22,7 @@ ONTAPSNAPLOCKLOG_MAPPING = TypeMapping(
     model_class=OntapSnaplockLog,
     api_endpoint="/storage/snaplock/audit-logs?fields=*",
     api_type="ontap",
+    identifier_field="svm.uuid",
     fields=(
         FieldMapping(
             cache_attr="log_archive.archive",

--- a/src/pynetappfoundry/cache/ontap/storage/snaplock/compliance_clocks/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snaplock/compliance_clocks/mapping.py
@@ -13,6 +13,7 @@ ONTAPSNAPLOCKCOMPLIANCECLOCK_MAPPING = TypeMapping(
     model_class=OntapSnaplockComplianceClock,
     api_endpoint="/storage/snaplock/compliance-clocks?fields=*",
     api_type="ontap",
+    identifier_field="node.uuid",
     fields=(
         FieldMapping(
             cache_attr="node.name",

--- a/src/pynetappfoundry/cache/ontap/storage/snaplock/event_retention/operations/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snaplock/event_retention/operations/mapping.py
@@ -13,6 +13,7 @@ ONTAPEBROPERATION_MAPPING = TypeMapping(
     model_class=OntapEbrOperation,
     api_endpoint="/storage/snaplock/event-retention/operations?fields=*",
     api_type="ontap",
+    identifier_field="id",
     fields=(
         FieldMapping(
             cache_attr="id",

--- a/src/pynetappfoundry/cache/ontap/storage/snaplock/event_retention/policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snaplock/event_retention/policies/mapping.py
@@ -13,6 +13,7 @@ ONTAPSNAPLOCKRETENTIONPOLICY_MAPPING = TypeMapping(
     model_class=OntapSnaplockRetentionPolicy,
     api_endpoint="/storage/snaplock/event-retention/policies?fields=*",
     api_type="ontap",
+    identifier_field="policy.name",
     fields=(
         FieldMapping(
             cache_attr="name",

--- a/src/pynetappfoundry/cache/ontap/storage/snaplock/file/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snaplock/file/mapping.py
@@ -11,8 +11,6 @@ ONTAPSNAPLOCKFILERETENTION_MAPPING = TypeMapping(
     model_class=OntapSnaplockFileRetention,
     api_endpoint="/storage/snaplock/file/{volume.uuid}/{path}?fields=*",
     api_type="ontap",
-    parent_mapping="OntapVolume",
-    parent_id_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="expiry_time",

--- a/src/pynetappfoundry/cache/ontap/storage/snapshot_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/snapshot_policies/mapping.py
@@ -22,6 +22,7 @@ ONTAPSNAPSHOTPOLICY_MAPPING = TypeMapping(
     model_class=OntapSnapshotPolicy,
     api_endpoint="/storage/snapshot-policies?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="comment",

--- a/src/pynetappfoundry/cache/ontap/storage/switches/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/switches/mapping.py
@@ -67,6 +67,7 @@ ONTAPSTORAGESWITCH_MAPPING = TypeMapping(
     model_class=OntapStorageSwitch,
     api_endpoint="/storage/switches?fields=*",
     api_type="ontap",
+    identifier_field="name",
     fields=(
         FieldMapping(
             cache_attr="connections",

--- a/src/pynetappfoundry/cache/ontap/storage/volume_efficiency_policies/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/storage/volume_efficiency_policies/mapping.py
@@ -13,6 +13,7 @@ ONTAPVOLUMEEFFICIENCYPOLICY_MAPPING = TypeMapping(
     model_class=OntapVolumeEfficiencyPolicy,
     api_endpoint="/storage/volume-efficiency-policies?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="comment",

--- a/src/pynetappfoundry/cache/ontap/support/auto_update/configurations/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/auto_update/configurations/mapping.py
@@ -13,6 +13,7 @@ ONTAPAUTOUPDATECONFIGURATION_MAPPING = TypeMapping(
     model_class=OntapAutoUpdateConfiguration,
     api_endpoint="/support/auto-update/configurations?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="action",

--- a/src/pynetappfoundry/cache/ontap/support/auto_update/updates/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/auto_update/updates/mapping.py
@@ -29,6 +29,7 @@ ONTAPAUTOUPDATESTATUS_MAPPING = TypeMapping(
     model_class=OntapAutoUpdateStatus,
     api_endpoint="/support/auto-update/updates?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="action",

--- a/src/pynetappfoundry/cache/ontap/support/ems/destinations/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/ems/destinations/mapping.py
@@ -22,6 +22,7 @@ ONTAPEMSDESTINATIONRESPONSE_MAPPING = TypeMapping(
     model_class=OntapEmsDestinationResponse,
     api_endpoint="/support/ems/destinations?fields=*",
     api_type="ontap",
+    identifier_field="name",
     fields=(
         FieldMapping(
             cache_attr="access_control_role.name",

--- a/src/pynetappfoundry/cache/ontap/support/ems/filters/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/ems/filters/mapping.py
@@ -25,8 +25,6 @@ ONTAPEMSFILTER_MAPPING = TypeMapping(
     api_endpoint="/support/ems/filters/{name}?fields=*",
     api_type="ontap",
     records_path="rules",
-    parent_mapping=None,
-    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="index",

--- a/src/pynetappfoundry/cache/ontap/support/ems/filters/rules/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/ems/filters/rules/mapping.py
@@ -27,8 +27,6 @@ ONTAPEMSFILTERRULERESPONSE_MAPPING = TypeMapping(
     model_class=OntapEmsFilterRuleResponse,
     api_endpoint="/support/ems/filters/{name}/rules?fields=*",
     api_type="ontap",
-    parent_mapping=None,
-    parent_id_field=None,
     fields=(
         FieldMapping(
             cache_attr="index",

--- a/src/pynetappfoundry/cache/ontap/support/ems/role_configs/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/ems/role_configs/mapping.py
@@ -11,6 +11,7 @@ ONTAPEMSROLECONFIGRESPONSE_MAPPING = TypeMapping(
     model_class=OntapEmsRoleConfigResponse,
     api_endpoint="/support/ems/role-configs?fields=*",
     api_type="ontap",
+    identifier_field="access_control_role.name",
     fields=(
         FieldMapping(
             cache_attr="access_control_role.name",

--- a/src/pynetappfoundry/cache/ontap/support/snmp/traphosts/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/support/snmp/traphosts/mapping.py
@@ -11,6 +11,7 @@ ONTAPSNMPTRAPHOST_MAPPING = TypeMapping(
     model_class=OntapSnmpTraphost,
     api_endpoint="/support/snmp/traphosts?fields=*",
     api_type="ontap",
+    identifier_field="host",
     fields=(
         FieldMapping(
             cache_attr="host",

--- a/src/pynetappfoundry/cache/ontap/svm/migrations/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/svm/migrations/mapping.py
@@ -36,6 +36,7 @@ ONTAPSVMMIGRATION_MAPPING = TypeMapping(
     model_class=OntapSvmMigration,
     api_endpoint="/svm/migrations?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="auto_cutover",

--- a/src/pynetappfoundry/cache/ontap/svm/svms/mapping.py
+++ b/src/pynetappfoundry/cache/ontap/svm/svms/mapping.py
@@ -40,6 +40,7 @@ ONTAPSVM_MAPPING = TypeMapping(
     model_class=OntapSvm,
     api_endpoint="/svm/svms?fields=*",
     api_type="ontap",
+    identifier_field="uuid",
     fields=(
         FieldMapping(
             cache_attr="aggregates",


### PR DESCRIPTION
## Description

Regenerate ONTAP mappings to apply `identifier_field` inference and `parent_mapping`/`parent_id_field` corrections from codegen fixes #606, #609, #611. 134 mapping files updated; ~10 child endpoints with dedup-winner class name mismatches excluded (manual overrides preserved).

## Related Issue

Addresses #605

## Type of Change

- [x] Chore (maintenance, tooling)

## Changes Made

- ~106 ONTAP mappings gain `identifier_field="uuid"` (or similar, inferred from OpenAPI path parameters)
- ~28 child endpoint mappings gain corrected `parent_mapping`/`parent_id_field` or have explicit `None` values removed
- `svm/migrations/volumes` manual override (`identifier_field="volume.uuid"`) preserved
- Storage shelves gains `identifier_field="uid"` (non-uuid identifier)
- Snaplock audit-logs gains `identifier_field="svm.uuid"` (dotted identifier)

BREAKING CHANGE: TypeMapping constants gain `identifier_field` attribute values where previously unset. This is a correctness improvement — `DataSource.get(id=...)` lookups now filter on the correct field instead of silently returning None or filtering on a wrong key. Code relying on the previous broken lookup behavior may see changed results.

## Testing

- [x] All existing tests pass
- [x] Full ONTAP regen followed by `doit check` — 0 failures
- [x] Round-trip test validates byte-identity for 3 ONTAP + 1 child + 2 DII endpoints
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings