### PR TITLE
fix(codegen): validate parent_id_field against dedup-winner model fields

### DIFF
--- a/tests/unit/codegen/test_roundtrip.py
+++ b/tests/unit/codegen/test_roundtrip.py
@@ -57,7 +57,12 @@ from pathlib import Path
 import pytest
 
 from tools.codegen.adapters import detect_shared_schemas, parse_openapi_spec
-from tools.codegen.generators import write_endpoint_files
+from tools.codegen.generators import (
+    _collect_all_leaves,
+    _field_to_cache_attr,
+    _path_to_module_parts,
+    write_endpoint_files,
+)
 from tools.codegen.openapi_codegen import _deduplicate_endpoints
 
 # Resolve the repo root so the test is robust to pytest being invoked
@@ -169,12 +174,22 @@ def test_codegen_round_trip(
     seed_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(ondisk_toml, seed_dir / f"{toml_stem}.toml")
 
-    # Build schema_lookup and identifier_map from the full (pre-dedup)
-    # endpoint list — mirrors production code in openapi_codegen.py so
-    # child endpoints can always resolve their parent's schema and
-    # identifier field even when the parent was collapsed by dedup (#606).
+    # Build schema_lookup, identifier_map, and parent_field_names
+    # mirroring production code in openapi_codegen.py so child endpoints
+    # can always resolve their parent's schema and identifier field even
+    # when the parent was collapsed by dedup (#606, #609).
     schema_lookup = {e.path: e.schema_name for e in full_endpoints}
     identifier_map = {e.path: e.identifier_field for e in full_endpoints if e.identifier_field}
+    # parent_field_names from dedup winners, aliased for collapsed siblings
+    pfn: dict[str, set[str]] = {}
+    dedup_mod_map = {tuple(_path_to_module_parts(e.path)): e.path for e in endpoints}
+    for e in endpoints:
+        leaves = _collect_all_leaves(e.fields)
+        pfn[e.path] = {_field_to_cache_attr(f).split(".")[0] for f in leaves}
+    for e in full_endpoints:
+        parts = tuple(_path_to_module_parts(e.path))
+        if parts in dedup_mod_map and e.path != dedup_mod_map[parts]:
+            pfn[e.path] = pfn[dedup_mod_map[parts]]
     write_endpoint_files(
         endpoint,
         temp_cache_dir,
@@ -184,6 +199,7 @@ def test_codegen_round_trip(
         models_dir=temp_models_dir,
         shared_schemas=shared_schemas,
         identifier_map=identifier_map,
+        parent_field_names=pfn,
     )
 
     generated_mapping = temp_cache_dir / api_type / Path(*module_parts) / "mapping.py"

--- a/tools/codegen/generators.py
+++ b/tools/codegen/generators.py
@@ -739,6 +739,7 @@ def generate_mapping(
     *,
     shared_schemas: frozenset[str] | set[str] = frozenset(),
     identifier_map: dict[str, str] | None = None,
+    parent_field_names: dict[str, set[str]] | None = None,
 ) -> str:
     """Generate a TypeMapping/FieldMapping module for an endpoint.
 
@@ -958,13 +959,18 @@ def generate_mapping(
     if parent_resolvable:
         lines.append(f'    parent_mapping="{parent_class}",')
         # Look up the parent endpoint's actual ``identifier_field`` from
-        # the pre-built map.  This correctly handles parents that use
-        # non-default identifiers (e.g. ``"name"`` instead of ``"uuid"``).
-        # Fall back to the API-default dispatch table when the parent
-        # path is absent from the map (legacy behavior).
-        parent_id_field = (identifier_map or {}).get(
-            endpoint.parent_path
-        ) or _PARENT_ID_FIELD_BY_API.get(api_type, "uuid")
+        # the pre-built map.  Only use it when the root segment of the
+        # identifier exists as a field on the parent's schema — the
+        # spec's path parameter name (e.g. ``svm.uuid``) doesn't always
+        # correspond to a field on the parent model (the item endpoint
+        # may win dedup and lack the field the collection had).
+        # Fall back to the API-default dispatch table otherwise.
+        candidate = (identifier_map or {}).get(endpoint.parent_path)
+        parent_fields = (parent_field_names or {}).get(endpoint.parent_path, set())
+        if candidate and candidate.split(".")[0] in parent_fields:
+            parent_id_field = candidate
+        else:
+            parent_id_field = _PARENT_ID_FIELD_BY_API.get(api_type, "uuid")
         lines.append(f'    parent_id_field="{parent_id_field}",')
 
     lines.append("    fields=(")
@@ -1175,6 +1181,7 @@ def write_endpoint_files(
     *,
     shared_schemas: frozenset[str] | set[str] = frozenset(),
     identifier_map: dict[str, str] | None = None,
+    parent_field_names: dict[str, set[str]] | None = None,
 ) -> list[Path]:
     """Write all generated files for an endpoint.
 
@@ -1258,6 +1265,7 @@ def write_endpoint_files(
             existing_toml_path=existing_toml,
             shared_schemas=shared_schemas,
             identifier_map=identifier_map,
+            parent_field_names=parent_field_names,
         )
     )
     written.append(mapping_path)

--- a/tools/codegen/openapi_codegen.py
+++ b/tools/codegen/openapi_codegen.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from tools.codegen.adapters import ParsedEndpoint, detect_shared_schemas, parse_openapi_spec
 from tools.codegen.generators import (
     _collect_all_leaves,
+    _field_to_cache_attr,
     _path_to_class_name,
     _path_to_module_parts,
     write_endpoint_files,
@@ -173,6 +174,29 @@ def run(
         ep.path: ep.identifier_field for ep in full_spec_endpoints if ep.identifier_field
     }
 
+    # Build a map of top-level field names per *dedup-winner* endpoint so
+    # ``generate_mapping`` can validate that a parent's identifier_field
+    # actually exists on the generated parent model before using it as
+    # ``parent_id_field``.  Uses the dedup winners (not the full list)
+    # because the model that gets generated and registered comes from
+    # the winner — the collection endpoint's fields may differ from the
+    # item endpoint's fields that actually end up in the model.
+    # Keyed by all paths that map to the same module (so child endpoints
+    # can look up their parent_path regardless of which sibling won).
+    parent_field_names: dict[str, set[str]] = {}
+    for ep in endpoints:
+        leaves = _collect_all_leaves(ep.fields)
+        field_roots = {_field_to_cache_attr(f).split(".")[0] for f in leaves}
+        parent_field_names[ep.path] = field_roots
+    # Also register under sibling paths that collapsed to the same module
+    # path during dedup, so ``parent_path`` lookups work for parents
+    # whose collection endpoint was deduped away.
+    dedup_module_map = {tuple(_path_to_module_parts(ep.path)): ep.path for ep in endpoints}
+    for ep in full_spec_endpoints:
+        parts = tuple(_path_to_module_parts(ep.path))
+        if parts in dedup_module_map and ep.path != dedup_module_map[parts]:
+            parent_field_names[ep.path] = parent_field_names[dedup_module_map[parts]]
+
     del full_spec_endpoints
 
     all_written: list[Path] = []
@@ -193,6 +217,7 @@ def run(
             schema_lookup,
             shared_schemas=shared_schemas,
             identifier_map=identifier_map,
+            parent_field_names=parent_field_names,
         )
         all_written.extend(written)
         field_count = len([f for f in ep.fields if not f.is_object or f.is_list])


### PR DESCRIPTION
## Description

Fix `parent_id_field` derivation to validate the identifier against the dedup-winner's field set rather than the pre-dedup collection's fields. When the spec's path parameter (e.g., `svm.uuid`) doesn't exist on the generated parent model, falls back to the API default (`uuid` for ONTAP).

## Related Issue

Addresses #609

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **`tools/codegen/generators.py`** — Added `parent_field_names` parameter to `generate_mapping()` and `write_endpoint_files()`. The `parent_id_field` derivation now checks that the identifier's root field exists in the parent's generated model fields before using it.
- **`tools/codegen/openapi_codegen.py`** — Builds `parent_field_names` from dedup winners (not pre-dedup list), then aliases collapsed sibling paths so child endpoints can look up their parent regardless of which sibling won dedup.
- **`tests/unit/codegen/test_roundtrip.py`** — Updated to mirror the dedup-winner field name building, matching production behavior.

## Testing

- [x] All existing tests pass (including the 40 `test_parent_id_field_exists_on_parent_model` tests that previously failed during full regen)
- [x] Round-trip test passes for all 6 endpoints (3 ONTAP + 1 child + 2 DII)
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
