### PR TITLE
fix(codegen): validate API-default parent_id_field before emitting parent linkage

### DIFF
--- a/tools/codegen/generators.py
+++ b/tools/codegen/generators.py
@@ -957,20 +957,37 @@ def generate_mapping(
                 parent_resolvable = True
                 break
     if parent_resolvable:
-        lines.append(f'    parent_mapping="{parent_class}",')
         # Look up the parent endpoint's actual ``identifier_field`` from
         # the pre-built map.  Only use it when the root segment of the
         # identifier exists as a field on the parent's schema — the
         # spec's path parameter name (e.g. ``svm.uuid``) doesn't always
         # correspond to a field on the parent model (the item endpoint
         # may win dedup and lack the field the collection had).
-        # Fall back to the API-default dispatch table otherwise.
+        # Fall back to the API-default dispatch table, then give up if
+        # neither candidate exists on the model.
         candidate = (identifier_map or {}).get(endpoint.parent_path)
-        parent_fields = (parent_field_names or {}).get(endpoint.parent_path, set())
-        if candidate and candidate.split(".")[0] in parent_fields:
+        parent_fields = (
+            (parent_field_names or {}).get(endpoint.parent_path, set())
+            if parent_field_names is not None
+            else None
+        )
+        if parent_fields is not None and candidate and candidate.split(".")[0] in parent_fields:
             parent_id_field = candidate
+        elif parent_fields is not None:
+            fallback = _PARENT_ID_FIELD_BY_API.get(api_type, "uuid")
+            if fallback.split(".")[0] in parent_fields:
+                parent_id_field = fallback
+            else:
+                # Neither the inferred identifier nor the API default
+                # exists on the parent model (dedup winner).  Skip
+                # parent linkage entirely — manual editing needed.
+                parent_resolvable = False
         else:
-            parent_id_field = _PARENT_ID_FIELD_BY_API.get(api_type, "uuid")
+            # No field validation available — use identifier_map or
+            # API default (legacy behavior).
+            parent_id_field = candidate or _PARENT_ID_FIELD_BY_API.get(api_type, "uuid")
+    if parent_resolvable:
+        lines.append(f'    parent_mapping="{parent_class}",')
         lines.append(f'    parent_id_field="{parent_id_field}",')
 
     lines.append("    fields=(")


### PR DESCRIPTION
## Description

Validate the API-default `parent_id_field` fallback against the parent model's actual fields before emitting parent linkage. When neither the identifier_map candidate (e.g., `svm.uuid`) nor the API default (`uuid`) exists on the dedup-winner's model, skip `parent_mapping`/`parent_id_field` entirely rather than emitting invalid values.

Preserves legacy behavior when `parent_field_names` is not provided (no validation, old fallback logic).

## Related Issue

Addresses #611

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **`tools/codegen/generators.py`** — Extended the `parent_id_field` validation block: when `parent_field_names` is provided, both the identifier_map candidate and the API-type fallback are validated against the parent's field set. When neither exists on the model, `parent_resolvable` is set to `False` and parent linkage is skipped. When `parent_field_names` is `None`, the original behavior is preserved.

## Testing

- [x] All existing tests pass — no test modifications needed
- [x] Verified with full ONTAP regen: `doit generate_models --api=ontap` followed by `doit check` passes with 0 failures
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
