### PR TITLE
chore: sync with pyproject-template (75cbe9b3 → 64c7aca0)

### DIFF
--- a/.claude/agents/implement-worker.md
+++ b/.claude/agents/implement-worker.md
@@ -1,0 +1,67 @@
+---
+name: implement-worker
+description: >-
+  Performs the implementation step of the /implement workflow after the
+  plan comment exists and the branch is created. Reads project rules,
+  fetches the plan, edits files, writes tests, and runs `doit check`.
+  Do NOT invoke directly — /implement drives this subagent.
+tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
+permissionMode: default
+---
+
+You implement a GitHub issue's approved plan on an already-created branch. The parent `/implement` command has verified preconditions and created the branch; your job is to read the rules, fetch the plan, edit files, write tests, run `doit check`, and return a summary.
+
+## Inputs from the parent
+
+The parent prompt will provide:
+
+- The **issue number** (so you can fetch the plan).
+- The **branch name** (for context only — you will not switch branches).
+- Any **issue-specific notes** or scope clarifications.
+
+## Steps
+
+### 1. Read the project rules
+
+- Read `AGENTS.md` — understand workflow, conventions, code style, and testing guidelines.
+- Read `.claude/CLAUDE.md` — understand TodoWrite requirements.
+
+### 2. Fetch the implementation plan
+
+Retrieve all comments and find the one containing `## Implementation Plan for`:
+
+```bash
+gh api repos/{owner}/{repo}/issues/<issue-number>/comments --jq '.[] | select(.body | contains("## Implementation Plan for")) | .body'
+```
+
+- If multiple plan comments exist, use the most recent one.
+- Parse the plan to extract the file list and test plan.
+
+### 3. Implement the plan
+
+- Follow the plan step by step.
+- Create implementation files.
+- Create test files — this is MANDATORY per AGENTS.md. Never skip tests when there is Python code to test.
+- Follow existing code patterns and conventions.
+- All new code must be type-annotated (mypy strict).
+
+### 4. Run validation
+
+- Run: `doit check`
+- If checks fail, fix the issues and re-run.
+- Do NOT give up after the first failure — investigate and fix.
+
+### 5. Return a summary
+
+Report to the parent:
+
+- Files created/modified with brief descriptions.
+- Test results (pass/fail counts).
+- Any deviations from the plan and why.
+
+## Constraints
+
+- **Do NOT switch branches.** The parent `/implement` command has already created and checked out the correct branch.
+- **Do NOT commit.** Committing is handled by the parent's `/finalize` step, not by you.
+- **Do NOT enter plan mode.** Do not call `EnterPlanMode`. You run with `permissionMode: default` so you can edit files directly.
+- **All new code must be type-annotated** (mypy strict mode is enforced by `doit check`).

--- a/.claude/commands/finalize.md
+++ b/.claude/commands/finalize.md
@@ -59,7 +59,8 @@ Use the Task tool with `subagent_type: "general-purpose"` and provide it with th
 
 5. **Draft the PR description** and write it to a temp file:
    - Read `.github/pull_request_template.md` for structure
-   - Write the PR body to `/tmp/pr-body.md`
+   - Run `mkdir -p tmp/agents/claude` to ensure the directory exists
+   - Write the PR body to `tmp/agents/claude/pr-body-issue-<n>.md`
    - The body MUST include `Addresses #<issue-number>`
 
 6. **Return** a summary of:
@@ -67,7 +68,7 @@ Use the Task tool with `subagent_type: "general-purpose"` and provide it with th
    - ADR changes made (if any)
    - Suggested commit message following conventional format: `<type>: <subject>`
    - Suggested PR title following conventional format: `<type>: <subject>`
-   - Path to the PR body file (`/tmp/pr-body.md`)
+   - Path to the PR body file (`tmp/agents/claude/pr-body-issue-<n>.md`)
 
 ### Step 3: Commit and create PR
 
@@ -78,7 +79,8 @@ After the agent returns, in the main context:
 3. **Only after user confirms:**
    - Stage files: `git add <specific files>` (include all changed files from implementation and review/fix cycle)
    - Commit with the approved message
-   - Create PR: `doit pr --title="<type>: <subject>" --body-file=/tmp/pr-body.md`
+   - Create PR: `doit pr --title="<type>: <subject>" --body-file=tmp/agents/claude/pr-body-issue-<n>.md`
+   - Delete the temp file: `rm tmp/agents/claude/pr-body-issue-<n>.md`
 4. **Report** the PR URL to the user
 
 **IMPORTANT:** Do NOT commit or create the PR without explicit user confirmation.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -4,9 +4,9 @@ Implement the plan for GitHub issue #$ARGUMENTS.
 
 ## Instructions
 
-**CRITICAL: Do NOT enter plan mode. Do NOT use EnterPlanMode. This command executes code directly — plan mode will block the implementation agent from writing files.**
+The implementation is delegated to a sub-agent (Task tool) so raw tool output stays out of the main conversation context. The agent does the coding; you receive the summary for user review.
 
-You MUST delegate the implementation to an agent (Task tool) to keep the main conversation context clean. The agent does all the coding. You receive the summary for user review.
+**Plan-mode trap:** parent plan-mode state propagates to the spawned sub-agent mid-execution and freezes it after its first non-readonly action (typically the first `Write`). Check your Claude Code status line before running — if it shows "plan mode", exit before invoking.
 
 ### Step 1: Validate preconditions
 
@@ -57,37 +57,15 @@ Only if not already on the correct branch:
    git checkout -b <type>/$ARGUMENTS-<short-description>
    ```
 
-### Step 3: Spawn an implementation agent
+### Step 3: Spawn the implementation subagent
 
-Use the Task tool with `subagent_type: "general-purpose"` and provide it with the issue number and branch name. The agent should:
+Use the Task tool with `subagent_type: "implement-worker"`. In the prompt, pass:
 
-1. **Read the project rules:**
-   - Read `AGENTS.md` — understand workflow, conventions, code style, testing guidelines
-   - Read `.claude/CLAUDE.md` — understand TodoWrite requirements
+- The issue number (so the subagent can fetch the plan).
+- The branch name (for context; the subagent will not switch branches).
+- Any issue-specific notes or scope clarifications.
 
-2. **Fetch the implementation plan:**
-   Retrieve all comments and find the one containing `## Implementation Plan for`:
-   ```bash
-   gh api repos/{owner}/{repo}/issues/$ARGUMENTS/comments --jq '.[] | select(.body | contains("## Implementation Plan for")) | .body'
-   ```
-   - If multiple plan comments exist, use the most recent one
-   - Parse the plan to extract the file list and test plan
-
-3. **Implement the plan:**
-   - Follow the plan step by step
-   - Create implementation files
-   - Create test files — this is MANDATORY, never skip tests
-   - Follow existing code patterns and conventions
-
-4. **Run validation:**
-   - Run: `doit check`
-   - If checks fail, fix the issues and re-run
-   - Do NOT give up after first failure — investigate and fix
-
-5. **Return a summary** of all changes made:
-   - Files created/modified with brief descriptions
-   - Test results (pass/fail counts)
-   - Any deviations from the plan and why
+The subagent carries its own system prompt covering project rules, plan fetch, implementation, and validation — this command does not repeat them. The subagent has `permissionMode: default`, which (per Claude Code's sub-agent precedence rules) should override parent plan mode for operations inside the subagent's context.
 
 ### Step 4: Present changes to user
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/ruff-fix-on-edit.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -10,7 +10,17 @@
 default_policy = "untrusted"  # Prompt before running untrusted commands
 
 # =============================================================================
-# BLOCKED COMMANDS - These bypass security controls
+# PRE-TOOL-USE HOOK — Primary defense
+# =============================================================================
+# The shared hook script provides context-aware blocking (shlex tokenization,
+# protected-branch detection, chained-command scanning). The approval_policy
+# deny rules below act as a secondary (belt-and-suspenders) defense layer in
+# case the hook fails to load or Codex evaluates policies before hooks.
+[hooks]
+pre_tool_use = "python3 tools/hooks/ai/block-dangerous-commands.py"
+
+# =============================================================================
+# BLOCKED COMMANDS - Secondary defense (approval_policy deny rules)
 # =============================================================================
 
 # Block --admin flag (bypasses branch protection)

--- a/.config/pyproject_template/settings.toml
+++ b/.config/pyproject_template/settings.toml
@@ -1,3 +1,3 @@
 [template]
-commit = "75cbe9b37181359365d57b4e54cb59b8a47507fb"
-commit_date = "2026-04-02"
+commit = "64c7aca0128313e98b49143f4d91e00346f8847b"
+commit_date = "2026-04-17"

--- a/.copilot/README.md
+++ b/.copilot/README.md
@@ -1,0 +1,33 @@
+# Copilot CLI Configuration
+
+This directory is the GitHub Copilot CLI configuration directory for this repository, parallel to `.claude/`, `.gemini/`, and `.codex/`.
+
+## Workflow Skills
+
+Copilot CLI automatically discovers project skills from `.claude/commands/`. No separate Copilot command files are needed — the full workflow (`/plan-issue`, `/implement`, `/finalize`, `/close-issue`, `/where-am-i`, etc.) is available out of the box.
+
+## Dangerous Command Hook
+
+The dangerous command hook is wired in `.github/hooks/copilot-hooks.json`. It blocks shell commands identified as dangerous before they execute:
+
+```
+.github/hooks/copilot-hooks.json → tools/hooks/ai/block-dangerous-commands.py
+```
+
+No changes to this hook are needed when adding new slash commands.
+
+## Subagent / Implement Worker
+
+The `implement-worker` subagent used by `/implement` is defined in `.claude/agents/implement-worker.md`. Copilot CLI's `task` tool reads this file when spawning the subagent.
+
+## Temporary Files
+
+Agents must write temporary files to `tmp/agents/copilot/` (not `/tmp/`). Include a context identifier (issue number, PR number, or task ID) in the filename to avoid collisions.
+
+## See Also
+
+- `.claude/commands/` — slash command definitions (auto-discovered by Copilot CLI)
+- `.claude/agents/implement-worker.md` — implement-worker subagent definition
+- `.github/hooks/copilot-hooks.json` — dangerous command hook wiring
+- `docs/development/ai/slash-commands.md` — full workflow and command reference
+- `docs/development/ai/command-blocking.md` — hook documentation

--- a/.github/automerge-config.json
+++ b/.github/automerge-config.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Auto-merge configuration for dependabot PRs. See docs/development/dependabot-automerge.md.",
+  "sensitive_dependencies": [
+    "crypt*",
+    "*ssl*",
+    "*security*",
+    "auth*",
+    "*jwt*",
+    "*oauth*"
+  ],
+  "allowed_update_types": [
+    "version-update:semver-patch",
+    "version-update:semver-minor"
+  ],
+  "blocking_labels": [
+    "do-not-merge",
+    "automerge-blocked"
+  ]
+}

--- a/.github/hooks/copilot-hooks.json
+++ b/.github/hooks/copilot-hooks.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "python3 ../../tools/hooks/ai/block-dangerous-commands.py",
+        "cwd": ".github/hooks",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,56 @@
+# GitHub label definitions for this repository.
+#
+# Source of truth for labels replicated to GitHub. Edit this file and run
+# `doit labels_sync` (or `doit labels_sync --dry-run` to preview) to reconcile
+# the repository's labels with the list below.
+#
+# Fields:
+#   name        (required) Label name exactly as it appears on GitHub.
+#   color       6-char hex (no leading "#"). Defaults to "ededed".
+#   description Plain text description. Defaults to "".
+
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+- name: bug
+  color: d73a4a
+  description: Something isn't working
+- name: documentation
+  color: 0075ca
+  description: Improvements or additions to documentation
+- name: refactor
+  color: F9D0C4
+  description: Code refactoring and cleanup
+- name: chore
+  color: FEF2C0
+  description: Maintenance, tooling, CI tasks
+- name: needs-triage
+  color: FBCA04
+  description: Needs review and prioritization
+- name: needs-adr
+  color: d4c5f9
+  description: This issue requires an Architecture Decision Record
+- name: ready-to-merge
+  color: 0E8A16
+  description: PR is reviewed and ready to merge
+- name: full-matrix
+  color: 1D76DB
+  description: Run CI on all supported Python versions
+- name: automerge-blocked
+  color: B60205
+  description: Block dependabot auto-merge for this PR
+- name: do-not-merge
+  color: B60205
+  description: Prevent the merge gate from allowing this PR
+- name: security
+  color: d73a4a
+  description: Security vulnerability or fix
+- name: automated
+  color: 02db74
+  description: Created or managed by automation
+- name: dependencies
+  color: 0366d6
+  description: Pull requests that update a dependency file
+- name: github_actions
+  color: "000000"
+  description: Pull requests that update GitHub Actions code

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,15 +20,28 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check for benchmark tests
+        id: check-benchmarks
+        run: |
+          if [ -d "tests/benchmarks" ] && find tests/benchmarks -name 'test_*.py' -print -quit | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No benchmark tests found at tests/benchmarks/; skipping benchmark workflow."
+          fi
+
       - uses: actions/setup-python@v6
+        if: steps.check-benchmarks.outputs.exists == 'true'
         with:
           python-version: "3.13"
 
       - uses: astral-sh/setup-uv@v7
+        if: steps.check-benchmarks.outputs.exists == 'true'
         with:
           version: "latest"
 
       - name: Cache uv dependencies
+        if: steps.check-benchmarks.outputs.exists == 'true'
         uses: actions/cache@v5
         with:
           path: ${{ env.UV_CACHE_DIR }}
@@ -37,21 +50,19 @@ jobs:
             ${{ runner.os }}-uv-
 
       - name: Install dependencies
+        if: steps.check-benchmarks.outputs.exists == 'true'
         run: uv sync --all-extras --dev
 
       - name: Run benchmarks
+        if: steps.check-benchmarks.outputs.exists == 'true'
         run: |
           mkdir -p tmp
-          if [ -d tests/benchmarks ]; then
-            uv run pytest tests/benchmarks/ \
-              --benchmark-enable --benchmark-only \
-              --benchmark-json=tmp/benchmark-results.json -v
-          else
-            echo '{"machine_info": {}, "commit_info": {}, "benchmarks": []}' > tmp/benchmark-results.json
-            echo "No benchmark tests found in tests/benchmarks/ — skipping"
-          fi
+          uv run pytest tests/benchmarks/ \
+            --benchmark-enable --benchmark-only \
+            --benchmark-json=tmp/benchmark-results.json -v
 
       - name: Check for benchmark data branch
+        if: steps.check-benchmarks.outputs.exists == 'true'
         id: check-bench-branch
         run: |
           if git ls-remote --exit-code origin gh-benchmarks >/dev/null 2>&1; then
@@ -61,7 +72,7 @@ jobs:
           fi
 
       - name: Create benchmark data branch
-        if: steps.check-bench-branch.outputs.exists != 'true' && github.event_name == 'push'
+        if: steps.check-benchmarks.outputs.exists == 'true' && steps.check-bench-branch.outputs.exists != 'true' && github.event_name == 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -71,7 +82,7 @@ jobs:
           git checkout ${{ github.sha }}
 
       - name: Store benchmark results
-        if: github.event_name == 'push' || steps.check-bench-branch.outputs.exists == 'true'
+        if: steps.check-benchmarks.outputs.exists == 'true' && (github.event_name == 'push' || steps.check-bench-branch.outputs.exists == 'true')
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: 'pytest'
@@ -85,7 +96,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload benchmark results
-        if: always()
+        if: always() && steps.check-benchmarks.outputs.exists == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      newest: ${{ steps.set-matrix.outputs.newest }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -29,6 +30,7 @@ jobs:
           # Read config
           oldest=$(jq -r '.oldest' .github/python-versions.json)
           newest=$(jq -r '.newest' .github/python-versions.json)
+          echo "newest=$newest" >> $GITHUB_OUTPUT
 
           oldest_minor=${oldest#3.}
           newest_minor=${newest#3.}
@@ -153,19 +155,53 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  docs:
+    needs: setup
+    if: ${{ needs.setup.outputs.matrix != '{"include":[]}' }}
+    runs-on: ubuntu-latest
+    env:
+      UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ needs.setup.outputs.newest }}
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.UV_CACHE_DIR }}
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Build documentation
+        run: uv run doit docs_build
+
   ci-complete:
     # Always run unless this is a non-full-matrix label event
     if: always() && (github.event.action != 'labeled' || github.event.label.name == 'full-matrix')
-    needs: [setup, test]
+    needs: [setup, test, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI status
         run: |
           setup_result="${{ needs.setup.result }}"
           test_result="${{ needs.test.result }}"
+          docs_result="${{ needs.docs.result }}"
 
           echo "Setup result: $setup_result"
           echo "Test result: $test_result"
+          echo "Docs result: $docs_result"
 
           # Setup must succeed
           if [[ "$setup_result" != "success" ]]; then
@@ -176,6 +212,12 @@ jobs:
           # Test must succeed or be skipped (skipped = no middle versions)
           if [[ "$test_result" != "success" && "$test_result" != "skipped" ]]; then
             echo "Test job failed"
+            exit 1
+          fi
+
+          # Docs must succeed or be skipped (skipped = no middle versions)
+          if [[ "$docs_result" != "success" && "$docs_result" != "skipped" ]]; then
+            echo "Docs job failed"
             exit 1
           fi
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,306 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  evaluate:
+    name: Evaluate dependabot PR
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.actor == 'dependabot[bot]' &&
+      github.event.action != 'labeled'
+    outputs:
+      qualifies: ${{ steps.decide.outputs.qualifies }}
+      reason: ${{ steps.decide.outputs.reason }}
+      pr_number: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide eligibility
+        id: decide
+        uses: actions/github-script@v9
+        env:
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.meta.outputs.dependency-names }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = '.github/automerge-config.json';
+            const config = JSON.parse(fs.readFileSync(path, 'utf8'));
+
+            const updateType = process.env.UPDATE_TYPE || '';
+            const depNames = (process.env.DEPENDENCY_NAMES || '')
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean);
+            const prLabels = (context.payload.pull_request.labels || [])
+              .map(l => l.name);
+
+            // Glob to regex: '*' -> '.*', anchored.
+            const globToRegex = (glob) => {
+              const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+              return new RegExp('^' + escaped.replace(/\*/g, '.*') + '$', 'i');
+            };
+
+            const sensitiveRegexes = (config.sensitive_dependencies || [])
+              .map(globToRegex);
+
+            let qualifies = true;
+            let reason = 'eligible for auto-merge';
+
+            // Check update type.
+            if (updateType === 'version-update:semver-major') {
+              qualifies = false;
+              reason = 'major version bump';
+            }
+
+            // Check sensitive dependencies.
+            if (qualifies) {
+              for (const dep of depNames) {
+                const match = sensitiveRegexes.find(re => re.test(dep));
+                if (match) {
+                  qualifies = false;
+                  reason = `sensitive dependency: ${dep}`;
+                  break;
+                }
+              }
+            }
+
+            // Check blocking labels.
+            if (qualifies) {
+              const blocking = config.blocking_labels || [];
+              const hit = prLabels.find(l => blocking.includes(l));
+              if (hit) {
+                qualifies = false;
+                reason = `blocking label present: ${hit}`;
+              }
+            }
+
+            // Optionally enforce allowed update types (defense in depth).
+            if (qualifies) {
+              const allowed = config.allowed_update_types || [];
+              if (allowed.length && updateType && !allowed.includes(updateType)) {
+                qualifies = false;
+                reason = `update type not in allowlist: ${updateType}`;
+              }
+            }
+
+            core.setOutput('qualifies', String(qualifies));
+            core.setOutput('reason', reason);
+            core.info(`update-type=${updateType} deps=${depNames.join(',')} qualifies=${qualifies} reason=${reason}`);
+
+  enable-automerge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    needs: evaluate
+    if: needs.evaluate.outputs.qualifies == 'true'
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
+    steps:
+      - name: Enable auto-merge (squash)
+        run: gh pr merge --auto --squash "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+
+      - name: Add ready-to-merge label
+        run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label ready-to-merge
+
+      - name: Post sticky status comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const marker = '<!-- dependabot-automerge:status -->';
+            const body =
+              marker +
+              '\n✅ **Auto-merge enabled.** This PR will merge automatically when required CI checks pass. To block, add label `automerge-blocked`.';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+  comment-skip:
+    name: Comment skip reason
+    runs-on: ubuntu-latest
+    needs: evaluate
+    if: needs.evaluate.outputs.qualifies == 'false'
+    steps:
+      - name: Post sticky skip comment
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
+          REASON: ${{ needs.evaluate.outputs.reason }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const reason = process.env.REASON || 'unknown';
+            const marker = '<!-- dependabot-automerge:status -->';
+            const body =
+              marker +
+              `\n⏸️ **Auto-merge skipped:** ${reason}. Human review required.`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+  handle-blocked-label:
+    name: Handle blocking label
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'labeled' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      (github.event.label.name == 'automerge-blocked' || github.event.label.name == 'do-not-merge')
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      LABEL_NAME: ${{ github.event.label.name }}
+    steps:
+      - name: Disable auto-merge
+        run: gh pr merge --disable-auto "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" || true
+
+      - name: Remove ready-to-merge label
+        run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label ready-to-merge || true
+
+      - name: Post sticky blocked comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const label = process.env.LABEL_NAME;
+            const marker = '<!-- dependabot-automerge:status -->';
+            const body =
+              marker +
+              `\n🛑 **Auto-merge disabled** by \`${label}\` label.`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+  request-rebase:
+    name: Request dependabot rebase for stale PRs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Find stale dependabot PRs and request rebase
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const oneHourAgo = Date.now() - 60 * 60 * 1000;
+
+            for (const pr of prs) {
+              if (!pr.user || pr.user.login !== 'dependabot[bot]') continue;
+
+              const labels = (pr.labels || []).map(l => l.name);
+              if (!labels.includes('ready-to-merge')) continue;
+
+              // Fetch fresh PR to get mergeable_state.
+              const { data: fresh } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+              if (fresh.mergeable_state !== 'behind') continue;
+
+              // Skip if @dependabot rebase was requested in the last hour.
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+              const recentRebase = comments.some(c =>
+                c.body && c.body.includes('@dependabot rebase') &&
+                new Date(c.created_at).getTime() > oneHourAgo
+              );
+              if (recentRebase) {
+                core.info(`PR #${pr.number}: recent rebase request; skipping`);
+                continue;
+              }
+
+              core.info(`PR #${pr.number}: requesting @dependabot rebase`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: '@dependabot rebase',
+              });
+            }

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -36,16 +36,36 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
-      - name: Run mutation testing
+      - name: Run mutmut
+        timeout-minutes: 120
         run: |
-          uv run mutmut run || true
-          uv run mutmut results
-          uv run mutmut html --html-dir tmp/mutmut
+          mkdir -p tmp
+          uv run mutmut run > tmp/mutmut-run-raw.log 2>&1 || true
+
+      - name: Mutation results
+        if: always()
+        run: |
+          mkdir -p tmp
+          if [ -f tmp/mutmut-run-raw.log ]; then
+            # Strip spinner/carriage-return noise from log.
+            # mutmut renders progress with braille spinners + \r; convert \r to \n,
+            # drop blank lines, and drop the repeating spinner phrases.
+            tr '\r' '\n' < tmp/mutmut-run-raw.log \
+              | grep -v '^[[:space:]]*$' \
+              | grep -avE 'Generating mutants|Running stats|Running clean tests|Running mutation testing|Running forced fail test|^[[:space:]]*[^[:alnum:]]*[[:space:]]*[0-9]+/[0-9]+' \
+              > tmp/mutmut-run.log || true
+            echo "=== Mutation run log ==="
+            cat tmp/mutmut-run.log
+          fi
+          uv run mutmut results 2>/dev/null | tee tmp/mutmut-results.txt || true
+          echo ""
+          echo "=== Summary ==="
+          awk -F': ' '{print $NF}' tmp/mutmut-results.txt 2>/dev/null | sort | uniq -c | sort -rn || true
 
       - name: Upload mutation results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: mutation-results
-          path: tmp/mutmut/
+          path: tmp/mutmut-results.txt
           retention-days: 90

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -76,6 +76,11 @@ jobs:
               return;
             }
 
+            if (pr.user.login === 'dependabot[bot]') {
+              console.log('✅ Dependabot PR - issue link not required');
+              return;
+            }
+
             // Check for issue reference in PR body or title
             const issuePatterns = [
               /addresses\s+#\d+/i,

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ docs/_build/
 coverage.xml
 .nfs*
 .gemini/settings.json.orig
+tools/hooks/ai/hook-debug.jsonl
 
 # Project-specific data directories (top-level only -- the
 # `pynetappfoundry.data` package and `tests/unit/data` are tracked.)

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Current File",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Python: Debug Tests",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["tests", "-v"],
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Python: Module with Args",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "${input:moduleName}",
+      "args": "${input:moduleArgs}",
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "moduleName",
+      "type": "promptString",
+      "description": "Module name to run (e.g., package_name)"
+    },
+    {
+      "id": "moduleArgs",
+      "type": "promptString",
+      "description": "Arguments to pass to the module"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,54 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "doit check",
+      "type": "shell",
+      "command": "doit check",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
+      "label": "doit test",
+      "type": "shell",
+      "command": "doit test",
+      "group": "test",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
+      "label": "doit format",
+      "type": "shell",
+      "command": "doit format",
+      "group": "build",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
+      "label": "doit lint",
+      "type": "shell",
+      "command": "doit lint",
+      "group": "build",
+      "problemMatcher": [
+        "$eslint-compact"
+      ],
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 - **NEVER implement based on a question.** Wait for explicit "Do it" or "Proceed".
 - **Stop & Verify:** If the user says "Stop", "Wait", "Hold on", "Cancel", "Wrong", or "No", immediately halt and ask for clarification.
 - **Summary Before Commit:** At the end of any implementation (docs, fix, feature, chore, etc.), summarize what was changed for the user before committing and wait for the user's explicit instruction to commit the changes.
+- **Failing Tests:** Never modify a test to make it pass. Stop, explain *why* the test broke (what behavior changed, what the test was asserting), and discuss with the user whether the code or the test should change. A failing test is a signal, not a problem to silence.
 
 ### 2. Task Planning Protocol
 - **Plan First:** Before writing code, you MUST present a checklist:
@@ -56,6 +57,7 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 | **Committing** | `.github/CONTRIBUTING.md` (Commit Guidelines) | `<type>: <subject>` format. |
 | **New Dependency** | `.github/CONTRIBUTING.md` (Dependencies) | "Ask First" policy. |
 | **Creating Code** | `.claude/CLAUDE.md` (TodoWrite) | Plan -> Test -> Code loop. |
+| **Generating new code** | `docs/development/ai/architectural-conventions.md` | Layering rules and anti-patterns to avoid before writing code. |
 | **Architectural Decision** | `docs/decisions/README.md` | Check for related ADRs to update. |
 
 ### 6. Decision Framework
@@ -103,6 +105,9 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 | **Code Style** | `.github/CONTRIBUTING.md` | Python standards, naming, typing. |
 | **Testing** | `.github/CONTRIBUTING.md` | Test patterns, coverage rules. |
 | **Security** | `.github/SECURITY.md` | Policy, sensitive data handling. |
+| **Architecture & Layering** | `docs/development/ai/architectural-conventions.md` | Imperative-form rules for AI agents. |
+| **Slash Commands & Workflows** | `docs/development/ai/slash-commands.md` | Reference for /plan-issue, /implement, /finalize, dual-agent workflow. |
+| **AI Agent Walkthrough** | `docs/development/ai/first-5-minutes.md` | Narrative onboarding for the AI agent workflow (plan → implement → review → PR → merge). |
 
 ## Common Pitfalls
 
@@ -161,6 +166,8 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 
 ## Tooling & Environment
 
+> For the architectural rationale behind this hierarchy — what each tool is for, who uses it, and where runtime code ends and dev tooling begins — see [Tooling Roles and Architectural Boundaries](docs/development/tooling-roles.md).
+
 ### Principle: Use the Highest-Level Tool Available
 
 This project wraps common operations in `doit` tasks that enforce conventions, validate inputs, and reduce errors. **Always check if a `doit` task exists before running a raw command.**
@@ -188,6 +195,7 @@ The tool hierarchy (prefer higher over lower):
 | Create PRs | `doit pr` | `gh pr create` |
 | Merge PRs | `doit pr_merge` | `gh pr merge` |
 | Create ADRs | `doit adr` | Manual file creation |
+| Sync GitHub labels | `doit labels_sync` | `gh label create` / `gh label edit` manually |
 | Commit (interactive) | `doit commit` | `git commit` without format |
 | Install/add packages | `uv add <pkg>` | `pip install` |
 | Sync dependencies | `uv sync` | `pip install -r` |
@@ -236,6 +244,8 @@ gh pr list --state open
 **Write operations** should go through `doit` when a task exists. Use raw `git`/`gh` for write operations only when no `doit` task covers the need (e.g., `git checkout -b`, `git add`, `gh issue close`).
 
 ### Dependabot PRs
+
+Dependabot PRs that pass CI are now auto-merged by `.github/workflows/dependabot-automerge.yml`. The manual workflow below applies only to PRs the bot skips (major bumps, sensitive deps, or PRs labeled `automerge-blocked`). See [docs/development/dependabot-automerge.md](docs/development/dependabot-automerge.md) for details.
 
 When merging dependabot PRs that are behind `main`, **never** use the GitHub API `update-branch` endpoint or local rebase to update the branch. This strips the verified commit signatures from dependabot commits, which are required by branch protection rules.
 
@@ -290,6 +300,19 @@ AI agents with native file tools (Read, Grep, Glob, Edit, Write) **must** prefer
 
 Native tools provide better visibility, review capabilities, and error handling for the user.
 
+### AI Config Directories
+
+Each supported AI CLI has a dedicated config directory at the repo root:
+
+| CLI | Config Directory | Notes |
+| :--- | :--- | :--- |
+| Claude Code | `.claude/` | Commands, agents, settings. Primary source of slash commands. |
+| Gemini CLI | `.gemini/` | Commands and settings. Output-only commands (orchestrated by Claude). |
+| GitHub Copilot CLI | `.copilot/` | Config directory. Skills auto-discovered from `.claude/commands/`. Hook wired in `.github/hooks/copilot-hooks.json`. |
+| Codex CLI | `.codex/` | `config.toml` only (command approval policies). No slash commands. |
+
+Copilot CLI does **not** need a `commands/` subdirectory: it discovers skills from `.claude/commands/` automatically, so the full workflow (`/plan-issue`, `/implement`, `/finalize`, etc.) works out of the box.
+
 ### Temporary Files
 
 AI agents **must never** write temporary files to generic locations like `/tmp/`. Instead, use the project-scoped directory:
@@ -315,7 +338,7 @@ Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the r
 - **No Speculation:** Don't read files you don't need.
 
 ## Critical Reminders
-- **Flow:** Issue (`doit issue`) -> Branch -> Commit -> PR (`doit pr`) -> Merge (`doit pr_merge`). NEVER commit to main.
+- **Flow:** Issue (`doit issue`) -> **`git checkout main && git pull`** -> Branch -> Commit -> PR (`doit pr`) -> Merge (`doit pr_merge`). NEVER commit to main. Pull `main` before branching — local `main` may be behind the remote (e.g., after dependabot PRs merged via the web UI). `doit pr` enforces this by aborting if the branch is behind `origin/main`; pass `--no-update-check` to override.
 - **Scope:** Never mix refactoring, features, and docs in one PR. Create separate branches.
 - **Verify:** Check file paths (`ls`) and branch (`git status`) before assuming they exist.
 - **Security:** NEVER bypass security checks (e.g., `--no-verify`, ignoring secrets).
@@ -323,11 +346,11 @@ Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the r
 - **Integrity:** Respect architectural patterns (modularity) over "quick fixes".
 - **Local State:** Protect user config (e.g., `.envrc.local`, settings). Do not revert/delete without backup.
 - **Version:** Source of truth is Git tags. Never edit `pyproject.toml` version.
-- **Tests:** Creating code = Creating tests. No exceptions.
+- **Tests:** Creating code = Creating tests. No exceptions. Never modify a failing test to make it pass — stop, explain why it broke, and discuss with the user whether the code or the test should change.
 - **Commits:** One logical change per commit. Use conventional commits.
 - **Releases:** Never run `doit release` without explicit command.
-- **PRs:** Use `doit pr` to create PRs and `doit pr_merge` to merge with proper commit format. Issues are not automatically closed. Ask the user if they would like the related issue closed.
-- **The Merge Gate action:** is a manual action for the user to add to a PR. It requires the ready-to-merge label and should never be added by automation.
+- **PRs:** Use `doit pr` to create PRs and `doit pr_merge` to merge with proper commit format. Issues are not automatically closed. Ask the user if they would like the related issue closed — pass `--auto-close` to `doit pr_merge` to close linked issues in one step.
+- **The Merge Gate action:** is a manual action for the user to add to a PR. It requires the ready-to-merge label and should never be added by automation. Exception: the dependabot auto-merge workflow (`.github/workflows/dependabot-automerge.yml`) applies the `ready-to-merge` label to qualifying dependabot PRs only.
 - **Issues:** Use `doit issue --type=<type>` to create issues (types: feature, bug, refactor, doc, chore). Labels are auto-applied. Manually close after PR merge with comment "Addressed in PR #XXX". Issues are not closed automatically when PRs are merged.
 - **ADRs:** When implementing architectural decisions (typically `feat` or `refactor`, rarely `fix`), update related ADRs in `docs/decisions/` to add the issue link. Create new ADRs for significant decisions using `doit adr`. Every ADR must link to the documentation in `docs/` that describes the implementation. Doc and chore issues do not need ADRs. Issues with the `needs-adr` label require an ADR before the PR can be merged.
 
@@ -364,10 +387,13 @@ doit pr --title="feat: add caching" --body="## Summary\nAdded caching support\n\
 doit pr --title="fix: handle null" --body-file=pr.md
 ```
 
+`doit pr` auto-pushes the current branch to `origin` if it has no upstream. Pass `--no-push` to skip the auto-push (the task aborts instead).
+
 ### PR Merge
 ```bash
-doit pr_merge                    # Merge PR for current branch
-doit pr_merge --pr=123           # Merge specific PR
+doit pr_merge                        # Merge PR for current branch
+doit pr_merge --pr=123               # Merge specific PR
+doit pr_merge --pr=123 --auto-close  # Also close linked issues after merge
 ```
 
 ### ADR Creation

--- a/completions/doit.bash
+++ b/completions/doit.bash
@@ -1,0 +1,130 @@
+# bash completion for doit
+# auto-generate by `doit tabcompletion`
+
+# to activate it you need to 'source' the generate script
+# $ source <generated-script>
+
+# reference => http://www.debian-administration.org/articles/317
+# patch => http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=711879
+
+_doit()
+{
+    local cur prev words cword basetask sub_cmds tasks i dodof
+    COMPREPLY=() # contains list of words with suitable completion
+    # remove colon from word separator list because doit uses colon on task names
+    _get_comp_words_by_ref -n : cur prev words cword
+    # list of sub-commands
+    sub_cmds="clean dumpdb forget help ignore info list reset-dep run strace tabcompletion"
+
+
+    # options that take file/dir as values should complete file-system
+    if [[ "$prev" == "-f" || "$prev" == "-d" || "$prev" == "-o" ]]; then
+        _filedir
+        return 0
+    fi
+    if [[ "$cur" == *=* ]]; then
+        prev=${cur/=*/}
+        cur=${cur/*=/}
+        if [[ "$prev" == "--file=" || "$prev" == "--dir=" || "$prev" == "--output-file=" ]]; then
+            _filedir -o nospace
+            return 0
+        fi
+    fi
+
+
+    # get name of the dodo file
+    for (( i=0; i < ${#words[@]}; i++)); do
+        case "${words[i]}" in
+        -f)
+            dodof=${words[i+1]}
+            break
+            ;;
+        --file=*)
+            dodof=${words[i]/*=/}
+            break
+            ;;
+        esac
+    done
+    # dodo file not specified, use default
+    if [ ! $dodof ]
+      then
+         dodof="dodo.py"
+    fi
+
+
+    # get task list
+    # if it there is colon it is getting a subtask, complete only subtask names
+    if [[ "$cur" == *:* ]]; then
+        # extract base task name (remove everything after colon)
+        basetask=${cur%:*}
+        # sub-tasks
+        tasks=$(doit list --file="$dodof" --quiet --all ${basetask} 2>/dev/null)
+        COMPREPLY=( $(compgen -W "${tasks}" -- ${cur}) )
+        __ltrim_colon_completions "$cur"
+        return 0
+    # without colons get only top tasks
+    else
+        tasks=$(doit list --file="$dodof" --quiet 2>/dev/null)
+    fi
+
+
+    # match for first parameter must be sub-command or task
+    # FIXME doit accepts options "-" in the first parameter but we ignore this case
+    if [[ ${cword} == 1 ]] ; then
+        COMPREPLY=( $(compgen -W "${sub_cmds} ${tasks}" -- ${cur}) )
+        return 0
+    fi
+
+    case ${words[1]} in
+
+        clean)
+            COMPREPLY=( $(compgen -W "${tasks}" -- $cur) )
+            return 0
+            ;;
+        dumpdb)
+            COMPREPLY=( $(compgen -f -- $cur) )
+            return 0
+            ;;
+        forget)
+            COMPREPLY=( $(compgen -W "${tasks}" -- $cur) )
+            return 0
+            ;;
+        help)
+            COMPREPLY=( $(compgen -W "${tasks} ${sub_cmds}" -- $cur) )
+            return 0
+            ;;
+        ignore)
+            COMPREPLY=( $(compgen -W "${tasks}" -- $cur) )
+            return 0
+            ;;
+        info)
+            COMPREPLY=( $(compgen -W "${tasks}" -- $cur) )
+            return 0
+            ;;
+        list)
+            COMPREPLY=( $(compgen -W "${tasks}" -- $cur) )
+            return 0
+            ;;
+        reset-dep)
+            COMPREPLY=( $(compgen -W "${tasks}" -- $cur) )
+            return 0
+            ;;
+        run)
+            COMPREPLY=( $(compgen -W "${tasks}" -- $cur) )
+            return 0
+            ;;
+        strace)
+            COMPREPLY=( $(compgen -W "${tasks}" -- $cur) )
+            return 0
+            ;;
+        tabcompletion)
+            COMPREPLY=( $(compgen -f -- $cur) )
+            return 0
+            ;;
+    esac
+
+    # if there is already one parameter match only tasks (no commands)
+    COMPREPLY=( $(compgen -W "${tasks}" -- ${cur}) )
+
+}
+complete -o filenames -F _doit doit

--- a/completions/doit.zsh
+++ b/completions/doit.zsh
@@ -1,0 +1,236 @@
+#compdef doit
+
+_doit() {
+    local -a commands tasks
+    # format is 'completion:description'
+    commands=(
+        'clean: clean action / remove targets'
+        'dumpdb: dump dependency DB'
+        'forget: clear successful run status from internal DB'
+        'help: show help'
+        'ignore: ignore task (skip) on subsequent runs'
+        'info: show info about a task'
+        'list: list tasks from dodo file'
+        'reset-dep: recompute and save the state of file dependencies without executing actions'
+        'run: run tasks'
+        'strace: use strace to list file_deps and targets'
+        'tabcompletion: generate script for tab-completion'
+    )
+
+    # split output by lines to create an array
+    tasks=("${(f)$(doit list --template '{name}: {doc}')}")
+
+    # complete command or task name
+    if (( CURRENT == 2 )); then
+        _arguments -A : '::cmd:(($commands))' '::task:(($tasks))'
+        return
+    fi
+
+    # revome program name from $words and decrement CURRENT
+    local curcontext context state state_desc line
+    _arguments -C '*:: :->'
+
+    # complete sub-command or task options
+    local -a _command_args
+    case "$words[1]" in
+
+      (clean)
+          _command_args=(
+            "--db-file[file used to save successful runs [default: %(default)s\]]" \
+            "--backend[Select dependency file backend. [default: %(default)s\]]" \
+
+            "--check_file_uptodate[Choose how to check if files have been modified. Available options [default: %(default)s\]:   'md5': use the md5sum   'timestamp': use the timestamp ]" \
+            "(-f|--file)"{-f,--file}"[load task from dodo FILE [default: %(default)s\]]" \
+            "(-d|--dir)"{-d,--dir}"[set path to be used as cwd directory (file paths on dodo file are relative to dodo.py location).]" \
+            "(-k|--seek-file)"{-k,--seek-file}"[seek dodo file on parent folders [default: %(default)s\]]" \
+            "(-c|--clean-dep)"{-c,--clean-dep}"[clean task dependencies too]" \
+            "(-a|--clean-all)"{-a,--clean-all}"[clean all task]" \
+            "(-n|--dry-run)"{-n,--dry-run}"[print actions without really executing them]" \
+            "--forget[also forget tasks after cleaning]" \
+            '*::task:(($tasks))'
+            ''
+        )
+      ;;
+
+
+      (dumpdb)
+          _command_args=(
+            "--db-file[file used to save successful runs [default: %(default)s\]]" \
+            ''
+        )
+      ;;
+
+
+      (forget)
+          _command_args=(
+            "--db-file[file used to save successful runs [default: %(default)s\]]" \
+            "--backend[Select dependency file backend. [default: %(default)s\]]" \
+
+            "--check_file_uptodate[Choose how to check if files have been modified. Available options [default: %(default)s\]:   'md5': use the md5sum   'timestamp': use the timestamp ]" \
+            "(-f|--file)"{-f,--file}"[load task from dodo FILE [default: %(default)s\]]" \
+            "(-d|--dir)"{-d,--dir}"[set path to be used as cwd directory (file paths on dodo file are relative to dodo.py location).]" \
+            "(-k|--seek-file)"{-k,--seek-file}"[seek dodo file on parent folders [default: %(default)s\]]" \
+            "(-s|--follow-sub)"{-s,--follow-sub}"[forget task dependencies too]" \
+            "--disable-default[disable forgetting default tasks (when no arguments are passed)]" \
+            "(-a|--all)"{-a,--all}"[forget all tasks]" \
+            '*::task:(($tasks))'
+            ''
+        )
+      ;;
+
+
+      (help)
+          _command_args=(
+            "--db-file[file used to save successful runs [default: %(default)s\]]" \
+            "--backend[Select dependency file backend. [default: %(default)s\]]" \
+
+            "--check_file_uptodate[Choose how to check if files have been modified. Available options [default: %(default)s\]:   'md5': use the md5sum   'timestamp': use the timestamp ]" \
+            "(-f|--file)"{-f,--file}"[load task from dodo FILE [default: %(default)s\]]" \
+            "(-d|--dir)"{-d,--dir}"[set path to be used as cwd directory (file paths on dodo file are relative to dodo.py location).]" \
+            "(-k|--seek-file)"{-k,--seek-file}"[seek dodo file on parent folders [default: %(default)s\]]" \
+            '*::task:(($tasks))'
+            '::cmd:(($commands))'
+            ''
+        )
+      ;;
+
+
+      (ignore)
+          _command_args=(
+            "--db-file[file used to save successful runs [default: %(default)s\]]" \
+            "--backend[Select dependency file backend. [default: %(default)s\]]" \
+
+            "--check_file_uptodate[Choose how to check if files have been modified. Available options [default: %(default)s\]:   'md5': use the md5sum   'timestamp': use the timestamp ]" \
+            "(-f|--file)"{-f,--file}"[load task from dodo FILE [default: %(default)s\]]" \
+            "(-d|--dir)"{-d,--dir}"[set path to be used as cwd directory (file paths on dodo file are relative to dodo.py location).]" \
+            "(-k|--seek-file)"{-k,--seek-file}"[seek dodo file on parent folders [default: %(default)s\]]" \
+            '*::task:(($tasks))'
+            ''
+        )
+      ;;
+
+
+      (info)
+          _command_args=(
+            "--db-file[file used to save successful runs [default: %(default)s\]]" \
+            "--backend[Select dependency file backend. [default: %(default)s\]]" \
+
+            "--check_file_uptodate[Choose how to check if files have been modified. Available options [default: %(default)s\]:   'md5': use the md5sum   'timestamp': use the timestamp ]" \
+            "(-f|--file)"{-f,--file}"[load task from dodo FILE [default: %(default)s\]]" \
+            "(-d|--dir)"{-d,--dir}"[set path to be used as cwd directory (file paths on dodo file are relative to dodo.py location).]" \
+            "(-k|--seek-file)"{-k,--seek-file}"[seek dodo file on parent folders [default: %(default)s\]]" \
+            "--no-status[Hides reasons why this task would be executed.  [default: %(default)s\]]" \
+            '*::task:(($tasks))'
+            ''
+        )
+      ;;
+
+
+      (list)
+          _command_args=(
+            "--db-file[file used to save successful runs [default: %(default)s\]]" \
+            "--backend[Select dependency file backend. [default: %(default)s\]]" \
+
+            "--check_file_uptodate[Choose how to check if files have been modified. Available options [default: %(default)s\]:   'md5': use the md5sum   'timestamp': use the timestamp ]" \
+            "(-f|--file)"{-f,--file}"[load task from dodo FILE [default: %(default)s\]]" \
+            "(-d|--dir)"{-d,--dir}"[set path to be used as cwd directory (file paths on dodo file are relative to dodo.py location).]" \
+            "(-k|--seek-file)"{-k,--seek-file}"[seek dodo file on parent folders [default: %(default)s\]]" \
+            "--all[list include all sub-tasks from dodo file]" \
+            "(-q|--quiet)"{-q,--quiet}"[print just task name (less verbose than default)]" \
+            "(-s|--status)"{-s,--status}"[print task status (R)un, (U)p-to-date, (I)gnored]" \
+            "(-p|--private)"{-p,--private}"[print private tasks (start with '_')]" \
+            "--deps[print list of dependencies (file dependencies only)]" \
+            "--template[display entries with template]" \
+            "--sort[choose the manner in which the task list is sorted. [default: %(default)s\]]" \
+            '*::task:(($tasks))'
+            ''
+        )
+      ;;
+
+
+      (reset-dep)
+          _command_args=(
+            "--db-file[file used to save successful runs [default: %(default)s\]]" \
+            "--backend[Select dependency file backend. [default: %(default)s\]]" \
+
+            "--check_file_uptodate[Choose how to check if files have been modified. Available options [default: %(default)s\]:   'md5': use the md5sum   'timestamp': use the timestamp ]" \
+            "(-f|--file)"{-f,--file}"[load task from dodo FILE [default: %(default)s\]]" \
+            "(-d|--dir)"{-d,--dir}"[set path to be used as cwd directory (file paths on dodo file are relative to dodo.py location).]" \
+            "(-k|--seek-file)"{-k,--seek-file}"[seek dodo file on parent folders [default: %(default)s\]]" \
+            '*::task:(($tasks))'
+            ''
+        )
+      ;;
+
+
+      (run)
+          _command_args=(
+            "--db-file[file used to save successful runs [default: %(default)s\]]" \
+            "--backend[Select dependency file backend. [default: %(default)s\]]" \
+
+            "--check_file_uptodate[Choose how to check if files have been modified. Available options [default: %(default)s\]:   'md5': use the md5sum   'timestamp': use the timestamp ]" \
+            "(-f|--file)"{-f,--file}"[load task from dodo FILE [default: %(default)s\]]" \
+            "(-d|--dir)"{-d,--dir}"[set path to be used as cwd directory (file paths on dodo file are relative to dodo.py location).]" \
+            "(-k|--seek-file)"{-k,--seek-file}"[seek dodo file on parent folders [default: %(default)s\]]" \
+            "(-a|--always-execute)"{-a,--always-execute}"[always execute tasks even if up-to-date [default: %(default)s\]]" \
+            "(-c|--continue)"{-c,--continue}"[continue executing tasks even after a failure [default: %(default)s\]]" \
+            "(-v|--verbosity)"{-v,--verbosity}"[0 capture (do not print) stdout/stderr from task. 1 capture stdout only. 2 do not capture anything (print everything immediately). [default: 1\]]" \
+            "(-r|--reporter)"{-r,--reporter}"[Choose output reporter. [default: %(default)s\]]" \
+            "(-o|--output-file)"{-o,--output-file}"[write output into file [default: stdout\]]" \
+            "(-n|--process)"{-n,--process}"[number of subprocesses [default: %(default)s\]]" \
+            "(-P|--parallel-type)"{-P,--parallel-type}"[Tasks can be executed in parallel in different ways: 'process': uses python multiprocessing module 'thread': uses threads [default: %(default)s\] ]" \
+            "--pdb[get into PDB (python debugger) post-mortem in case of unhandled exception]" \
+            "(-s|--single)"{-s,--single}"[Execute only specified tasks ignoring their task_dep [default: %(default)s\]]" \
+            "--auto-delayed-regex[Uses the default regex \".*\" for every delayed task loaderfor which no regex was explicitly defined]" \
+            "--failure-verbosity[Control re-display stdout/stderr for failed tasks on report summary. 0 do not show re-display 1 re-display stderr only 2 re-display both stderr/stdout [default: 0\] ]" \
+            '*::task:(($tasks))'
+            ''
+        )
+      ;;
+
+
+      (strace)
+          _command_args=(
+            "--db-file[file used to save successful runs [default: %(default)s\]]" \
+            "--backend[Select dependency file backend. [default: %(default)s\]]" \
+
+            "--check_file_uptodate[Choose how to check if files have been modified. Available options [default: %(default)s\]:   'md5': use the md5sum   'timestamp': use the timestamp ]" \
+            "(-f|--file)"{-f,--file}"[load task from dodo FILE [default: %(default)s\]]" \
+            "(-d|--dir)"{-d,--dir}"[set path to be used as cwd directory (file paths on dodo file are relative to dodo.py location).]" \
+            "(-k|--seek-file)"{-k,--seek-file}"[seek dodo file on parent folders [default: %(default)s\]]" \
+            "(-a|--all)"{-a,--all}"[display all files (not only from within CWD path)]" \
+            "--keep[save strace command output into strace.txt]" \
+            '*::task:(($tasks))'
+            ''
+        )
+      ;;
+
+
+      (tabcompletion)
+          _command_args=(
+            "--db-file[file used to save successful runs [default: %(default)s\]]" \
+            "--backend[Select dependency file backend. [default: %(default)s\]]" \
+
+            "--check_file_uptodate[Choose how to check if files have been modified. Available options [default: %(default)s\]:   'md5': use the md5sum   'timestamp': use the timestamp ]" \
+            "(-f|--file)"{-f,--file}"[load task from dodo FILE [default: %(default)s\]]" \
+            "(-d|--dir)"{-d,--dir}"[set path to be used as cwd directory (file paths on dodo file are relative to dodo.py location).]" \
+            "(-k|--seek-file)"{-k,--seek-file}"[seek dodo file on parent folders [default: %(default)s\]]" \
+            "(-s|--shell)"{-s,--shell}"[Completion code for SHELL. [default: %(default)s\]]" \
+            "--hardcode-tasks[Hardcode tasks from current task list.]" \
+            ''
+        )
+      ;;
+
+
+        # default completes task names
+        (*)
+           _command_args='*::task:(($tasks))'
+        ;;
+    esac
+
+    # -A no options will be completed after the first non-option argument
+    _arguments -A : $_command_args
+    return 0
+}
+
+_doit

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -39,7 +39,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 <!-- BEGIN:audience=contributors -->
 - [Add a Feature: End-to-End Walkthrough](examples/add-a-feature.md) - Step-by-step example of adding a module, CLI subcommand, tests, and docs to the project
 - [Adding a New API Backend](development/adding-backends.md) - Developer guide for extending the DataSource framework with new API backends
-- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
+- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, Copilot, and Codex for this project
 - [AI Architectural Conventions](development/ai/architectural-conventions.md) - Imperative-form architectural rules AI agents must follow when generating code
 - [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
 - [AI Enforcement Principles](development/ai/enforcement-principles.md) - How we enforce AI agent behavior in code and settings
@@ -52,12 +52,12 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Dependabot Auto-merge](development/dependabot-automerge.md) - How the dependabot auto-merge workflow evaluates, enables, and skips PRs
 - [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments
 - [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
-- [Extensions](development/extensions.md) - How to extend pynetappfoundry
 - [Field Mapping Framework](development/field-mapping.md) - Declarative framework for mapping API/CLI data to cache models
 - [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
 - [GitHub Repository Settings](development/github-repository-settings.md) - Complete reference for all GitHub repository settings the template expects
 - [Installation Guide](getting-started/installation.md) - How to install and set up your project
 - [ONTAP Access Patterns](usage/ontap-access-patterns.md) - Guide to choosing between the three ONTAP access methods
+- [Optional Extensions](development/extensions.md) - Additional tools and extensions for testing, security, and more
 - [Performance Benchmarks](development/benchmarks.md) - Running, interpreting, and comparing the pytest-benchmark suite
 - [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
 - [pynetappfoundry Documentation](index.md) - ONTAP administration library and CLI tools
@@ -73,7 +73,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 
 ### For AI Agents
 <!-- BEGIN:audience=ai-agents -->
-- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
+- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, Copilot, and Codex for this project
 - [AI Agent Sync Checklist](template/ai-sync-checklist.md) - Step-by-step checklist for AI agents synchronizing downstream projects with pyproject-template
 - [AI Architectural Conventions](development/ai/architectural-conventions.md) - Imperative-form architectural rules AI agents must follow when generating code
 - [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
@@ -120,7 +120,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [ADR-9014: Use click for application CLI](template/decisions/9014-use-click-for-application-cli.md)
 - [ADR-9015: install_tools framework: archive extraction and custom URLs](template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md)
 - [ADR-NNNN: Title](decisions/adr-template.md)
-- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
+- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, Copilot, and Codex for this project
 - [AI Agent Sync Checklist](template/ai-sync-checklist.md) - Step-by-step checklist for AI agents synchronizing downstream projects with pyproject-template
 - [AI Architectural Conventions](development/ai/architectural-conventions.md) - Imperative-form architectural rules AI agents must follow when generating code
 - [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
@@ -143,7 +143,6 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments
 - [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
 - [Examples](examples/README.md) - Code examples for pynetappfoundry
-- [Extensions](development/extensions.md) - How to extend pynetappfoundry
 - [Field Mapping Framework](development/field-mapping.md) - Declarative framework for mapping API/CLI data to cache models
 - [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
 - [GitHub Repository Settings](development/github-repository-settings.md) - Complete reference for all GitHub repository settings the template expects
@@ -153,6 +152,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Migration Guide](template/migration.md) - Migrate existing Python projects to use this template
 - [New Project Setup](template/new-project.md) - Create a new Python project from this template
 - [ONTAP Access Patterns](usage/ontap-access-patterns.md) - Guide to choosing between the three ONTAP access methods
+- [Optional Extensions](development/extensions.md) - Additional tools and extensions for testing, security, and more
 - [Performance Benchmarks](development/benchmarks.md) - Running, interpreting, and comparing the pytest-benchmark suite
 - [Plan: Add `nf cache query` Command](plans/cache-query-command.md)
 - [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -1,0 +1,198 @@
+# All Documents
+
+Complete index of all documentation, organized by audience and as a full alphabetical list.
+
+> These lists are auto-generated from document frontmatter.
+> Run `python tools/generate_doc_toc.py` to update.
+
+## By Audience
+
+### For Users
+<!-- BEGIN:audience=users -->
+- [API Examples](examples/api.md) - Detailed Python API usage examples
+- [API Reference](reference/api.md) - Python API documentation
+- [Basic Usage](usage/basics.md) - Getting started with pynetappfoundry
+- [Cache System](reference/cache.md) - Architecture, storage layout, lazy loading, and CLI for the cluster metadata cache
+- [CLI Guide](usage/cli.md) - The application's user-facing command-line interface and how to extend it
+- [CLI Reference](reference/cli.md) - Command-line interface documentation
+- [Compliance Checks](usage/compliance-checks.md) - Configure and run config-driven compliance checks against cached cluster metadata
+- [Configuration Schema Reference](reference/config-schema.md) - Complete reference for pynetappfoundry TOML configuration files
+- [DataSource](usage/data-source.md) - Unified entry point for reading cluster data from cache or live API
+- [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments
+- [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
+- [Examples](examples/README.md) - Code examples for pynetappfoundry
+- [GitHub Repository Settings](development/github-repository-settings.md) - Complete reference for all GitHub repository settings the template expects
+- [Installation Guide](getting-started/installation.md) - How to install and set up your project
+- [Keeping Up to Date](template/updates.md) - Stay in sync with improvements to the pyproject-template
+- [Migration Guide](template/migration.md) - Migrate existing Python projects to use this template
+- [New Project Setup](template/new-project.md) - Create a new Python project from this template
+- [ONTAP Access Patterns](usage/ontap-access-patterns.md) - Guide to choosing between the three ONTAP access methods
+- [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
+- [pynetappfoundry Documentation](index.md) - ONTAP administration library and CLI tools
+- [Query Layer](usage/query-layer.md) - Guide to the REST query layer (QuerySet, Mutation, JobTracker, related, realtime)
+- [Template Management](template/manage.md) - Unified interface for creating projects, checking updates, and syncing
+- [Template Tools Reference](template/tools-reference.md) - Complete reference for all template tools in tools/pyproject_template/
+- [Using This Template](template/index.md) - Overview of using pyproject-template for your Python projects
+<!-- END:audience=users -->
+
+### For Contributors
+<!-- BEGIN:audience=contributors -->
+- [Add a Feature: End-to-End Walkthrough](examples/add-a-feature.md) - Step-by-step example of adding a module, CLI subcommand, tests, and docs to the project
+- [Adding a New API Backend](development/adding-backends.md) - Developer guide for extending the DataSource framework with new API backends
+- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
+- [AI Architectural Conventions](development/ai/architectural-conventions.md) - Imperative-form architectural rules AI agents must follow when generating code
+- [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
+- [AI Enforcement Principles](development/ai/enforcement-principles.md) - How we enforce AI agent behavior in code and settings
+- [API Reference](reference/api.md) - Python API documentation
+- [Cache Model Architecture](development/cache-models.md) - End-to-end guide for the codegen pipeline, cache models, field strategies, and SQL storage
+- [Cache System](reference/cache.md) - Architecture, storage layout, lazy loading, and CLI for the cluster metadata cache
+- [CI/CD Testing Guide](development/ci-cd-testing.md) - GitHub Actions pipelines for testing, linting, and coverage
+- [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
+- [CLI Guide](usage/cli.md) - The application's user-facing command-line interface and how to extend it
+- [Dependabot Auto-merge](development/dependabot-automerge.md) - How the dependabot auto-merge workflow evaluates, enables, and skips PRs
+- [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments
+- [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
+- [Extensions](development/extensions.md) - How to extend pynetappfoundry
+- [Field Mapping Framework](development/field-mapping.md) - Declarative framework for mapping API/CLI data to cache models
+- [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
+- [GitHub Repository Settings](development/github-repository-settings.md) - Complete reference for all GitHub repository settings the template expects
+- [Installation Guide](getting-started/installation.md) - How to install and set up your project
+- [ONTAP Access Patterns](usage/ontap-access-patterns.md) - Guide to choosing between the three ONTAP access methods
+- [Performance Benchmarks](development/benchmarks.md) - Running, interpreting, and comparing the pytest-benchmark suite
+- [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
+- [pynetappfoundry Documentation](index.md) - ONTAP administration library and CLI tools
+- [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
+- [Query Layer](usage/query-layer.md) - Guide to the REST query layer (QuerySet, Mutation, JobTracker, related, realtime)
+- [Release Automation & Security](development/release-and-automation.md) - Automated versioning, release management, and security tooling
+- [Ruff Auto-Fix on Edit Hook](development/ai/ruff-fix-hook.md) - PostToolUse hook that runs ruff --fix on edited Python files
+- [Slash Commands and Workflows](development/ai/slash-commands.md) - Reference for the slash commands and dual-agent workflow this template ships with
+- [Template Tools Reference](template/tools-reference.md) - Complete reference for all template tools in tools/pyproject_template/
+- [Tooling Roles and Architectural Boundaries](development/tooling-roles.md) - What each tool is for, who uses it, and where runtime code ends and dev tooling begins
+- [Unit Registry](development/unit-registry.md) - Standalone unit registry for ONTAP API field measurements
+<!-- END:audience=contributors -->
+
+### For AI Agents
+<!-- BEGIN:audience=ai-agents -->
+- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
+- [AI Agent Sync Checklist](template/ai-sync-checklist.md) - Step-by-step checklist for AI agents synchronizing downstream projects with pyproject-template
+- [AI Architectural Conventions](development/ai/architectural-conventions.md) - Imperative-form architectural rules AI agents must follow when generating code
+- [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
+- [AI Enforcement Principles](development/ai/enforcement-principles.md) - How we enforce AI agent behavior in code and settings
+- [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
+- [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
+- [Ruff Auto-Fix on Edit Hook](development/ai/ruff-fix-hook.md) - PostToolUse hook that runs ruff --fix on edited Python files
+- [Slash Commands and Workflows](development/ai/slash-commands.md) - Reference for the slash commands and dual-agent workflow this template ships with
+- [Tooling Roles and Architectural Boundaries](development/tooling-roles.md) - What each tool is for, who uses it, and where runtime code ends and dev tooling begins
+<!-- END:audience=ai-agents -->
+
+## Complete Index
+<!-- BEGIN:all -->
+- [Add a Feature: End-to-End Walkthrough](examples/add-a-feature.md) - Step-by-step example of adding a module, CLI subcommand, tests, and docs to the project
+- [Adding a New API Backend](development/adding-backends.md) - Developer guide for extending the DataSource framework with new API backends
+- [ADR-0001: Use SQLite for cluster metadata caching](decisions/0001-use-sqlite-for-cluster-metadata-caching.md)
+- [ADR-0002: Track SMB Client Impact During Azure Maintenance Events](decisions/0002-track-smb-client-impact-azure-maintenance.md)
+- [ADR-0003: Use base SQLiteDB class with version-based migrations](decisions/0003-use-base-sqlitedb-class-with-version-based-migrations.md)
+- [ADR-0004: Declarative field mapping framework for ONTAP collection](decisions/0004-declarative-field-mapping-framework.md)
+- [ADR-0005: UUID index for cache cross-references](decisions/0005-uuid-index-for-cache-cross-references.md)
+- [ADR-0006: Generalize field mapping framework for multi-API data collection](decisions/0006-generalize-field-mapping-for-multi-api.md)
+- [ADR-0007: Deep URL-tree structure with automatic model and mapping discovery](decisions/0007-url-tree-model-registry.md)
+- [ADR-0008: OpenAPI codegen for model and mapping generation](decisions/0008-openapi-codegen-for-model-generation.md)
+- [ADR-0009: Per-Model SQL Table Storage for Cache Layer](decisions/0009-sql-table-storage.md)
+- [ADR-0010: ClusterEntry and namespace access pattern](decisions/0010-clusterentry-and-namespace-access-pattern.md)
+- [ADR-0011: Nested models to replace flat model pattern](decisions/0011-nested-models-to-replace-flat-model-pattern.md)
+- [ADR-0012: Unified DataSource Accessor for All Cluster Reads](decisions/0012-unified-datasource-accessor.md)
+- [ADR-0013: DataSource as a Thin Facade Over the Collector](decisions/0013-datasource-as-a-thin-facade-over-the-collector.md)
+- [ADR-0014: Parallel Cluster Refresh](decisions/0014-parallel-cluster-refresh.md)
+- [ADR-0015: DII backend: live-only, bare-array envelope, offset/limit pagination](decisions/0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md)
+- [ADR-9001: Use uv for package management](template/decisions/9001-use-uv-for-package-management.md)
+- [ADR-9002: Use doit for task automation](template/decisions/9002-use-doit-for-task-automation.md)
+- [ADR-9003: Use ruff for linting and formatting](template/decisions/9003-use-ruff-for-linting-and-formatting.md)
+- [ADR-9004: Auto-discover doit tasks from modules](template/decisions/9004-auto-discover-doit-tasks.md)
+- [ADR-9005: AI agent command restrictions via hooks](template/decisions/9005-ai-agent-command-restrictions.md)
+- [ADR-9006: Merge-gate workflow requiring ready-to-merge label](template/decisions/9006-merge-gate-workflow.md)
+- [ADR-9007: Use mypy for static type checking](template/decisions/9007-use-mypy-for-type-checking.md)
+- [ADR-9008: PR-based development workflow](template/decisions/9008-pr-based-development-workflow.md)
+- [ADR-9009: Use pre-commit hooks for quality gates](template/decisions/9009-use-pre-commit-hooks-for-quality-gates.md)
+- [ADR-9010: Use conventional commits format](template/decisions/9010-use-conventional-commits-format.md)
+- [ADR-9011: Use pytest for testing](template/decisions/9011-use-pytest-for-testing.md)
+- [ADR-9012: Use mkdocs with Material theme for documentation](template/decisions/9012-use-mkdocs-with-material-theme-for-documentation.md)
+- [ADR-9013: Python version support policy with bookend CI strategy](template/decisions/9013-python-version-support-policy.md)
+- [ADR-9014: Use click for application CLI](template/decisions/9014-use-click-for-application-cli.md)
+- [ADR-9015: install_tools framework: archive extraction and custom URLs](template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md)
+- [ADR-NNNN: Title](decisions/adr-template.md)
+- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
+- [AI Agent Sync Checklist](template/ai-sync-checklist.md) - Step-by-step checklist for AI agents synchronizing downstream projects with pyproject-template
+- [AI Architectural Conventions](development/ai/architectural-conventions.md) - Imperative-form architectural rules AI agents must follow when generating code
+- [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
+- [AI Enforcement Principles](development/ai/enforcement-principles.md) - How we enforce AI agent behavior in code and settings
+- [API Examples](examples/api.md) - Detailed Python API usage examples
+- [API Reference](reference/api.md) - Python API documentation
+- [Architecture Decision Records](decisions/README.md)
+- [Azure Maintenance SMB Client Impact Tracking](plans/azure-smb-impact-tracking.md)
+- [Basic Usage](usage/basics.md) - Getting started with pynetappfoundry
+- [Cache Model Architecture](development/cache-models.md) - End-to-end guide for the codegen pipeline, cache models, field strategies, and SQL storage
+- [Cache System](reference/cache.md) - Architecture, storage layout, lazy loading, and CLI for the cluster metadata cache
+- [CI/CD Testing Guide](development/ci-cd-testing.md) - GitHub Actions pipelines for testing, linting, and coverage
+- [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
+- [CLI Guide](usage/cli.md) - The application's user-facing command-line interface and how to extend it
+- [CLI Reference](reference/cli.md) - Command-line interface documentation
+- [Compliance Checks](usage/compliance-checks.md) - Configure and run config-driven compliance checks against cached cluster metadata
+- [Configuration Schema Reference](reference/config-schema.md) - Complete reference for pynetappfoundry TOML configuration files
+- [DataSource](usage/data-source.md) - Unified entry point for reading cluster data from cache or live API
+- [Dependabot Auto-merge](development/dependabot-automerge.md) - How the dependabot auto-merge workflow evaluates, enables, and skips PRs
+- [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments
+- [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
+- [Examples](examples/README.md) - Code examples for pynetappfoundry
+- [Extensions](development/extensions.md) - How to extend pynetappfoundry
+- [Field Mapping Framework](development/field-mapping.md) - Declarative framework for mapping API/CLI data to cache models
+- [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
+- [GitHub Repository Settings](development/github-repository-settings.md) - Complete reference for all GitHub repository settings the template expects
+- [install_tools Framework](development/install-tools-framework.md)
+- [Installation Guide](getting-started/installation.md) - How to install and set up your project
+- [Keeping Up to Date](template/updates.md) - Stay in sync with improvements to the pyproject-template
+- [Migration Guide](template/migration.md) - Migrate existing Python projects to use this template
+- [New Project Setup](template/new-project.md) - Create a new Python project from this template
+- [ONTAP Access Patterns](usage/ontap-access-patterns.md) - Guide to choosing between the three ONTAP access methods
+- [Performance Benchmarks](development/benchmarks.md) - Running, interpreting, and comparing the pytest-benchmark suite
+- [Plan: Add `nf cache query` Command](plans/cache-query-command.md)
+- [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
+- [PyNetAppFoundry Code Review & Improvement Plan](plans/first-pass-refactor.md)
+- [pynetappfoundry Documentation](index.md) - ONTAP administration library and CLI tools
+- [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
+- [Query Layer](usage/query-layer.md) - Guide to the REST query layer (QuerySet, Mutation, JobTracker, related, realtime)
+- [Release Automation & Security](development/release-and-automation.md) - Automated versioning, release management, and security tooling
+- [Ruff Auto-Fix on Edit Hook](development/ai/ruff-fix-hook.md) - PostToolUse hook that runs ruff --fix on edited Python files
+- [Slash Commands and Workflows](development/ai/slash-commands.md) - Reference for the slash commands and dual-agent workflow this template ships with
+- [Template Architecture Decision Records](template/decisions/README.md)
+- [Template Management](template/manage.md) - Unified interface for creating projects, checking updates, and syncing
+- [Template Tools Reference](template/tools-reference.md) - Complete reference for all template tools in tools/pyproject_template/
+- [Tooling Roles and Architectural Boundaries](development/tooling-roles.md) - What each tool is for, who uses it, and where runtime code ends and dev tooling begins
+- [Unit Registry](development/unit-registry.md) - Standalone unit registry for ONTAP API field measurements
+- [Using This Template](template/index.md) - Overview of using pyproject-template for your Python projects
+<!-- END:all -->
+
+---
+
+## Contributing to Documentation
+
+When adding new documentation:
+
+1. Add frontmatter with `title`, `description`, `audience`, and `tags`:
+   ```yaml
+   ---
+   title: My New Guide
+   description: Short description for the index
+   audience:
+     - users
+     - contributors
+   tags:
+     - setup
+     - getting-started
+   ---
+   ```
+
+2. Place the file in the appropriate directory
+
+3. Run `python tools/generate_doc_toc.py` to update this index
+
+4. The pre-commit hook will also run automatically on commit

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -1,6 +1,6 @@
 ---
 title: AI Agent Setup Guide
-description: Configure Claude, Gemini, and Codex for this project
+description: Configure Claude, Gemini, Copilot, and Codex for this project
 audience:
   - contributors
   - ai-agents
@@ -12,13 +12,28 @@ tags:
 
 # AI Agent Setup Guide
 
-This template includes pre-configured settings for multiple AI coding assistants.
+This template is designed primarily for **Claude Code**, which is the only agent that ships the full slash-command workflow and acts as the orchestrator in single-agent and dual-agent flows. **Gemini CLI** is supported in a narrower role (second-opinion planner/reviewer inside Claude-orchestrated commands). **GitHub Copilot CLI** is supported as a standalone alternative that auto-discovers the full slash-command workflow from `.claude/commands/`. **Codex CLI** is supported as a standalone alternative without slash commands. See the comparison table below for the per-agent breakdown.
+
+> **New here?** Start with the [First 5 Minutes walkthrough](ai/first-5-minutes.md) for a narrative tour of the AI agent workflow. This page is the configuration reference.
 
 ## Supported AI Agents
+
+### Agent comparison
+
+| Agent | Permission model | Hooks support | Slash commands | LSP | Dual-agent role |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Codex CLI** | TOML approval policies (`.codex/config.toml`) | Project-level `tools/hooks/ai/` apply via shell | None shipped | Not documented | Standalone alternative (not part of dual-agent flow) |
+| **Gemini CLI** | JSON allowlists + lifecycle hooks (`.gemini/settings.json`) | Project-level hooks apply; Gemini lifecycle hooks supported | 2 output-only (`/plan-issue`, `/review-pr`) | Not documented | Second-opinion reviewer / planner in dual-agent flow |
+| **GitHub Copilot CLI** | JSON hook config (`.github/hooks/copilot-hooks.json`) | Project-level hooks apply; Copilot `preToolUse` hook wired | Auto-discovers from `.claude/commands/` | Not documented | Standalone alternative (auto-discovers Claude commands) |
+| **Claude Code** | Layered permissions (`.claude/settings.local.json` + `.claude/settings.json` PreToolUse hooks) | Project-level hooks plus Claude PreToolUse hooks | 8 (`plan-issue`, `implement`, `finalize`, `close-issue`, `plan-both`, `review-both`, `gemini-review`, `where-am-i`) | Supported | Primary orchestrator in single-agent and dual-agent flows |
+
+The project-level dangerous-command hooks under `tools/hooks/ai/` apply to all four agents regardless of per-agent config and cannot be bypassed by editing `.claude/settings.local.json`, `.codex/config.toml`, `.gemini/settings.json`, or `.github/hooks/copilot-hooks.json`. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
 
 ### 1. Codex CLI (OpenAI)
 
 **Configuration:** `.codex/config.toml`
+
+> **Note**: Project-level dangerous-command hooks under `tools/hooks/ai/` apply to this agent regardless of the per-agent config below. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
 
 Codex CLI directly reads `AGENTS.md` from the project root. The configuration file whitelists common development commands.
 
@@ -45,9 +60,13 @@ codex
 - [Configuring Codex](https://developers.openai.com/codex/local-config/)
 - [Codex Security Guide](https://developers.openai.com/codex/security/)
 
+**Codex parity status:** Codex ships no slash commands in this template — `.codex/` contains only `config.toml`. LSP integration is not documented for Codex here. Codex is not part of the dual-agent workflow (Claude and Gemini are); it works as a standalone alternative for contributors who prefer the OpenAI CLI. The project-level hooks under `tools/hooks/ai/` still apply to Codex — see [Command Blocking](ai/command-blocking.md). For the broader slash-command and dual-agent picture, see [Slash Commands and Workflows](ai/slash-commands.md).
+
 ### 2. Gemini CLI (Google)
 
 **Configuration:** `.gemini/settings.json`
+
+> **Note**: Project-level dangerous-command hooks under `tools/hooks/ai/` apply to this agent regardless of the per-agent config below. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
 
 Gemini CLI can read `AGENTS.md` (or `GEMINI.md`) from the project root. The configuration file uses allowlists for tools and shell commands, and configures lifecycle hooks.
 
@@ -87,6 +106,8 @@ gemini --yolo
 ### 3. Claude Code (Anthropic)
 
 **Configuration:** `.claude/` directory
+
+> **Note**: Project-level dangerous-command hooks under `tools/hooks/ai/` apply to this agent regardless of the per-agent config below. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
 
 Claude Code uses a reference file (`.claude/claude.md`) that imports `AGENTS.md`.
 
@@ -134,14 +155,61 @@ claude
 
 For complete setup instructions and troubleshooting, see `.claude/lsp-setup.md` in the repository root.
 
-### 4. Other AI Tools
+### 4. GitHub Copilot CLI
+
+**Configuration:** `.copilot/` directory
+
+> **Note**: Project-level dangerous-command hooks under `tools/hooks/ai/` apply to this agent regardless of the per-agent config below. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
+
+GitHub Copilot CLI reads `AGENTS.md` directly and auto-discovers project skills from `.claude/commands/`, so the full slash-command workflow (`/plan-issue`, `/implement`, `/finalize`, `/close-issue`, `/where-am-i`, etc.) is available in Copilot sessions without any parallel command files. The `implement-worker` subagent used by `/implement` is shared with Claude (defined in `.claude/agents/implement-worker.md`).
+
+**Hook wiring:**
+
+The dangerous-command hook is wired in `.github/hooks/copilot-hooks.json`:
+```json
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "python3 ../../tools/hooks/ai/block-dangerous-commands.py",
+        "cwd": ".github/hooks",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}
+```
+
+**Setup:**
+```bash
+# Copilot CLI automatically picks up .github/hooks/copilot-hooks.json
+# and reads AGENTS.md; no additional setup needed.
+copilot
+```
+
+**Files:**
+- `.copilot/README.md` - Description of the Copilot CLI config directory
+- `.github/hooks/copilot-hooks.json` - `preToolUse` hook wiring
+- `.claude/commands/*.md` - Slash commands (auto-discovered by Copilot CLI)
+- `.claude/agents/implement-worker.md` - Shared subagent definition
+
+**Documentation:**
+- [GitHub Copilot CLI](https://github.com/github/copilot-cli)
+- [Copilot CLI Hooks](https://docs.github.com/en/copilot/how-tos/use-copilot-for-common-tasks/use-copilot-in-the-cli)
+
+**Copilot parity status:** Copilot CLI ships no parallel command or agent files — it auto-discovers from `.claude/commands/` and `.claude/agents/`, so every Claude slash command works unchanged in Copilot sessions. Copilot is not part of the dual-agent workflow (Claude and Gemini are); it works as a standalone alternative for contributors who prefer GitHub Copilot. The project-level hooks under `tools/hooks/ai/` apply to Copilot via `.github/hooks/copilot-hooks.json` — see [Command Blocking](ai/command-blocking.md). For the broader slash-command picture, see [Slash Commands and Workflows](ai/slash-commands.md).
+
+### 5. Other AI Tools
 
 The `AGENTS.md` file serves as general-purpose documentation for any AI coding assistant:
 
-- **GitHub Copilot**: Reference in `.github/copilot-instructions.md`
 - **Cursor**: Reference in `.cursorrules`
 - **Codeium**: Reference in project settings
 - **Tabnine**: Reference in configuration
+
+> **Note**: For the slash commands and dual-agent workflow this template ships with, see [Slash Commands and Workflows](ai/slash-commands.md).
 
 ## AGENTS.md - Universal Context File
 
@@ -155,9 +223,34 @@ The `AGENTS.md` file provides comprehensive project context including:
 - Troubleshooting guides
 
 This file is:
-- **Read directly** by Codex CLI and Gemini CLI
+- **Read directly** by Codex CLI, Gemini CLI, and GitHub Copilot CLI
 - **Imported** by Claude Code via `.claude/claude.md`
 - **Referenceable** by other AI tools
+
+## Context files and precedence
+
+This template ships several files that influence agent behavior. They fall into two categories: **context/instruction files** (markdown) and **settings/config files** (JSON or TOML). Knowing which is which — and which one wins on conflict — matters when adapting the template for a new project.
+
+**File inventory:**
+
+- **`AGENTS.md`** (project root, ~20 KB) — universal source of truth for architecture, workflow, tooling hierarchy, and security rules. Read directly by Codex CLI, Gemini CLI, and GitHub Copilot CLI; imported by Claude Code via `@../AGENTS.md` in `.claude/CLAUDE.md`.
+- **`.claude/CLAUDE.md`** (~2 KB) — Claude-specific complement. First line is `@../AGENTS.md`, which imports the universal rules; the rest adds Claude-specific layers (token-efficiency guidance, the mandatory TodoWrite plan-test-code loop, the development workflow reminder, and the commit workflow reminder).
+- **`GEMINI.md`** (project root, ~1 KB) — Gemini-specific complement. Covers Gemini's stdout-only collaboration mode (so Claude handles GitHub writes), the output signing footer, and Gemini's tool-usage rules. Read alongside `AGENTS.md` by Gemini CLI, not instead of it.
+- **`.copilot/README.md`** — describes the Copilot CLI config directory. Copilot CLI reads `AGENTS.md` directly and auto-discovers slash commands from `.claude/commands/`; no Copilot-specific context markdown is required.
+- **`.codex/config.toml`** — Codex approval policy file (TOML). Not a context file; configures permissions only. Codex reads `AGENTS.md` directly for instructions.
+- **`.claude/settings.json`** — Claude PreToolUse hooks and statusline configuration. Committed.
+- **`.claude/settings.local.json`** — local Claude permissions overlay. Not committed.
+- **`.gemini/settings.json`** — Gemini tool allowlists and lifecycle hook configuration.
+- **`.github/hooks/copilot-hooks.json`** — Copilot CLI `preToolUse` hook wiring that routes shell commands through `tools/hooks/ai/block-dangerous-commands.py`.
+
+**Precedence rules:**
+
+- All four agents treat `AGENTS.md` as the architectural and workflow source of truth.
+- Agent-specific markdown files (`.claude/CLAUDE.md`, `GEMINI.md`) **complement** `AGENTS.md` — they cover behaviors specific to that agent's interaction model and do not override the universal rules.
+- Settings/config files (`.codex/config.toml`, `.gemini/settings.json`, `.claude/settings*.json`, `.github/hooks/copilot-hooks.json`) configure **permissions and tooling**, not workflow rules. They cannot grant an agent permission to do something `AGENTS.md` forbids.
+- Project-level hooks under `tools/hooks/ai/` apply to all agents and cannot be bypassed by per-agent config. This is the strongest layer.
+
+**Conflict resolution:** if an agent-specific file conflicts with `AGENTS.md`, `AGENTS.md` wins for cross-cutting concerns (workflow, architecture, security). An agent-specific file may further restrict its own agent's behavior, but it should not loosen a universal rule.
 
 ## Customization
 
@@ -202,11 +295,17 @@ reason = "Description of command"
 }
 ```
 
+**GitHub Copilot CLI** (`.github/hooks/copilot-hooks.json`):
+
+Copilot CLI does not use a per-command allowlist — the dangerous-command hook blocks unsafe patterns; everything else is allowed. To adjust what is blocked, edit the shared hook at `tools/hooks/ai/block-dangerous-commands.py` (which applies to Claude, Gemini, and Copilot alike). New slash commands added under `.claude/commands/<name>.md` are automatically discovered by Copilot CLI — no additional configuration is needed.
+
 ## Security Considerations
 
 All configuration files are set up with security in mind.
 
 > **Note**: This template enforces security rules in code and settings, not just instructions. See [AI Enforcement Principles](ai/enforcement-principles.md) for details.
+
+> **Note**: For the architectural rules AI agents must follow when generating code, see [Architectural Conventions](ai/architectural-conventions.md).
 
 **Whitelisted Operations:**
 - Read-only file operations
@@ -275,6 +374,21 @@ gemini --yolo
 - Check `.gemini/settings.json` has `"context": {"files": ["AGENTS.md"]}`
 - Verify settings.json is valid JSON
 
+### Copilot CLI
+
+**Hook not firing (dangerous commands going through):**
+- Verify `.github/hooks/copilot-hooks.json` exists and is valid JSON
+- The hook uses a relative `bash` path (`python3 ../../tools/hooks/ai/block-dangerous-commands.py`) and a `cwd` of `.github/hooks`; both must match your layout
+- Run `python3 tools/hooks/ai/test_hook.py` to confirm the shared hook script still passes its test suite
+
+**Slash commands not appearing:**
+- Copilot CLI auto-discovers skills from `.claude/commands/` — make sure that directory exists and contains `.md` files with the CLI file format (no YAML frontmatter; leading `# Title` and `## Instructions` sections)
+- Restart the Copilot CLI session after adding new command files
+
+**`.copilot/` auto-detection:**
+- The `.copilot/` directory exists primarily to document Copilot-specific wiring; Copilot CLI does not require any config files there
+- If you move the repository, Copilot CLI still loads `AGENTS.md` from the repo root and the hook from `.github/hooks/copilot-hooks.json`
+
 ## Resources
 
 ### Codex CLI
@@ -295,11 +409,15 @@ gemini --yolo
 - [Claude Code Documentation](https://claude.com/claude-code)
 - [Claude Agent SDK](https://github.com/anthropics/claude-code)
 
-### General AI Coding
+### GitHub Copilot CLI
+- [GitHub Copilot CLI](https://github.com/github/copilot-cli)
+- [Using Copilot in the CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-for-common-tasks/use-copilot-in-the-cli)
 - [GitHub Copilot](https://github.com/features/copilot)
+
+### General AI Coding
 - [Cursor](https://cursor.sh/)
 - [Codeium](https://codeium.com/)
 
 ---
 
-**Note**: The `.codex/`, `.gemini/`, and `.claude/` directories should be committed to version control to share consistent AI assistant configuration across the team. .local files should not be committed.
+**Note**: The `.codex/`, `.gemini/`, `.claude/`, and `.copilot/` directories should be committed to version control to share consistent AI assistant configuration across the team. .local files should not be committed.

--- a/docs/development/ai/architectural-conventions.md
+++ b/docs/development/ai/architectural-conventions.md
@@ -1,0 +1,87 @@
+---
+title: AI Architectural Conventions
+description: Imperative-form architectural rules AI agents must follow when generating code
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - architecture
+---
+
+# AI Architectural Conventions
+
+## Purpose
+
+This page is the imperative-form rulebook AI agents must follow when generating code in this template. It complements [Tooling Roles and Architectural Boundaries](../tooling-roles.md), which explains *why* the layering exists and is written for human readers. This page restates those rules as short directives plus concrete anti-patterns AI agents frequently hit. Do not duplicate the rationale here — read `tooling-roles.md` when you need the reasoning.
+
+## Rules
+
+**DO:**
+
+- DO put runtime application code under `src/package_name/`.
+- DO put development tooling, scaffolding, install scripts, and doit task definitions under `tools/`.
+- DO expose the application's user-facing command-line interface as a console script declared in `[project.scripts]` in `pyproject.toml`, backed by a module under `src/package_name/`.
+- DO keep `[project] dependencies` minimal. Every entry ships to every end user of the package.
+- DO use `doit <task>` for development workflows (test, lint, type-check, build, release, issue and PR creation).
+- DO add heavy libraries used only by tests or tooling to `[dependency-groups] dev`, not `[project] dependencies`.
+
+**DO NOT:**
+
+- DO NOT import from `tools/` or `dodo.py` in any module under `src/package_name/`. Runtime code must be installable and runnable without any dev tooling present.
+- DO NOT use `doit` tasks to expose application functionality to end users. `doit` is a dev surface, not a runtime surface.
+- DO NOT add a runtime dependency without asking the user first. See the "Ask First" policy in `.github/CONTRIBUTING.md`.
+- DO NOT conflate the development CLI (`doit`) with the application's runtime CLI (console script) in code, PR descriptions, or docs.
+
+## Common failure modes
+
+Concrete anti-patterns AI agents hit in this template, with the correct framing for each.
+
+### 1. Adding a new user-facing feature as a doit task
+
+**Wrong:** User asks for a "greet" command. Agent adds `def task_greet()` under `tools/doit/` so the user runs `doit greet`.
+
+**Right:** Add a module under `src/package_name/` that implements `greet`, register a console script in `[project.scripts]` (e.g. `greet = "package_name.greet:main"`), and test it as runtime code under `tests/`. End users install the package and run `greet` directly — they should never need `doit` installed.
+
+### 2. Importing a helper from `tools/` into `src/package_name/`
+
+**Wrong:** Runtime module does `from tools.doit.helpers import something` because the helper "already exists and does what I need."
+
+**Right:** If the helper is needed by runtime code, move it into `src/package_name/` and test it as runtime code. If it is only needed by dev tooling, duplicate the small bit of logic or keep it in `tools/` — `src/package_name/` never imports from `tools/` or `dodo.py`.
+
+### 3. Adding a heavy library to `[project] dependencies` for tests or tooling
+
+**Wrong:** Test needs `hypothesis`, so agent runs `uv add hypothesis`, which adds it to `[project] dependencies`. Every downstream user of the package now pulls `hypothesis` at install time.
+
+**Right:** Add test-only and tooling-only libraries to `[dependency-groups] dev`. Runtime dependencies ship to every user of the package and must stay minimal. New runtime deps require explicit user approval (do not run `uv add` on your own — that command is blocked for AI agents).
+
+### 4. Proposing `doit run_app` as the user entry point
+
+**Wrong:** Agent drafts a README section telling end users to `pip install package_name && doit run_app` to launch the application.
+
+**Right:** End users run the console script declared in `[project.scripts]`. They install the package and invoke the entry point by name. `doit` is not in the runtime dependency surface for end users and must not be presented as a runtime entry point.
+
+### 5. Conflating the dev CLI with the runtime CLI
+
+**Wrong:** PR description says "adds `doit foo` command for users." Docs under `docs/usage/` reference `doit` tasks as the way to use the package.
+
+**Right:** Keep the two surfaces distinct in both code and prose. `doit` tasks live in contributor-facing docs (`docs/development/`). The application's user-facing commands live in end-user docs (`docs/usage/`, `docs/getting-started/`) and are invoked via the console script, not `doit`.
+
+## Before generating code
+
+Short checklist to run through before writing any new code:
+
+1. Read [Tooling Roles and Architectural Boundaries](../tooling-roles.md) for the layering rationale.
+2. Identify the layer the change belongs in: runtime (`src/package_name/`), dev tooling (`tools/`), or dev entry point (`dodo.py`).
+3. Confirm imports respect the boundary: nothing under `src/package_name/` imports from `tools/` or `dodo.py`.
+4. If the change adds a user-facing command, plan it as a console script under `[project.scripts]`, not a `doit` task.
+5. If the change needs a new runtime dependency, stop and ask the user first.
+
+## See also
+
+- [Tooling Roles and Architectural Boundaries](../tooling-roles.md) — the human-facing rationale for the layering
+- [ADR-9002: Use doit for task automation](../../template/decisions/9002-use-doit-for-task-automation.md)
+- [ADR-9005: AI agent command restrictions](../../template/decisions/9005-ai-agent-command-restrictions.md)
+- [AI Enforcement Principles](enforcement-principles.md)
+- [AI Command Blocking](command-blocking.md)
+- [`AGENTS.md`](../../../AGENTS.md) — imperative tool reference and workflow rules

--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -12,7 +12,7 @@ tags:
 
 # AI CLI Hooks
 
-The `tools/hooks/ai/` directory contains hooks for AI coding assistants (Claude Code, Gemini CLI).
+The `tools/hooks/ai/` directory contains hooks for AI coding assistants (Claude Code, Gemini CLI, Copilot CLI, Codex CLI).
 
 ## Block Dangerous Commands
 
@@ -42,6 +42,20 @@ The hook uses Python's `shlex` module to properly parse shell quoting:
 6. **Check** for merge commits on protected branches (linear history)
 7. **Block** (exit code 2) or **Allow** (exit code 0)
 
+#### Key Feature: Chained Command Detection
+
+The hook scans all token positions, so chained commands using `&&` or `;` are caught:
+
+```bash
+# BLOCKED - dangerous command after safe one
+git status; git push --force origin main
+cd /path && doit release
+
+# ALLOWED - all commands in the chain are safe
+cd /path && doit check
+git status; git push origin feat/branch
+```
+
 #### Key Feature: Quote-Aware Parsing
 
 The hook correctly distinguishes between:
@@ -64,8 +78,8 @@ EOF
 
 | File | Description |
 |------|-------------|
-| [`block-dangerous-commands.py`](https://github.com/endavis/pynetappfoundry/blob/main/tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude and Gemini) |
-| [`test_hook.py`](https://github.com/endavis/pynetappfoundry/blob/main/tools/hooks/ai/test_hook.py) | Test suite to verify hook behavior |
+| [`block-dangerous-commands.py`](../../../tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude, Gemini, Copilot, and Codex) |
+| [`test_hook.py`](../../../tools/hooks/ai/test_hook.py) | Test suite to verify hook behavior |
 
 ### Configuration
 
@@ -112,9 +126,34 @@ EOF
 }
 ```
 
+#### Copilot CLI
+
+`.github/hooks/copilot-hooks.json`:
+```json
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "python3 ../../tools/hooks/ai/block-dangerous-commands.py",
+        "cwd": ".github/hooks",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}
+```
+
 #### Codex CLI
 
-Codex uses approval policies instead of hooks. See `.codex/config.toml` for deny rules.
+`.codex/config.toml`:
+```toml
+[hooks]
+pre_tool_use = "python3 tools/hooks/ai/block-dangerous-commands.py"
+```
+
+Codex also keeps `approval_policy` deny rules as a secondary defense layer. See `.codex/config.toml` for the full configuration.
 
 ### Testing
 
@@ -220,5 +259,5 @@ Then run the test suite to verify.
 ## Related
 
 - [AI Enforcement Principles](enforcement-principles.md) - Why and how we enforce rules in code
-- [AGENTS.md](https://github.com/endavis/pynetappfoundry/blob/main/AGENTS.md) - AI agent rules including "When Blocked Protocol"
+- [AGENTS.md](../../../AGENTS.md) - AI agent rules including "When Blocked Protocol"
 - [AI Agent Setup](../AI_SETUP.md) - Setting up AI coding assistants

--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -164,26 +164,26 @@ reason = "BLOCKED: Use 'doit pr' instead of 'gh pr create'. See AGENTS.md."
 
 > **Note**: GitHub settings require repository admin access to configure. See Settings → Rules → Rulesets.
 
-### By AI Agent Enforcement (Claude, Gemini, Codex)
+### By AI Agent Enforcement (Claude, Gemini, Copilot, Codex)
 
-These patterns are blocked across all AI agents. Claude and Gemini use the shared hook at `tools/hooks/ai/block-dangerous-commands.py`. Codex uses approval policies in `.codex/config.toml` (no hook support).
+These patterns are blocked across all AI agents. Claude, Gemini, and Copilot all use the shared hook at `tools/hooks/ai/block-dangerous-commands.py` (wired via `.claude/settings.json`, `.gemini/settings.json`, and `.github/hooks/copilot-hooks.json` respectively). Codex uses approval policies in `.codex/config.toml` (no hook support).
 
-| Pattern | Command | Claude | Gemini | Codex |
-|---------|---------|--------|--------|-------|
-| `--admin` flag | `gh pr merge --admin` | Hook | Hook | Config |
-| `--no-verify` flag | `git commit --no-verify`, `git push --no-verify` | Hook | Hook | Config |
-| `--hard` flag | `git reset --hard` | Hook | Hook | Config |
-| `rm -rf /` or `rm -rf ~` | Any shell | Hook | Hook | Config |
-| `sudo rm` | Any shell | Hook | Hook | Config |
-| Force push to protected branch | `git push --force origin main` | Hook | Hook | Config |
-| Delete protected branch | `git push origin --delete main`, `git branch -D main` | Hook | Hook | — |
-| Merge commit on protected branch | `git merge` (without `--ff-only`) on `main` | Hook | Hook | — |
-| `gh pr create` | Use `doit pr` instead | Hook | Hook | Config |
-| `gh issue create` | Use `doit issue` instead | Hook | Hook | Config |
-| `uv add` | User runs manually | Hook | Hook | Config |
-| `doit release*` | User runs manually | Hook | Hook | Config |
+| Pattern | Command | Claude | Gemini | Copilot | Codex |
+|---------|---------|--------|--------|---------|-------|
+| `--admin` flag | `gh pr merge --admin` | Hook | Hook | Hook | Config |
+| `--no-verify` flag | `git commit --no-verify`, `git push --no-verify` | Hook | Hook | Hook | Config |
+| `--hard` flag | `git reset --hard` | Hook | Hook | Hook | Config |
+| `rm -rf /` or `rm -rf ~` | Any shell | Hook | Hook | Hook | Config |
+| `sudo rm` | Any shell | Hook | Hook | Hook | Config |
+| Force push to protected branch | `git push --force origin main` | Hook | Hook | Hook | Config |
+| Delete protected branch | `git push origin --delete main`, `git branch -D main` | Hook | Hook | Hook | — |
+| Merge commit on protected branch | `git merge` (without `--ff-only`) on `main` | Hook | Hook | Hook | — |
+| `gh pr create` | Use `doit pr` instead | Hook | Hook | Hook | Config |
+| `gh issue create` | Use `doit issue` instead | Hook | Hook | Hook | Config |
+| `uv add` | User runs manually | Hook | Hook | Hook | Config |
+| `doit release*` | User runs manually | Hook | Hook | Hook | Config |
 
-> **Note**: "Hook" = `block-dangerous-commands.py`, "Config" = `.codex/config.toml` approval policy, "—" = not enforced for this agent.
+> **Note**: "Hook" = `block-dangerous-commands.py` (shared across Claude, Gemini, and Copilot), "Config" = `.codex/config.toml` approval policy, "—" = not enforced for this agent.
 
 ### By Pre-commit Hooks (All Developers and Agents)
 
@@ -287,5 +287,5 @@ The following AGENTS.md rules are currently instruction-only and could benefit f
 ## Related Documentation
 
 - [AI Command Blocking](command-blocking.md) - Hook implementation details
-- [AGENTS.md](https://github.com/endavis/pynetappfoundry/blob/main/AGENTS.md) - Full AI agent instructions
+- [AGENTS.md](../../../AGENTS.md) - Full AI agent instructions
 - [AI Setup Guide](../AI_SETUP.md) - Setting up AI coding assistants

--- a/docs/development/ai/first-5-minutes.md
+++ b/docs/development/ai/first-5-minutes.md
@@ -1,0 +1,150 @@
+---
+title: First 5 Minutes with an AI Agent
+description: Narrative walkthrough of the AI agent workflow from issue to merge
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - onboarding
+  - walkthrough
+---
+
+# First 5 Minutes with an AI Agent
+
+## Purpose
+
+This page is a narrative walkthrough of the AI agent workflow this template ships with. It is aimed at a new adopter who has Claude Code installed, has opened the repository for the first time, and wants to see what a full issue-to-merge cycle looks like before diving into the reference material. It is intentionally not a reference — the command-by-command reference lives in [Slash Commands and Workflows](slash-commands.md). Read this page once, then use the reference when you need the details.
+
+## Prerequisites
+
+- Claude Code installed and authenticated. See [AI Agent Setup](../AI_SETUP.md) for installation and per-agent configuration.
+- The [GitHub CLI](https://cli.github.com/) (`gh`) installed and logged in. The slash commands shell out to `gh` for issue and PR operations.
+- Optionally, the [Gemini CLI](https://github.com/google-gemini/gemini-cli) if you want to run the dual-agent review commands. The single-agent flow described below does not require it.
+- Alternatively, the [GitHub Copilot CLI](https://github.com/github/copilot-cli) can be used in place of Claude Code for the single-agent flow — it auto-discovers the same slash commands from `.claude/commands/`. See [AI Agent Setup § 4. GitHub Copilot CLI](../AI_SETUP.md#4-github-copilot-cli) for the wiring.
+
+The rest of this page assumes you have these working.
+
+## The walkthrough
+
+### 1. Open Claude Code in the repo
+
+Launch Claude Code from the repository root. On startup Claude automatically loads `AGENTS.md` (workflow and conventions), `.claude/CLAUDE.md` (Claude-specific rules on top of `AGENTS.md`), and the project hooks under `tools/hooks/ai/` (which block dangerous commands for every agent, not just Claude). You do not need to paste any context — the template is designed so a fresh session already knows the rules.
+
+If you are not sure what state you are in, run `/where-am-i` at any time. It inspects the branch, issue state, plan comments, uncommitted changes, unpushed commits, and open PRs, then reports a summary and suggests the next command. It is read-only and safe to run whenever you are unsure.
+
+### 2. Pick an issue
+
+Every change starts from an issue. Either list the open backlog with `gh issue list` and pick one, or create a new issue with `doit issue --type=<type>` (types are `feature`, `bug`, `refactor`, `doc`, `chore`). The template enforces Issue → Branch → Commit → PR → Merge; there is no supported path that skips the issue.
+
+For the rest of this walkthrough assume you have picked issue number `42`.
+
+### 3. `/plan-issue 42`
+
+Run `/plan-issue 42` in the main conversation. Claude enters plan mode, reads `AGENTS.md` and `.claude/CLAUDE.md`, fetches the issue, explores the codebase, and drafts a plan. Plan mode is interactive: Claude will ask questions and iterate with you until you approve the plan. Only on approval does it exit plan mode and post the plan as a comment on the issue with the header `## Implementation Plan for #42: <title>`. That posted comment is the artifact the next command reads.
+
+What you'll see (illustrative — your plan will look different):
+
+```markdown
+## Implementation Plan for #42: feat: add caching layer to provider
+
+### Context
+The provider module currently makes a network call on every lookup...
+
+### Files to create
+- `src/package_name/cache.py` — new LRU cache wrapper
+- `tests/test_cache.py` — unit tests for hit, miss, eviction
+
+### Files to modify
+- `src/package_name/provider.py` — wrap lookups in the cache
+
+### Test plan
+- Unit tests for cache hit, cache miss, eviction ordering
+- Provider tests updated to assert the cache is consulted
+
+### Validation
+- `doit check` passes
+```
+
+Read the comment, discuss revisions in chat if anything is off, and re-run `/plan-issue 42` if you need a fresh pass.
+
+### 4. `/implement 42`
+
+Once the plan comment exists, run `/implement 42`. Claude checks out `main`, pulls, and creates a branch whose type is derived from the issue's labels — for example, a `feature` issue becomes `feat/42-add-caching-layer`. Claude then spawns a subagent via the Task tool. The subagent does the heavy work: re-reads `AGENTS.md`, fetches the plan via `gh api`, creates files, writes tests, and runs `doit check`, fixing failures rather than giving up. The main conversation context receives only the subagent's summary, which keeps your scrollback clean and your context window small.
+
+The artifact at the end of this step is an uncommitted working tree on the feature branch. Nothing has been committed yet — that is deliberate.
+
+### 5. (Optional) `/gemini-review`
+
+If you have the Gemini CLI installed and want a second opinion on the changes, you can run `/gemini-review` at this point (after a PR exists) or use `/review-both` for a parallel Claude + Gemini review. The template invokes Gemini in an isolated context, captures its stdout, and posts it as a comment on the PR. Gemini never writes to GitHub directly — the orchestrating Claude agent does the posting. Skip this step if you are running single-agent.
+
+### 6. `/finalize`
+
+Run `/finalize` when you are satisfied with the changes. Claude detects the branch and issue number, spawns a finalization subagent that reviews changed files for doc/ADR updates, runs `doit check` one more time, and drafts both a commit message and a PR body. The main conversation then presents the drafts to you and **waits for explicit approval** before staging files, committing, and running `doit pr`. Nothing gets committed without your go-ahead.
+
+What you'll see (illustrative — your drafts will look different):
+
+```markdown
+Proposed commit message:
+
+  feat: add LRU cache to provider lookups
+
+  Wraps provider.lookup() in a bounded LRU cache to eliminate
+  repeated network calls for the same key within a session.
+
+  Addresses #42
+
+Proposed PR body:
+
+  ## Summary
+  Adds a small LRU cache in front of the provider network calls.
+
+  ## Changes
+  - New `cache.py` with an LRU wrapper
+  - Provider updated to consult the cache
+  - Unit tests for hit, miss, eviction
+
+  ## Validation
+  - `doit check` passes locally
+
+  Addresses #42
+
+Approve and commit? (yes / edit / no)
+```
+
+Approve, and Claude stages the files, commits, and opens the PR via `doit pr`. The artifact is an open PR referencing `Addresses #42`.
+
+### 7. Merge
+
+Merging is never automated. Review the PR yourself, wait for CI to go green, add the `ready-to-merge` label, and merge via `doit pr_merge` (or the GitHub web UI). The `ready-to-merge` label and the Merge Gate action are designed to be a human checkpoint — do not let an agent add that label for you.
+
+### 8. `/close-issue 42`
+
+After the PR merges, run `/close-issue 42`. Claude verifies a merged PR references `#42`, updates the task checkboxes in the issue body, posts the closing comment `Addressed in PR #<pr-number>`, and closes the issue. It then scans the PR body and comments for related-issue references (`Addresses`, `Part of`, `Closes`, bare `#N`, and so on) and asks you, one at a time, whether to close each open related issue. It never closes a related issue without per-issue confirmation.
+
+That is the full loop.
+
+## What each command produces
+
+Every step in the flow produces a specific artifact the next step expects:
+
+- `/plan-issue <n>` → a plan comment on the issue with the header `## Implementation Plan for #<n>`
+- `/implement <n>` → a feature branch with an uncommitted working tree
+- `/finalize` → a staged commit plus an open PR referencing `Addresses #<n>`
+- Merge → a merged commit on `main` and a closed PR
+- `/close-issue <n>` → a closed issue with updated checkboxes and a closing comment
+
+Knowing the artifact chain is the fastest way to figure out where you are if you get interrupted mid-flow.
+
+## If you get lost
+
+Run `/where-am-i`. It is read-only, has no side effects, and will tell you the current branch, issue state, plan comment status, uncommitted changes, unpushed commits, open PRs, and the suggested next command. Run it any time you are unsure. For the full command-by-command reference and the dual-agent variants, see [Slash Commands and Workflows](slash-commands.md).
+
+## See also
+
+- [Slash Commands and Workflows](slash-commands.md) — full command reference and dual-agent workflow.
+- [AI Agent Setup](../AI_SETUP.md) — per-CLI configuration, permissions, and hooks.
+- [Architectural Conventions](architectural-conventions.md) — imperative rules for AI-generated code.
+- [AGENTS.md](../../../AGENTS.md) — universal context file and workflow reference.
+- <!-- TODO: wire this link up properly when #342 lands -->
+  For an end-to-end example of the *coding* side of a feature (creating a module, CLI subcommand, tests, and docs), see [the add-a-feature example](../../examples/add-a-feature.md) (tracked in [#342](https://github.com/endavis/pyproject-template/issues/342)).

--- a/docs/development/ai/ruff-fix-hook.md
+++ b/docs/development/ai/ruff-fix-hook.md
@@ -1,0 +1,86 @@
+---
+title: Ruff Auto-Fix on Edit Hook
+description: PostToolUse hook that runs ruff --fix on edited Python files
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - hooks
+  - ruff
+---
+
+# Ruff Auto-Fix on Edit
+
+A Claude Code `PostToolUse` hook that runs `ruff --fix` plus `ruff format` on a Python file immediately after an AI agent edits it. Cuts the feedback loop on trivial issues (unused imports, unused variables, import ordering) from "discovered at `doit check` many turns later" to "fixed before the next tool call".
+
+## What It Does
+
+After every `Edit`, `Write`, or `MultiEdit` call, the hook:
+
+1. Reads the tool payload from stdin and extracts `tool_input.file_path`.
+2. Skips the file unless it's a tracked Python source path (see scope below).
+3. Runs `uv run ruff check --fix --select F401,F841,I --quiet <path>`.
+4. Runs `uv run ruff format --quiet <path>`.
+5. Always exits 0. Hook errors must never block tool calls.
+
+The hook is best-effort — timeouts, missing `ruff`, malformed payloads, and ruff non-zero exits are all swallowed silently. The next `doit check` will surface anything genuine.
+
+## Scope
+
+| Path pattern | Auto-fixed? |
+|---|---|
+| `src/**/*.py` | yes |
+| `tests/**/*.py` | yes |
+| `tools/**/*.py` | yes |
+| `bootstrap.py` | yes |
+| Anything else (including `scripts/*.py`, `*.md`, `*.toml`, etc.) | no |
+
+This mirrors the scope `doit format` and `doit lint` already target.
+
+## Rules Fixed
+
+Only deterministic, judgment-free rules are selected:
+
+| Rule | Description |
+|---|---|
+| `F401` | Unused imports |
+| `F841` | Unused local variables |
+| `I` | Import sorting (`isort`-compatible) |
+
+All other ruff rules (`E`, `W`, `B`, `RUF`, etc.) are intentionally **not** enabled by the hook — they require human judgment. They still run as part of `doit lint` / `doit check`.
+
+## Disabling Locally
+
+Override the hook entry in `.claude/settings.local.json` (gitignored):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": []
+  }
+}
+```
+
+Restart Claude Code for the change to take effect.
+
+## Known Limitation: Stale `old_string` After Reorder
+
+If you make two consecutive `Edit` calls on the same file and the first edit's ruff pass reorders imports or removes a line you were about to target, the second `Edit`'s `old_string` may no longer match. Mitigations:
+
+- Use `Write` for large rewrites that touch many lines.
+- Re-`Read` the file between consecutive `Edit` calls on imports or unused-variable-adjacent code.
+
+The friction is intentional — silencing the noise on every other turn is worth the occasional re-read.
+
+## Files
+
+| File | Description |
+|---|---|
+| [`tools/hooks/ai/ruff-fix-on-edit.py`](../../../tools/hooks/ai/ruff-fix-on-edit.py) | The hook script |
+| [`tests/test_hook_ruff_fix.py`](../../../tests/test_hook_ruff_fix.py) | Pytest coverage |
+| [`.claude/settings.json`](../../../.claude/settings.json) | Wires the hook into `PostToolUse` |
+
+## Related
+
+- [AI Command Blocking](command-blocking.md) — sibling `PreToolUse` hook for dangerous commands

--- a/docs/development/ai/slash-commands.md
+++ b/docs/development/ai/slash-commands.md
@@ -1,0 +1,144 @@
+---
+title: Slash Commands and Workflows
+description: Reference for the slash commands and dual-agent workflow this template ships with
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - workflow
+  - slash-commands
+---
+
+# Slash Commands and Workflows
+
+## Purpose
+
+This page documents the slash commands this template ships under `.claude/commands/` and `.gemini/commands/`, and the single-agent and dual-agent workflows built on top of them. It is written for contributors who want to understand or extend the workflow, and for AI agents that need to know which command to run at each stage of the issue lifecycle.
+
+## Workflows
+
+### Single-agent workflow
+
+The default Claude flow takes an issue from unplanned to closed. Each step produces an artifact the next step expects.
+
+1. **`/plan-issue <n>`** — Claude enters plan mode in the main conversation, reads project rules, explores the codebase, drafts a plan, and iterates with the user until approved. On approval the plan is posted as a comment on issue `#n` with the header `## Implementation Plan for #<n>: <title>`. The next step expects this comment to exist.
+2. **User review of the plan** — read the comment, discuss revisions in chat, re-run `/plan-issue` if needed.
+3. **`/implement <n>`** — Claude verifies the plan comment exists, creates a branch (`<type>/<n>-<short-description>`) off fresh `main`, then spawns a subagent (Task tool) that reads `AGENTS.md`, fetches the plan, implements files and tests, and runs `doit check`. The main context receives only the summary. The artifact is an uncommitted working tree on the feature branch.
+4. **User review of the changes** — inspect the diff and discuss fixes directly in chat; no command is needed for fix-ups.
+5. **`/finalize`** — Claude detects the branch and issue, spawns a finalization subagent that updates docs/ADRs as needed, runs `doit check`, and drafts a commit message and PR body. The main context presents the drafts and waits for explicit user approval before staging, committing, and creating the PR via `doit pr`. The artifact is an open PR referencing `Addresses #<n>`.
+6. **User-driven merge** — the user reviews the PR, adds the `ready-to-merge` label, and merges via `doit pr_merge` (or the web UI). This step is never automated.
+7. **`/close-issue <n>`** — Claude verifies a merged PR addresses `#n`, updates task checkboxes in the issue body, posts `Addressed in PR #<pr>`, closes the issue, and scans the PR for related issues to optionally close as well.
+
+### Dual-agent workflow
+
+The dual-agent flow replaces the planning and (optionally) review steps with orchestrated calls that spawn Claude and Gemini in **isolated contexts**. The design intent is that neither agent can bias the other: each generates its output without seeing the other's work, and the orchestrating Claude agent in the main conversation posts both raw outputs plus a synthesis.
+
+Gemini commands under `.gemini/commands/` are **output-only**: Gemini does not post to GitHub itself. The orchestrating Claude agent captures Gemini's stdout and posts it via `gh`.
+
+1. **`/plan-both <n>`** — replaces `/plan-issue`. Claude validates the issue, then in parallel (a) spawns a general-purpose subagent to produce a Claude plan and (b) invokes `gemini -p "/plan-issue <n>" --yolo` to produce a Gemini plan. Both are posted as separate comments on the issue, Claude synthesizes a combined plan, reviews it with the user, and posts the approved synthesized plan.
+2. **`/implement <n>`** — same as the single-agent flow. The synthesized plan comment is the input.
+3. **`/review-both`** — runs after a PR exists. In parallel spawns a Claude review subagent and invokes `gemini -p "/review-pr" --yolo`, posts both reviews as PR comments, and posts a combined synthesis listing consensus findings, agent-specific findings, and a combined verdict. Alternatively, **`/gemini-review`** runs only the Gemini review and posts it (useful when the user wants a second opinion without a full Claude review).
+4. **`/finalize`**, merge, and **`/close-issue <n>`** — same as the single-agent flow.
+
+### Diagnostic command
+
+**`/where-am-i`** can be invoked at any point. It inspects the current branch, issue state, plan comment, uncommitted changes, unpushed commits, and open PRs, then reports a status summary and the suggested next command. It has no side effects.
+
+## Command reference
+
+Entries are alphabetical. Each one names the command, its arguments, what it does, its position in the workflow, and any design note worth knowing.
+
+### `/close-issue <n>`
+
+**Args:** issue number. **Source:** `.claude/commands/close-issue.md`.
+
+Verifies a merged PR references `#n`, updates task checkboxes in the issue body, posts the closing comment `Addressed in PR #<pr-number>`, closes the issue via `gh issue close`, then scans the PR body and comments for related issue references (`Addresses`, `Part of`, `Related to`, `Closes`, `Fixes`, `References`, bare `#N`) and asks the user individually whether to close each open related issue. **Workflow position:** last step of both single-agent and dual-agent flows. **Design note:** never closes an issue without a merged PR unless the user explicitly confirms; never closes related issues without per-issue confirmation.
+
+### `/finalize`
+
+**Args:** none. **Source:** `.claude/commands/finalize.md`.
+
+Operates on the current feature branch, assuming implementation and review are complete. In the main context it detects the branch, extracts the issue number from the branch name, fetches issue details, and checks for uncommitted changes. It then spawns a general-purpose subagent that reads `AGENTS.md`, `.github/CONTRIBUTING.md`, and `.github/pull_request_template.md`, reviews changed files for doc/ADR updates, runs `doit check`, and drafts a commit message plus a PR body written to a temp file. The main context then presents the drafts to the user, waits for explicit approval, stages files, commits, and creates the PR via `doit pr --title=... --body-file=...`. **Workflow position:** after implementation and review. **Design note:** will not commit or create the PR without explicit user confirmation; stops if run on `main`.
+
+### `/gemini-review`
+
+**Args:** none. **Source:** `.claude/commands/gemini-review.md`.
+
+Runs in the main conversation context. Verifies a PR exists for the current branch, invokes `gemini -p "/review-pr" --yolo` to get a Gemini-authored review as stdout markdown, and posts the output as a comment on the PR via `gh pr comment`, then reports a brief summary to the user. **Workflow position:** optional second-opinion review on an open PR. **Design note:** Gemini does not post to GitHub itself — the orchestrating Claude agent posts the captured stdout.
+
+### `/implement <n>`
+
+**Args:** issue number. **Source:** `.claude/commands/implement.md`.
+
+Validates that the issue is open and that a plan comment exists (otherwise instructs the user to run `/plan-issue <n>` first). Checks the current branch: if already on `<type>/<n>-*` it resumes work on that branch, otherwise it checks out `main`, pulls, and creates a new branch whose type is derived from the issue's labels (`enhancement`→`feat`, `bug`→`fix`, `refactor`→`refactor`, `documentation`→`docs`, `chore`→`chore`, else `issue`). It then spawns the custom `implement-worker` subagent (defined in `.claude/agents/implement-worker.md`) that reads `AGENTS.md` and `.claude/CLAUDE.md`, fetches the plan via `gh api`, implements files and tests, and runs `doit check`, fixing failures rather than giving up. The main context receives only the summary. **Workflow position:** after plan exists, before `/finalize`. **Design note:** the subagent pattern keeps the main conversation context clean. The command now spawns `implement-worker` rather than the built-in `general-purpose` subagent. The custom subagent has `permissionMode: default` in its YAML frontmatter — per Claude Code's documented sub-agent precedence rules, this should escape parent plan mode because plan mode is not in the parent-overrides-child list. The status-line preamble warning (telling the user to check for "plan mode" before running) is retained as belt-and-suspenders while the override is empirically validated; it can be removed in a follow-up once confirmed on the shipping Claude Code version.
+
+
+### `/plan-both <n>`
+
+**Args:** issue number. **Source:** `.claude/commands/plan-both.md`.
+
+Dual-agent replacement for `/plan-issue`. Validates the issue, warns if plan comments already exist, then generates two plans in isolated contexts — a Claude plan via a spawned subagent and a Gemini plan via `gemini -p "/plan-issue <n>" --yolo` — posts both as separate issue comments, synthesizes a combined plan that highlights agreements and divergences, reviews the synthesis with the user, and only posts the synthesized plan after explicit approval. **Workflow position:** first step of the dual-agent workflow. **Design note:** isolated contexts are mandatory so neither agent can see the other's output while drafting; Claude is the orchestrator and the only agent that writes to GitHub.
+
+### `/plan-issue <n>`
+
+**Args:** issue number. **Source:** `.claude/commands/plan-issue.md`.
+
+Runs in the main conversation context (not a subagent) so the user can ask questions and refine the plan interactively. Enters plan mode, validates the issue, warns if a plan comment already exists, reads `AGENTS.md` and `.claude/CLAUDE.md`, fetches issue details, explores the codebase, and drafts a plan with the standard sections (Overview, Files to Create/Modify, Test Plan, Documentation, Validation). It iterates inside plan mode with `AskUserQuestion` until the user approves, then exits plan mode and posts the approved plan as an issue comment. **Workflow position:** first step of the single-agent workflow. **Design note:** plan mode is preserved throughout iteration; exiting plan mode means "post the approved plan", nothing more.
+
+### `/review-both`
+
+**Args:** none. **Source:** `.claude/commands/review-both.md`.
+
+Dual-agent PR review. Verifies a PR exists for the current branch, then in parallel spawns a general-purpose Claude review subagent and invokes `gemini -p "/review-pr" --yolo`, posts both reviews as separate PR comments, and posts a synthesis listing consensus findings (both agents flagged), Claude-only findings, Gemini-only findings, and a combined verdict. **Workflow position:** after `/implement`, before `/finalize`, in the dual-agent workflow. **Design note:** same isolation guarantee as `/plan-both` — neither reviewer sees the other's output; the synthesis is posted after both raw reviews so readers can audit the synthesis against the sources.
+
+### `/where-am-i`
+
+**Args:** none. **Source:** `.claude/commands/where-am-i.md`.
+
+Inspects the current git state (branch, uncommitted changes, recent log), extracts the issue number from the branch name if on a feature branch, checks for a plan comment, unpushed commits, and open PRs, then reports a status summary and suggests the next command to run. **Workflow position:** any time. **Design note:** read-only and side-effect-free — safe to run whenever the user is unsure where they are in the lifecycle.
+
+### `/plan-issue <n>` (Gemini)
+
+**Args:** issue number. **Source:** `.gemini/commands/plan-issue.md`.
+
+Invoked by Claude's `/plan-both` orchestration command via `gemini -p "/plan-issue <n>" --yolo`. Fetches the issue, reads `AGENTS.md`, explores the codebase, and outputs a plan in the standard format to stdout, signed `*Plan by: Gemini*`. **Workflow position:** called indirectly from `/plan-both`. **Design note:** output-only — the command explicitly instructs Gemini not to post to GitHub; the orchestrating Claude agent captures stdout and posts it.
+
+### `/review-pr` (Gemini)
+
+**Args:** none. **Source:** `.gemini/commands/review-pr.md`.
+
+Invoked by Claude's `/review-both` and `/gemini-review` commands via `gemini -p "/review-pr" --yolo`. Identifies the current branch's PR, scans for `Addresses #XXX` to find the issue, reads `AGENTS.md` and `.github/CONTRIBUTING.md`, runs `gh pr diff`, reviews the changes for correctness, style, testing, security, documentation, architecture, and breaking changes, and outputs a review in the standard format to stdout, signed `*Review by: Gemini*`. **Workflow position:** called indirectly from `/review-both` or `/gemini-review`. **Design note:** output-only for the same reason as the Gemini plan command.
+
+## Codex
+
+The `.codex/` directory contains only `config.toml`, which configures command approval policies for the Codex CLI. No slash commands ship for Codex. The dual-agent workflow in this template targets Claude and Gemini.
+
+## Copilot
+
+GitHub Copilot CLI automatically discovers project skills from `.claude/commands/`. All workflow commands (`/plan-issue`, `/implement`, `/finalize`, `/close-issue`, `/where-am-i`, etc.) are available in Copilot sessions without any additional files.
+
+**Config directory:** `.copilot/` — established as the Copilot CLI config directory for this repo, parallel to `.claude/`, `.gemini/`, and `.codex/`.
+
+**Dangerous command hook:** Already wired in `.github/hooks/copilot-hooks.json`. It invokes `tools/hooks/ai/block-dangerous-commands.py` as a `preToolUse` hook, blocking dangerous shell commands before they execute. See [AI Command Blocking](command-blocking.md) for details.
+
+**Implement-worker subagent:** Shared with Claude — defined in `.claude/agents/implement-worker.md`. Copilot CLI's `task` tool reads this file when `/implement` spawns the subagent.
+
+**No parallel command files needed:** Because Copilot CLI discovers skills from `.claude/commands/` directly, you do not need to maintain a separate `.copilot/commands/` directory unless you need to override Claude-specific behavior for Copilot sessions.
+
+## Adding a new slash command
+
+1. **Pick the location.** Claude commands live in `.claude/commands/<name>.md` and become `/<name>` in Claude Code. Gemini commands live in `.gemini/commands/<name>.md` and become `/<name>` in Gemini CLI. Copilot CLI auto-discovers skills from `.claude/commands/` — no separate `.copilot/commands/<name>.md` is needed unless you want to override Claude-specific behaviour for Copilot sessions.
+2. **Use the CLI file format** — not the `docs/` frontmatter format. Start with a top-level `# Title` heading, follow with a one-line description (which may include the `$ARGUMENTS` placeholder if the command takes arguments), then a `## Instructions` section containing the step-by-step body. **Do not add YAML frontmatter.** The CLIs expect plain markdown; frontmatter would appear verbatim in the rendered prompt.
+3. **Use `$ARGUMENTS` for inputs.** When the user invokes `/<command> foo bar`, every `$ARGUMENTS` occurrence in the file is substituted with `foo bar` before the command body is sent to the model. For commands that take no arguments (like `/finalize` or `/where-am-i`), omit the placeholder.
+4. **Decide: subagent or main context?** Delegate to a general-purpose subagent via the Task tool when the command does heavy codebase exploration, writes files, or runs long commands whose output would bloat the main conversation — `.claude/commands/implement.md` is the canonical example. Run in the main context when the user needs to interact step by step (plan mode, iteration, explicit approvals) — `.claude/commands/plan-issue.md` is the canonical example.
+5. **Update this document** when you add or remove a command. The command reference section should list every file under `.claude/commands/` and `.gemini/commands/`.
+
+## See also
+
+- [First 5 Minutes with an AI Agent](first-5-minutes.md) — narrative onboarding walkthrough showing the workflow end to end.
+- [AI Agent Setup Guide](../AI_SETUP.md) — per-CLI configuration and whitelists.
+- [Architectural Conventions](architectural-conventions.md) — imperative rules for AI-generated code.
+- [AI Enforcement Principles](enforcement-principles.md) — how this template enforces rules in code, not just instructions.
+- [AI Command Blocking](command-blocking.md) — tool-level hooks that block dangerous commands.
+- [AGENTS.md](../../../AGENTS.md) — universal context file and workflow reference.

--- a/docs/development/ai/statusline.md
+++ b/docs/development/ai/statusline.md
@@ -18,7 +18,7 @@ The template includes a custom statusline for Claude Code sessions that provides
 
 ```
 📁 project-name | 🐍 .venv | Python: 3.12.12
-@endavis | 🔀 main (0 files uncommitted, synced 5m ago)
+@username | 🔀 main (0 files uncommitted, synced 5m ago)
 Claude Opus 4.5 | ▓▓░░░░░░░░ ~10% of 200k tokens
 💬 work on issue #130
 ```
@@ -27,7 +27,7 @@ Claude Opus 4.5 | ▓▓░░░░░░░░ ~10% of 200k tokens
 
 - **Current directory** and Python virtual environment name
 - **Python version** currently active
-- **GitHub endavis** (from `gh` CLI)
+- **GitHub username** (from `gh` CLI)
 - **Git branch** with uncommitted file count
 - **Sync status** showing ahead/behind commits and last fetch time
 - **Model name** with context usage bar (visual + percentage)
@@ -81,14 +81,14 @@ Comment out or remove lines in the "Build output" section of the script:
 output="📁 ${dir}"
 [[ -n "$venv_name" ]] && output+=" | 🐍 ${venv_name}"
 [[ -n "$python_version" ]] && output+=" | Python: ${python_version}"
-# [[ -n "$gh_user" ]] && output+="\n@${gh_user}"  # Remove GitHub endavis
+# [[ -n "$gh_user" ]] && output+="\n@${gh_user}"  # Remove GitHub username
 [[ -n "$branch" ]] && output+=" | 🔀 ${branch} ${git_status}"
 ```
 
 ## Requirements
 
 - `jq` - JSON processor (used for parsing Claude's input)
-- `gh` - GitHub CLI (optional, for endavis display)
+- `gh` - GitHub CLI (optional, for username display)
 - `git` - For branch and status information
 
 ## Troubleshooting

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -31,7 +31,7 @@ CI runs lint/format, tests, coverage, and quality checks to guard against regres
 Local commands:
 ```bash
 doit format && doit lint
-uv run pytest
+doit test
 doit coverage
 ```
 
@@ -207,6 +207,28 @@ security:
       run: uv run doit security
 ```
 
+#### Documentation Build Job
+
+Runs `doit docs_build` once on `ubuntu-latest` using the project's newest supported Python version (read dynamically from `.github/python-versions.json`). This job gates PRs against hard-crash regressions in the mkdocs build pipeline — for example, plugin incompatibilities, broken macros, or malformed configuration. See issue [#349](https://github.com/endavis/pyproject-template/issues/349) for the historical incident that motivated this gate.
+
+Note: This job does **not** currently run `mkdocs build --strict`, so doc-link warnings and other non-fatal mkdocs warnings do not fail the build. Tightening this to strict mode is a potential future improvement once the existing warning backlog is cleared.
+
+```yaml
+docs:
+  needs: setup
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      with:
+        python-version: ${{ needs.setup.outputs.newest }}
+    - uses: astral-sh/setup-uv@v7
+    - name: Install dependencies
+      run: uv sync --all-extras --dev
+    - name: Build documentation
+      run: uv run doit docs_build
+```
+
 ### Coverage Requirements
 
 - **Recommended threshold**: ≥70%
@@ -249,7 +271,7 @@ Add coverage comments to PRs using GitHub Actions:
 
 ```bash
 # Run all tests
-uv run pytest
+doit test
 
 # Run specific test file
 uv run pytest tests/test_config.py
@@ -261,7 +283,7 @@ uv run pytest tests/test_config.py::test_load_config
 uv run pytest -v
 
 # Run with coverage
-uv run pytest --cov=src
+doit coverage
 
 # Generate HTML coverage report
 uv run pytest --cov=src --cov-report=html
@@ -362,6 +384,7 @@ Before pushing to CI:
 - [ ] Run `doit type_check` to verify types
 - [ ] Run `doit test` to ensure tests pass
 - [ ] Run `doit coverage` to check coverage threshold
+- [ ] Run `doit docs_build` to verify the documentation build succeeds
 - [ ] Review changes and commit messages
 
 ## Testing Best Practices
@@ -597,6 +620,164 @@ PR opened → CI runs (6 jobs) → Review/Approval → Add ready-to-merge label 
 PR opened → CI runs → Add full-matrix label → Full CI runs (9-15 jobs) → Review → Add ready-to-merge → Merge
 ```
 
+## Property-Based Testing
+
+### What Is Property-Based Testing?
+
+Property-based testing verifies *invariant properties* of your code by feeding it hundreds of randomly generated inputs rather than a handful of hand-picked examples. If a property holds for every input the framework can dream up, you gain much higher confidence than example-based tests alone.
+
+This project uses [Hypothesis](https://hypothesis.readthedocs.io/) for property-based testing.
+
+### When to Use Property-Based Tests
+
+| Good fit | Not a good fit |
+|----------|----------------|
+| Pure functions with clear contracts (validators, formatters, parsers) | Tests that require complex external state (databases, APIs) |
+| Functions whose output must satisfy invariants (e.g., "always lowercase") | Behaviour that depends on side effects or ordering |
+| Edge-case-heavy logic (string processing, numeric conversions) | Simple CRUD with no transformation logic |
+
+### Writing Property Tests
+
+```python
+import pytest
+from hypothesis import given, example
+from hypothesis import strategies as st
+
+@pytest.mark.property
+@given(name=st.text(min_size=1))
+@example("edge-case-value")
+def test_output_is_always_lowercase(name: str) -> None:
+    result = normalize(name)
+    assert result == result.lower()
+```
+
+**Key decorators and strategies:**
+
+| Element | Purpose |
+|---------|---------|
+| `@given(...)` | Declares the randomly generated inputs |
+| `@example(...)` | Pins a specific input that must always be tested |
+| `st.text()` | Generates arbitrary Unicode strings |
+| `st.from_regex(r"...")` | Generates strings matching a regular expression |
+| `st.integers()`, `st.floats()` | Numeric strategies |
+| `@pytest.mark.property` | Custom marker to select/deselect property tests |
+
+### Hypothesis Profiles
+
+Two profiles are configured in `tests/conftest.py`:
+
+| Profile | `max_examples` | `deadline` | Used when |
+|---------|---------------|------------|-----------|
+| `default` | 200 | Hypothesis default | Local development |
+| `ci` | 50 | 500 ms | GitHub Actions CI |
+
+The CI workflow sets `HYPOTHESIS_PROFILE: ci` so property tests run faster in pipelines.
+
+### Running Property Tests
+
+```bash
+# Run only property tests
+uv run pytest -m property -v
+
+# Run with a specific seed for reproducibility
+uv run pytest -m property --hypothesis-seed=12345
+
+# Run with more examples locally
+HYPOTHESIS_PROFILE=default uv run pytest -m property -v
+```
+
+### Debugging Failures
+
+When a property test fails, Hypothesis prints the **minimal failing example**. To reproduce:
+
+1. Copy the seed from the failure output (e.g., `--hypothesis-seed=98765`)
+2. Re-run: `uv run pytest tests/test_properties.py --hypothesis-seed=98765 -v`
+3. Hypothesis will reproduce the exact same sequence of inputs
+
+Hypothesis also stores failing examples in a `.hypothesis/` directory (git-ignored) so they are replayed automatically on the next run.
+
+## Mutation Testing
+
+### What Is Mutation Testing?
+
+Mutation testing evaluates the effectiveness of your test suite by introducing small changes (mutations) to your source code and checking whether the tests detect them. Each mutation represents a potential bug -- if your tests catch it (a "killed" mutant), that area is well tested. If they don't (a "survived" mutant), your tests may have a gap.
+
+This project uses [mutmut](https://mutmut.readthedocs.io/) for mutation testing.
+
+### Running Locally
+
+```bash
+# Run mutation testing (generates results and prints summary)
+doit mutate
+
+# View text results again without re-running
+uv run mutmut results
+```
+
+### Interpreting Results
+
+| Term | Meaning |
+|------|---------|
+| **Killed** | A mutation was detected by the test suite -- good coverage |
+| **Survived** | A mutation was NOT detected -- potential test gap |
+| **Timeout** | The mutation caused the tests to hang -- typically counted as killed |
+| **Suspicious** | The mutation caused an unexpected result -- review manually |
+
+The **mutation score** is the percentage of mutants killed out of total mutants generated. A higher score indicates a more thorough test suite. There is no enforced threshold -- use the score as a guide to identify areas that need better test coverage.
+
+### CI Schedule
+
+Mutation testing runs weekly in CI (Sunday midnight UTC) via the `.github/workflows/mutation.yml` workflow. It is informational only and does not block merges or fail the build.
+
+Results are uploaded as the `mutmut-results.txt` artifact with 90-day retention. You can also trigger the workflow manually from the Actions tab using the `workflow_dispatch` event.
+
+## Benchmark Tracking
+
+### Overview
+
+Benchmark results are tracked historically using [benchmark-action/github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark). This enables performance trend visualization and automatic regression detection across commits.
+
+### How It Works
+
+The `benchmark.yml` workflow operates in two modes:
+
+| Trigger | Behavior |
+|---------|----------|
+| **Push to `main`** | Runs benchmarks and commits results to the `gh-benchmarks` data branch for long-term tracking |
+| **Pull request** | Runs benchmarks and posts a comparison comment on the PR if the `gh-benchmarks` branch exists (no commit to data branch) |
+| **Manual dispatch** | Runs benchmarks and uploads artifact only |
+
+Only main branch results are stored to keep the historical data clean and consistent.
+
+If `tests/benchmarks/` does not exist or contains no `test_*.py` files, the workflow skips all benchmark steps and finishes successfully. This allows downstream projects generated from this template to enable the workflow incrementally without CI failures before any benchmark tests are written.
+
+### The `gh-benchmarks` Branch
+
+Benchmark data is stored in a dedicated `gh-benchmarks` branch, separate from the main codebase. This branch is auto-created by the benchmark action on the first push to `main` after the workflow is enabled. Until the branch exists, PR benchmark comparisons are skipped gracefully.
+
+- **Data directory:** `dev/bench/` within the branch
+- **Format:** JSON files with benchmark metrics over time
+- **Purpose:** Serves as the data source for trend charts and regression detection
+
+### PR Comments
+
+On every pull request, the benchmark action posts a comment comparing the PR's benchmark results against the latest stored baseline from `main`. This gives reviewers immediate visibility into performance impact.
+
+### Alert Threshold
+
+The alert threshold is set to `110%`, meaning the workflow flags a warning if any benchmark is more than 10% slower than the baseline. To adjust this threshold, edit the `alert-threshold` value in `.github/workflows/benchmark.yml`.
+
+### GitHub Pages (Optional)
+
+The `gh-benchmarks` branch can optionally serve a trend chart via GitHub Pages:
+
+1. Go to **Settings** > **Pages**
+2. Set the source branch to `gh-benchmarks`
+3. Set the directory to `/ (root)`
+4. The trend chart will be available at `https://<owner>.github.io/<repo>/dev/bench/`
+
+This step is optional and not required for the core tracking functionality.
+
 ## Troubleshooting
 
 ### Coverage Below Threshold
@@ -649,4 +830,4 @@ PR opened → CI runs → Add full-matrix label → Full CI runs (9-15 jobs) →
 
 ---
 
-[Back to Documentation Index](../index.md)
+[Back to Documentation Index](../TABLE_OF_CONTENTS.md)

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -614,4 +614,4 @@ def process(data, mode):
 
 ---
 
-[Back to Documentation Index](../index.md)
+[Back to Documentation Index](../TABLE_OF_CONTENTS.md)

--- a/docs/development/dependabot-automerge.md
+++ b/docs/development/dependabot-automerge.md
@@ -1,0 +1,92 @@
+---
+title: Dependabot Auto-merge
+description: How the dependabot auto-merge workflow evaluates, enables, and skips PRs
+audience:
+  - contributors
+  - maintainers
+tags:
+  - dependabot
+  - automation
+  - ci
+---
+
+# Dependabot Auto-merge
+
+The workflow at `.github/workflows/dependabot-automerge.yml` evaluates each
+dependabot PR and enables GitHub's native auto-merge for PRs that meet the
+project's safety criteria. Qualifying PRs are merged automatically once the
+required CI checks pass.
+
+## What gets auto-merged
+
+A dependabot PR qualifies when **all** of the following are true:
+
+- The update type is `version-update:semver-patch` or `version-update:semver-minor`.
+- None of the updated dependency names match a glob in the
+  `sensitive_dependencies` list.
+- The PR has no label listed in `blocking_labels`.
+
+Qualifying PRs receive:
+
+- GitHub's native auto-merge enabled with the **squash** strategy.
+- The `ready-to-merge` label applied automatically (satisfying the Merge Gate).
+- A sticky status comment confirming auto-merge is enabled.
+
+## What gets skipped
+
+A PR is skipped (no auto-merge, sticky comment posted for human review) when:
+
+- The update is a **major version bump** (`version-update:semver-major`).
+- A **sensitive dependency** is touched (e.g. anything matching `*ssl*`,
+  `*security*`, `auth*`, `crypt*`, `*jwt*`, `*oauth*`).
+- A **blocking label** (`do-not-merge` or `automerge-blocked`) is present.
+
+Skipped PRs require a human reviewer to merge them using the normal workflow.
+
+## The `automerge-blocked` opt-out
+
+To stop auto-merge on a PR that already qualified, add the label
+`automerge-blocked` (or `do-not-merge`). The workflow reacts to the `labeled`
+event:
+
+- Disables GitHub's auto-merge on the PR.
+- Removes the `ready-to-merge` label.
+- Posts a sticky comment recording the block.
+
+## Configuration
+
+Lists live in `.github/automerge-config.json`:
+
+```json
+{
+  "sensitive_dependencies": ["crypt*", "*ssl*", "*security*", "auth*", "*jwt*", "*oauth*"],
+  "allowed_update_types": ["version-update:semver-patch", "version-update:semver-minor"],
+  "blocking_labels": ["do-not-merge", "automerge-blocked"]
+}
+```
+
+Globs use `*` as a wildcard and are matched case-insensitively against the full
+dependency name. Edit the file via a normal PR to change policy.
+
+## Rebase handling for stale PRs
+
+The workflow includes a scheduled job (every 6 hours, plus `workflow_dispatch`)
+that finds qualifying dependabot PRs whose branches have fallen behind `main`
+and asks dependabot to rebase:
+
+```
+@dependabot rebase
+```
+
+This follows the signed-commit rule documented in the
+[Dependabot PRs](../../AGENTS.md#dependabot-prs) section of `AGENTS.md`:
+**never** call the GitHub `update-branch` API or rebase locally, because both
+strip dependabot's verified commit signatures. The job also skips any PR that
+already received a `@dependabot rebase` comment within the last hour, so it
+does not spam the bot while a rebase is in progress.
+
+## Related
+
+- `AGENTS.md` section [Dependabot PRs](../../AGENTS.md#dependabot-prs)
+- `.github/workflows/dependabot-automerge.yml`
+- `.github/automerge-config.json`

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -31,14 +31,14 @@ doit <task_name>
 
 | Category | Tasks | Description |
 |----------|-------|-------------|
-| [Testing](#testing-tasks) | `test`, `coverage`, `mutate`, `mutate_html` | Run tests, coverage, and mutation testing |
-| [Benchmarking](#benchmarking-tasks) | `benchmark`, `benchmark_save`, `benchmark_compare` | Performance benchmarking |
+| [Testing](#testing-tasks) | `test`, `coverage`, `mutate` | Run tests, coverage, and mutation testing |
+| [Benchmarking](#benchmarking-tasks) | `benchmark`, `benchmark_save`, `benchmark_compare` | Performance benchmarks |
 | [Code Quality](#code-quality-tasks) | `format`, `lint`, `type_check`, `check` | Code formatting and linting |
 | [Code Analysis](#code-analysis-tasks) | `complexity`, `maintainability`, `deadcode` | Code metrics and analysis |
 | [Security](#security-tasks) | `security`, `audit`, `licenses`, `sbom` | Security scanning and SBOM |
 | [Documentation](#documentation-tasks) | `docs_serve`, `docs_build`, `docs_deploy`, `docs_toc` | Documentation management |
 | [Dependencies](#dependency-tasks) | `install`, `install_dev`, `update_deps` | Package management |
-| [GitHub Workflow](#github-workflow-tasks) | `issue`, `pr`, `pr_merge`, `adr` | Issue and PR management |
+| [GitHub Workflow](#github-workflow-tasks) | `issue`, `pr`, `pr_merge`, `adr`, `labels_sync` | Issue and PR management |
 | [Release](#release-tasks) | `release`, `release_dev`, `release_pr`, `release_tag`, `publish` | Version and release management |
 | [Version](#version-tasks) | `bump`, `changelog` | Version bumping and changelog |
 | [Setup](#setup-tasks) | `pre_commit_install`, `completions`, `install_direnv` | Development environment |
@@ -97,30 +97,19 @@ doit mutate
 ```
 
 **What it does:**
-- Runs `mutmut run` to apply mutations to source code and check if tests catch them
-- Runs `mutmut results` to display the summary
+- Introduces small changes (mutations) to source code
+- Runs the test suite against each mutation
+- Reports which mutations were killed (detected) vs survived (missed)
+- Prints a summary with the mutation score
 
-**Equivalent command:**
-```bash
-uv run mutmut run && uv run mutmut results
-```
+**Output:** Results are stored in the `mutants/` cache directory. Re-run `uv run mutmut results` at any time to re-display the text summary.
 
-### `mutate_html`
+**When to use:**
+- To evaluate how effective your test suite is at detecting bugs
+- To identify areas where tests could be strengthened
+- Informational only -- no enforced threshold
 
-Generate HTML report from mutmut results.
-
-```bash
-doit mutate_html
-```
-
-**What it does:**
-- Generates an HTML report from the latest mutmut run
-- Report is saved to `tmp/mutmut/`
-
-**Equivalent command:**
-```bash
-uv run mutmut html --html-dir tmp/mutmut
-```
+See [Mutation Testing](ci-cd-testing.md#mutation-testing) for details on interpreting results.
 
 ---
 
@@ -135,7 +124,8 @@ doit benchmark
 ```
 
 **What it does:**
-- Runs pytest benchmarks from `tests/benchmarks/` with benchmark mode enabled
+- Runs pytest on `tests/benchmarks/` with `--benchmark-enable --benchmark-only`
+- Benchmarks are disabled by default during normal test runs
 
 **Equivalent command:**
 ```bash
@@ -144,14 +134,15 @@ uv run pytest tests/benchmarks/ --benchmark-enable --benchmark-only -v
 
 ### `benchmark_save`
 
-Run benchmarks and save results as baseline.
+Run benchmarks and save results as a baseline.
 
 ```bash
 doit benchmark_save
 ```
 
 **What it does:**
-- Runs benchmarks and saves results as a baseline to `tmp/benchmarks/`
+- Runs benchmarks and saves results to `tmp/benchmarks/`
+- Saved baseline can be used for comparison with `benchmark_compare`
 
 **Equivalent command:**
 ```bash
@@ -160,14 +151,15 @@ uv run pytest tests/benchmarks/ --benchmark-enable --benchmark-only --benchmark-
 
 ### `benchmark_compare`
 
-Run benchmarks and compare against saved baseline.
+Run benchmarks and compare against a saved baseline.
 
 ```bash
 doit benchmark_compare
 ```
 
 **What it does:**
-- Runs benchmarks and compares against the previously saved baseline
+- Runs benchmarks and compares results against the saved baseline
+- Shows performance regressions or improvements
 
 **Equivalent command:**
 ```bash
@@ -439,23 +431,28 @@ doit licenses
 
 ### `sbom`
 
-Generate SBOM in CycloneDX format.
+Generate a Software Bill of Materials (SBOM) in CycloneDX format.
 
 ```bash
 doit sbom
 ```
 
 **What it does:**
-- Generates Software Bill of Materials in both JSON and XML formats
-- Files are saved to `tmp/sbom.json` and `tmp/sbom.xml`
+- Generates SBOM files from the project's dependency tree
+- Produces both JSON and XML formats
+
+**Output locations:**
+- `tmp/sbom.json` -- CycloneDX JSON format
+- `tmp/sbom.xml` -- CycloneDX XML format
 
 **Requires:** `[security]` extras installed (`uv sync --extra security`)
 
-**Equivalent command:**
-```bash
-uv run cyclonedx-py environment --of JSON -o tmp/sbom.json
-uv run cyclonedx-py environment --of XML -o tmp/sbom.xml
-```
+**When to use:**
+- For regulatory compliance (e.g., US Executive Order 14028)
+- For security auditing and vulnerability scanning
+- Before releases (SBOMs are also auto-generated in CI release workflows)
+
+See [SBOM Generation](release-and-automation.md#sbom-generation) for details on usage and CI integration.
 
 ---
 
@@ -559,12 +556,17 @@ doit install_dev
 **What it does:**
 - Syncs all dependencies including dev extras
 - Installs pre-commit hooks
+- Marks `src/package_name/_version.py` as assume-unchanged so the version file regenerated by setuptools-scm does not appear as modified in `git status`
 
 **Equivalent command:**
 ```bash
 uv sync --all-extras --dev
 uv run pre-commit install
+git update-index --assume-unchanged src/package_name/_version.py
 ```
+
+> **Note:** To undo the assume-unchanged flag, run:
+> `git update-index --no-assume-unchanged src/package_name/_version.py`
 
 ### `update_deps`
 
@@ -658,15 +660,21 @@ doit pr_merge
 
 # Merge specific PR
 doit pr_merge --pr=123
+
+# Merge and automatically close linked issues
+doit pr_merge --auto-close
 ```
 
 **What it does:**
 1. Finds PR associated with current branch (or uses `--pr`)
 2. Validates PR is approved and checks pass
 3. Merges with conventional commit format: `<type>: <subject> (merges PR #XX, addresses #YY)`
+4. If `--auto-close` is set, closes each linked issue with a `Addressed in PR #XX` comment; otherwise prints the `gh issue close` commands as a reminder.
 
 **Options:**
 - `--pr`: PR number to merge (defaults to PR for current branch)
+- `--delete-branch`: Delete the source branch after merge (default: `true`)
+- `--auto-close`: Close linked issues (parsed from `Addresses #XX` in the PR body) after a successful merge (default: `false`)
 
 ### `adr`
 
@@ -692,6 +700,39 @@ doit adr --title="Use Redis" --body-file=adr.md
 - `--body-file`: File containing ADR body (non-interactive)
 
 See [ADR Documentation](../decisions/README.md) for more information.
+
+---
+
+### `labels_sync`
+
+Reconcile GitHub labels with `.github/labels.yml` (idempotent).
+
+```bash
+# Preview changes without touching GitHub
+doit labels_sync --dry-run
+
+# Create missing labels and update drift (no deletion)
+doit labels_sync
+
+# Also delete labels present on GitHub but absent from the file
+doit labels_sync --prune
+
+# Use a different labels file
+doit labels_sync --file=.github/labels.custom.yml
+```
+
+**What it does:**
+- Reads `.github/labels.yml` (flat list of `{name, color, description}` entries).
+- Fetches current labels from GitHub via `gh label list`.
+- Creates, updates, or (with `--prune`) deletes labels to match the file.
+- Color comparison is case-insensitive; running twice is a no-op.
+
+**Options:**
+- `--dry-run`: Print planned changes, make no API calls.
+- `--prune`: Also delete labels on GitHub that are missing from the file (off by default).
+- `--file=<path>`: Path to the labels file (default `.github/labels.yml`).
+
+See [GitHub Repository Settings → Labels](github-repository-settings.md#labels) for the canonical label list and the file schema.
 
 ---
 
@@ -918,6 +959,8 @@ echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
 direnv allow
 ```
 
+This task uses the reusable install_tools framework — see [install_tools framework](install-tools-framework.md) for adding more tools.
+
 ### `commit`
 
 Interactive commit with commitizen.
@@ -1049,4 +1092,4 @@ The `protect-dynamic-version` hook prevents accidental changes to the `dynamic` 
 
 ---
 
-[Back to Documentation Index](../index.md)
+[Back to Documentation Index](../TABLE_OF_CONTENTS.md)

--- a/docs/development/extensions.md
+++ b/docs/development/extensions.md
@@ -1,179 +1,992 @@
 ---
-title: Extensions
-description: How to extend pynetappfoundry
+title: Optional Extensions
+description: Additional tools and extensions for testing, security, and more
 audience:
   - contributors
 tags:
-  - development
   - extensions
+  - tooling
+  - configuration
 ---
 
-# Extensions
+# Optional Extensions
 
-This guide covers how to extend pynetappfoundry with custom functionality.
-
-## Adding New CLI Commands
-
-### Create a New Command Group
-
-```python
-# src/pynetappfoundry/cli/custom.py
-import click
-from pynetappfoundry.cli import nf
-
-@nf.group()
-def custom():
-    """Custom commands."""
-    pass
-
-@custom.command()
-@click.option("--name", required=True, help="Name to greet")
-def greet(name: str):
-    """Greet someone."""
-    click.echo(f"Hello, {name}!")
-```
-
-### Register the Command
-
-Add the import to `src/pynetappfoundry/cli.py`:
-
-```python
-from pynetappfoundry.cli.custom import custom  # noqa: F401
-```
-
-## Adding New Clients
-
-### Create a Custom Client
-
-```python
-# src/pynetappfoundry/clients/custom/api.py
-from pynetappfoundry.clients.openapi import APIWrapper
-from pynetappfoundry.core.config import Config
-
-class CustomAPIClient(APIWrapper):
-    """Client for custom API."""
-
-    def __init__(self, config: Config, name: str):
-        super().__init__(config, name)
-        self.base_url = config.get_endpoint(name)
-
-    def get_resources(self) -> list[dict]:
-        """Get resources from API."""
-        return self._get("/resources")
-
-    def create_resource(self, data: dict) -> dict:
-        """Create a new resource."""
-        return self._post("/resources", data)
-```
-
-### Export from Package
-
-Add to `src/pynetappfoundry/__init__.py`:
-
-```python
-from pynetappfoundry.clients.custom.api import CustomAPIClient
-
-__all__ = [
-    # ... existing exports
-    "CustomAPIClient",
-]
-```
-
-## Adding New Database Models
-
-### Create a Database Class
-
-```python
-# src/pynetappfoundry/db/custom.py
-import sqlite3
-from pathlib import Path
-
-class CustomDB:
-    """Database for custom data."""
-
-    def __init__(self, db_path: str | Path):
-        self.db_path = Path(db_path)
-        self._init_db()
-
-    def _init_db(self):
-        """Initialize database schema."""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.execute('''
-                CREATE TABLE IF NOT EXISTS custom_data (
-                    id INTEGER PRIMARY KEY,
-                    name TEXT NOT NULL,
-                    value TEXT,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                )
-            ''')
-
-    def store(self, name: str, value: str) -> int:
-        """Store data."""
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.execute(
-                "INSERT INTO custom_data (name, value) VALUES (?, ?)",
-                (name, value)
-            )
-            return cursor.lastrowid
-
-    def get(self, name: str) -> list[dict]:
-        """Get data by name."""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
-            cursor = conn.execute(
-                "SELECT * FROM custom_data WHERE name = ?",
-                (name,)
-            )
-            return [dict(row) for row in cursor.fetchall()]
-```
-
-## Adding New Report Types
-
-### Create a Report Generator
-
-```python
-# src/pynetappfoundry/reports/custom.py
-from pathlib import Path
-from pynetappfoundry.core.config import Config
-
-class CustomReport:
-    """Generate custom reports."""
-
-    def __init__(self, config: Config):
-        self.config = config
-
-    def generate(self, data: list[dict], output: Path) -> None:
-        """Generate report from data."""
-        # Implementation here
-        pass
-```
+This guide covers optional tools and extensions that you can add to your project based on your specific needs.
 
 ## Testing Extensions
 
-### Write Tests for Custom Code
+### pytest-watch - Auto-run tests on file changes
 
-```python
-# tests/test_custom.py
-import pytest
-from pynetappfoundry.clients.custom.api import CustomAPIClient
+Automatically run tests when files change, perfect for TDD workflow.
 
-@pytest.fixture
-def mock_config(tmp_path):
-    """Create mock configuration."""
-    # Setup mock config
-    pass
+```bash
+# Add to pyproject.toml
+[project.optional-dependencies]
+dev = [
+    # ... existing deps ...
+    "pytest-watch>=4.2",
+]
 
-def test_custom_client_get_resources(mock_config):
-    """Test getting resources."""
-    client = CustomAPIClient(mock_config, "test")
-    # Add test assertions
-    pass
+# Install
+uv sync
+
+# Usage
+uv run ptw
 ```
 
-## Best Practices
+### hypothesis - Property-based testing
 
-1. **Follow existing patterns** - Look at existing code for examples
-2. **Add type hints** - All public functions should have type annotations
-3. **Write tests** - Aim for high test coverage
-4. **Document public APIs** - Add docstrings to all public functions
-5. **Handle errors gracefully** - Use appropriate exception types
+Generate test cases automatically based on property specifications.
+
+```bash
+# Add to pyproject.toml
+[project.optional-dependencies]
+dev = [
+    # ... existing deps ...
+    "hypothesis>=6.0",
+]
+
+# Install
+uv sync
+```
+
+Example test:
+
+```python
+from hypothesis import given
+from hypothesis import strategies as st
+
+@given(st.integers(), st.integers())
+def test_addition_commutative(a, b):
+    assert a + b == b + a
+```
+
+### faker - Generate realistic fake data
+
+Create realistic test data for your tests.
+
+```bash
+# Add to pyproject.toml
+[project.optional-dependencies]
+dev = [
+    # ... existing deps ...
+    "faker>=20.0",
+]
+
+# Install
+uv sync
+```
+
+Example usage:
+
+```python
+from faker import Faker
+
+fake = Faker()
+email = fake.email()
+name = fake.name()
+address = fake.address()
+```
+
+### factory-boy - Test fixtures/factories
+
+Build complex test objects with minimal boilerplate.
+
+```bash
+# Add to pyproject.toml
+[project.optional-dependencies]
+dev = [
+    # ... existing deps ...
+    "factory-boy>=3.3",
+]
+
+# Install
+uv sync
+```
+
+Example:
+
+```python
+import factory
+
+class UserFactory(factory.Factory):
+    class Meta:
+        model = User
+
+    username = factory.Sequence(lambda n: f"user{n}")
+    email = factory.LazyAttribute(lambda obj: f"{obj.username}@example.com")
+```
+
+### mutmut - Mutation testing
+
+Test your tests by introducing bugs and verifying they catch them.
+
+```bash
+# Add to pyproject.toml
+[project.optional-dependencies]
+dev = [
+    # ... existing deps ...
+    "mutmut>=3.0",
+]
+
+# Install
+uv sync
+
+# Usage
+uv run mutmut run
+uv run mutmut results
+```
+
+### vcrpy - Record and replay HTTP interactions
+
+Record HTTP interactions once and replay them in tests for faster, deterministic testing.
+
+```bash
+# Add to pyproject.toml
+[project.optional-dependencies]
+dev = [
+    # ... existing deps ...
+    "vcrpy>=5.0",
+    "pytest-vcr>=1.0",  # pytest integration
+]
+
+# Install
+uv sync
+```
+
+Example:
+
+```python
+import vcr
+
+@vcr.use_cassette('fixtures/vcr_cassettes/api_call.yaml')
+def test_api_call():
+    response = requests.get('https://api.example.com/data')
+    assert response.status_code == 200
+```
+
+## Performance & Profiling
+
+### py-spy - Low-overhead sampling profiler
+
+Profile your Python code with minimal performance impact.
+
+```bash
+# Install globally (not as project dependency)
+pip install py-spy
+
+# Usage
+py-spy record -o profile.svg -- python your_script.py
+py-spy top -- python your_script.py
+```
+
+### memray - Memory profiler
+
+Track memory allocations and find memory leaks.
+
+```bash
+# Install
+pip install memray
+
+# Usage
+memray run your_script.py
+memray flamegraph memray-output.bin
+```
+
+### scalene - CPU+GPU+memory profiler
+
+Comprehensive profiling showing CPU, GPU, and memory usage.
+
+```bash
+# Install
+pip install scalene
+
+# Usage
+scalene your_script.py
+```
+
+### line_profiler - Line-by-line profiling
+
+See exactly which lines are slow.
+
+```bash
+# Install
+pip install line_profiler
+
+# Usage - add @profile decorator to functions
+kernprof -l -v your_script.py
+```
+
+### Profiling task automation
+
+Add profiling tasks to `dodo.py`:
+
+```python
+def task_profile():
+    """Profile the application."""
+    return {
+        "actions": [
+            "uv run py-spy record -o tmp/profile.svg -- python -m package_name",
+        ],
+        "title": title_with_actions,
+    }
+
+def task_profile_memory():
+    """Profile memory usage."""
+    return {
+        "actions": [
+            "memray run -o tmp/memray.bin python -m package_name",
+            "memray flamegraph tmp/memray.bin -o tmp/memray.html",
+        ],
+        "title": title_with_actions,
+    }
+```
+
+## Configuration Management
+
+### pydantic-settings - Type-safe configuration
+
+Load and validate configuration from environment variables.
+
+```bash
+# Add to pyproject.toml
+dependencies = [
+    "pydantic>=2.0",
+    "pydantic-settings>=2.0",
+]
+
+# Install
+uv sync
+```
+
+Example:
+
+```python
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    api_key: str
+    debug: bool = False
+    max_connections: int = 10
+
+    class Config:
+        env_file = ".env"
+
+settings = Settings()
+```
+
+### dynaconf - Multi-environment configuration
+
+Manage settings across development, staging, and production environments.
+
+```bash
+# Add to pyproject.toml
+dependencies = [
+    "dynaconf>=3.2",
+]
+
+# Install
+uv sync
+```
+
+Example structure:
+
+```
+settings/
+  ├── settings.toml      # Default settings
+  ├── .secrets.toml      # Sensitive data (git-ignored)
+  └── development.toml   # Development overrides
+```
+
+### python-decouple - Strict separation of settings
+
+Simple, strict separation of settings from code.
+
+```bash
+# Add to pyproject.toml
+dependencies = [
+    "python-decouple>=3.8",
+]
+
+# Install
+uv sync
+```
+
+Example:
+
+```python
+from decouple import config
+
+DEBUG = config('DEBUG', default=False, cast=bool)
+DATABASE_URL = config('DATABASE_URL')
+```
+
+## Logging & Monitoring
+
+### loguru - Simplified logging
+
+Easy-to-use logging with sensible defaults.
+
+```bash
+# Add to pyproject.toml
+dependencies = [
+    "loguru>=0.7",
+]
+
+# Install
+uv sync
+```
+
+Example:
+
+```python
+from loguru import logger
+
+logger.add("app.log", rotation="500 MB")
+logger.info("Application started")
+logger.error("An error occurred")
+```
+
+### structlog - Structured logging
+
+Output structured, machine-readable logs.
+
+```bash
+# Add to pyproject.toml
+dependencies = [
+    "structlog>=24.0",
+]
+
+# Install
+uv sync
+```
+
+Example:
+
+```python
+import structlog
+
+log = structlog.get_logger()
+log.info("user_action", user_id=123, action="login")
+```
+
+### Sentry integration - Error tracking
+
+Automatically capture and report errors.
+
+```bash
+# Add to pyproject.toml
+dependencies = [
+    "sentry-sdk>=1.40",
+]
+
+# Install
+uv sync
+```
+
+Example:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="your-dsn-here",
+    traces_sample_rate=1.0,
+)
+```
+
+### OpenTelemetry - Observability
+
+Complete observability with traces, metrics, and logs.
+
+```bash
+# Add to pyproject.toml
+dependencies = [
+    "opentelemetry-api>=1.20",
+    "opentelemetry-sdk>=1.20",
+]
+
+# Install
+uv sync
+```
+
+## Dependency Management
+
+### pipdeptree - Visualize dependency tree
+
+See your dependency tree and identify conflicts.
+
+```bash
+# Add to pyproject.toml
+[project.optional-dependencies]
+dev = [
+    # ... existing deps ...
+    "pipdeptree>=2.13",
+]
+
+# Install and use
+uv sync
+uv run pipdeptree
+uv run pipdeptree --reverse  # Show what depends on a package
+```
+
+## Building Extensible Applications with Entry Points
+
+Python entry points enable plugin architectures that allow users to extend your package without modifying core code.
+
+### Why Use Entry Points?
+
+Entry points are ideal when you want to:
+- Allow third-party plugins to extend your application
+- Discover extensions automatically at runtime
+- Create a plugin ecosystem around your package
+- Keep core code separate from optional functionality
+
+### Basic Pattern
+
+**1. Define Plugin Interface**
+
+Create a protocol or abstract base class that all plugins must implement:
+
+```python
+# src/package_name/plugin_interface.py
+from typing import Protocol
+
+class PluginInterface(Protocol):
+    """Protocol that all plugins must implement."""
+
+    @property
+    def name(self) -> str:
+        """Plugin name."""
+        ...
+
+    @property
+    def version(self) -> str:
+        """Plugin version."""
+        ...
+
+    def execute(self, data: dict) -> dict:
+        """Execute plugin logic."""
+        ...
+```
+
+**2. Create Plugin Discovery**
+
+Load and validate plugins from entry points:
+
+```python
+# src/package_name/plugin_loader.py
+from importlib.metadata import entry_points
+from typing import Dict
+from .plugin_interface import PluginInterface
+
+def discover_plugins() -> Dict[str, PluginInterface]:
+    """Discover and load all plugins."""
+    plugins = {}
+
+    # Find all entry points in 'package_name.plugins' group
+    eps = entry_points(group='package_name.plugins')
+
+    for ep in eps:
+        try:
+            # Load the plugin class
+            plugin_class = ep.load()
+
+            # Instantiate and validate
+            plugin = plugin_class()
+            if not isinstance(plugin, PluginInterface):
+                print(f"Warning: {ep.name} doesn't implement PluginInterface")
+                continue
+
+            plugins[plugin.name] = plugin
+            print(f"Loaded plugin: {plugin.name} v{plugin.version}")
+
+        except Exception as e:
+            print(f"Failed to load plugin {ep.name}: {e}")
+            continue
+
+    return plugins
+```
+
+**3. Use Plugins in Your Application**
+
+```python
+# src/package_name/main.py
+from .plugin_loader import discover_plugins
+
+def main():
+    """Main application entry point."""
+    plugins = discover_plugins()
+
+    print(f"Found {len(plugins)} plugins")
+
+    for name, plugin in plugins.items():
+        print(f"Running plugin: {name}")
+        result = plugin.execute({"input": "data"})
+        print(f"Result: {result}")
+```
+
+**4. Create Built-in Plugins**
+
+Register your own plugins in `pyproject.toml`:
+
+```toml
+[project.entry-points."package_name.plugins"]
+default = "package_name.plugins.default:DefaultPlugin"
+csv_export = "package_name.plugins.csv_export:CSVExportPlugin"
+```
+
+**5. Enable Third-Party Plugins**
+
+Users can create their own plugins:
+
+```python
+# third-party-plugin/src/myplugin/analytics.py
+class AnalyticsPlugin:
+    """Custom analytics plugin."""
+
+    @property
+    def name(self) -> str:
+        return "analytics"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    def execute(self, data: dict) -> dict:
+        # Custom analytics logic
+        return {"result": "analyzed", "data": data}
+```
+
+And register it in their `pyproject.toml`:
+
+```toml
+[project.entry-points."package_name.plugins"]
+analytics = "myplugin.analytics:AnalyticsPlugin"
+```
+
+When users install both packages:
+
+```bash
+pip install package-name
+pip install package-name-analytics
+```
+
+Your application automatically discovers and loads the third-party plugin!
+
+### Advanced: Multiple Plugin Types
+
+For complex systems, you can have different types of plugins with different entry point groups:
+
+**Define plugin types in your pyproject.toml:**
+
+```toml
+# Your core package
+[project.entry-points."package_name.plugin_types"]
+processor = "package_name.plugin_types.processor:ProcessorPluginType"
+exporter = "package_name.plugin_types.exporter:ExporterPluginType"
+
+# Register built-in plugins by type
+[project.entry-points."package_name.processors"]
+csv = "package_name.plugins.csv_processor:CSVProcessor"
+json = "package_name.plugins.json_processor:JSONProcessor"
+
+[project.entry-points."package_name.exporters"]
+s3 = "package_name.plugins.s3_exporter:S3Exporter"
+local = "package_name.plugins.local_exporter:LocalExporter"
+```
+
+**Plugin Type Manager:**
+
+```python
+# src/package_name/plugin_types/processor.py
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+class ProcessorProtocol(Protocol):
+    """Protocol for processor plugins."""
+
+    def process(self, data: Any) -> Any:
+        """Process data."""
+        ...
+
+@dataclass
+class PluginMetadata:
+    """Generic plugin metadata."""
+    name: str
+    version: str
+    plugin_type: str
+    implementation: type
+    description: str = ""
+
+class ProcessorPluginType:
+    """Manages processor plugins."""
+
+    @property
+    def entry_point_group(self) -> str:
+        return "package_name.processors"
+
+    @property
+    def type_name(self) -> str:
+        return "processor"
+
+    def load_plugin(self, entry_point) -> PluginMetadata:
+        """Load a processor plugin."""
+        plugin_class = entry_point.load()
+
+        # Validate it implements the protocol
+        if not hasattr(plugin_class, 'process'):
+            raise ValueError(f"{entry_point.name} missing 'process' method")
+
+        return PluginMetadata(
+            name=entry_point.name,
+            version=getattr(plugin_class, '__version__', '0.0.0'),
+            plugin_type=self.type_name,
+            implementation=plugin_class,
+        )
+```
+
+**Third-party developers can now create plugins:**
+
+```toml
+# third-party-package/pyproject.toml
+[project.entry-points."package_name.processors"]
+xml = "thirdparty_plugin.xml:XMLProcessor"
+
+[project.entry-points."package_name.exporters"]
+ftp = "thirdparty_plugin.ftp:FTPExporter"
+```
+
+### Real-World Example: CLI Command Registration
+
+A common use case is auto-registering CLI commands from plugins:
+
+```python
+# src/package_name/cli.py
+import click
+from importlib.metadata import entry_points
+
+@click.group()
+def cli():
+    """Main CLI application."""
+    pass
+
+# Discover and register all plugin commands
+for ep in entry_points(group='package_name.cli_plugins'):
+    try:
+        command = ep.load()
+        cli.add_command(command)
+    except Exception as e:
+        click.echo(f"Failed to load plugin {ep.name}: {e}", err=True)
+
+if __name__ == '__main__':
+    cli()
+```
+
+Third-party plugins can add commands:
+
+```python
+# third-party-plugin/src/myplugin/commands.py
+import click
+
+@click.command()
+@click.option('--output', help='Output file')
+def export(output):
+    """Export data to file."""
+    click.echo(f"Exporting to {output}")
+```
+
+Register in their pyproject.toml:
+
+```toml
+[project.entry-points."package_name.cli_plugins"]
+export = "myplugin.commands:export"
+```
+
+Now the command is automatically available:
+
+```bash
+$ package-cli export --output data.csv
+Exporting to data.csv
+```
+
+### Testing Plugin Systems
+
+**Test plugin discovery:**
+
+```python
+# tests/test_plugins.py
+from package_name.plugin_loader import discover_plugins
+
+def test_discovers_built_in_plugins():
+    plugins = discover_plugins()
+    assert 'default' in plugins
+    assert 'csv_export' in plugins
+
+def test_plugin_implements_interface():
+    plugins = discover_plugins()
+    for name, plugin in plugins.items():
+        assert hasattr(plugin, 'execute')
+        assert hasattr(plugin, 'name')
+        assert hasattr(plugin, 'version')
+```
+
+**Test plugin execution:**
+
+```python
+def test_plugin_execution():
+    plugins = discover_plugins()
+    plugin = plugins['default']
+
+    result = plugin.execute({'test': 'data'})
+    assert 'result' in result
+```
+
+### Best Practices
+
+1. **Use Protocols**: Define clear interfaces using `typing.Protocol`
+2. **Validate Plugins**: Check plugins implement required methods
+3. **Handle Errors**: Gracefully handle plugin loading failures
+4. **Document Interface**: Clearly document what plugins must implement
+5. **Version Compatibility**: Consider plugin version compatibility
+6. **Lazy Loading**: Load plugins only when needed
+7. **Provide Examples**: Include example plugin implementation
+8. **Test Discovery**: Test that built-in plugins are discovered correctly
+
+### Resources
+
+- [Python Packaging Guide - Entry Points](https://packaging.python.org/en/latest/specifications/entry-points/)
+- [Setuptools Entry Points](https://setuptools.pypa.io/en/latest/userguide/entry_point.html)
+- [PEP 621 - Storing project metadata in pyproject.toml](https://peps.python.org/pep-0621/)
+
+### Example Plugin Systems in the Wild
+
+- **pytest**: Plugins via `pytest11` entry points
+- **setuptools**: Build backends and plugins
+- **Flask**: Extensions via entry points
+- **Sphinx**: Documentation extensions
+- **Pylint**: Custom checkers
+
+## Additional Code Quality Tools
+
+### vulture - Dead code detection
+
+Find unused code in your project.
+
+```bash
+# Add to pyproject.toml
+[project.optional-dependencies]
+dev = [
+    # ... existing deps ...
+    "vulture>=2.10",
+]
+
+# Install and use
+uv sync
+uv run vulture src/
+```
+
+Add to `dodo.py`:
+
+```python
+def task_dead_code():
+    """Find dead code with vulture."""
+    return {
+        "actions": ["uv run vulture src/"],
+        "title": title_with_actions,
+    }
+```
+
+### radon - Code complexity metrics
+
+Measure cyclomatic complexity and maintainability.
+
+```bash
+# Add to pyproject.toml
+[project.optional-dependencies]
+dev = [
+    # ... existing deps ...
+    "radon>=6.0",
+]
+
+# Install and use
+uv sync
+uv run radon cc src/ -a  # Cyclomatic complexity
+uv run radon mi src/     # Maintainability index
+```
+
+### interrogate - Docstring coverage
+
+Measure documentation coverage.
+
+```bash
+# Add to pyproject.toml
+[project.optional-dependencies]
+dev = [
+    # ... existing deps ...
+    "interrogate>=1.5",
+]
+
+# Install and use
+uv sync
+uv run interrogate src/
+```
+
+Configuration in `pyproject.toml`:
+
+```toml
+[tool.interrogate]
+ignore-init-method = true
+ignore-init-module = false
+ignore-magic = true
+ignore-semiprivate = false
+ignore-private = false
+ignore-property-decorators = false
+ignore-module = false
+fail-under = 80
+verbose = 2
+```
+
+## Container Support
+
+### Basic Dockerfile
+
+Create a `Dockerfile` for containerized deployment:
+
+```dockerfile
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install uv
+RUN pip install uv
+
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies
+RUN uv sync --no-dev
+
+# Copy application code
+COPY src/ ./src/
+
+# Run the application
+CMD ["uv", "run", "python", "-m", "package_name"]
+```
+
+### Docker Compose for development
+
+Create `docker-compose.yml` for local development:
+
+```yaml
+version: '3.8'
+
+services:
+  app:
+    build: .
+    volumes:
+      - ./src:/app/src
+      - ./tests:/app/tests
+    environment:
+      - DEBUG=true
+    ports:
+      - "8000:8000"
+```
+
+## Multi-version Testing with tox
+
+Test your package across multiple Python versions.
+
+```bash
+# Add to pyproject.toml
+[project.optional-dependencies]
+dev = [
+    # ... existing deps ...
+    "tox>=4.0",
+]
+
+# Install
+uv sync
+```
+
+Create `tox.ini`:
+
+```ini
+[tox]
+envlist = py312,py313
+
+[testenv]
+deps =
+    pytest>=8.0
+    pytest-cov>=5.0
+commands =
+    pytest {posargs}
+
+[testenv:lint]
+deps =
+    ruff>=0.5
+commands =
+    ruff check src/ tests/
+```
+
+Usage:
+
+```bash
+uv run tox          # Run all environments
+uv run tox -e py312 # Run specific environment
+uv run tox -e lint  # Run linting
+```
+
+## Alternative: nox for testing
+
+More flexible than tox, uses Python for configuration.
+
+```bash
+# Add to pyproject.toml
+[project.optional-dependencies]
+dev = [
+    # ... existing deps ...
+    "nox>=2023.0",
+]
+
+# Install
+uv sync
+```
+
+Create `noxfile.py`:
+
+```python
+import nox
+
+@nox.session(python=["3.12", "3.13"])
+def tests(session):
+    session.install(".[dev]")
+    session.run("pytest")
+
+@nox.session
+def lint(session):
+    session.install("ruff")
+    session.run("ruff", "check", "src/", "tests/")
+```
+
+Usage:
+
+```bash
+uv run nox          # Run all sessions
+uv run nox -s tests # Run specific session
+```
+
+## Summary
+
+This template provides a solid foundation with the most commonly needed tools. Add extensions from this guide as your project grows and your needs evolve.
+
+### Quick Reference: When to Add What
+
+- **Testing extensions**: When you have complex test scenarios or want to improve test coverage
+- **Profiling tools**: When you identify performance issues and need to optimize
+- **Configuration management**: When you need multi-environment support or complex settings
+- **Logging/monitoring**: When deploying to production and need observability
+- **Containers**: When you need consistent deployment environments
+- **Multi-version testing**: When releasing a library that must support multiple Python versions
+
+Remember: Start simple, add complexity only when needed.

--- a/docs/development/github-repository-settings.md
+++ b/docs/development/github-repository-settings.md
@@ -1,0 +1,312 @@
+---
+title: GitHub Repository Settings
+description: Complete reference for all GitHub repository settings the template expects
+audience:
+  - users
+  - contributors
+tags:
+  - github
+  - settings
+  - setup
+  - configuration
+---
+
+# GitHub Repository Settings
+
+Complete reference for the GitHub repository settings this template expects.
+New repositories created from the template are configured automatically by
+[`repo_settings.py`](../../tools/pyproject_template/repo_settings.py) via
+`update_all_repo_settings()`. This page documents what each setting is, why
+it is needed, and whether it is set automatically or requires manual action.
+
+For the initial setup workflow, see the [New Project Setup](../template/new-project.md) guide.
+
+## Repository Settings
+
+These are the general repository-level settings applied by
+`configure_repository_settings()`.
+
+| Setting | Value | Purpose |
+| :--- | :--- | :--- |
+| **Default branch** | `main` | Standard branch for PRs and CI |
+| **Issues** | Enabled | Issue tracking with custom templates |
+| **Wiki** | Disabled | Documentation lives in `docs/` via MkDocs |
+| **Projects** | Enabled | Available for project management if needed |
+| **Discussions** | Disabled | Not used by default |
+| **Allow squash merge** | Yes | Only merge strategy allowed (linear history) |
+| **Allow merge commit** | No | Enforces squash-only policy |
+| **Allow rebase merge** | No | Enforces squash-only policy |
+| **Delete branch on merge** | Yes | Cleans up feature branches automatically |
+| **Visibility** | Public | Template default; private repos may lack some security features |
+
+**Automated:** Yes, all settings above are copied from the template repository.
+
+## Branch Protection (Rulesets)
+
+Branch protection uses GitHub **repository rulesets** rather than the legacy
+branch protection API. The template has a single ruleset named `main` applied
+to the default branch.
+
+### Ruleset: `main`
+
+| Rule | Details |
+| :--- | :--- |
+| **Enforcement** | Active |
+| **Target** | Default branch (`main`) |
+| **Deletion** | Blocked -- cannot delete `main` |
+| **Non-fast-forward** | Blocked -- no force pushes |
+| **Creation** | Controlled |
+| **Required linear history** | Enforced (squash merges only) |
+| **Required signatures** | Commits must be signed |
+| **Pull request required** | Yes, with the following parameters: |
+| | Required approving reviews: 0 |
+| | Dismiss stale reviews on push: Yes |
+| | Require code owner review: No |
+| | Require last push approval: No |
+| | Required review thread resolution: Yes |
+| | Allowed merge methods: squash only |
+| **Required status checks** | `require-label` (from the Merge Gate workflow) |
+| | Strict policy: Yes (branch must be up to date) |
+| **Code scanning** | CodeQL -- errors threshold, high-or-higher security alerts |
+| **Code quality** | Errors severity threshold |
+| **Bypass actors** | Repository admin role (always) |
+
+**Automated:** Yes, rulesets are replicated from the template by
+`configure_branch_protection()`.
+
+## Labels
+
+Labels are used by issue templates, workflows, release notes, and Dependabot.
+
+**Source of truth:** `.github/labels.yml`. The file is a flat list of entries with `name`, `color` (6-char hex, no leading `#`), and `description`. Run `doit labels_sync` to reconcile the repository's labels with the file.
+
+```bash
+doit labels_sync --dry-run   # Preview changes
+doit labels_sync             # Create missing labels, update drift
+doit labels_sync --prune     # Also delete labels not in the file
+```
+
+The task is idempotent — running it twice in a row is a no-op the second time. Color comparison is case-insensitive. `--prune` is off by default because deletion is destructive.
+
+To add a label: edit `.github/labels.yml`, run `doit labels_sync --dry-run` to preview, then `doit labels_sync` to apply.
+
+| Label | Color | Description | Used By |
+| :--- | :--- | :--- | :--- |
+| `automated` | `#02db74` | -- | Dependabot PRs |
+| `bug` | `#d73a4a` | Something isn't working | Issue template, release notes |
+| `chore` | `#FEF2C0` | Maintenance, tooling, CI tasks | Issue template |
+| `dependencies` | `#0366d6` | Pull requests that update a dependency file | Dependabot PRs, release notes exclusion |
+| `documentation` | `#0075ca` | Improvements or additions to documentation | Issue template, release notes |
+| `duplicate` | `#cfd3d7` | This issue or pull request already exists | Manual triage |
+| `enhancement` | `#a2eeef` | New feature or request | Issue template, release notes |
+| `full-matrix` | `#1D76DB` | Run CI on all supported Python versions | CI workflow (triggers full matrix) |
+| `github_actions` | `#000000` | Pull requests that update GitHub Actions code | Dependabot PRs |
+| `good first issue` | `#7057ff` | Good for newcomers | Manual triage |
+| `help wanted` | `#008672` | Extra attention is needed | Manual triage |
+| `invalid` | `#e4e669` | This doesn't seem right | Manual triage |
+| `needs-adr` | `#d4c5f9` | This issue requires an Architecture Decision Record | PR merge gate |
+| `needs-triage` | `#FBCA04` | Needs review and prioritization | All issue templates |
+| `question` | `#d876e3` | Further information is requested | Manual triage |
+| `ready-to-merge` | `#0E8A16` | PR is reviewed and ready to merge. Exception: the `dependabot-automerge` workflow applies this label automatically to qualifying dependabot PRs. | Merge Gate workflow |
+| `refactor` | `#F9D0C4` | Code refactoring and cleanup | Issue template |
+| `security` | `#d73a4a` | Security vulnerability or fix | Manual triage |
+| `wontfix` | `#ffffff` | This will not be worked on | Manual triage |
+
+### Label usage by issue template
+
+| Template | Auto-applied labels |
+| :--- | :--- |
+| Bug Report | `bug`, `needs-triage` |
+| Feature Request | `enhancement`, `needs-triage` |
+| Refactor Request | `refactor`, `needs-triage` |
+| Documentation Request | `documentation`, `needs-triage` |
+| Chore / Maintenance | `chore`, `needs-triage` |
+
+**Automated:** Yes, labels are copied from the template repository.
+
+## GitHub Actions Workflows
+
+All workflow files live in `.github/workflows/`. The table below summarizes
+each workflow, its trigger, and required permissions.
+
+| Workflow | File | Trigger | Permissions |
+| :--- | :--- | :--- | :--- |
+| **CI** | `ci.yml` | PR to `main` (opened, synchronize, reopened, labeled), `workflow_dispatch`, `workflow_call` | `contents: read` |
+| **Merge Gate** | `merge-gate.yml` | PR to `main` (opened, labeled, unlabeled, synchronize, reopened) | `contents: read` |
+| **PR Validation** | `pr-checks.yml` | PR (opened, edited, synchronize) | Default |
+| **Breaking Change Detection** | `breaking-change-detection.yml` | PR (opened, synchronize, edited) | `contents: read`, `issues: write`, `pull-requests: write` |
+| **Benchmark** | `benchmark.yml` | Push to `main`, PR to `main`, `workflow_dispatch` | `contents: write`, `pull-requests: write` |
+| **Mutation Testing** | `mutation.yml` | Scheduled (Sunday midnight UTC), `workflow_dispatch` | `contents: read` |
+| **Release** | `release.yml` | Tag push (`v*.*.*`), `workflow_dispatch` | `contents: read`, `id-token: write` (per job: `contents: write`) |
+| **TestPyPI** | `testpypi.yml` | Tag push (`v*-*`), `workflow_dispatch` | `contents: read`, `id-token: write` |
+
+### Key workflow details
+
+- **CI** uses a matrix strategy with Python versions from
+  `.github/python-versions.json`. Adding the `full-matrix` label to a PR runs
+  all versions; otherwise, only the bookend versions are tested.
+- **Merge Gate** requires the `ready-to-merge` label on a PR before the
+  `require-label` status check passes. This is a manual gate added by a reviewer.
+- **Release** publishes to TestPyPI first, then PyPI, then creates a GitHub
+  Release with auto-generated notes and SBOM attachments.
+
+For detailed CI configuration, see the [CI/CD Testing Guide](ci-cd-testing.md).
+
+## GitHub Environments
+
+Release workflows use GitHub environments for OIDC-based publishing.
+
+| Environment | Used By | Purpose |
+| :--- | :--- | :--- |
+| `testpypi` | `release.yml`, `testpypi.yml` | Publish pre-release and release packages to TestPyPI |
+| `pypi` | `release.yml` | Publish release packages to PyPI |
+
+### OIDC Trusted Publisher Configuration
+
+Both environments use PyPI's trusted publisher mechanism instead of API tokens.
+Configure the trusted publisher on PyPI and TestPyPI:
+
+- **Publisher:** GitHub Actions
+- **Owner:** Your GitHub username or organization
+- **Repository:** Your repository name
+- **Workflow:** `release.yml` (for PyPI) or `testpypi.yml` (for TestPyPI)
+- **Environment:** `pypi` or `testpypi` respectively
+
+**Automated:** No. Environments must be created manually in the repository
+settings, and trusted publishers must be configured on PyPI/TestPyPI.
+
+## Secrets and Variables
+
+| Secret/Variable | Required | Purpose |
+| :--- | :--- | :--- |
+| `GITHUB_TOKEN` | Automatic | Provided by GitHub Actions; used by most workflows |
+| `CODECOV_TOKEN` | Optional | Upload coverage reports to Codecov |
+| `RELEASE_APP_ID` | Optional | GitHub App ID for release automation |
+| `RELEASE_APP_PRIVATE_KEY` | Optional | GitHub App private key for release automation |
+
+PyPI publishing uses OIDC (trusted publishers), so no `PYPI_TOKEN` secret is
+needed.
+
+**Automated:** No. Secrets must be added manually in repository settings.
+
+## Security Settings
+
+Security features are configured by `_configure_security_settings()` in
+`repo_settings.py`.
+
+| Setting | Status | Purpose |
+| :--- | :--- | :--- |
+| **Secret scanning** | Enabled | Detects accidentally committed secrets |
+| **Secret scanning push protection** | Enabled | Blocks pushes containing secrets |
+| **Dependabot security updates** | Enabled | Automatic PRs for vulnerable dependencies |
+| **CodeQL analysis** | Configured | Static analysis for security vulnerabilities |
+
+!!! note
+    Secret scanning and push protection are available for free on public
+    repositories. Private repositories require GitHub Advanced Security (GHAS).
+
+**Automated:** Yes, security settings are copied from the template. CodeQL is
+configured separately by `configure_codeql()`.
+
+## Dependabot
+
+Dependabot is configured via `.github/dependabot.yml` with two ecosystems:
+
+| Ecosystem | Directory | Schedule | Labels |
+| :--- | :--- | :--- | :--- |
+| `uv` | `/` | Weekly (Monday 09:00 UTC) | `dependencies`, `automated` |
+| `github-actions` | `/` | Weekly (Monday 09:00 UTC) | `dependencies`, `automated` |
+
+### Grouping
+
+Dev dependencies (`pytest*`, `ruff`, `mypy`, `coverage`) are grouped into a
+single PR under the `uv` ecosystem.
+
+### Commit message prefix
+
+All Dependabot commits use the `chore(deps)` prefix to follow conventional
+commits format.
+
+**Automated:** No. The `.github/dependabot.yml` file is part of the template
+and included in new repositories, but Dependabot itself must be enabled in
+repository settings if not already active.
+
+## GitHub Pages
+
+Documentation is published to GitHub Pages from the `gh-pages` branch.
+
+| Setting | Value |
+| :--- | :--- |
+| **Source branch** | `gh-pages` |
+| **Source path** | `/` (root) |
+| **Build tool** | MkDocs with Material theme |
+| **Deployment** | Handled by CI or manual `doit docs_build` |
+
+**Automated:** Yes, `enable_github_pages()` configures Pages on the
+`gh-pages` branch. The branch itself is created on the first documentation
+deployment.
+
+## Code Owners
+
+The `.github/CODEOWNERS` file defines default reviewers for pull requests.
+The template sets `@username` as the owner for all paths. After creating a
+new project, update the file with the actual repository owner's GitHub
+username.
+
+Key ownership areas defined:
+
+- `*` -- Default owner for all files
+- `/docs/` and `*.md` -- Documentation
+- `/.github/` -- GitHub configuration
+- `/.github/workflows/` -- CI/CD pipelines
+- `/src/` -- Core source code
+- `/tests/` -- Test files
+- `pyproject.toml` -- Project configuration
+- `dodo.py` -- Task automation
+
+**Automated:** No. The file is part of the template but requires manual
+update with the correct username.
+
+## Release Notes
+
+Auto-generated release notes are configured in `.github/release.yml`.
+
+| Category | Labels |
+| :--- | :--- |
+| Breaking Changes | `breaking` |
+| New Features | `enhancement`, `feat` |
+| Bug Fixes | `bug`, `fix` |
+| Documentation | `documentation`, `docs` |
+| Performance | `performance`, `perf` |
+| Other Changes | `*` (catch-all) |
+
+### Excluded from release notes
+
+PRs with these labels are excluded from auto-generated notes:
+
+- `dependencies`
+- `needs-triage`
+
+**Automated:** No. The `.github/release.yml` file is part of the template.
+
+## Special Branches
+
+| Branch | Purpose | Protected |
+| :--- | :--- | :--- |
+| `main` | Default branch; all PRs target this branch | Yes (ruleset) |
+| `gh-pages` | Published documentation site | No |
+| `gh-benchmarks` | Benchmark trend data for the Benchmark workflow | No |
+
+## Summary of Manual Steps
+
+After creating a new repository from the template, these items require manual
+configuration:
+
+1. **Environments** -- Create `testpypi` and `pypi` environments
+2. **OIDC Trusted Publishers** -- Configure on PyPI and TestPyPI
+3. **Secrets** -- Add `CODECOV_TOKEN` and optional release app credentials
+4. **CODEOWNERS** -- Replace `@username` with the actual owner
+5. **Dependabot** -- Verify Dependabot is enabled in repository settings
+6. **CodeQL** -- Verify CodeQL is active after initial setup
+
+For the full post-setup checklist, see the [New Project Setup](../template/new-project.md) guide.

--- a/docs/development/install-tools-framework.md
+++ b/docs/development/install-tools-framework.md
@@ -1,0 +1,169 @@
+# install_tools Framework
+
+A reusable Python framework for installing developer tools from GitHub
+releases (and other URLs) into the user-local `~/.local/bin` directory.
+Lives in [`tools/doit/install_tools.py`](https://github.com/username/package_name/blob/main/tools/doit/install_tools.py)
+and is consumed by `doit` install tasks (e.g., `doit install_direnv`).
+
+## Overview
+
+Use this framework when you need to install a developer-facing CLI tool
+that ships pre-built binaries from a GitHub release or a stable HTTPS URL.
+It handles version discovery, download, archive extraction, and
+permissions in a single call. It is **not** a substitute for the OS
+package manager — system libraries and services should still be installed
+via apt/dnf/brew/pacman.
+
+The framework supports three release shapes:
+
+| Shape | Example tool | Use |
+| :--- | :--- | :--- |
+| Single binary from a GitHub release | direnv | default — pass `asset_patterns` only |
+| Multi-binary archive (tar.gz / zip) from a GitHub release | age, sops | add `extract_binaries=[...]` |
+| Single binary or archive from a non-GitHub URL | terraform, opentofu | add `url_template=...`, optionally with `prefer_brew=False` |
+
+## Public API
+
+| Function | Purpose |
+| :--- | :--- |
+| `get_latest_github_release(repo)` | Query the GitHub API for the latest release tag (strips leading `v`). Honors `GITHUB_TOKEN`. |
+| `get_install_dir()` | Return `~/.local/bin`, creating it if missing. |
+| `download_github_release_binary(repo, version, asset_pattern, dest_name)` | Download a single binary from a GitHub release and chmod 755. |
+| `download_and_extract_archive(url, extract_binaries, dest_dir)` | Download a `.tar.gz`/`.tgz`/`.zip` and extract the requested binaries by basename. |
+| `install_tool(name, repo, asset_patterns, ...)` | High-level installer: skip-if-installed, fetch latest, download, extract. |
+| `create_install_task(name, repo, asset_patterns, ...)` | Factory returning a doit task dict that calls `install_tool`. |
+
+## Examples
+
+### Single binary from GitHub releases (direnv)
+
+```python
+from tools.doit.install_tools import create_install_task
+
+def task_install_direnv():
+    return create_install_task(
+        name="direnv",
+        repo="direnv/direnv",
+        asset_patterns={
+            "linux": "direnv.linux-amd64",
+            "darwin": "direnv.darwin-amd64",
+        },
+    )
+```
+
+### Multi-binary archive from GitHub releases (age)
+
+```python
+from tools.doit.install_tools import create_install_task
+
+def task_install_age():
+    return create_install_task(
+        name="age",
+        repo="FiloSottile/age",
+        asset_patterns={
+            "linux": "age-v{version}-linux-amd64.tar.gz",
+            "darwin": "age-v{version}-darwin-amd64.tar.gz",
+        },
+        extract_binaries=["age", "age-keygen"],
+    )
+```
+
+`extract_binaries` matches by **basename**, so any directory structure
+inside the archive (e.g., `age/age`, `age/age-keygen`) is ignored.
+
+### Multi-arch archive from GitHub releases via `url_template` (gh)
+
+```python
+from tools.doit.install_tools import create_install_task
+
+def task_install_gh():
+    return create_install_task(
+        name="gh",
+        repo="cli/cli",
+        asset_patterns={},
+        url_template=(
+            "https://github.com/cli/cli/releases/download/v{version}/"
+            "gh_{version}_{os}_{arch}.tar.gz"
+        ),
+        extract_binaries=["gh"],
+        version_cmd=["gh", "--version"],
+        prefer_brew=False,
+    )
+```
+
+When the release URL itself is on GitHub but includes architecture-specific
+filenames (e.g., `gh_2.45.0_linux_amd64.tar.gz`), `url_template` is the
+right choice because `asset_patterns` does not support `{arch}` placeholders.
+
+### Zip from a non-GitHub URL (terraform)
+
+```python
+from tools.doit.install_tools import create_install_task
+
+def task_install_terraform():
+    return create_install_task(
+        name="terraform",
+        repo="hashicorp/terraform",  # still used for version discovery
+        asset_patterns={},            # ignored when url_template is set
+        url_template=(
+            "https://releases.hashicorp.com/terraform/{version}/"
+            "terraform_{version}_{os}_{arch}.zip"
+        ),
+        extract_binaries=["terraform"],
+        prefer_brew=False,  # force download even on macOS
+    )
+```
+
+The `{version}`, `{os}`, and `{arch}` placeholders are substituted from
+`get_latest_github_release(repo)`, `platform.system().lower()`, and
+`_get_arch()` respectively.
+
+## Architecture mapping
+
+`_get_arch()` normalizes `platform.machine()` to the values most release
+artifacts use:
+
+| `platform.machine()` | `_get_arch()` |
+| :--- | :--- |
+| `x86_64` | `amd64` |
+| `aarch64` | `arm64` |
+| `arm64` | `arm64` (passthrough) |
+| anything else | passthrough (lowercased) |
+
+## macOS handling
+
+By default, `install_tool()` runs `brew install <name>` on macOS. This
+matches expectations on developer machines and avoids fighting Homebrew
+over file ownership in `~/.local/bin`.
+
+Pass `prefer_brew=False` to opt out — useful when you want consistent
+cross-platform behavior (same binary, same version, same install path)
+or when no brew formula exists. Setting `url_template` also implicitly
+bypasses brew, since the template only makes sense when the caller wants
+the download path on every OS.
+
+## Security notes
+
+- **Tar archives** use `tarfile.data_filter` (Python 3.12+) when
+  available. This blocks symlink traversal, absolute paths, and
+  parent-directory escapes at the tarfile layer.
+- **All extraction** is basename-only — any path components inside the
+  archive are stripped before writing into `dest_dir`. Even without
+  `data_filter` this prevents writing outside the install directory.
+- **Zip archives** additionally do a `Path.resolve()` zip-slip check as
+  defense in depth.
+- Extracted binaries are chmod'd to `0o755`.
+- Status output uses ASCII `[OK]` rather than a checkmark glyph so it
+  encodes cleanly on Windows cp1252 consoles (see issue #328).
+
+## Future work
+
+- **Checksum verification** (SHA256 from a `*.sha256` sibling URL).
+- **GPG signature verification** for projects that publish detached signatures.
+- **Archive caching** between runs to avoid redownloading on a fresh
+  clone or CI runner.
+- **Windows binary support** (PowerShell-friendly install path).
+
+## Related ADR
+
+- [ADR-9015: install_tools framework: archive extraction and custom URLs](../template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md)

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -17,8 +17,10 @@ This guide covers automated versioning, release management, governance validatio
 ## Table of Contents
 - [Automated Versioning](#automated-versioning)
 - [Release Management](#release-management)
+- [Release Notes](#release-notes)
 - [PR Merging](#pr-merging)
 - [Security & Quality Tasks](#security-quality-tasks)
+- [SBOM Generation](#sbom-generation)
 - [Governance Validation](#governance-validation)
 - [Environment Configuration](#environment-configuration)
 
@@ -209,6 +211,63 @@ This creates the git tag and pushes it, triggering CI/CD to build and publish th
 | Governance | Built-in validation | Validation in both steps |
 | Best for | Solo maintainers, trusted CI | Teams, regulated environments |
 
+## Release Notes
+
+Release notes are automatically generated from merged pull requests when a GitHub release is created. The release workflow creates a GitHub release with auto-generated notes after publishing to PyPI.
+
+### How It Works
+
+1. When a version tag (e.g., `v1.0.0`) is pushed, the release workflow runs
+2. After the package is published to PyPI, the `github-release` job creates a GitHub release
+3. GitHub generates release notes by categorizing merged PRs since the last release
+4. SBOM files are attached to the release as downloadable assets
+
+### Category Configuration
+
+PR labels and conventional commit prefixes are mapped to release note sections in `.github/release.yml`:
+
+| Section | Labels |
+|---------|--------|
+| **Breaking Changes** | `breaking` |
+| **New Features** | `enhancement`, `feat` |
+| **Bug Fixes** | `bug`, `fix` |
+| **Documentation** | `documentation`, `docs` |
+| **Performance** | `performance`, `perf` |
+| **Other Changes** | Everything else |
+
+PRs with the `dependencies` or `needs-triage` labels are excluded from release notes.
+
+### Customizing Categories
+
+To add or modify categories, edit `.github/release.yml`:
+
+```yaml
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - needs-triage
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: New Features
+      labels:
+        - enhancement
+        - feat
+    # Add more categories here
+    - title: Other Changes
+      labels:
+        - "*"
+```
+
+Categories are evaluated in order. A PR is placed in the first matching category. The `"*"` wildcard matches any label and serves as a catch-all.
+
+### Further Reading
+
+- [GitHub Docs: Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
+- [GitHub Docs: Configuring automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes)
+
 ## PR Merging
 
 Use `doit pr_merge` to merge pull requests with properly formatted commit messages. This task enforces the merge commit format and provides a consistent workflow.
@@ -224,12 +283,15 @@ doit pr_merge --pr=123
 
 # Keep the branch after merge (default deletes it)
 doit pr_merge --delete-branch=false
+
+# Automatically close linked issues after merge
+doit pr_merge --auto-close
 ```
 
 ### What It Does
 
 1. **Validates PR title** - Ensures the title follows conventional commit format (`<type>: <subject>`)
-2. **Extracts linked issues** - Parses PR body for `closes #XX`, `fixes #XX`, or `part of #XX`
+2. **Extracts linked issues** - Parses PR body for `addresses #XX`
 3. **Formats merge commit** - Creates a standardized commit message with PR and issue references
 4. **Squash merges** - Uses squash merge to maintain clean history
 5. **Deletes branch** - Removes the source branch after merge (default behavior)
@@ -240,27 +302,25 @@ doit pr_merge --delete-branch=false
 The task automatically formats the merge commit subject:
 
 ```
-<type>: <subject> (merges PR #XX, closes #YY)
-<type>: <subject> (merges PR #XX, part of #YY)
+<type>: <subject> (merges PR #XX, addresses #YY)
 <type>: <subject> (merges PR #XX)
 ```
 
 **Examples:**
 ```
-feat: add user authentication (merges PR #102, closes #99)
-fix: resolve parsing error (merges PR #103, closes #100, #101)
+feat: add user authentication (merges PR #102, addresses #99)
+fix: resolve parsing error (merges PR #103, addresses #100, #101)
 docs: update installation guide (merges PR #104)
-refactor: extract helper functions (merges PR #105, part of #50)
+refactor: extract helper functions (merges PR #105, addresses #50)
 ```
 
 ### Linking Issues in PRs
 
-In your PR body, use these keywords to link issues:
+In your PR body, use the `Addresses` keyword to link issues:
 
 | Keyword | Effect | Use When |
 |---------|--------|----------|
-| `closes #XX`, `fixes #XX`, `resolves #XX` | Included as `closes #XX` in merge commit | PR fully completes the issue |
-| `part of #XX` | Included as `part of #XX` in merge commit | Issue requires multiple PRs |
+| `Addresses #XX` | Included as `addresses #XX` in merge commit | PR relates to the issue |
 
 **Example PR body:**
 ```markdown
@@ -268,34 +328,34 @@ In your PR body, use these keywords to link issues:
 - Add login form component
 - Implement session management
 
-Closes #99
+Addresses #99
 
 ## Test Plan
 - [ ] Test login flow
 ```
 
-For multi-PR issues:
-```markdown
-## Summary
-First part of the authentication system refactor.
-
-Part of #50
-
-## Test Plan
-- [ ] Existing tests pass
-```
-
 ### Closing Issues After Merge
 
-Issues are **not automatically closed** by GitHub when using squash merge with custom commit messages. After merging, manually close linked issues:
+By default, issues are **not automatically closed** when using `Addresses`. After merging, `doit pr_merge` prints the `gh issue close` commands so you can close linked issues manually:
 
 ```bash
 # The task displays these commands after merge
-gh issue close 99 --comment "Fixed in PR #102"
-gh issue close 100 --comment "Fixed in PR #103"
+gh issue close 99 --comment "Addressed in PR #102"
+gh issue close 100 --comment "Addressed in PR #103"
 ```
 
-This ensures issues are explicitly closed with a reference to the PR that fixed them.
+This ensures issues are explicitly closed with a reference to the PR that addressed them.
+
+#### Auto-closing linked issues
+
+Pass `--auto-close` to have `doit pr_merge` run the `gh issue close` commands itself after a successful merge:
+
+```bash
+doit pr_merge --auto-close
+doit pr_merge --pr=123 --auto-close
+```
+
+Each linked issue is closed with the comment `Addressed in PR #XX`, matching the format used in the manual reminder.
 
 ### Why Use `doit pr_merge`?
 
@@ -402,6 +462,69 @@ uv run doit fmt_pyproject
   | pydantic     | 2.5.0   | MIT         |
   ```
 
+#### `doit sbom`
+- **Tool**: cyclonedx-py
+- **Purpose**: Generates a Software Bill of Materials (SBOM) in CycloneDX format
+- **Output**: `tmp/sbom.json` (JSON) and `tmp/sbom.xml` (XML)
+- **Example**:
+  ```bash
+  $ uv run doit sbom
+  # Generates tmp/sbom.json and tmp/sbom.xml
+  ```
+
+### SBOM Generation
+
+A **Software Bill of Materials (SBOM)** is a machine-readable inventory of all software components and dependencies in a project. SBOMs are increasingly required for regulatory compliance (e.g., US Executive Order 14028) and are essential for security auditing and supply chain transparency.
+
+#### Why SBOM Matters
+
+- **Compliance**: Many organizations and government agencies require SBOMs for software procurement
+- **Security Auditing**: Enables automated vulnerability scanning across all dependencies
+- **Supply Chain Transparency**: Provides a complete picture of third-party components
+- **Incident Response**: Quickly determine if a newly discovered vulnerability affects your software
+
+#### Local Usage
+
+Generate SBOMs locally using the `doit sbom` task:
+
+```bash
+# Install security extras (if not already installed)
+uv sync --extra security
+
+# Generate SBOM files
+uv run doit sbom
+```
+
+This produces two files in the `tmp/` directory:
+
+- `tmp/sbom.json` — CycloneDX JSON format
+- `tmp/sbom.xml` — CycloneDX XML format
+
+#### Release Integration
+
+SBOMs are automatically generated and attached to every GitHub release:
+
+1. During the **build** job, `cyclonedx-py` generates both JSON and XML SBOMs
+2. The SBOM files are included in the `dist/` artifact alongside wheel and sdist packages
+3. After publishing to PyPI, the **github-release** job creates a GitHub release with auto-generated notes and attaches the SBOMs as release assets
+
+Users can download the SBOM from the GitHub release page for any version.
+
+#### Using SBOMs for Vulnerability Scanning
+
+You can feed the generated SBOM into vulnerability scanners for continuous monitoring:
+
+```bash
+# Using grype (https://github.com/anchore/grype)
+grype sbom:tmp/sbom.json
+
+# Using trivy (https://github.com/aquasecurity/trivy)
+trivy sbom tmp/sbom.json
+
+# Using osv-scanner (https://github.com/google/osv-scanner)
+osv-scanner --sbom=tmp/sbom.json
+```
+
 ### Integrating into CI
 
 Add security checks to your CI pipeline:
@@ -440,24 +563,23 @@ This template enforces governance rules to ensure code quality and traceability.
 
 **Required Format**:
 ```
-<type>: <subject> (merges PR #XX, closes #YY)
-<type>: <subject> (merges PR #XX, part of #YY)
+<type>: <subject> (merges PR #XX, addresses #YY)
 <type>: <subject> (merges PR #XX)
 ```
 
 **Examples**:
 ```
-✅ feat: add new feature (merges PR #102, closes #99)
-✅ fix: resolve bug (merges PR #103, closes #100)
+✅ feat: add new feature (merges PR #102, addresses #99)
+✅ fix: resolve bug (merges PR #103, addresses #100)
 ✅ docs: update guide (merges PR #104)
-✅ refactor: extract utils (merges PR #105, part of #50)
+✅ refactor: extract utils (merges PR #105, addresses #50)
 
 ❌ Add new feature                    # Missing type
 ❌ feat: add feature                  # Missing PR reference
 ❌ feat: add feature (PR #102)        # Wrong format
 ```
 
-Use `closes` when the PR fully resolves an issue. Use `part of` when an issue requires multiple PRs to complete. See [PR Merging](#pr-merging) for details.
+See [PR Merging](#pr-merging) for details.
 
 **Valid Types**: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf`
 
@@ -472,7 +594,7 @@ Use `closes` when the PR fully resolves an issue. Use `part of` when an issue re
 **Examples**:
 ```
 ✅ feat: add new feature (#99)
-✅ fix: resolve bug closes #100
+✅ fix: resolve bug addresses #100
 ✅ docs: update README                # Docs exempt
 
 ⚠️ feat: add new feature             # Warning only
@@ -639,6 +761,7 @@ uv run doit audit           # Vulnerability scan
 uv run doit security        # Security analysis
 uv run doit spell_check     # Spell checking
 uv run doit licenses        # License compliance
+uv run doit sbom            # Generate SBOM (CycloneDX)
 
 # Releases
 uv run doit release_dev     # Create pre-release (TestPyPI)
@@ -662,10 +785,10 @@ uv sync --dev --all-extras
 
 ```bash
 # Install hooks
-uv run pre-commit install
+doit pre_commit_install
 
 # Run manually on all files
-uv run pre-commit run --all-files
+doit pre_commit_run
 
 # Skip hooks (emergency only)
 git commit --no-verify
@@ -710,7 +833,7 @@ If you need to fix an existing merge commit, use interactive rebase (advanced):
 ```bash
 git rebase -i HEAD~1
 # Change 'pick' to 'reword', then edit the message to:
-# feat: add new feature (merges PR #102, closes #99)
+# feat: add new feature (merges PR #102, addresses #99)
 ```
 
 ### Security Task Fails: "pip-audit not installed"
@@ -740,4 +863,4 @@ ignore-words-list = "crate,kubernetes,terraform"
 
 ---
 
-[Back to Documentation Index](../index.md)
+[Back to Documentation Index](../TABLE_OF_CONTENTS.md)

--- a/docs/development/tooling-roles.md
+++ b/docs/development/tooling-roles.md
@@ -1,0 +1,101 @@
+---
+title: Tooling Roles and Architectural Boundaries
+description: What each tool is for, who uses it, and where runtime code ends and dev tooling begins
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - architecture
+  - tooling
+  - doit
+---
+
+# Tooling Roles and Architectural Boundaries
+
+## Overview
+
+This project ships with a deliberately layered set of tools: a small runtime
+package, a heavier set of development tools, and a task runner that ties the
+dev workflow together. New contributors (human and AI) often blur these
+layers — the most common mistake is treating `doit` as if it were the
+application's user-facing CLI. This page is the source of truth for **what
+tool belongs to which audience** and **where runtime code ends and
+development tooling begins**.
+
+## Layering
+
+The repository has three distinct layers. Each layer has a different
+audience, a different lifecycle, and a different set of allowed dependencies.
+
+| Layer | Path | Audience | Purpose |
+| :--- | :--- | :--- | :--- |
+| **Runtime** | `src/package_name/` | End users of the published package | The actual application/library code that gets shipped to PyPI. |
+| **Dev tooling** | `tools/` | Contributors and CI | Helpers, scaffolding, install scripts, doit task definitions, and template-management code. Not shipped. |
+| **Dev entry point** | `dodo.py` | Contributors and CI | The doit task discovery file. Loads tasks from `tools/doit/`. Not shipped. |
+
+The hard rule that holds these layers together:
+
+> **`src/package_name/` never imports from `tools/` or `dodo.py`.**
+
+Runtime code must be installable and runnable without any dev tooling
+present. If you find yourself wanting to import from `tools/` inside the
+runtime package, that is a signal the helper belongs in the runtime package
+itself (and needs to be tested as runtime code).
+
+## Tooling Roles
+
+| Tool | Role | Audience | Never use for |
+| :--- | :--- | :--- | :--- |
+| **Application console script** | The package's user-facing command-line interface, defined as a `[project.scripts]` entry under `src/package_name/`. | End users of the published package. | Development workflow tasks. See the [CLI Guide](../usage/cli.md) for the application CLI. |
+| **`doit`** | Development task runner. Wraps tests, linting, type-checking, releases, issue and PR creation, and other contributor workflows. | Contributors and CI. | Fronting the application's user-facing CLI. doit is a *dev* surface, not a runtime surface. |
+| **`uv`** | Package and environment management. Installs dependencies, runs Python, manages the lockfile. | Contributors and CI. | Replacing the application's runtime entry point. |
+| **`gh`** | GitHub API access for operations not wrapped by `doit` (read-only queries, ad-hoc API calls). | Contributors and CI. | Write operations that already have a `doit` wrapper (e.g. use `doit pr` not `gh pr create`). |
+| **`git`** | Version control. | Contributors and CI. | Workflow shortcuts that bypass branch protection or signed-commit requirements. |
+| **Raw shell commands** | Last resort when nothing above covers the need. | Contributors and CI. | Anything a higher-level tool already wraps. |
+
+This table mirrors the imperative "Tool Reference" table in
+[`AGENTS.md`](../../AGENTS.md), which tells contributors *what command to
+run*. This page tells them *why the layering exists*.
+
+## Template Philosophy
+
+The template is opinionated about a small number of things:
+
+- **Runtime dependencies stay minimal.** Anything in `[project] dependencies`
+  ships to every user of the package. Add to it sparingly.
+- **Dev tooling is heavy and lives under `tools/`.** Contributors get the
+  full suite (doit, ruff, mypy, pytest, mkdocs, mutmut, etc.) via
+  `[dependency-groups] dev`.
+- **`doit` is a development tool, not a runtime tool.** Tasks under
+  `tools/doit/` exist to make contributor workflows reproducible. They are
+  not part of the package's public API.
+- **The application's user-facing CLI is a console script under
+  `src/package_name/`, not a doit task.** End users should never need to
+  install `doit` to use the published package. See the
+  [CLI Guide](../usage/cli.md) for how the CLI is structured and how to
+  add subcommands.
+- **ADRs document the *why*.** When a tooling decision is non-obvious, it
+  gets an ADR under `docs/template/decisions/` or `docs/decisions/`.
+
+## Dependency placement
+
+`doit` is declared under `[project.optional-dependencies] dev` in
+`pyproject.toml` and is **not** installed when adopters install the
+published package. `rich` remains a runtime dependency because most CLIs
+built on this template use it for user-facing output, which is a
+legitimate runtime use.
+
+> **Historical note:** `doit` was briefly placed in `[project] dependencies`
+> per [#65](https://github.com/endavis/pyproject-template/issues/65) as a
+> packaging convenience for adopters of the template. That placement
+> contradicted the boundary documented above and was reversed in
+> [#348](https://github.com/endavis/pyproject-template/issues/348). Current
+> state matches target state.
+
+## See also
+
+- [ADR-9002: Use doit for task automation](../template/decisions/9002-use-doit-for-task-automation.md)
+- [ADR-9005: AI agent command restrictions](../template/decisions/9005-ai-agent-command-restrictions.md)
+- [Doit Tasks Reference](doit-tasks-reference.md)
+- [`AGENTS.md`](../../AGENTS.md) — imperative tool reference for contributors and AI agents
+- [New Project Setup](../template/new-project.md)

--- a/docs/examples/add-a-feature.md
+++ b/docs/examples/add-a-feature.md
@@ -1,0 +1,321 @@
+---
+title: "Add a Feature: End-to-End Walkthrough"
+description: Step-by-step example of adding a module, CLI subcommand, tests, and docs to the project
+audience:
+  - contributors
+tags:
+  - examples
+  - walkthrough
+  - feature
+  - cli
+---
+
+# Add a Feature: End-to-End Walkthrough
+
+This guide walks through adding a hypothetical **farewell** feature from
+start to finish. The feature is intentionally small -- a `farewell()` function
+and a `farewell` CLI subcommand -- so the focus stays on the *workflow and
+conventions* rather than the code itself.
+
+By the end you will have touched every layer of the project: issue tracking,
+branching, runtime code, tests, documentation, and the PR process.
+
+!!! note "This is an illustrative example"
+    The code snippets below are **not** committed to the repository. They show
+    what you *would* write if you were adding this feature for real.
+
+## Prerequisites
+
+- The project is cloned and dependencies are installed (`uv sync`).
+- You have read the [CLI Guide](../usage/cli.md) and understand the existing
+  `greet` subcommand.
+- You are familiar with [Tooling Roles and Architectural Boundaries](../development/tooling-roles.md),
+  particularly the separation between runtime code and dev tooling.
+
+---
+
+## Step 1: Create an Issue
+
+Every change starts with a GitHub issue. Use the `doit issue` task to create
+one with the correct labels and template sections:
+
+```bash
+doit issue --type=feature --title="feat: add farewell command" \
+  --body="## Problem
+Users can greet but cannot say goodbye.
+
+## Proposed Solution
+Add a \`farewell(name)\` function in a new \`farewell.py\` module and expose
+it as a \`farewell\` CLI subcommand."
+```
+
+Note the issue number in the output -- we will call it **#NNN** for the rest of
+this guide.
+
+## Step 2: Create a Branch
+
+Pull the latest `main` and create a feature branch linked to the issue:
+
+```bash
+git checkout main && git pull
+git checkout -b feat/NNN-add-farewell
+```
+
+Branch naming follows the convention `<type>/<issue>-<description>`.
+
+## Step 3: Add the Core Module
+
+Create `src/package_name/farewell.py`. The function mirrors the existing
+`greet()` pattern in `core.py`:
+
+```python
+"""Farewell functionality for package_name."""
+
+
+def farewell(name: str = "World") -> str:
+    """Return a farewell message.
+
+    Args:
+        name: The name to bid farewell. Defaults to "World".
+
+    Returns:
+        A farewell message string.
+
+    Examples:
+        >>> farewell()
+        'Goodbye, World!'
+        >>> farewell("Python")
+        'Goodbye, Python!'
+    """
+    return f"Goodbye, {name}!"
+```
+
+Key points:
+
+- **Type hints** on the signature and return type.
+- **Google-style docstring** with `Args`, `Returns`, and `Examples`.
+- Pure function with no side effects -- easy to test.
+
+## Step 4: Export from `__init__.py`
+
+Add the new function to the package's public API in
+`src/package_name/__init__.py`:
+
+```python
+"""Package Name - A short description of your package."""
+
+from ._version import __version__
+from .core import greet
+from .farewell import farewell
+from .logging import get_logger, setup_logging
+
+__all__ = ["__version__", "farewell", "get_logger", "greet", "setup_logging"]
+```
+
+Keep `__all__` sorted alphabetically.
+
+## Step 5: Add a CLI Subcommand
+
+Extend `src/package_name/cli.py` with a `farewell` command. The CLI is a
+**thin adapter** -- it delegates to the core function and handles only I/O
+(printing, exit codes):
+
+```python
+from package_name.farewell import farewell as _farewell
+
+# ... existing code ...
+
+@main.command()
+@click.option(
+    "--name",
+    "-n",
+    default="World",
+    show_default=True,
+    help="Name to bid farewell.",
+)
+def farewell(name: str) -> None:
+    """Print a farewell for NAME."""
+    click.echo(_farewell(name))
+```
+
+!!! tip "Thin-adapter pattern"
+    The CLI layer imports and calls `farewell()` from the core module rather
+    than containing business logic itself. This keeps the logic testable
+    without invoking the CLI runner. See
+    [Tooling Roles](../development/tooling-roles.md) for more on this
+    boundary.
+
+## Step 6: Write Tests
+
+Tests are created *with* the implementation, never after. You need two files:
+a unit test for the core function and a CLI integration test.
+
+### Unit tests -- `tests/test_farewell.py`
+
+Follow the patterns in `tests/test_example.py`:
+
+```python
+"""Tests for the farewell module."""
+
+import pytest
+
+from package_name.farewell import farewell
+
+
+def test_farewell_default() -> None:
+    """farewell() with no arguments returns the default message."""
+    assert farewell() == "Goodbye, World!"
+
+
+def test_farewell_custom_name() -> None:
+    """farewell(name) substitutes the provided name."""
+    assert farewell("Python") == "Goodbye, Python!"
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("Alice", "Goodbye, Alice!"),
+        ("Bob", "Goodbye, Bob!"),
+        ("World", "Goodbye, World!"),
+    ],
+)
+def test_farewell_parametrized(name: str, expected: str) -> None:
+    """Parametrized test covering multiple inputs."""
+    assert farewell(name) == expected
+```
+
+### CLI tests -- `tests/test_cli_farewell.py`
+
+Follow the patterns in `tests/test_cli.py`:
+
+```python
+"""Tests for the farewell CLI subcommand."""
+
+from click.testing import CliRunner
+
+from package_name.cli import main
+
+
+def test_farewell_default_name() -> None:
+    """farewell with no arguments prints the default message."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["farewell"])
+    assert result.exit_code == 0
+    assert result.output == "Goodbye, World!\n"
+
+
+def test_farewell_custom_name_long_option() -> None:
+    """farewell --name substitutes the provided name."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["farewell", "--name", "Python"])
+    assert result.exit_code == 0
+    assert result.output == "Goodbye, Python!\n"
+
+
+def test_farewell_custom_name_short_option() -> None:
+    """farewell -n is the short alias for --name."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["farewell", "-n", "Python"])
+    assert result.exit_code == 0
+    assert result.output == "Goodbye, Python!\n"
+
+
+def test_farewell_help() -> None:
+    """farewell --help documents the --name option."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["farewell", "--help"])
+    assert result.exit_code == 0
+    assert "--name" in result.output
+```
+
+## Step 7: Run Checks
+
+Run the full check suite before committing:
+
+```bash
+doit check
+```
+
+This runs linting (ruff), type checking (mypy), tests (pytest), and security
+scanning (bandit) in one command. Fix any failures before proceeding.
+
+## Step 8: Update Documentation
+
+Add the new function to the API reference page so that `mkdocstrings` picks it
+up. In `docs/reference/api.md`, add a section for the farewell module:
+
+```markdown
+## Farewell
+
+::: package_name.farewell
+```
+
+Then build the docs to make sure everything renders:
+
+```bash
+doit docs_build
+```
+
+## Step 9: Commit and Create a PR
+
+Stage, commit (with a conventional commit message), and push:
+
+```bash
+git add .
+doit commit   # interactive prompt enforces conventional format
+git push -u origin feat/NNN-add-farewell
+```
+
+Then create the PR:
+
+```bash
+doit pr --title="feat: add farewell command" \
+  --body="## Summary
+- Add \`farewell()\` function in \`farewell.py\`
+- Add \`farewell\` CLI subcommand
+- Add unit and CLI tests
+
+Addresses #NNN"
+```
+
+After CI passes and the PR is reviewed, merge with:
+
+```bash
+doit pr_merge
+```
+
+---
+
+## Key Takeaways
+
+1. **Issue first.** Every change, no matter how small, starts with a tracked
+   issue.
+
+2. **Branch per feature.** Never commit directly to `main`.
+
+3. **Runtime code is separate from dev tooling.** `doit` tasks are for
+   *contributors*; the user-facing CLI is built with `click` and lives in
+   `src/`. See [Tooling Roles](../development/tooling-roles.md).
+
+4. **Thin CLI adapters.** The CLI layer delegates to pure-function core
+   modules. This keeps logic testable without the CLI runner.
+
+5. **Tests ship with code.** Creating code means creating tests -- no
+   exceptions. Follow existing patterns in `tests/`.
+
+6. **`doit check` before committing.** Catches lint, type, test, and security
+   issues locally before CI does.
+
+7. **Conventional commits.** `feat:`, `fix:`, `refactor:`, `docs:`, etc.
+   Messages describe *why*, not *what*.
+
+## See Also
+
+- [CLI Guide](../usage/cli.md) -- reference for the `click`-based CLI
+- [Tooling Roles and Architectural Boundaries](../development/tooling-roles.md) --
+  runtime vs dev tooling
+- [API Reference](../reference/api.md) -- generated API docs
+- [Contributing Guide](https://github.com/endavis/pyproject-template/blob/main/.github/CONTRIBUTING.md) --
+  full development workflow
+- [ADR-9014: Use click for application CLI](../template/decisions/9014-use-click-for-application-cli.md)

--- a/docs/template/ai-sync-checklist.md
+++ b/docs/template/ai-sync-checklist.md
@@ -79,11 +79,50 @@ This will (per [Tools Reference](tools-reference.md)):
 diff <file> tmp/extracted/pyproject-template-main/<file>
 ```
 
-Review the output and proceed with Phases 3-7 to selectively apply changes.
+Review the output and proceed with Phases 3-8 to selectively apply changes.
 
 ---
 
-## Phase 3: GitHub Workflows (`.github/workflows/`)
+## Phase 3: pyproject.toml Tool Configuration
+
+Configuration changes often enable new doit tasks and workflows, so this phase comes first.
+
+### 3.1 Add Missing Tool Sections
+
+Check template's pyproject.toml for sections not present in the project:
+
+- [ ] `[tool.vulture]` - Dead code detection configuration
+- [ ] `[tool.pyright]` - LSP/type checking for AI code editors
+
+### 3.2 Update Existing Sections
+
+Compare each `[tool.*]` section and apply template improvements:
+
+- [ ] `[tool.ruff]` - New rules, updated ignores
+- [ ] `[tool.mypy]` - Configuration updates
+- [ ] `[tool.pytest.ini_options]` - Version bumps, new options
+- [ ] `[tool.coverage]` - Threshold changes, exclude patterns
+- [ ] `[tool.bandit]` - New skips, exclude patterns
+- [ ] `[tool.commitizen]` - Format updates
+
+**Decision points (ask user):**
+
+- Coverage `fail_under` threshold (project may intentionally differ)
+- Cache directory locations (template uses defaults, project may customize)
+- Extended ignores/excludes (project-specific suppressions should be preserved)
+
+### 3.3 Dev Dependencies
+
+Add any new dev dependencies required by new doit tasks:
+
+- [ ] `vulture` (for `task_deadcode()`)
+- [ ] `radon` (for `task_complexity()` and `task_maintainability()`)
+- [ ] `pyright` (for `[tool.pyright]`)
+- [ ] Any other new tools referenced by updated doit tasks
+
+---
+
+## Phase 4: GitHub Workflows (`.github/workflows/`)
 
 For each workflow file flagged as **Modified** or **Missing**:
 
@@ -105,14 +144,14 @@ For each workflow file flagged as **Modified** or **Missing**:
 
 ---
 
-## Phase 4: Doit Tasks (`tools/doit/`)
+## Phase 5: Doit Tasks (`tools/doit/`)
 
-### 4.1 Core Task Infrastructure
+### 5.1 Core Task Infrastructure
 
 - [ ] Compare `tools/doit/__init__.py` for discovery mechanism updates
 - [ ] Compare `tools/doit/base.py` for configuration changes (DOIT_CONFIG, helpers)
 
-### 4.2 Quality Tasks
+### 5.2 Quality Tasks
 
 - [ ] Compare `tools/doit/quality.py` - check for new tasks:
     - `task_deadcode()` (uses vulture)
@@ -120,48 +159,11 @@ For each workflow file flagged as **Modified** or **Missing**:
     - `task_maintainability()` (uses radon mi)
     - Any new linting/formatting improvements
 
-### 4.3 All Other Task Files
+### 5.3 All Other Task Files
 
 - [ ] Compare each of: `github.py`, `testing.py`, `security.py`, `maintenance.py`, `release.py`, `build.py`, `docs.py`, `git.py`, `install.py`, `adr.py`, `templates.py`
 - [ ] Apply differences that are template improvements (not project-specific)
 - [ ] Skip `template_clean.py` unless cleanup capability is desired
-
----
-
-## Phase 5: pyproject.toml Tool Configuration
-
-### 5.1 Add Missing Tool Sections
-
-Check template's pyproject.toml for sections not present in the project:
-
-- [ ] `[tool.vulture]` - Dead code detection configuration
-- [ ] `[tool.pyright]` - LSP/type checking for AI code editors
-
-### 5.2 Update Existing Sections
-
-Compare each `[tool.*]` section and apply template improvements:
-
-- [ ] `[tool.ruff]` - New rules, updated ignores
-- [ ] `[tool.mypy]` - Configuration updates
-- [ ] `[tool.pytest.ini_options]` - Version bumps, new options
-- [ ] `[tool.coverage]` - Threshold changes, exclude patterns
-- [ ] `[tool.bandit]` - New skips, exclude patterns
-- [ ] `[tool.commitizen]` - Format updates
-
-**Decision points (ask user):**
-
-- Coverage `fail_under` threshold (project may intentionally differ)
-- Cache directory locations (template uses defaults, project may customize)
-- Extended ignores/excludes (project-specific suppressions should be preserved)
-
-### 5.3 Dev Dependencies
-
-Add any new dev dependencies required by new doit tasks:
-
-- [ ] `vulture` (for `task_deadcode()`)
-- [ ] `radon` (for `task_complexity()` and `task_maintainability()`)
-- [ ] `pyright` (for `[tool.pyright]`)
-- [ ] Any other new tools referenced by updated doit tasks
 
 ---
 
@@ -184,18 +186,38 @@ Add any new dev dependencies required by new doit tasks:
 
 ---
 
-## Phase 8: Validation
+## Phase 8: AI Hooks
+
+AI coding assistants (Claude Code, Gemini CLI, Codex) use hooks to block dangerous commands. See [AI Command Blocking](../development/ai/command-blocking.md) for details.
+
+### 8.1 Hook Scripts
+
+- [ ] Compare `tools/hooks/ai/block-dangerous-commands.py` for new blocked patterns
+- [ ] Compare `tools/hooks/ai/test_hook.py` for new test cases
+- [ ] Run `python3 tools/hooks/ai/test_hook.py` to verify hooks work
+
+### 8.2 AI Agent Configuration
+
+- [ ] Compare `.claude/settings.json` for Claude Code hook configuration
+- [ ] Compare `.gemini/settings.json` for Gemini CLI hook configuration
+- [ ] Compare `.codex/config.toml` for Codex CLI approval policies
+
+**Note:** If these configuration files don't exist in the downstream project, copy them from the template to enable AI safety hooks.
+
+---
+
+## Phase 9: Validation
 
 - [ ] Run `doit check` - all checks must pass
-- [ ] Run `uv run pytest` - all tests must pass
-- [ ] Run `uv run pre-commit run --all-files` - all hooks must pass
+- [ ] Run `doit test` - all tests must pass
+- [ ] Run `doit pre_commit_run` - all hooks must pass
 - [ ] Run `doit lint` - no new linting issues
 - [ ] Run `doit type_check` - no new type errors
 - [ ] If new quality tasks added: run them and verify output is reasonable
 
 ---
 
-## Phase 9: Mark as Synced
+## Phase 10: Mark as Synced
 
 Per [Template Manager](manage.md) step [5]:
 
@@ -212,7 +234,7 @@ This:
 
 ---
 
-## Phase 10: Commit & PR
+## Phase 11: Commit & PR
 
 - [ ] Stage all changes
 - [ ] Commit with conventional format:
@@ -246,7 +268,7 @@ Once `tools/pyproject_template/manage.py` is installed and sync state is tracked
 
 - **Selective merging:** Not all template changes apply to every project - review diffs carefully
 - **Preserve divergences:** Projects may intentionally differ from template (document with ADRs)
-- **Replace placeholders:** Any `pynetappfoundry` references in copied template content must be replaced with the actual package name
+- **Replace placeholders:** Any `package_name` references in copied template content must be replaced with the actual package name
 - **Validate before commit:** Always run `doit check` before staging - mandatory per project workflow
 - **One PR per sync:** Keep all template synchronization changes in a single PR unless scope is too large
 - **manage.py is the official tool:** Use it for checking updates and marking sync state

--- a/docs/template/decisions/9002-use-doit-for-task-automation.md
+++ b/docs/template/decisions/9002-use-doit-for-task-automation.md
@@ -12,13 +12,39 @@ Use **doit** as the task automation framework for common operations like testing
 
 doit is a Python-based build tool that uses pure Python for task definitions (no DSL to learn), provides automatic task dependency resolution and incremental builds, and encourages modular task organization. Being Python-native means no context switching for developers already working in Python.
 
+## Scope
+
+doit is a **development task runner only**. It exists to make contributor
+workflows (testing, linting, releases, issue and PR creation) reproducible
+and discoverable. It is not part of the published package's public API.
+
+- doit must **not** be used to front the application's user-facing CLI. The
+  application's CLI is a console script under `src/package_name/`. End users
+  of the published package should never need to install `doit` to use it.
+- `doit` is a **development dependency only**, declared under
+  `[project.optional-dependencies] dev` in `pyproject.toml`. It is not
+  installed when adopters install the published package. (Historical note:
+  it was briefly placed in `[project] dependencies` per #65 as a packaging
+  convenience; #348 moved it to dev to align with the boundary above.)
+
+For the broader layering rationale, see
+[Tooling Roles and Architectural Boundaries](../../development/tooling-roles.md).
+
 ## Related Issues
 
 - Issue #170: Rename tools/tasks to tools/doit
 - Issue #87: Add shell completions for doit tasks
 - Issue #80: Add doit issue and doit pr commands for GitHub workflow
 - Issue #65: Promote doit and rich to runtime dependencies
+- Issue #340: Document tooling roles and architectural boundaries
+- Issue #341: Add application CLI guide (implements the runtime-CLI half of the split)
+- Issue #348: Move doit from runtime to dev dependencies
+
+## Related Decisions
+
+- [ADR-9014: Use click for application CLI](9014-use-click-for-application-cli.md) — defines the runtime CLI surface that complements doit's dev-only role.
 
 ## Related Documentation
 
 - [Tools Reference](../tools-reference.md)
+- [CLI Guide](../../usage/cli.md)

--- a/docs/template/decisions/9005-ai-agent-command-restrictions.md
+++ b/docs/template/decisions/9005-ai-agent-command-restrictions.md
@@ -19,6 +19,8 @@ Documentation alone is insufficient - AI agents may violate rules after context 
 - Issue #163: Add pre-commit hook to block pyproject.toml version changes
 - Issue #164: Block doit release in AI agent hooks
 - Issue #166: Block uv add in AI agent hooks
+- Issue #362: Add Copilot CLI command-blocking hook integration
+- Issue #409: Complete Copilot CLI coverage in AI_SETUP, enforcement-principles, first-5-minutes
 
 ## Related Documentation
 

--- a/docs/template/decisions/9008-pr-based-development-workflow.md
+++ b/docs/template/decisions/9008-pr-based-development-workflow.md
@@ -21,4 +21,4 @@ Provides clear audit trail linking issues to PRs to commits, enables code review
 ## Related Documentation
 
 - [CI/CD Testing Guide](../../development/ci-cd-testing.md)
-- [CONTRIBUTING.md](https://github.com/endavis/pynetappfoundry/blob/main/.github/CONTRIBUTING.md)
+- [CONTRIBUTING.md](../../../.github/CONTRIBUTING.md)

--- a/docs/template/decisions/9010-use-conventional-commits-format.md
+++ b/docs/template/decisions/9010-use-conventional-commits-format.md
@@ -20,4 +20,4 @@ Provides consistent, readable git history, enables automated changelog generatio
 
 ## Related Documentation
 
-- [CONTRIBUTING.md](https://github.com/endavis/pynetappfoundry/blob/main/.github/CONTRIBUTING.md)
+- [CONTRIBUTING.md](../../../.github/CONTRIBUTING.md)

--- a/docs/template/decisions/9014-use-click-for-application-cli.md
+++ b/docs/template/decisions/9014-use-click-for-application-cli.md
@@ -1,0 +1,92 @@
+# ADR-9014: Use click for application CLI
+
+## Status
+
+Accepted
+
+## Decision
+
+Use **[click](https://click.palletsprojects.com/)** as the framework for
+the package's user-facing command-line interface. The CLI lives at
+`src/package_name/cli.py` and is registered as a console script via
+`[project.scripts]` in `pyproject.toml`:
+
+```toml
+[project.scripts]
+package-name = "package_name.cli:main"
+```
+
+`click` is added to `[project] dependencies` as a runtime dependency
+alongside `rich`.
+
+## Rationale
+
+The template previously shipped with an empty `[project.scripts]` block
+and no CLI module. Contributors adding a CLI had no obvious convention to
+follow, and `docs/development/tooling-roles.md` forward-referenced a
+guide that did not yet exist. This ADR documents the chosen framework and
+grounds the new [CLI Guide](../../usage/cli.md) in real code.
+
+The runtime/dev split documented in
+[ADR-9002](9002-use-doit-for-task-automation.md)
+and [Tooling Roles and Architectural Boundaries](../../development/tooling-roles.md)
+requires the application CLI to live under `src/package_name/` and to be
+runnable without any dev tooling (no `doit`, no `uv`). A standardized
+runtime CLI framework is needed to make that boundary concrete.
+
+`click` was chosen because it is:
+
+- **Mature and widely known.** Most Python developers have used it; the
+  learning curve is near zero.
+- **Decorator-based.** Commands, options, and arguments compose with
+  `@click.command`, `@click.option`, and `@click.argument`, which matches
+  the style already used by `pytest` fixtures and other decorator-heavy
+  libraries in the ecosystem.
+- **Low ceremony for nested subcommands.** `click.Group` + `@main.command()`
+  makes adding new subcommands a single function definition.
+- **Testable in-process.** `click.testing.CliRunner` allows asserting on
+  output and exit codes without spawning subprocesses.
+- **Small, focused, and stable.** One runtime dependency with a long
+  track record of backward compatibility.
+
+## Alternatives Considered
+
+- **`argparse` (stdlib).** No new runtime dependency, but significantly
+  more boilerplate for nested subcommands, and no in-process test runner
+  equivalent to `CliRunner`. Rejected because the boilerplate cost
+  outweighs the "no new dep" benefit for a template that expects
+  contributors to extend the CLI.
+- **`typer`.** Ergonomic type-hint-driven API, but it is built on top of
+  `click` (so it drags click in anyway), and its Rich-based help
+  formatting adds hidden coupling between the CLI framework and
+  presentation. Rejected as heavier than necessary for a template
+  baseline.
+
+## Consequences
+
+**Positive:**
+
+- The template now has a concrete, testable CLI surface that contributors
+  can extend by copying the pattern in `src/package_name/cli.py`.
+- The runtime/dev boundary is enforceable: end users of the published
+  package run `package-name ...` without needing `doit` installed.
+- New subcommands have one obvious home and one obvious test pattern.
+
+**Negative:**
+
+- Adds one runtime dependency (`click>=8.1`) to every install of the
+  published package.
+- The template now has an opinion about CLI framework that adopters who
+  prefer `argparse` or `typer` will need to replace.
+
+## Related Issues
+
+- Issue #341: Add application CLI and CLI guide
+- Issue #340: Document tooling roles and architectural boundaries
+- Issue #342: End-to-end "add a feature" example (forward reference)
+
+## Related Documentation
+
+- [CLI Guide](../../usage/cli.md)
+- [Tooling Roles and Architectural Boundaries](../../development/tooling-roles.md)
+- [ADR-9002: Use doit for task automation](9002-use-doit-for-task-automation.md)

--- a/docs/template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
+++ b/docs/template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
@@ -1,0 +1,47 @@
+# ADR-9015: install_tools framework: archive extraction and custom URLs
+
+## Status
+
+Accepted
+
+## Decision
+
+Extend `tools/doit/install_tools.py` with three orthogonal capabilities while preserving full backward compatibility:
+
+1. **`download_and_extract_archive(url, extract_binaries, dest_dir)`** — new public function for `.tar.gz`/`.tgz`/`.zip` archives with path-traversal protection (tarfile `data_filter` plus basename-only extraction and a defense-in-depth zip-slip check).
+2. **`url_template` parameter** on `install_tool()` and `create_install_task()` supporting `{version}`, `{os}`, and `{arch}` placeholders for non-GitHub-release downloads (e.g., `releases.hashicorp.com`).
+3. **`prefer_brew` flag** so callers can opt out of the macOS brew fallback when they need consistent cross-platform downloads.
+
+Supporting refactors: a private `_get_arch()` helper that maps `platform.machine()` to amd64/arm64 (passthrough for unknowns), and a private `_build_github_release_url()` so the binary path and the new archive path share URL construction.
+
+## Rationale
+
+Downstream consumers (e.g., InfraFoundry) need to install five tools, but only direnv-style single binaries from GitHub releases work today. age and sops ship as multi-binary tar.gz archives; terraform and opentofu ship from non-GitHub URLs. Without these extensions every downstream consumer reinvents download/extract code with inconsistent (often missing) security handling.
+
+The three capabilities are intentionally orthogonal so simple cases stay simple — existing direnv install code does not change — and complex cases compose naturally (`extract_binaries` and `url_template` can be combined).
+
+## Consequences
+
+**Positive:**
+- 100% backward compatible — existing direnv install task and the original 22 tests pass unchanged.
+- Downstream consumers install age, sops, terraform, and opentofu without custom download/extract code.
+- Centralized, audited safe extraction (tarfile data_filter + basename-only + zip-slip resolve check).
+- macOS users can opt into brew (default) or force download for cross-platform consistency.
+
+**Negative:**
+- Larger public API surface to maintain.
+- The framework is now responsible for safe archive extraction; security regressions here affect every downstream consumer.
+
+**Future work:**
+- SHA256 checksum verification.
+- GPG signature verification.
+- Local archive caching between runs.
+- Windows binary download support.
+
+## Related Issues
+
+- Issue #326: install_tools framework: archive extraction and custom URLs
+
+## Related Documentation
+
+- [install_tools Framework](../../development/install-tools-framework.md)

--- a/docs/template/decisions/README.md
+++ b/docs/template/decisions/README.md
@@ -25,3 +25,5 @@ Template ADRs use the **9XXX** range to avoid conflicts with project-specific AD
 | [9011](9011-use-pytest-for-testing.md) | Use pytest for testing | Accepted |
 | [9012](9012-use-mkdocs-with-material-theme-for-documentation.md) | Use mkdocs with Material theme for documentation | Accepted |
 | [9013](9013-python-version-support-policy.md) | Python version support policy with bookend CI strategy | Accepted |
+| [9014](9014-use-click-for-application-cli.md) | Use click for application CLI | Accepted |
+| [9015](9015-install-tools-framework-archive-extraction-and-custom-urls.md) | install_tools framework: archive extraction and custom URLs | Accepted |

--- a/docs/template/migration.md
+++ b/docs/template/migration.md
@@ -38,7 +38,7 @@ Use this checklist for a manual migration. The flow assumes hatch-vcs for versio
 - From the template root: `python tools/pyproject_template/manage.py`.
 - Select **[2] Configure project** to run the configurator.
 - Provide project name, package name (import), PyPI name, author, GitHub user, description.
-- **What it does:** Rewrites placeholders (badges/links/docs/workflows), renames `src/pynetappfoundry → src/<your_package>`.
+- **What it does:** Rewrites placeholders (badges/links/docs/workflows), renames `src/package_name → src/<your_package>`.
 
 See [Template Management](manage.md) for full documentation on the management script.
 

--- a/docs/template/new-project.md
+++ b/docs/template/new-project.md
@@ -127,7 +127,7 @@ The script will prompt for:
 - Package name (import name, snake_case)
 - PyPI name (package name on PyPI, typically with hyphens)
 - Author name and email
-- GitHub endavis
+- GitHub username
 - Project description
 
 ### What Configure Does
@@ -142,7 +142,7 @@ The `configure.py` script:
    - `docs/*` - Documentation content
 
 2. **Renames the source directory**:
-   - `src/pynetappfoundry/` → `src/your_pynetappfoundry/`
+   - `src/package_name/` → `src/your_package_name/`
 
 3. **Updates badge URLs** for CI, coverage, and PyPI
 
@@ -154,7 +154,7 @@ direnv allow
 
 # Or manually set up
 uv sync --all-extras --dev
-uv run pre-commit install
+doit pre_commit_install
 ```
 
 #### Enable Shell Completions (Optional)
@@ -216,9 +216,9 @@ Manually configure what the automated setup does automatically:
 
 After setup is complete:
 
-1. **Start coding** in `src/your_pynetappfoundry/`
+1. **Start coding** in `src/your_package_name/`
 2. **Write tests** in `tests/`
 3. **Update documentation** in `docs/`
 4. **Follow the workflow**: Issue → Branch → Commit → PR → Merge
 
-See [CONTRIBUTING.md](https://github.com/endavis/pyproject-template/blob/main/.github/CONTRIBUTING.md) for the development workflow.
+See [CONTRIBUTING.md](https://github.com/endavis/pyproject-template/blob/main/.github/CONTRIBUTING.md) for the development workflow, and [Tooling Roles and Architectural Boundaries](../development/tooling-roles.md) for the conventions you are inheriting from the template.

--- a/docs/template/tools-reference.md
+++ b/docs/template/tools-reference.md
@@ -103,12 +103,12 @@ Interactively prompts for project information and replaces all placeholder value
 
 | Prompt | Default | Description |
 |--------|---------|-------------|
-| Project name | pynetappfoundry | Display name for the project |
-| Package name | pynetappfoundry | Python import name (snake_case) |
-| PyPI name | pynetappfoundry | Name on PyPI (typically hyphenated) |
+| Project name | Package Name | Display name for the project |
+| Package name | package_name | Python import name (snake_case) |
+| PyPI name | package-name | Name on PyPI (typically hyphenated) |
 | Author name | Your Name | Author for package metadata |
 | Author email | your.email@example.com | Contact email |
-| GitHub endavis | endavis | Your GitHub endavis |
+| GitHub username | username | Your GitHub username |
 | Description | A short description... | One-line project description |
 
 ### Files Modified
@@ -127,7 +127,7 @@ Interactively prompts for project information and replaces all placeholder value
 ### Actions Performed
 
 1. Replaces placeholder strings with provided values
-2. Renames `src/pynetappfoundry/` to `src/your_pynetappfoundry/`
+2. Renames `src/package_name/` to `src/your_package_name/`
 3. Updates all URLs and badge links
 4. Updates documentation references
 
@@ -202,7 +202,7 @@ The script copies these template files/directories:
 - `.devcontainer/`
 - `.claude/`, `.codex/`, `.gemini/`
 - `tools/pyproject_template/`
-- `src/pynetappfoundry/` (template source)
+- `src/package_name/` (template source)
 - `tests/` (template tests)
 
 ### Backup Behavior
@@ -216,7 +216,7 @@ The script copies these template files/directories:
 After running the script:
 
 1. Run `python tools/pyproject_template/configure.py`
-2. Move your code into `src/your_pynetappfoundry/`
+2. Move your code into `src/your_package_name/`
 3. Merge your dependencies into `pyproject.toml`
 4. Run `uv lock` to regenerate lock file
 5. Run `doit check` to verify

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -1,0 +1,195 @@
+---
+title: CLI Guide
+description: The application's user-facing command-line interface and how to extend it
+audience:
+  - users
+  - contributors
+tags:
+  - cli
+  - usage
+---
+
+# CLI Guide
+
+## Purpose
+
+This page documents the **application's user-facing command-line
+interface** — the `package-name` console script shipped by the published
+package. It covers the entry point, the module layout, how to add new
+subcommands, and how to test them.
+
+This page does **not** cover `doit`, which is a contributor-only
+development task runner. For `doit` tasks, see the
+[Doit Tasks Reference](../development/doit-tasks-reference.md). For the
+architectural rationale behind the runtime/dev split, see
+[Tooling Roles and Architectural Boundaries](../development/tooling-roles.md).
+
+## Quick reference
+
+After installing the package, the `package-name` command is available on
+your `PATH`:
+
+```bash
+$ package-name greet
+Hello, World!
+
+$ package-name greet --name Python
+Hello, Python!
+
+$ package-name greet -n Python
+Hello, Python!
+
+$ package-name --version
+package_name, version 0.0.0
+```
+
+During development, prefix invocations with `uv run` to use the project
+virtual environment:
+
+```bash
+uv run package-name greet --name Python
+```
+
+## Entry point and module layout
+
+The CLI is registered in `pyproject.toml` as a console script:
+
+```toml
+[project.scripts]
+package-name = "package_name.cli:main"
+```
+
+The script name on the left (`package-name`) is the hyphen-cased
+distribution name. The value on the right points at the `main` function
+in `src/package_name/cli.py`. When the package is installed (via `uv
+sync`, `pip install`, etc.), the build backend generates an executable
+shim that calls `package_name.cli.main()`.
+
+The CLI module lives at `src/package_name/cli.py` and is a single file
+for the baseline template. Larger projects may split it into a
+`cli/` package with one file per subcommand group.
+
+## How the CLI is structured
+
+The CLI uses [click](https://click.palletsprojects.com/) as its
+framework. The top-level entry point is a `click.Group` named `main`, and
+subcommands attach to it via the `@main.command()` decorator:
+
+```python
+import click
+
+from package_name.core import greet as _greet
+
+
+@click.group()
+@click.version_option(package_name="package_name")
+def main() -> None:
+    """package_name command-line interface."""
+
+
+@main.command()
+@click.option("--name", "-n", default="World", show_default=True, help="Name to greet.")
+def greet(name: str) -> None:
+    """Print a greeting for NAME."""
+    click.echo(_greet(name))
+```
+
+Key properties:
+
+- **`main` is a `click.Group`.** This is what `[project.scripts]` points
+  at. It has no behavior of its own — it dispatches to subcommands.
+- **`@click.version_option(package_name="package_name")`** wires up
+  `--version` using the installed package metadata, so the version never
+  drifts out of sync with the git tag.
+- **Subcommands call into the runtime package.** The `greet` command
+  delegates to `package_name.core.greet`. The CLI layer handles parsing
+  and output; the core module owns the logic. This keeps the core
+  testable without invoking click and makes the CLI a thin presentation
+  layer.
+
+For the rationale behind choosing click (versus `argparse` or `typer`),
+see [ADR-9014: Use click for application CLI](../template/decisions/9014-use-click-for-application-cli.md).
+
+## How to add a new subcommand
+
+1. **Open `src/package_name/cli.py`.**
+2. **Write a function decorated with `@main.command()`.** Add options
+   and arguments with `@click.option` / `@click.argument`.
+3. **Delegate to a function in the runtime package.** Do not put business
+   logic in `cli.py` — call into `package_name.core` (or a new module)
+   and use the CLI function as a thin adapter.
+4. **Add tests in `tests/test_cli.py`** (see [Testing CLI commands](#testing-cli-commands)
+   below).
+
+Example: adding a `shout` subcommand that uppercases a name and greets
+it loudly.
+
+```python
+# src/package_name/cli.py
+
+@main.command()
+@click.argument("name")
+@click.option("--exclaim", "-e", default=1, show_default=True, help="Number of !s.")
+def shout(name: str, exclaim: int) -> None:
+    """Print an uppercase greeting for NAME."""
+    message = _greet(name.upper())
+    click.echo(message + "!" * (exclaim - 1))
+```
+
+Usage:
+
+```bash
+$ package-name shout python --exclaim 3
+Hello, PYTHON!!!
+```
+
+## Testing CLI commands
+
+Use click's in-process `CliRunner` to invoke the CLI without spawning a
+subprocess. This is faster than `subprocess.run`, has no shell-quoting
+pitfalls, and gives you direct access to exit codes and captured output.
+
+```python
+# tests/test_cli.py
+from click.testing import CliRunner
+
+from package_name.cli import main
+
+
+def test_greet_default_name() -> None:
+    """greet with no arguments prints the default greeting."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["greet"])
+    assert result.exit_code == 0
+    assert result.output == "Hello, World!\n"
+
+
+def test_greet_custom_name_long_option() -> None:
+    """greet --name substitutes the provided name."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["greet", "--name", "Python"])
+    assert result.exit_code == 0
+    assert result.output == "Hello, Python!\n"
+```
+
+What to cover for every new subcommand:
+
+- **Happy path** with default arguments (exit code 0, expected output).
+- **Each option**, long form and short form.
+- **`--help`** — exit code 0 and the option text appears.
+- **Error paths** — missing required arguments, invalid values. Click
+  returns a non-zero exit code and writes a usage message to
+  `result.output`.
+
+## See also
+
+- [Usage Guide](basics.md) — importing the package as a library.
+- [API Reference](../reference/api.md) — full API documentation.
+- [Doit Tasks Reference](../development/doit-tasks-reference.md) — the
+  contributor-only task runner. Not the same thing as this page.
+- [Tooling Roles and Architectural Boundaries](../development/tooling-roles.md) —
+  why runtime CLI and dev tooling are kept separate.
+- [ADR-9014: Use click for application CLI](../template/decisions/9014-use-click-for-application-cli.md)
+
+- [Add a Feature End-to-End](../examples/add-a-feature.md) —
+  narrative walkthrough of adding a module, CLI subcommand, tests, and docs.

--- a/examples/advanced_usage.py
+++ b/examples/advanced_usage.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Advanced usage example for package_name.
+
+This example demonstrates advanced features and best practices.
+"""
+
+from pathlib import Path
+
+from package_name import __version__, get_logger, setup_logging
+
+# Configure logging with both console and file output
+# Console: simple output (INFO: message)
+# File: structured JSON with ISO8601 timestamps
+setup_logging(level="INFO", log_file="tmp/advanced_example.log")
+logger = get_logger(__name__)
+
+
+class AdvancedExample:
+    """Example class demonstrating advanced usage patterns."""
+
+    def __init__(self, config: dict[str, str] | None = None) -> None:
+        """Initialize with optional configuration.
+
+        Args:
+            config: Optional configuration dictionary
+        """
+        self.config = config or {}
+        logger.info("Initialized AdvancedExample with config: %s", self.config)
+
+    def process_file(self, file_path: Path) -> dict[str, int]:
+        """Process a file and return statistics.
+
+        Args:
+            file_path: Path to file to process
+
+        Returns:
+            Dictionary with file statistics
+        """
+        logger.info("Processing file: %s", file_path)
+
+        # Example file processing
+        stats = {
+            "lines": 0,
+            "words": 0,
+            "chars": 0,
+        }
+
+        try:
+            if file_path.exists():
+                content = file_path.read_text()
+                stats["lines"] = len(content.splitlines())
+                stats["words"] = len(content.split())
+                stats["chars"] = len(content)
+        except Exception as e:
+            logger.error("Failed to process file: %s", e)
+            raise
+
+        return stats
+
+    def batch_process(self, files: list[Path]) -> list[dict[str, int]]:
+        """Process multiple files.
+
+        Args:
+            files: List of file paths
+
+        Returns:
+            List of statistics for each file
+        """
+        results = []
+        for file_path in files:
+            try:
+                stats = self.process_file(file_path)
+                results.append(stats)
+            except Exception as e:
+                logger.warning("Skipping file %s due to error: %s", file_path, e)
+                continue
+
+        return results
+
+
+def main() -> None:
+    """Run advanced usage examples."""
+    print(f"Advanced Examples - package_name v{__version__}")
+    print("=" * 60)
+    print()
+
+    # Example 1: Configuration
+    print("Example 1: Advanced Configuration")
+    print("-" * 60)
+    config = {
+        "option1": "value1",
+        "option2": "value2",
+    }
+    example = AdvancedExample(config=config)
+    print(f"Created instance with config: {config}")
+    print()
+
+    # Example 2: File processing
+    print("Example 2: File Processing")
+    print("-" * 60)
+    # Create a temporary file for demonstration
+    temp_file = Path("temp_example.txt")
+    temp_file.write_text("Hello, World!\nThis is a test file.")
+
+    stats = example.process_file(temp_file)
+    print(f"File statistics: {stats}")
+
+    # Clean up
+    temp_file.unlink()
+    print()
+
+    # Example 3: Batch processing
+    print("Example 3: Batch Processing")
+    print("-" * 60)
+    # Create multiple temporary files
+    files = []
+    for i in range(3):
+        file_path = Path(f"temp_{i}.txt")
+        file_path.write_text(f"File {i}\n" * (i + 1))
+        files.append(file_path)
+
+    results = example.batch_process(files)
+    for i, stats in enumerate(results):
+        print(f"File {i}: {stats}")
+
+    # Clean up
+    for file_path in files:
+        file_path.unlink()
+    print()
+
+    # Example 4: Context manager usage
+    print("Example 4: Best Practices")
+    print("-" * 60)
+    print("Using context managers for resource management:")
+    # TODO: Add context manager example if your package supports it
+    # with YourResource() as resource:
+    #     result = resource.do_something()
+    print("Resources automatically cleaned up!")
+    print()
+
+    print("All advanced examples completed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/__init__.py
+++ b/examples/api/__init__.py
@@ -1,0 +1,16 @@
+"""FastAPI example application package.
+
+This package demonstrates best practices for building REST APIs with FastAPI:
+
+- Application factory pattern (main.py)
+- Configuration with Pydantic Settings (config.py)
+- Request/response validation with Pydantic (schemas.py)
+- Dependency injection (deps.py)
+- Custom error handling (errors.py)
+- Router organization (routes/)
+
+To run:
+    uvicorn examples.api.main:app --reload
+
+Then visit http://localhost:8000/docs for Swagger UI.
+"""

--- a/examples/api/config.py
+++ b/examples/api/config.py
@@ -1,0 +1,28 @@
+"""Application configuration using Pydantic Settings.
+
+Configuration is loaded from environment variables with sensible defaults
+for development. In production, set these via environment variables or .env file.
+"""
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application settings."""
+
+    # Application
+    app_name: str = "Example API"
+    version: str = "1.0.0"
+    debug: bool = True
+
+    # Security
+    secret_key: str = "dev-secret-key-change-in-production"
+    access_token_expire_minutes: int = 30
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+# Global settings instance
+settings = Settings()

--- a/examples/api/deps.py
+++ b/examples/api/deps.py
@@ -1,0 +1,49 @@
+"""Shared dependencies for dependency injection.
+
+Dependencies are reusable components that FastAPI injects into route handlers.
+This keeps routes clean and makes testing easier through dependency overrides.
+"""
+
+from typing import Annotated
+
+from fastapi import Depends, Header, HTTPException, Query, status
+
+
+def get_api_key(x_api_key: str = Header(None)) -> str | None:
+    """Extract API key from header (optional).
+
+    In a real application, you would validate this against a database
+    or authentication service.
+    """
+    return x_api_key
+
+
+def require_api_key(x_api_key: str = Header(..., description="API key for authentication")) -> str:
+    """Require and validate API key.
+
+    Raises:
+        HTTPException: If API key is missing or invalid.
+    """
+    # In production, validate against database/service
+    valid_keys = {"test-api-key", "dev-key-12345"}
+    if x_api_key not in valid_keys:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing API key",
+            headers={"WWW-Authenticate": "ApiKey"},
+        )
+    return x_api_key
+
+
+def get_pagination(
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum records to return"),
+) -> dict[str, int]:
+    """Common pagination parameters."""
+    return {"skip": skip, "limit": limit}
+
+
+# Type aliases for cleaner route signatures
+APIKey = Annotated[str, Depends(require_api_key)]
+OptionalAPIKey = Annotated[str | None, Depends(get_api_key)]
+Pagination = Annotated[dict[str, int], Depends(get_pagination)]

--- a/examples/api/errors.py
+++ b/examples/api/errors.py
@@ -1,0 +1,69 @@
+"""Custom exceptions and error handlers.
+
+This module defines application-specific exceptions and registers
+FastAPI exception handlers for consistent error responses.
+"""
+
+from fastapi import FastAPI, Request, status
+from fastapi.responses import JSONResponse
+
+
+class NotFoundError(Exception):
+    """Resource not found."""
+
+    def __init__(self, resource: str, id: int | str) -> None:
+        self.resource = resource
+        self.id = id
+        super().__init__(f"{resource} with id {id} not found")
+
+
+class ConflictError(Exception):
+    """Resource conflict (e.g., duplicate)."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class ValidationError(Exception):
+    """Business logic validation error."""
+
+    def __init__(self, message: str, details: dict | None = None) -> None:
+        self.message = message
+        self.details = details
+        super().__init__(message)
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register custom exception handlers on the FastAPI app."""
+
+    @app.exception_handler(NotFoundError)
+    async def not_found_handler(request: Request, exc: NotFoundError):
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={
+                "error": "not_found",
+                "message": f"{exc.resource} with id {exc.id} not found",
+            },
+        )
+
+    @app.exception_handler(ConflictError)
+    async def conflict_handler(request: Request, exc: ConflictError):
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content={
+                "error": "conflict",
+                "message": exc.message,
+            },
+        )
+
+    @app.exception_handler(ValidationError)
+    async def validation_error_handler(request: Request, exc: ValidationError):
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content={
+                "error": "validation_error",
+                "message": exc.message,
+                "details": exc.details,
+            },
+        )

--- a/examples/api/main.py
+++ b/examples/api/main.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""FastAPI example application.
+
+This example demonstrates:
+- Application factory pattern
+- Router organization
+- Pydantic validation
+- Dependency injection
+- Error handling
+- OpenAPI documentation
+
+Run with:
+    uvicorn examples.api.main:app --reload
+
+Visit http://localhost:8000/docs for Swagger UI.
+"""
+
+from fastapi import FastAPI
+
+from examples.api.config import settings
+from examples.api.errors import register_exception_handlers
+from examples.api.routes import items, users
+
+
+def create_app() -> FastAPI:
+    """Application factory for creating FastAPI instances."""
+    app = FastAPI(
+        title=settings.app_name,
+        description="Example FastAPI application demonstrating best practices",
+        version=settings.version,
+        docs_url="/docs" if settings.debug else None,
+        redoc_url="/redoc" if settings.debug else None,
+    )
+
+    # Register exception handlers
+    register_exception_handlers(app)
+
+    # Include routers
+    app.include_router(users.router, prefix="/users", tags=["users"])
+    app.include_router(items.router, prefix="/items", tags=["items"])
+
+    @app.get("/", tags=["health"])
+    def root():
+        """Health check endpoint."""
+        return {"status": "ok", "app": settings.app_name, "version": settings.version}
+
+    @app.get("/health", tags=["health"])
+    def health_check():
+        """Detailed health check."""
+        return {
+            "status": "healthy",
+            "checks": {
+                "app": "ok",
+                "config": "ok",
+            },
+        }
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("examples.api.main:app", host="127.0.0.1", port=8000, reload=True)

--- a/examples/api/routes/__init__.py
+++ b/examples/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API routes package."""

--- a/examples/api/routes/items.py
+++ b/examples/api/routes/items.py
@@ -1,0 +1,155 @@
+"""Item management routes.
+
+This module demonstrates:
+- CRUD operations with owner relationship
+- Query parameters for filtering
+- Multiple response types in OpenAPI
+"""
+
+from fastapi import APIRouter, Path, Query, status
+
+from examples.api.deps import Pagination
+from examples.api.errors import NotFoundError
+from examples.api.schemas import ErrorResponse, ItemCreate, ItemResponse, ItemUpdate
+
+router = APIRouter()
+
+# In-memory "database" for demonstration
+_items_db: dict[int, dict] = {
+    1: {
+        "id": 1,
+        "name": "Widget",
+        "description": "A useful widget",
+        "price": 29.99,
+        "quantity": 100,
+        "owner_id": 1,
+    },
+    2: {
+        "id": 2,
+        "name": "Gadget",
+        "description": "An amazing gadget",
+        "price": 49.99,
+        "quantity": 50,
+        "owner_id": 1,
+    },
+    3: {
+        "id": 3,
+        "name": "Gizmo",
+        "description": None,
+        "price": 19.99,
+        "quantity": 200,
+        "owner_id": 2,
+    },
+}
+_next_id = 4
+
+
+@router.get(
+    "",
+    response_model=list[ItemResponse],
+    summary="List all items",
+    description="Retrieve items with optional filtering by owner or price range.",
+)
+def list_items(
+    pagination: Pagination,
+    owner_id: int | None = Query(None, description="Filter by owner ID"),
+    min_price: float | None = Query(None, ge=0, description="Minimum price filter"),
+    max_price: float | None = Query(None, ge=0, description="Maximum price filter"),
+):
+    """List items with pagination and optional filters."""
+    items = list(_items_db.values())
+
+    # Apply filters
+    if owner_id is not None:
+        items = [i for i in items if i["owner_id"] == owner_id]
+    if min_price is not None:
+        items = [i for i in items if i["price"] >= min_price]
+    if max_price is not None:
+        items = [i for i in items if i["price"] <= max_price]
+
+    # Apply pagination
+    skip = pagination["skip"]
+    limit = pagination["limit"]
+    return items[skip : skip + limit]
+
+
+@router.get(
+    "/{item_id}",
+    response_model=ItemResponse,
+    responses={404: {"model": ErrorResponse, "description": "Item not found"}},
+    summary="Get an item by ID",
+)
+def get_item(item_id: int = Path(..., gt=0, description="The item ID")):
+    """Get a specific item by ID."""
+    if item_id not in _items_db:
+        raise NotFoundError("Item", item_id)
+    return _items_db[item_id]
+
+
+@router.post(
+    "",
+    response_model=ItemResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a new item",
+)
+def create_item(
+    item: ItemCreate,
+    owner_id: int = Query(..., gt=0, description="ID of the item owner"),
+):
+    """Create a new item.
+
+    - **name**: Item name (1-100 characters)
+    - **description**: Optional description (up to 500 characters)
+    - **price**: Price in USD (must be positive)
+    - **quantity**: Stock quantity (default: 0)
+    """
+    global _next_id
+
+    new_item = {
+        "id": _next_id,
+        "name": item.name,
+        "description": item.description,
+        "price": item.price,
+        "quantity": item.quantity,
+        "owner_id": owner_id,
+    }
+    _items_db[_next_id] = new_item
+    _next_id += 1
+
+    return new_item
+
+
+@router.patch(
+    "/{item_id}",
+    response_model=ItemResponse,
+    responses={404: {"model": ErrorResponse, "description": "Item not found"}},
+    summary="Update an item",
+)
+def update_item(
+    item_id: int = Path(..., gt=0),
+    item_update: ItemUpdate = ...,
+):
+    """Update an existing item. Only provided fields are updated."""
+    if item_id not in _items_db:
+        raise NotFoundError("Item", item_id)
+
+    item = _items_db[item_id]
+    update_data = item_update.model_dump(exclude_unset=True)
+    item.update(update_data)
+
+    return item
+
+
+@router.delete(
+    "/{item_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={404: {"model": ErrorResponse, "description": "Item not found"}},
+    summary="Delete an item",
+)
+def delete_item(item_id: int = Path(..., gt=0)):
+    """Delete an item."""
+    if item_id not in _items_db:
+        raise NotFoundError("Item", item_id)
+
+    del _items_db[item_id]
+    return None

--- a/examples/api/routes/users.py
+++ b/examples/api/routes/users.py
@@ -1,0 +1,122 @@
+"""User management routes.
+
+This module demonstrates:
+- CRUD operations
+- Request/response validation with Pydantic
+- Dependency injection
+- Error handling
+"""
+
+from fastapi import APIRouter, Path, status
+
+from examples.api.deps import APIKey, Pagination
+from examples.api.errors import ConflictError, NotFoundError
+from examples.api.schemas import ErrorResponse, UserCreate, UserResponse, UserUpdate
+
+router = APIRouter()
+
+# In-memory "database" for demonstration
+_users_db: dict[int, dict] = {
+    1: {"id": 1, "username": "alice", "email": "alice@example.com", "is_active": True},
+    2: {"id": 2, "username": "bob", "email": "bob@example.com", "is_active": True},
+}
+_next_id = 3
+
+
+@router.get(
+    "",
+    response_model=list[UserResponse],
+    summary="List all users",
+    description="Retrieve a paginated list of all users.",
+)
+def list_users(pagination: Pagination):
+    """List users with pagination."""
+    users = list(_users_db.values())
+    skip = pagination["skip"]
+    limit = pagination["limit"]
+    return users[skip : skip + limit]
+
+
+@router.get(
+    "/{user_id}",
+    response_model=UserResponse,
+    responses={404: {"model": ErrorResponse, "description": "User not found"}},
+    summary="Get a user by ID",
+)
+def get_user(user_id: int = Path(..., gt=0, description="The user ID")):
+    """Get a specific user by their ID."""
+    if user_id not in _users_db:
+        raise NotFoundError("User", user_id)
+    return _users_db[user_id]
+
+
+@router.post(
+    "",
+    response_model=UserResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={409: {"model": ErrorResponse, "description": "Username already exists"}},
+    summary="Create a new user",
+)
+def create_user(user: UserCreate):
+    """Create a new user account.
+
+    - **username**: Must be unique, 3-50 characters
+    - **email**: Valid email address
+    - **password**: Minimum 8 characters (not stored in response)
+    """
+    global _next_id
+
+    # Check for duplicate username
+    for existing in _users_db.values():
+        if existing["username"] == user.username:
+            raise ConflictError(f"Username '{user.username}' already exists")
+
+    new_user = {
+        "id": _next_id,
+        "username": user.username,
+        "email": user.email,
+        "is_active": True,
+    }
+    _users_db[_next_id] = new_user
+    _next_id += 1
+
+    return new_user
+
+
+@router.patch(
+    "/{user_id}",
+    response_model=UserResponse,
+    responses={404: {"model": ErrorResponse, "description": "User not found"}},
+    summary="Update a user",
+)
+def update_user(
+    user_id: int = Path(..., gt=0),
+    user_update: UserUpdate = ...,
+):
+    """Update an existing user. Only provided fields are updated."""
+    if user_id not in _users_db:
+        raise NotFoundError("User", user_id)
+
+    user = _users_db[user_id]
+    update_data = user_update.model_dump(exclude_unset=True)
+    user.update(update_data)
+
+    return user
+
+
+@router.delete(
+    "/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={404: {"model": ErrorResponse, "description": "User not found"}},
+    summary="Delete a user",
+)
+def delete_user(
+    user_id: int = Path(..., gt=0),
+    api_key: APIKey = ...,  # Require authentication for delete
+):
+    """Delete a user (requires API key authentication)."""
+    if user_id not in _users_db:
+        raise NotFoundError("User", user_id)
+
+    del _users_db[user_id]
+    return None

--- a/examples/api/schemas.py
+++ b/examples/api/schemas.py
@@ -1,0 +1,104 @@
+"""Pydantic schemas for request/response validation.
+
+Schemas define the shape of data for API requests and responses.
+They provide automatic validation, serialization, and OpenAPI documentation.
+"""
+
+from pydantic import BaseModel, EmailStr, Field
+
+# --- User Schemas ---
+
+
+class UserCreate(BaseModel):
+    """Schema for creating a new user."""
+
+    username: str = Field(
+        ...,
+        min_length=3,
+        max_length=50,
+        examples=["johndoe"],
+        description="Unique username",
+    )
+    email: EmailStr = Field(..., examples=["john@example.com"])
+    password: str = Field(
+        ...,
+        min_length=8,
+        examples=["SecurePass123!"],
+        description="Password (minimum 8 characters)",
+    )
+
+
+class UserUpdate(BaseModel):
+    """Schema for updating a user (all fields optional)."""
+
+    username: str | None = Field(None, min_length=3, max_length=50)
+    email: EmailStr | None = None
+    is_active: bool | None = None
+
+
+class UserResponse(BaseModel):
+    """Schema for user responses (excludes sensitive data)."""
+
+    id: int
+    username: str
+    email: EmailStr
+    is_active: bool = True
+
+    class Config:
+        from_attributes = True  # Enable ORM mode
+
+
+# --- Item Schemas ---
+
+
+class ItemCreate(BaseModel):
+    """Schema for creating a new item."""
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        examples=["Widget"],
+        description="Item name",
+    )
+    description: str | None = Field(
+        None,
+        max_length=500,
+        examples=["A useful widget"],
+    )
+    price: float = Field(..., gt=0, examples=[29.99], description="Price in USD")
+    quantity: int = Field(default=0, ge=0, description="Stock quantity")
+
+
+class ItemUpdate(BaseModel):
+    """Schema for updating an item (all fields optional)."""
+
+    name: str | None = Field(None, min_length=1, max_length=100)
+    description: str | None = Field(None, max_length=500)
+    price: float | None = Field(None, gt=0)
+    quantity: int | None = Field(None, ge=0)
+
+
+class ItemResponse(BaseModel):
+    """Schema for item responses."""
+
+    id: int
+    name: str
+    description: str | None = None
+    price: float
+    quantity: int = 0
+    owner_id: int
+
+    class Config:
+        from_attributes = True
+
+
+# --- Error Schemas ---
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response schema."""
+
+    error: str = Field(..., description="Error type identifier")
+    message: str = Field(..., description="Human-readable error message")
+    details: dict | None = Field(None, description="Additional error details")

--- a/examples/api/tests/__init__.py
+++ b/examples/api/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the FastAPI example application."""

--- a/examples/api/tests/test_api.py
+++ b/examples/api/tests/test_api.py
@@ -1,0 +1,323 @@
+"""Tests for the FastAPI example application.
+
+These tests demonstrate how to test FastAPI applications using TestClient.
+To run these tests, install the required dependencies:
+
+    uv add fastapi uvicorn[standard] httpx pytest
+
+Then run:
+
+    pytest examples/api/tests/
+"""
+
+import pytest
+
+# Skip all tests if FastAPI is not installed
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from examples.api.main import app
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the FastAPI app."""
+    return TestClient(app)
+
+
+class TestHealthEndpoints:
+    """Tests for health check endpoints."""
+
+    def test_root_returns_ok(self, client):
+        """Test the root endpoint returns status ok."""
+        response = client.get("/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert "app" in data
+        assert "version" in data
+
+    def test_health_check(self, client):
+        """Test the health check endpoint."""
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+        assert "checks" in data
+
+
+class TestUserEndpoints:
+    """Tests for user CRUD endpoints."""
+
+    def test_list_users(self, client):
+        """Test listing users."""
+        response = client.get("/users")
+        assert response.status_code == 200
+        users = response.json()
+        assert isinstance(users, list)
+        assert len(users) >= 2  # We have 2 default users
+
+    def test_list_users_with_pagination(self, client):
+        """Test listing users with pagination."""
+        response = client.get("/users?skip=1&limit=1")
+        assert response.status_code == 200
+        users = response.json()
+        assert len(users) == 1
+
+    def test_get_user(self, client):
+        """Test getting a single user."""
+        response = client.get("/users/1")
+        assert response.status_code == 200
+        user = response.json()
+        assert user["id"] == 1
+        assert "username" in user
+        assert "email" in user
+
+    def test_get_user_not_found(self, client):
+        """Test 404 when user doesn't exist."""
+        response = client.get("/users/99999")
+        assert response.status_code == 404
+        data = response.json()
+        assert data["error"] == "not_found"
+
+    def test_create_user(self, client):
+        """Test creating a new user."""
+        response = client.post(
+            "/users",
+            json={
+                "username": "newuser",
+                "email": "newuser@example.com",
+                "password": "securepassword123",
+            },
+        )
+        assert response.status_code == 201
+        user = response.json()
+        assert user["username"] == "newuser"
+        assert user["email"] == "newuser@example.com"
+        assert "password" not in user  # Password should not be returned
+        assert user["is_active"] is True
+
+    def test_create_user_invalid_email(self, client):
+        """Test validation error for invalid email."""
+        response = client.post(
+            "/users",
+            json={
+                "username": "testuser",
+                "email": "not-an-email",
+                "password": "securepassword123",
+            },
+        )
+        assert response.status_code == 422  # Validation error
+
+    def test_create_user_password_too_short(self, client):
+        """Test validation error for short password."""
+        response = client.post(
+            "/users",
+            json={
+                "username": "testuser",
+                "email": "test@example.com",
+                "password": "short",
+            },
+        )
+        assert response.status_code == 422
+
+    def test_create_user_duplicate_username(self, client):
+        """Test conflict error for duplicate username."""
+        # First create a user
+        client.post(
+            "/users",
+            json={
+                "username": "duplicateuser",
+                "email": "dup1@example.com",
+                "password": "securepassword123",
+            },
+        )
+        # Try to create another with same username
+        response = client.post(
+            "/users",
+            json={
+                "username": "duplicateuser",
+                "email": "dup2@example.com",
+                "password": "securepassword123",
+            },
+        )
+        assert response.status_code == 409
+        data = response.json()
+        assert data["error"] == "conflict"
+
+    def test_update_user(self, client):
+        """Test updating a user."""
+        response = client.patch("/users/1", json={"username": "updated_alice"})
+        assert response.status_code == 200
+        user = response.json()
+        assert user["username"] == "updated_alice"
+
+    def test_update_user_not_found(self, client):
+        """Test 404 when updating non-existent user."""
+        response = client.patch("/users/99999", json={"username": "ghost"})
+        assert response.status_code == 404
+
+    def test_delete_user_requires_api_key(self, client):
+        """Test that delete requires API key."""
+        response = client.delete("/users/2")
+        assert response.status_code == 422  # Missing required header
+
+    def test_delete_user_invalid_api_key(self, client):
+        """Test delete with invalid API key."""
+        response = client.delete("/users/2", headers={"x-api-key": "invalid-key"})
+        assert response.status_code == 401
+
+    def test_delete_user_with_valid_api_key(self, client):
+        """Test delete with valid API key."""
+        # First create a user to delete
+        create_response = client.post(
+            "/users",
+            json={
+                "username": "tobedeleted",
+                "email": "delete@example.com",
+                "password": "securepassword123",
+            },
+        )
+        user_id = create_response.json()["id"]
+
+        # Delete with valid API key
+        response = client.delete(f"/users/{user_id}", headers={"x-api-key": "test-api-key"})
+        assert response.status_code == 204
+
+        # Verify user is gone
+        get_response = client.get(f"/users/{user_id}")
+        assert get_response.status_code == 404
+
+
+class TestItemEndpoints:
+    """Tests for item CRUD endpoints."""
+
+    def test_list_items(self, client):
+        """Test listing items."""
+        response = client.get("/items")
+        assert response.status_code == 200
+        items = response.json()
+        assert isinstance(items, list)
+        assert len(items) >= 3  # We have 3 default items
+
+    def test_list_items_filter_by_owner(self, client):
+        """Test filtering items by owner."""
+        response = client.get("/items?owner_id=1")
+        assert response.status_code == 200
+        items = response.json()
+        for item in items:
+            assert item["owner_id"] == 1
+
+    def test_list_items_filter_by_price(self, client):
+        """Test filtering items by price range."""
+        response = client.get("/items?min_price=25&max_price=40")
+        assert response.status_code == 200
+        items = response.json()
+        for item in items:
+            assert 25 <= item["price"] <= 40
+
+    def test_get_item(self, client):
+        """Test getting a single item."""
+        response = client.get("/items/1")
+        assert response.status_code == 200
+        item = response.json()
+        assert item["id"] == 1
+        assert "name" in item
+        assert "price" in item
+
+    def test_get_item_not_found(self, client):
+        """Test 404 when item doesn't exist."""
+        response = client.get("/items/99999")
+        assert response.status_code == 404
+
+    def test_create_item(self, client):
+        """Test creating a new item."""
+        response = client.post(
+            "/items?owner_id=1",
+            json={
+                "name": "New Product",
+                "description": "A brand new product",
+                "price": 99.99,
+                "quantity": 10,
+            },
+        )
+        assert response.status_code == 201
+        item = response.json()
+        assert item["name"] == "New Product"
+        assert item["price"] == 99.99
+        assert item["owner_id"] == 1
+
+    def test_create_item_minimal(self, client):
+        """Test creating item with only required fields."""
+        response = client.post(
+            "/items?owner_id=2",
+            json={
+                "name": "Minimal Item",
+                "price": 9.99,
+            },
+        )
+        assert response.status_code == 201
+        item = response.json()
+        assert item["name"] == "Minimal Item"
+        assert item["quantity"] == 0  # Default value
+
+    def test_create_item_invalid_price(self, client):
+        """Test validation error for invalid price."""
+        response = client.post(
+            "/items?owner_id=1",
+            json={
+                "name": "Free Item",
+                "price": -5.00,  # Negative price not allowed
+            },
+        )
+        assert response.status_code == 422
+
+    def test_update_item(self, client):
+        """Test updating an item."""
+        response = client.patch("/items/1", json={"price": 34.99})
+        assert response.status_code == 200
+        item = response.json()
+        assert item["price"] == 34.99
+
+    def test_delete_item(self, client):
+        """Test deleting an item."""
+        # First create an item to delete
+        create_response = client.post(
+            "/items?owner_id=1",
+            json={"name": "To Delete", "price": 1.00},
+        )
+        item_id = create_response.json()["id"]
+
+        # Delete it
+        response = client.delete(f"/items/{item_id}")
+        assert response.status_code == 204
+
+        # Verify it's gone
+        get_response = client.get(f"/items/{item_id}")
+        assert get_response.status_code == 404
+
+
+class TestOpenAPIDocumentation:
+    """Tests for OpenAPI documentation endpoints."""
+
+    def test_openapi_schema_available(self, client):
+        """Test that OpenAPI schema is available."""
+        response = client.get("/openapi.json")
+        assert response.status_code == 200
+        schema = response.json()
+        assert "openapi" in schema
+        assert "paths" in schema
+        assert "info" in schema
+
+    def test_swagger_ui_available(self, client):
+        """Test that Swagger UI is available in debug mode."""
+        response = client.get("/docs")
+        assert response.status_code == 200
+        assert "swagger" in response.text.lower()
+
+    def test_redoc_available(self, client):
+        """Test that ReDoc is available in debug mode."""
+        response = client.get("/redoc")
+        assert response.status_code == 200
+        assert "redoc" in response.text.lower()

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Basic usage example for package_name.
+
+This example demonstrates the most common usage patterns for the package.
+"""
+
+from package_name import __version__, get_logger, greet, setup_logging
+
+
+def main() -> None:
+    """Run basic usage examples."""
+    # Display package version
+    print(f"Using package_name version {__version__}")
+    print()
+
+    # Example 1: Basic operation
+    print("Example 1: Basic Operation")
+    print("-" * 40)
+
+    # Use the greet function
+    message = greet()
+    print(f"Default greeting: {message}")
+
+    custom_message = greet("Developer")
+    print(f"Custom greeting:  {custom_message}")
+
+    print("Basic operation completed successfully!")
+    print()
+
+    # Example 2: Working with data
+    print("Example 2: Working with Data")
+    print("-" * 40)
+    data = {"key": "value", "count": 42}
+    print(f"Input data: {data}")
+    # Placeholder for future data processing capabilities
+    print("Data processing is ready to be implemented.")
+    print()
+
+    # Example 3: Error handling
+    print("Example 3: Error Handling")
+    print("-" * 40)
+    try:
+        # Example of handling potential errors (if applicable)
+        # result = might_fail()
+        print("Operation succeeded!")
+    except Exception as e:
+        print(f"Caught exception: {e}")
+    print()
+
+    # Example 4: Logging
+    print("Example 4: Basic Logging")
+    print("-" * 40)
+    # Setup simple console logging
+    setup_logging(level="INFO")
+    logger = get_logger(__name__)
+
+    # Log some messages at different levels
+    logger.info("This is an info message - appears in console")
+    logger.warning("This is a warning message")
+    logger.error("This is an error message")
+
+    print("Check the console output above for log messages")
+    print("For structured JSON logging, see examples/advanced_usage.py")
+    print()
+
+    print("All examples completed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cli_usage.py
+++ b/examples/cli_usage.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""CLI usage example for package_name.
+
+This example demonstrates how to use the command-line interface
+programmatically and provides examples of CLI commands.
+"""
+
+import subprocess  # nosec B404 - subprocess is required for CLI examples
+from pathlib import Path
+
+
+def run_command(cmd: list[str]) -> tuple[int, str, str]:
+    """Run a CLI command and return results.
+
+    Args:
+        cmd: Command and arguments as list
+
+    Returns:
+        Tuple of (return_code, stdout, stderr)
+    """
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.returncode, result.stdout, result.stderr
+
+
+def main() -> None:
+    """Run CLI usage examples."""
+    print("CLI Usage Examples")
+    print("=" * 60)
+    print()
+
+    # Check if CLI is available
+    cli_cmd = "package-cli"  # Replace with your actual CLI command
+
+    # Example 1: Show help
+    print("Example 1: Show Help")
+    print("-" * 60)
+    print(f"Command: {cli_cmd} --help")
+    print()
+    print("Expected output:")
+    print("  Usage: package-cli [OPTIONS] COMMAND [ARGS]...")
+    print("  Options:")
+    print("    --help  Show this message and exit")
+    print()
+
+    # Example 2: Run a basic command
+    print("Example 2: Basic Command")
+    print("-" * 60)
+    print(f"Command: {cli_cmd} command --option value")
+    print()
+    print("This would run a basic command with an option.")
+    print()
+
+    # Example 3: Process a file
+    print("Example 3: Process File")
+    print("-" * 60)
+    temp_file = Path("temp_input.txt")
+    temp_file.write_text("Sample input data")
+
+    print(f"Command: {cli_cmd} process {temp_file}")
+    print()
+    print("This would process the input file and display results.")
+
+    # Clean up
+    if temp_file.exists():
+        temp_file.unlink()
+    print()
+
+    # Example 4: Output formats
+    print("Example 4: Output Formats")
+    print("-" * 60)
+    print(f"Command: {cli_cmd} command --format json")
+    print(f"Command: {cli_cmd} command --format yaml")
+    print(f"Command: {cli_cmd} command --format table")
+    print()
+    print("Different output formats for various use cases.")
+    print()
+
+    # Example 5: Verbose mode
+    print("Example 5: Verbose Output")
+    print("-" * 60)
+    print(f"Command: {cli_cmd} --verbose command")
+    print()
+    print("Enables detailed logging for debugging.")
+    print()
+
+    # Programmatic usage example
+    print("Example 6: Programmatic Usage")
+    print("-" * 60)
+    print("You can also call CLI commands from Python code:")
+    print()
+    print("```python")
+    print("import subprocess")
+    print()
+    print("result = subprocess.run(")
+    print(f"    ['{cli_cmd}', 'command', '--option', 'value'],")
+    print("    capture_output=True,")
+    print("    text=True,")
+    print(")")
+    print("print(result.stdout)")
+    print("```")
+    print()
+
+    print("CLI examples completed!")
+    print()
+    print("Note: These are example commands. Replace with actual")
+    print("      commands from your package's CLI interface.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Installation: getting-started/installation.md
   - Usage:
       - Basics: usage/basics.md
+      - CLI Guide: usage/cli.md
       - ONTAP Access Patterns: usage/ontap-access-patterns.md
       - DataSource: usage/data-source.md
       - Query Layer: usage/query-layer.md
@@ -78,6 +79,7 @@ nav:
       - Cache: reference/cache.md
   - Examples:
       - Overview: examples/README.md
+      - Add a Feature: examples/add-a-feature.md
       - API Examples: examples/api.md
   - Development:
       - Coding Standards: development/coding-standards.md
@@ -85,10 +87,19 @@ nav:
       - CI/CD & Testing: development/ci-cd-testing.md
       - Benchmarks: development/benchmarks.md
       - Release Process: development/release-and-automation.md
-      - AI Setup: development/AI_SETUP.md
-      - AI Command Blocking: development/ai/command-blocking.md
-      - AI Enforcement Principles: development/ai/enforcement-principles.md
-      - AI Statusline: development/ai/statusline.md
+      - Dependabot Auto-Merge: development/dependabot-automerge.md
+      - GitHub Repository Settings: development/github-repository-settings.md
+      - install_tools Framework: development/install-tools-framework.md
+      - Tooling Roles: development/tooling-roles.md
+      - AI:
+          - Setup: development/AI_SETUP.md
+          - First 5 Minutes: development/ai/first-5-minutes.md
+          - Slash Commands: development/ai/slash-commands.md
+          - Architectural Conventions: development/ai/architectural-conventions.md
+          - Command Blocking: development/ai/command-blocking.md
+          - Enforcement Principles: development/ai/enforcement-principles.md
+          - Statusline: development/ai/statusline.md
+          - Ruff-Fix Hook: development/ai/ruff-fix-hook.md
       - Adding Backends: development/adding-backends.md
       - Field Mapping Framework: development/field-mapping.md
       - Unit Registry: development/unit-registry.md
@@ -118,6 +129,8 @@ nav:
           - ADR-9011 pytest Testing: template/decisions/9011-use-pytest-for-testing.md
           - ADR-9012 MkDocs Documentation: template/decisions/9012-use-mkdocs-with-material-theme-for-documentation.md
           - ADR-9013 Python Version Policy: template/decisions/9013-python-version-support-policy.md
+          - ADR-9014 Click for CLI: template/decisions/9014-use-click-for-application-cli.md
+          - ADR-9015 install_tools Framework: template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
   - Template:
       - Overview: template/index.md
       - New Project: template/new-project.md
@@ -126,6 +139,7 @@ nav:
       - Keeping Up to Date: template/updates.md
       - AI Sync Checklist: template/ai-sync-checklist.md
       - Tools Reference: template/tools-reference.md
+  - All Documents: TABLE_OF_CONTENTS.md
 
 extra:
   social:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,8 @@ version-file = "src/pynetappfoundry/_version.py"
 [tool.ruff]
 line-length = 100
 target-version = "py312"
-extend-exclude = ["**/_version.py"]
+extend-exclude = ["**/_version.py", "examples"]
+force-exclude = true
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,8 +305,8 @@ ignore_decorators = [
 ]
 
 [tool.mutmut]
-paths_to_mutate = "src/"
-tests_dir = "tests/"
+paths_to_mutate = ["src/"]
+tests_dir = ["tests/"]
 runner = "uv run python -m pytest -x --assert=plain"
 
 [tool.commitizen]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,68 @@
 
 from __future__ import annotations
 
+import os
+from collections.abc import Callable, Iterator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
 import pytest
+from hypothesis import HealthCheck, settings
+
+# CI profile: fewer examples, relaxed deadline for slow CI runners
+settings.register_profile(
+    "ci",
+    max_examples=50,
+    deadline=500,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.differing_executors],
+)
+
+# Default profile: more thorough exploration for local development
+settings.register_profile(
+    "default",
+    max_examples=200,
+    suppress_health_check=[HealthCheck.differing_executors],
+)
+
+settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "default"))
+
+
+Spec = dict[str, Any] | BaseException | Callable[[list[str]], MagicMock | BaseException]
+
+
+@pytest.fixture
+def mock_subprocess() -> Iterator[MagicMock]:
+    """Patch ``tools.doit.github.subprocess.run`` with a prefix-dispatch mock.
+
+    Register command-prefix -> spec mappings via ``.register({...})``. Spec is one
+    of: a dict of MagicMock kwargs (``stdout``/``stderr``/``returncode``,
+    default ``returncode=0``), a ``BaseException`` instance to raise, or a
+    callable ``(cmd) -> MagicMock | BaseException`` for prefix collisions where
+    behavior depends on a later argument. Unknown prefixes raise ``AssertionError``.
+    """
+    with patch("tools.doit.github.subprocess.run") as mock_run:
+        dispatch: dict[tuple[str, ...], Spec] = {}
+
+        def side_effect(cmd: list[str], *_a: object, **_kw: object) -> MagicMock:
+            for prefix, spec in dispatch.items():
+                if tuple(cmd[: len(prefix)]) == prefix:
+                    if isinstance(spec, BaseException):
+                        raise spec
+                    if callable(spec):
+                        result = spec(cmd)
+                        if isinstance(result, BaseException):
+                            raise result
+                        return result
+                    return MagicMock(
+                        returncode=spec.get("returncode", 0),
+                        stdout=spec.get("stdout", ""),
+                        stderr=spec.get("stderr", ""),
+                    )
+            raise AssertionError(f"unexpected cmd: {cmd}")
+
+        mock_run.side_effect = side_effect
+        mock_run.register = dispatch.update
+        yield mock_run
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/test_doit_github.py
+++ b/tests/test_doit_github.py
@@ -1,6 +1,25 @@
 """Tests for github.py doit tasks."""
 
-from tools.doit.github import _extract_linked_issues, _format_merge_subject
+import io
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from rich.console import Console
+
+from tools.doit.github import (
+    _check_branch_up_to_date,
+    _close_linked_issues,
+    _ensure_branch_pushed,
+    _extract_linked_issues,
+    _fetch_github_labels,
+    _format_merge_subject,
+    _load_labels_file,
+    _reconcile_labels,
+    task_labels_sync,
+)
 
 
 class TestExtractLinkedIssues:
@@ -95,3 +114,541 @@ class TestFormatMergeSubject:
         title = "refactor: simplify complex logic"
         result = _format_merge_subject(title, 99, ["55"])
         assert result.startswith(title)
+
+
+class TestCloseLinkedIssues:
+    """Tests for _close_linked_issues helper."""
+
+    def test_closes_single_linked_issue(self, mock_subprocess: MagicMock) -> None:
+        """Single issue results in one gh issue close invocation."""
+        console = Console()
+        mock_subprocess.register({("gh", "issue", "close"): {}})
+        _close_linked_issues(["123"], 45, console)
+
+        assert mock_subprocess.call_count == 1
+        args, kwargs = mock_subprocess.call_args
+        assert args[0] == [
+            "gh",
+            "issue",
+            "close",
+            "123",
+            "--comment",
+            "Addressed in PR #45",
+        ]
+        assert kwargs["check"] is True
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+
+    def test_closes_multiple_linked_issues(self, mock_subprocess: MagicMock) -> None:
+        """Multiple issues result in multiple calls in order."""
+        console = Console()
+        mock_subprocess.register({("gh", "issue", "close"): {}})
+        _close_linked_issues(["10", "20", "30"], 7, console)
+
+        assert mock_subprocess.call_count == 3
+        called_issues = [call.args[0][3] for call in mock_subprocess.call_args_list]
+        assert called_issues == ["10", "20", "30"]
+
+    def test_no_issues_is_noop(self, mock_subprocess: MagicMock) -> None:
+        """Empty issue list results in no subprocess calls."""
+        console = Console()
+        _close_linked_issues([], 99, console)
+
+        mock_subprocess.assert_not_called()
+
+    def test_partial_failure_continues(self, mock_subprocess: MagicMock) -> None:
+        """A failure on one issue does not stop subsequent closes."""
+        console = Console()
+
+        def spec(cmd: list[str]) -> MagicMock | BaseException:
+            if cmd[3] == "20":
+                return subprocess.CalledProcessError(returncode=1, cmd=cmd, stderr="boom")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_subprocess.register({("gh", "issue", "close"): spec})
+        # Should not raise.
+        _close_linked_issues(["10", "20", "30"], 7, console)
+
+        assert mock_subprocess.call_count == 3
+        called_issues = [call.args[0][3] for call in mock_subprocess.call_args_list]
+        assert called_issues == ["10", "20", "30"]
+
+    def test_close_comment_format(self, mock_subprocess: MagicMock) -> None:
+        """The close comment must be exactly 'Addressed in PR #<n>'."""
+        console = Console()
+        mock_subprocess.register({("gh", "issue", "close"): {}})
+        _close_linked_issues(["5"], 123, console)
+
+        cmd = mock_subprocess.call_args.args[0]
+        assert cmd[4] == "--comment"
+        assert cmd[5] == "Addressed in PR #123"
+
+
+class TestCheckBranchUpToDate:
+    """Tests for _check_branch_up_to_date helper."""
+
+    @staticmethod
+    def _make_console() -> Console:
+        return Console(file=io.StringIO(), width=200)
+
+    def test_up_to_date_branch_passes(self, mock_subprocess: MagicMock) -> None:
+        """rev-list --count == 0 → helper returns cleanly."""
+        console = self._make_console()
+        mock_subprocess.register(
+            {
+                ("git", "rev-list", "--count"): {"stdout": "0\n"},
+                ("git", "fetch"): {},
+            }
+        )
+        _check_branch_up_to_date("feat/x", console)
+
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "up to date" in output.lower()
+
+    def test_behind_branch_aborts(self, mock_subprocess: MagicMock) -> None:
+        """rev-list --count > 0 → SystemExit(1) with remediation message."""
+        console = self._make_console()
+        mock_subprocess.register(
+            {
+                ("git", "rev-list", "--count"): {"stdout": "3\n"},
+                ("git", "fetch"): {},
+                ("git", "log"): {"stdout": "abc1 one\n"},
+            }
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            _check_branch_up_to_date("feat/x", console)
+
+        assert excinfo.value.code == 1
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "3 commit" in output
+        assert "git rebase origin/main" in output
+        assert "feat/x" in output
+
+    def test_fetch_failure_warns_and_proceeds(self, mock_subprocess: MagicMock) -> None:
+        """git fetch failure → warning printed, helper returns."""
+        console = self._make_console()
+        mock_subprocess.register(
+            {
+                ("git", "fetch"): subprocess.CalledProcessError(
+                    returncode=128, cmd=["git", "fetch"], stderr="could not resolve host"
+                ),
+            }
+        )
+        _check_branch_up_to_date("feat/x", console)
+
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "warning" in output.lower()
+        assert "could not resolve host" in output
+
+    def test_behind_branch_lists_missing_commits(self, mock_subprocess: MagicMock) -> None:
+        """Missing commit SHAs from `git log` appear in the output."""
+        console = self._make_console()
+        log_out = "abc1234 feat: one\ndef5678 fix: two\n"
+        mock_subprocess.register(
+            {
+                ("git", "rev-list", "--count"): {"stdout": "2\n"},
+                ("git", "fetch"): {},
+                ("git", "log"): {"stdout": log_out},
+            }
+        )
+
+        with pytest.raises(SystemExit):
+            _check_branch_up_to_date("feat/x", console)
+
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "abc1234" in output
+        assert "def5678" in output
+
+
+class TestEnsureBranchPushed:
+    """Tests for _ensure_branch_pushed helper."""
+
+    @staticmethod
+    def _make_console() -> Console:
+        return Console(file=io.StringIO(), width=200)
+
+    def test_existing_upstream_is_noop(self, mock_subprocess: MagicMock) -> None:
+        """rev-parse @{u} succeeds → no push, helper returns."""
+        console = self._make_console()
+        mock_subprocess.register(
+            {
+                ("git", "rev-parse"): {"stdout": "origin/feat/x\n"},
+            }
+        )
+        _ensure_branch_pushed("feat/x", console, no_push=False)
+
+        assert mock_subprocess.call_count == 1
+
+    def test_no_upstream_pushes(self, mock_subprocess: MagicMock) -> None:
+        """rev-parse @{u} fails → git push -u origin is called."""
+        console = self._make_console()
+        mock_subprocess.register(
+            {
+                ("git", "rev-parse"): subprocess.CalledProcessError(
+                    returncode=128, cmd=["git", "rev-parse"], stderr="no upstream configured"
+                ),
+                ("git", "push", "-u"): {},
+            }
+        )
+        _ensure_branch_pushed("feat/x", console, no_push=False)
+
+        assert mock_subprocess.call_count == 2
+        push_cmd = mock_subprocess.call_args_list[1].args[0]
+        assert push_cmd == ["git", "push", "-u", "origin", "feat/x"]
+
+    def test_push_failure_aborts(self, mock_subprocess: MagicMock) -> None:
+        """rev-parse @{u} fails and git push fails → SystemExit(1)."""
+        console = self._make_console()
+        mock_subprocess.register(
+            {
+                ("git", "rev-parse"): subprocess.CalledProcessError(
+                    returncode=128, cmd=["git", "rev-parse"], stderr="no upstream"
+                ),
+                ("git", "push", "-u"): subprocess.CalledProcessError(
+                    returncode=1,
+                    cmd=["git", "push", "-u"],
+                    stderr="remote rejected: protected branch",
+                ),
+            }
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            _ensure_branch_pushed("feat/x", console, no_push=False)
+
+        assert excinfo.value.code == 1
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "Failed to push" in output
+        assert "remote rejected" in output
+
+    def test_no_push_flag_and_no_upstream_aborts(self, mock_subprocess: MagicMock) -> None:
+        """no_push=True with missing upstream → SystemExit(1), no push."""
+        console = self._make_console()
+        mock_subprocess.register(
+            {
+                ("git", "rev-parse"): subprocess.CalledProcessError(
+                    returncode=128, cmd=["git", "rev-parse"], stderr="no upstream"
+                ),
+            }
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            _ensure_branch_pushed("feat/x", console, no_push=True)
+
+        assert excinfo.value.code == 1
+        assert mock_subprocess.call_count == 1
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "no upstream" in output.lower()
+        assert "--no-push" in output
+
+    def test_no_push_flag_with_upstream_passes(self, mock_subprocess: MagicMock) -> None:
+        """no_push=True with an upstream → returns, no push."""
+        console = self._make_console()
+        mock_subprocess.register(
+            {
+                ("git", "rev-parse"): {"stdout": "origin/feat/x\n"},
+            }
+        )
+        _ensure_branch_pushed("feat/x", console, no_push=True)
+
+        assert mock_subprocess.call_count == 1
+
+
+class TestLabelsSync:
+    """Tests for the ``labels_sync`` doit task and its helpers."""
+
+    @staticmethod
+    def _make_console() -> Console:
+        return Console(file=io.StringIO(), width=200)
+
+    @staticmethod
+    def _labels_file(tmp_path: Path, body: str) -> Path:
+        path = tmp_path / "labels.yml"
+        path.write_text(body)
+        return path
+
+    @staticmethod
+    def _register_list(mock_subprocess: MagicMock, current: list[dict[str, str]]) -> None:
+        """Wire `gh label list` to return ``current`` as JSON."""
+        mock_subprocess.register({("gh", "label", "list"): {"stdout": json.dumps(current)}})
+
+    def _run_task(
+        self,
+        dry_run: bool = False,
+        prune: bool = False,
+        file: str = "",
+    ) -> None:
+        action = task_labels_sync()["actions"][0]
+        action(dry_run=dry_run, prune=prune, file=file)
+
+    def test_creates_missing_labels(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """File has 'foo', GH has none → one gh label create call."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: foo\n  color: aaa111\n  description: Foo label\n",
+        )
+        self._register_list(mock_subprocess, [])
+        mock_subprocess.register({("gh", "label", "create"): {}})
+
+        self._run_task(file=str(labels_file))
+
+        create_calls = [
+            c for c in mock_subprocess.call_args_list if c.args[0][:3] == ["gh", "label", "create"]
+        ]
+        assert len(create_calls) == 1
+        assert create_calls[0].args[0] == [
+            "gh",
+            "label",
+            "create",
+            "foo",
+            "--color",
+            "aaa111",
+            "--description",
+            "Foo label",
+        ]
+
+    def test_updates_mismatched_labels(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """File has 'foo' color aaa111, GH has color bbb222 → one gh label edit call."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: foo\n  color: aaa111\n  description: Foo label\n",
+        )
+        self._register_list(
+            mock_subprocess,
+            [{"name": "foo", "color": "bbb222", "description": "Foo label"}],
+        )
+        mock_subprocess.register({("gh", "label", "edit"): {}})
+
+        self._run_task(file=str(labels_file))
+
+        edit_calls = [
+            c for c in mock_subprocess.call_args_list if c.args[0][:3] == ["gh", "label", "edit"]
+        ]
+        assert len(edit_calls) == 1
+        assert edit_calls[0].args[0] == [
+            "gh",
+            "label",
+            "edit",
+            "foo",
+            "--color",
+            "aaa111",
+            "--description",
+            "Foo label",
+        ]
+
+    def test_no_change_when_match(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """File and GH identical → no mutating calls."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: foo\n  color: aaa111\n  description: Foo label\n",
+        )
+        self._register_list(
+            mock_subprocess,
+            [{"name": "foo", "color": "aaa111", "description": "Foo label"}],
+        )
+
+        self._run_task(file=str(labels_file))
+
+        mutating = [
+            c
+            for c in mock_subprocess.call_args_list
+            if c.args[0][:3]
+            in (["gh", "label", "create"], ["gh", "label", "edit"], ["gh", "label", "delete"])
+        ]
+        assert mutating == []
+
+    def test_prune_deletes_extras(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """With --prune, GH has a label not in file → gh label delete is called."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: foo\n  color: aaa111\n  description: Foo label\n",
+        )
+        self._register_list(
+            mock_subprocess,
+            [
+                {"name": "foo", "color": "aaa111", "description": "Foo label"},
+                {"name": "old-label", "color": "cccccc", "description": "legacy"},
+            ],
+        )
+        mock_subprocess.register({("gh", "label", "delete"): {}})
+
+        self._run_task(file=str(labels_file), prune=True)
+
+        delete_calls = [
+            c for c in mock_subprocess.call_args_list if c.args[0][:3] == ["gh", "label", "delete"]
+        ]
+        assert len(delete_calls) == 1
+        assert delete_calls[0].args[0] == ["gh", "label", "delete", "old-label", "--yes"]
+
+    def test_no_prune_by_default(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """GH has extra label, no --prune → no delete call; extra is reported as skipped."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: foo\n  color: aaa111\n  description: Foo label\n",
+        )
+        self._register_list(
+            mock_subprocess,
+            [
+                {"name": "foo", "color": "aaa111", "description": "Foo label"},
+                {"name": "old-label", "color": "cccccc", "description": "legacy"},
+            ],
+        )
+
+        self._run_task(file=str(labels_file))
+
+        delete_calls = [
+            c for c in mock_subprocess.call_args_list if c.args[0][:3] == ["gh", "label", "delete"]
+        ]
+        assert delete_calls == []
+
+    def test_dry_run_makes_no_mutations(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """With --dry-run, only gh label list is called; no create/edit/delete."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: foo\n  color: aaa111\n  description: Foo label\n"
+            "- name: bar\n  color: bbb222\n  description: Bar label\n",
+        )
+        self._register_list(
+            mock_subprocess,
+            [
+                {"name": "bar", "color": "999999", "description": "Bar label"},
+                {"name": "legacy", "color": "cccccc", "description": "to prune"},
+            ],
+        )
+
+        self._run_task(file=str(labels_file), prune=True, dry_run=True)
+
+        mutating = [
+            c
+            for c in mock_subprocess.call_args_list
+            if c.args[0][:3]
+            in (["gh", "label", "create"], ["gh", "label", "edit"], ["gh", "label", "delete"])
+        ]
+        assert mutating == []
+
+    def test_malformed_yaml_raises_clear_error(
+        self, tmp_path: Path, mock_subprocess: MagicMock
+    ) -> None:
+        """Entry without a 'name' field → SystemExit(1) naming the offending entry."""
+        labels_file = self._labels_file(tmp_path, "- color: red\n")
+
+        with pytest.raises(SystemExit) as excinfo:
+            self._run_task(file=str(labels_file))
+
+        assert excinfo.value.code == 1
+        mock_subprocess.assert_not_called()
+
+    def test_missing_file_raises(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """--file pointing at a nonexistent path → SystemExit(1)."""
+        missing = tmp_path / "does-not-exist.yml"
+
+        with pytest.raises(SystemExit) as excinfo:
+            self._run_task(file=str(missing))
+
+        assert excinfo.value.code == 1
+        mock_subprocess.assert_not_called()
+
+    def test_color_comparison_case_insensitive(
+        self, tmp_path: Path, mock_subprocess: MagicMock
+    ) -> None:
+        """File 'FBCA04', GH 'fbca04' → no update."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: needs-triage\n  color: FBCA04\n  description: triage\n",
+        )
+        self._register_list(
+            mock_subprocess,
+            [{"name": "needs-triage", "color": "fbca04", "description": "triage"}],
+        )
+
+        self._run_task(file=str(labels_file))
+
+        mutating = [
+            c
+            for c in mock_subprocess.call_args_list
+            if c.args[0][:3]
+            in (["gh", "label", "create"], ["gh", "label", "edit"], ["gh", "label", "delete"])
+        ]
+        assert mutating == []
+
+    def test_empty_description_handled(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """File entry with empty description → create call uses --description ''."""
+        labels_file = self._labels_file(
+            tmp_path,
+            '- name: foo\n  color: aaa111\n  description: ""\n',
+        )
+        self._register_list(mock_subprocess, [])
+        mock_subprocess.register({("gh", "label", "create"): {}})
+
+        self._run_task(file=str(labels_file))
+
+        create_calls = [
+            c for c in mock_subprocess.call_args_list if c.args[0][:3] == ["gh", "label", "create"]
+        ]
+        assert len(create_calls) == 1
+        cmd = create_calls[0].args[0]
+        assert cmd[-2:] == ["--description", ""]
+
+    def test_summary_counts_correct(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """Mixed scenario (create + update + no-change + skipped) → counters correct."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "\n".join(
+                [
+                    "- name: new-one",
+                    "  color: aaa111",
+                    "  description: new",
+                    "- name: updated",
+                    "  color: bbb222",
+                    "  description: updated desc",
+                    "- name: same",
+                    "  color: cccccc",
+                    "  description: same",
+                    "",
+                ]
+            ),
+        )
+        self._register_list(
+            mock_subprocess,
+            [
+                {"name": "updated", "color": "999999", "description": "old"},
+                {"name": "same", "color": "cccccc", "description": "same"},
+                {"name": "extra", "color": "111111", "description": "extra"},
+            ],
+        )
+        mock_subprocess.register(
+            {
+                ("gh", "label", "create"): {},
+                ("gh", "label", "edit"): {},
+            }
+        )
+
+        counters = _reconcile_labels(
+            _load_labels_file(labels_file, self._make_console()),
+            _fetch_github_labels(self._make_console()),
+            prune=False,
+            dry_run=False,
+            console=self._make_console(),
+        )
+
+        assert counters["created"] == 1
+        assert counters["updated"] == 1
+        assert counters["unchanged"] == 1
+        assert counters["deleted"] == 0
+        assert counters["skipped"] == 1
+
+    def test_labels_file_parses(self) -> None:
+        """The actual .github/labels.yml parses and has non-empty entries."""
+        repo_labels = Path(__file__).resolve().parent.parent / ".github" / "labels.yml"
+        assert repo_labels.exists(), f"{repo_labels} is missing"
+
+        entries = _load_labels_file(repo_labels, self._make_console())
+        assert entries, "labels.yml should not be empty"
+
+        names = {entry["name"] for entry in entries}
+        # Two labels the issue highlighted as missing on the repo must be present.
+        assert "automerge-blocked" in names
+        assert "do-not-merge" in names
+        # Every entry must have a 6-char hex color.
+        for entry in entries:
+            assert len(entry["color"]) == 6, f"bad color for {entry['name']}: {entry['color']!r}"

--- a/tools/doit/github.py
+++ b/tools/doit/github.py
@@ -1,12 +1,15 @@
 """GitHub issue and PR creation doit tasks."""
 
+import json
 import os
 import re
 import subprocess  # nosec B404 - subprocess is required for doit tasks
 import sys
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import yaml
 from doit.tools import title_with_actions
 from rich.console import Console
 from rich.panel import Panel
@@ -15,6 +18,9 @@ from tools.doit.templates import get_issue_template, get_pr_template, get_requir
 
 if TYPE_CHECKING:
     from rich.console import Console as ConsoleType
+
+DEFAULT_LABELS_FILE = ".github/labels.yml"
+DEFAULT_LABEL_COLOR = "ededed"
 
 
 def _get_editor() -> str:
@@ -322,10 +328,20 @@ def task_pr() -> dict[str, Any]:
     2. --body-file: Reads body from a file
     3. --title + --body: Provides content directly (for AI/scripts)
 
+    Before creating the PR, the task verifies that the current branch is up
+    to date with ``origin/main`` and aborts with a remediation message if
+    it is behind. Pass ``--no-update-check`` to skip this guard.
+
+    If the current branch has no upstream, the task pushes it to ``origin``
+    automatically before calling ``gh pr create``. Pass ``--no-push`` to
+    skip the auto-push (the task will then abort if no upstream exists).
+
     Examples:
         Interactive:  doit pr
         From file:    doit pr --title="feat: add export" --body-file=pr.md
         Direct:       doit pr --title="feat: add export" --body="## Description\\n..."
+        Skip check:   doit pr --no-update-check
+        No auto-push: doit pr --no-push
     """
 
     def create_pr(
@@ -333,6 +349,8 @@ def task_pr() -> dict[str, Any]:
         body: str | None = None,
         body_file: str | None = None,
         draft: bool = False,
+        no_update_check: bool = False,
+        no_push: bool = False,
     ) -> None:
         console = Console()
         console.print()
@@ -355,6 +373,13 @@ def task_pr() -> dict[str, Any]:
             sys.exit(1)
 
         console.print(f"[dim]Current branch: {current_branch}[/dim]")
+
+        if no_update_check:
+            console.print("[dim]Skipping up-to-date check (--no-update-check).[/dim]")
+        else:
+            _check_branch_up_to_date(current_branch, console)
+
+        _ensure_branch_pushed(current_branch, console, no_push)
 
         # Try to extract issue number from branch name (e.g., feat/42-description)
         detected_issue = None
@@ -449,6 +474,20 @@ def task_pr() -> dict[str, Any]:
                 "default": False,
                 "help": "Create as draft PR",
             },
+            {
+                "name": "no_update_check",
+                "long": "no-update-check",
+                "type": bool,
+                "default": False,
+                "help": "Skip check that branch is up to date with origin/main",
+            },
+            {
+                "name": "no_push",
+                "long": "no-push",
+                "type": bool,
+                "default": False,
+                "help": "Do not auto-push a branch with no upstream (aborts instead)",
+            },
         ],
         "title": title_with_actions,
     }
@@ -529,6 +568,147 @@ def _format_merge_subject(title: str, pr_number: int, issues: list[str]) -> str:
     return f"{title} {suffix}"
 
 
+def _close_linked_issues(issues: list[str], pr_number: int, console: Console) -> None:
+    """Close each linked issue via `gh issue close` with a standard comment.
+
+    On per-issue failure, prints a yellow warning and continues. Does not
+    raise — the merge has already succeeded, partial failure is reported
+    but not fatal.
+
+    Args:
+        issues: List of issue numbers to close.
+        pr_number: PR number used in the close comment.
+        console: Rich console for output.
+    """
+    if not issues:
+        console.print("[dim]No linked issues to close.[/dim]")
+        return
+
+    comment = f"Addressed in PR #{pr_number}"
+    for issue in issues:
+        try:
+            subprocess.run(
+                ["gh", "issue", "close", issue, "--comment", comment],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            console.print(f"[green]Closed issue #{issue}[/green]")
+        except subprocess.CalledProcessError as e:
+            stderr = (e.stderr or "").strip()
+            console.print(f"[yellow]Failed to close #{issue}: {stderr}[/yellow]")
+
+
+def _check_branch_up_to_date(current_branch: str, console: Console) -> None:
+    """Abort PR creation if the current branch is behind ``origin/main``.
+
+    Fetches ``origin/main`` and compares it to ``HEAD``. If the branch is
+    behind, prints the count, the missing commits, and the rebase command
+    to run, then calls ``sys.exit(1)``. If the fetch itself fails (network
+    down, unreachable remote), prints a warning and returns — a flaky
+    network should not block PR creation.
+
+    Args:
+        current_branch: Name of the feature branch (used in remediation message).
+        console: Rich console for output.
+    """
+    try:
+        subprocess.run(
+            ["git", "fetch", "origin", "main"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        console.print(f"[yellow]Warning: `git fetch origin main` failed: {stderr}[/yellow]")
+        console.print("[yellow]Skipping up-to-date check; proceeding.[/yellow]")
+        return
+
+    count_result = subprocess.run(
+        ["git", "rev-list", "--count", "HEAD..origin/main"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    behind = int(count_result.stdout.strip() or "0")
+
+    if behind == 0:
+        console.print("[green]Branch is up to date with origin/main.[/green]")
+        return
+
+    log_result = subprocess.run(
+        ["git", "log", "--oneline", "-n", "10", "HEAD..origin/main"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    console.print()
+    console.print(f"[red]Branch is {behind} commit(s) behind origin/main.[/red]")
+    console.print("[dim]Missing commits:[/dim]")
+    for line in log_result.stdout.strip().splitlines():
+        console.print(f"  {line}")
+    console.print()
+    console.print("[yellow]Rebase and force-push, then re-run `doit pr`:[/yellow]")
+    console.print(
+        f"  git rebase origin/main && git push --force-with-lease origin {current_branch}"
+    )
+    console.print()
+    console.print("[dim]Use `doit pr --no-update-check` to skip this check.[/dim]")
+    sys.exit(1)
+
+
+def _ensure_branch_pushed(current_branch: str, console: Console, no_push: bool) -> None:
+    """Ensure the current branch has an upstream on ``origin``.
+
+    If the branch already has an upstream, returns silently. Otherwise,
+    runs ``git push -u origin <branch>`` to create it. On push failure,
+    calls ``sys.exit(1)``.
+
+    When ``no_push`` is True and the branch has no upstream, aborts with
+    ``sys.exit(1)`` without attempting to push.
+
+    Args:
+        current_branch: Name of the branch to push.
+        console: Rich console for output.
+        no_push: If True, never push; abort if upstream is missing.
+    """
+    try:
+        subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return
+    except subprocess.CalledProcessError:
+        pass
+
+    if no_push:
+        console.print(
+            f"[red]Branch '{current_branch}' has no upstream and --no-push was passed.[/red]"
+        )
+        console.print(f"[yellow]Push manually: git push -u origin {current_branch}[/yellow]")
+        sys.exit(1)
+
+    console.print(f"[dim]Pushing {current_branch} to origin...[/dim]")
+    try:
+        subprocess.run(
+            ["git", "push", "-u", "origin", current_branch],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        console.print(f"[red]Failed to push {current_branch}:[/red]")
+        console.print(f"[red]{stderr}[/red]")
+        sys.exit(1)
+
+    console.print(f"[dim]Pushed {current_branch} to origin.[/dim]")
+
+
 def task_pr_merge() -> dict[str, Any]:
     """Merge a PR with properly formatted commit message.
 
@@ -542,11 +722,13 @@ def task_pr_merge() -> dict[str, Any]:
         doit pr_merge                    # Merge PR for current branch
         doit pr_merge --pr=123           # Merge specific PR
         doit pr_merge --delete-branch    # Also delete the branch after merge
+        doit pr_merge --pr=123 --auto-close  # Close linked issues after merge
     """
 
     def merge_pr(
         pr: str | None = None,
         delete_branch: bool = True,
+        auto_close: bool = False,
     ) -> None:
         console = Console()
         console.print()
@@ -616,17 +798,21 @@ def task_pr_merge() -> dict[str, Any]:
                 )
             )
 
-            # Reminder to update linked issues
-            console.print()
-            console.print(
-                Panel.fit(
-                    "[bold yellow]Reminder: Update linked issues[/bold yellow]\n\n"
-                    "Examples:\n"
-                    f'  gh issue close <number> --comment "Addressed in PR #{pr_number}"\n'
-                    f'  gh issue comment <number> --body "Addressed in PR #{pr_number}"',
-                    border_style="yellow",
+            if auto_close:
+                console.print()
+                _close_linked_issues(issues, pr_number, console)
+            else:
+                # Reminder to update linked issues
+                console.print()
+                console.print(
+                    Panel.fit(
+                        "[bold yellow]Reminder: Update linked issues[/bold yellow]\n\n"
+                        "Examples:\n"
+                        f'  gh issue close <number> --comment "Addressed in PR #{pr_number}"\n'
+                        f'  gh issue comment <number> --body "Addressed in PR #{pr_number}"',
+                        border_style="yellow",
+                    )
                 )
-            )
         except subprocess.CalledProcessError as e:
             console.print("[red]Failed to merge PR.[/red]")
             if e.stderr:
@@ -648,6 +834,351 @@ def task_pr_merge() -> dict[str, Any]:
                 "type": bool,
                 "default": True,
                 "help": "Delete branch after merge (default: True)",
+            },
+            {
+                "name": "auto_close",
+                "long": "auto-close",
+                "type": bool,
+                "default": False,
+                "help": "Close linked issues after merge with a standard comment",
+            },
+        ],
+        "title": title_with_actions,
+    }
+
+
+def _load_labels_file(path: Path, console: Console) -> list[dict[str, str]]:
+    """Parse a YAML labels file into a list of normalized label dicts.
+
+    Each entry must be a mapping with a required ``name`` field. ``color``
+    defaults to :data:`DEFAULT_LABEL_COLOR` and ``description`` defaults to
+    an empty string. Extra fields are ignored. Malformed entries cause
+    ``sys.exit(1)`` with a message naming the offending index.
+
+    Args:
+        path: Path to the labels YAML file.
+        console: Rich console for error output.
+
+    Returns:
+        List of ``{"name": str, "color": str, "description": str}`` dicts.
+    """
+    if not path.exists():
+        console.print(f"[red]Labels file not found: {path}[/red]")
+        sys.exit(1)
+
+    try:
+        raw = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as e:
+        console.print(f"[red]Failed to parse {path}: {e}[/red]")
+        sys.exit(1)
+
+    if raw is None:
+        return []
+
+    if not isinstance(raw, list):
+        console.print(f"[red]Labels file must be a YAML list, got {type(raw).__name__}.[/red]")
+        sys.exit(1)
+
+    labels: list[dict[str, str]] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            console.print(
+                f"[red]Labels file entry #{index} must be a mapping, "
+                f"got {type(entry).__name__}.[/red]"
+            )
+            sys.exit(1)
+
+        name = entry.get("name")
+        if not isinstance(name, str) or not name.strip():
+            console.print(
+                f"[red]Labels file entry #{index} is missing a 'name' field "
+                f"(entry: {entry!r}).[/red]"
+            )
+            sys.exit(1)
+
+        color_raw = entry.get("color", DEFAULT_LABEL_COLOR)
+        if not isinstance(color_raw, str):
+            console.print(
+                f"[red]Labels file entry '{name}' has a non-string 'color' "
+                f"(got {type(color_raw).__name__}).[/red]"
+            )
+            sys.exit(1)
+
+        description = entry.get("description", "")
+        if description is None:
+            description = ""
+        if not isinstance(description, str):
+            console.print(
+                f"[red]Labels file entry '{name}' has a non-string 'description' "
+                f"(got {type(description).__name__}).[/red]"
+            )
+            sys.exit(1)
+
+        labels.append(
+            {
+                "name": name.strip(),
+                "color": color_raw.strip().lstrip("#").lower(),
+                "description": description,
+            }
+        )
+
+    return labels
+
+
+def _fetch_github_labels(console: Console) -> dict[str, dict[str, str]]:
+    """Fetch the current label set from GitHub via ``gh label list``.
+
+    Parses the returned JSON into a ``{name: {color, description}}`` map
+    with colors lowercased for case-insensitive comparison.
+
+    Args:
+        console: Rich console for error output.
+
+    Returns:
+        Dict keyed by label name.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "label", "list", "--limit", "200", "--json", "name,color,description"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        console.print("[red]Failed to fetch labels from GitHub:[/red]")
+        console.print(f"[red]{stderr}[/red]")
+        sys.exit(1)
+
+    try:
+        data = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as e:
+        console.print(f"[red]Could not parse `gh label list` output: {e}[/red]")
+        sys.exit(1)
+
+    if not isinstance(data, list):
+        console.print("[red]Unexpected `gh label list` output (not a list).[/red]")
+        sys.exit(1)
+
+    labels: dict[str, dict[str, str]] = {}
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str):
+            continue
+        color = entry.get("color", "") or ""
+        description = entry.get("description", "") or ""
+        labels[name] = {
+            "name": name,
+            "color": str(color).lower(),
+            "description": str(description),
+        }
+    return labels
+
+
+def _reconcile_labels(
+    desired: list[dict[str, str]],
+    current: dict[str, dict[str, str]],
+    *,
+    prune: bool,
+    dry_run: bool,
+    console: Console,
+) -> dict[str, int]:
+    """Reconcile desired labels with the current GitHub state.
+
+    Performs create/edit/delete operations (or prints the planned actions
+    in ``dry_run`` mode). Colors are compared case-insensitively.
+
+    Args:
+        desired: Normalized list of labels from the YAML file.
+        current: Map of current GitHub labels keyed by name.
+        prune: If True, delete labels present on GitHub but absent from the file.
+        dry_run: If True, print planned actions and make no mutating API calls.
+        console: Rich console for output.
+
+    Returns:
+        Dict of counters: ``created``, ``updated``, ``unchanged``, ``deleted``, ``skipped``.
+    """
+    counters = {"created": 0, "updated": 0, "unchanged": 0, "deleted": 0, "skipped": 0}
+    desired_names = {entry["name"] for entry in desired}
+
+    for entry in desired:
+        name = entry["name"]
+        color = entry["color"]
+        description = entry["description"]
+        existing = current.get(name)
+
+        if existing is None:
+            prefix = "would create" if dry_run else "created"
+            console.print(f"[green]+ {prefix}[/green] {name} (color={color})")
+            counters["created"] += 1
+            if not dry_run:
+                _run_label_cmd(
+                    [
+                        "gh",
+                        "label",
+                        "create",
+                        name,
+                        "--color",
+                        color,
+                        "--description",
+                        description,
+                    ],
+                    console,
+                )
+            continue
+
+        if existing["color"] == color and existing["description"] == description:
+            console.print(f"[dim]= no change[/dim] {name}")
+            counters["unchanged"] += 1
+            continue
+
+        prefix = "would update" if dry_run else "updated"
+        console.print(f"[yellow]~ {prefix}[/yellow] {name} (color={color})")
+        counters["updated"] += 1
+        if not dry_run:
+            _run_label_cmd(
+                [
+                    "gh",
+                    "label",
+                    "edit",
+                    name,
+                    "--color",
+                    color,
+                    "--description",
+                    description,
+                ],
+                console,
+            )
+
+    extras = sorted(set(current) - desired_names)
+    for name in extras:
+        if prune:
+            prefix = "would delete" if dry_run else "deleted"
+            console.print(f"[red]- {prefix}[/red] {name}")
+            counters["deleted"] += 1
+            if not dry_run:
+                _run_label_cmd(["gh", "label", "delete", name, "--yes"], console)
+        else:
+            console.print(f"[dim]? skipped[/dim] {name} (not in file; use --prune to delete)")
+            counters["skipped"] += 1
+
+    return counters
+
+
+def _run_label_cmd(cmd: list[str], console: Console) -> None:
+    """Invoke a ``gh label`` subcommand and abort on failure.
+
+    Args:
+        cmd: Full command argument list.
+        console: Rich console for error output.
+    """
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        console.print(f"[red]Command failed: {' '.join(cmd)}[/red]")
+        console.print(f"[red]{stderr}[/red]")
+        sys.exit(1)
+
+
+def task_labels_sync() -> dict[str, Any]:
+    """Sync GitHub labels with ``.github/labels.yml`` (idempotent).
+
+    Reads the labels file and reconciles the repository's GitHub labels:
+
+    - Missing labels are created.
+    - Labels whose color or description differ are updated.
+    - Labels present on GitHub but absent from the file are left alone
+      unless ``--prune`` is passed (then they are deleted).
+
+    Color comparison is case-insensitive.
+
+    Examples:
+        doit labels_sync                        # Reconcile, do not prune.
+        doit labels_sync --dry-run              # Preview changes only.
+        doit labels_sync --prune                # Also delete extra labels.
+        doit labels_sync --file=custom/labels.yml
+    """
+
+    def sync_labels(
+        dry_run: bool = False,
+        prune: bool = False,
+        file: str = DEFAULT_LABELS_FILE,
+    ) -> None:
+        console = Console()
+        console.print()
+        mode = "(dry run)" if dry_run else ""
+        console.print(
+            Panel.fit(
+                f"[bold cyan]Syncing GitHub Labels[/bold cyan] {mode}".rstrip(),
+                border_style="cyan",
+            )
+        )
+        console.print()
+
+        try:
+            desired = _load_labels_file(Path(file), console)
+            if not desired:
+                console.print(f"[yellow]No labels defined in {file}; nothing to sync.[/yellow]")
+                return
+
+            console.print(f"[dim]Loaded {len(desired)} label(s) from {file}[/dim]")
+            current = _fetch_github_labels(console)
+            console.print(f"[dim]Fetched {len(current)} label(s) from GitHub[/dim]")
+            console.print()
+
+            counters = _reconcile_labels(
+                desired,
+                current,
+                prune=prune,
+                dry_run=dry_run,
+                console=console,
+            )
+
+            console.print()
+            summary = (
+                f"{counters['created']} created, "
+                f"{counters['updated']} updated, "
+                f"{counters['unchanged']} unchanged, "
+                f"{counters['deleted']} deleted, "
+                f"{counters['skipped']} skipped"
+            )
+            console.print(
+                Panel.fit(
+                    f"[bold green]Label sync complete[/bold green]\n\n{summary}",
+                    border_style="green",
+                )
+            )
+        except SystemExit:
+            raise
+        except Exception as e:  # pragma: no cover - defensive catch-all
+            console.print(f"[red]Unexpected error during label sync: {e}[/red]")
+            sys.exit(1)
+
+    return {
+        "actions": [sync_labels],
+        "params": [
+            {
+                "name": "dry_run",
+                "long": "dry-run",
+                "type": bool,
+                "default": False,
+                "help": "Print planned changes without calling gh label create/edit/delete",
+            },
+            {
+                "name": "prune",
+                "long": "prune",
+                "type": bool,
+                "default": False,
+                "help": "Delete labels present on GitHub but absent from the file",
+            },
+            {
+                "name": "file",
+                "long": "file",
+                "default": DEFAULT_LABELS_FILE,
+                "help": f"Path to labels YAML file (default: {DEFAULT_LABELS_FILE})",
             },
         ],
         "title": title_with_actions,

--- a/tools/doit/install.py
+++ b/tools/doit/install.py
@@ -39,6 +39,19 @@ def task_install_dev() -> dict[str, Any]:
     }
 
 
+def task_install_gh() -> dict[str, Any]:
+    """Install GitHub CLI for repository operations."""
+    return create_install_task(
+        name="gh",
+        repo="cli/cli",
+        asset_patterns={},
+        url_template="https://github.com/cli/cli/releases/download/v{version}/gh_{version}_{os}_{arch}.tar.gz",
+        extract_binaries=["gh"],
+        version_cmd=["gh", "--version"],
+        prefer_brew=False,
+    )
+
+
 def task_install_direnv() -> dict[str, Any]:
     """Install direnv for automatic environment loading."""
     return create_install_task(

--- a/tools/doit/install_tools.py
+++ b/tools/doit/install_tools.py
@@ -11,7 +11,10 @@ import platform
 import shutil
 import subprocess  # nosec B404 - subprocess is required for version checks
 import sys
+import tarfile
+import tempfile
 import urllib.request
+import zipfile
 from pathlib import Path
 from typing import Any
 
@@ -54,6 +57,36 @@ def get_install_dir() -> Path:
     return install_dir
 
 
+def _get_arch() -> str:
+    """Map platform.machine() output to a normalized architecture name.
+
+    Returns:
+        "amd64" for x86_64, "arm64" for aarch64, otherwise the raw machine
+        name lowercased (passthrough).
+    """
+    machine = platform.machine().lower()
+    if machine == "x86_64":
+        return "amd64"
+    if machine == "aarch64":
+        return "arm64"
+    return machine
+
+
+def _build_github_release_url(repo: str, version: str, asset_pattern: str) -> str:
+    """Build a GitHub release asset download URL.
+
+    Args:
+        repo: GitHub repository in "owner/name" format.
+        version: Release version (without leading 'v').
+        asset_pattern: Filename pattern with optional {version} placeholder.
+
+    Returns:
+        Fully constructed download URL.
+    """
+    asset_name = asset_pattern.format(version=version)
+    return f"https://github.com/{repo}/releases/download/v{version}/{asset_name}"
+
+
 def download_github_release_binary(
     repo: str, version: str, asset_pattern: str, dest_name: str
 ) -> Path:
@@ -73,8 +106,7 @@ def download_github_release_binary(
     Returns:
         Path to the downloaded and installed binary.
     """
-    asset_name = asset_pattern.format(version=version)
-    url = f"https://github.com/{repo}/releases/download/v{version}/{asset_name}"
+    url = _build_github_release_url(repo, version, asset_pattern)
     install_dir = get_install_dir()
     dest_path = install_dir / dest_name
 
@@ -85,12 +117,112 @@ def download_github_release_binary(
     return dest_path
 
 
+def download_and_extract_archive(
+    url: str, extract_binaries: list[str], dest_dir: Path
+) -> list[Path]:
+    """Download an archive and extract specific binaries from it.
+
+    Supports `.tar.gz`/`.tgz` and `.zip` archives. Binaries are matched by
+    basename (any directory structure inside the archive is ignored).
+    Each extracted file is made executable (0o755).
+
+    Security:
+        - Tar archives use ``tarfile.data_filter`` (Python 3.12+) when
+          available to block path traversal, symlinks, etc.
+        - Zip archives use basename-only extraction with a defense-in-depth
+          zip-slip resolve check.
+
+    Args:
+        url: URL to download the archive from. Format is detected from
+            the URL extension.
+        extract_binaries: List of binary basenames to extract from the
+            archive (e.g. ``["age", "age-keygen"]``).
+        dest_dir: Directory to write extracted binaries into. Created if
+            it does not exist.
+
+    Returns:
+        List of Paths to the extracted binaries.
+
+    Raises:
+        ValueError: If the URL has an unsupported archive extension.
+        RuntimeError: If a requested binary is not found in the archive.
+    """
+    url_lower = url.lower()
+    if url_lower.endswith((".tar.gz", ".tgz")):
+        suffix = ".tar.gz"
+        archive_kind = "tar"
+    elif url_lower.endswith(".zip"):
+        suffix = ".zip"
+        archive_kind = "zip"
+    else:
+        raise ValueError(f"Unsupported archive extension: {url}")
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    wanted = set(extract_binaries)
+    extracted: dict[str, Path] = {}
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        temp_path = Path(tmp.name)
+    try:
+        print(f"Downloading {url}...")
+        urllib.request.urlretrieve(url, temp_path)  # nosec B310 - URL provided by trusted caller
+
+        if archive_kind == "tar":
+            with tarfile.open(temp_path, "r:gz") as tar:  # nosec B202 - data_filter set below when available
+                if hasattr(tarfile, "data_filter"):
+                    tar.extraction_filter = tarfile.data_filter
+                for member in tar.getmembers():
+                    if not member.isfile():
+                        continue
+                    basename = Path(member.name).name
+                    if basename not in wanted or basename in extracted:
+                        continue
+                    src = tar.extractfile(member)
+                    if src is None:
+                        continue
+                    out_path = dest_dir / basename
+                    with open(out_path, "wb") as out:
+                        shutil.copyfileobj(src, out)
+                    out_path.chmod(0o755)  # nosec B103 - executable bit required
+                    extracted[basename] = out_path
+        else:  # zip
+            with zipfile.ZipFile(temp_path) as zf:
+                for entry in zf.namelist():
+                    if entry.endswith("/"):
+                        continue
+                    basename = Path(entry).name
+                    if basename not in wanted or basename in extracted:
+                        continue
+                    out_path = dest_dir / basename
+                    # Defense in depth against zip-slip; basename-only
+                    # extraction already prevents traversal.
+                    resolved = out_path.resolve()
+                    if not str(resolved).startswith(str(dest_dir.resolve())):
+                        raise RuntimeError(f"Refusing to extract outside dest_dir: {entry}")
+                    data = zf.read(entry)
+                    out_path.write_bytes(data)
+                    out_path.chmod(0o755)  # nosec B103 - executable bit required
+                    extracted[basename] = out_path
+
+        missing = [b for b in extract_binaries if b not in extracted]
+        if missing:
+            raise RuntimeError(f"Binary {missing[0]} not found in archive")
+
+        return [extracted[b] for b in extract_binaries]
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+
+
 def install_tool(
     name: str,
     repo: str,
     asset_patterns: dict[str, str],
     version_cmd: list[str] | None = None,
     post_install_message: str | None = None,
+    extract_binaries: list[str] | None = None,
+    url_template: str | None = None,
+    prefer_brew: bool = True,
 ) -> None:
     """Install a tool from GitHub releases if not already present.
 
@@ -107,6 +239,16 @@ def install_tool(
         version_cmd: Command list to run for checking installed version
             (e.g. ["tool", "--version"]). Defaults to [name, "--version"].
         post_install_message: Optional message printed after installation.
+        extract_binaries: Optional list of binary basenames to extract from
+            a downloaded archive (e.g. ``["age", "age-keygen"]``). When set,
+            the download is treated as an archive (`.tar.gz`/`.tgz`/`.zip`)
+            and binaries are extracted into the install dir.
+        url_template: Optional download URL template with ``{version}``,
+            ``{os}``, and ``{arch}`` placeholders. When set, this is used
+            instead of building a GitHub release URL from ``asset_patterns``.
+        prefer_brew: When True (the default), use ``brew install`` on macOS
+            instead of downloading. Set False to force download even on
+            macOS (useful for cross-platform consistency).
     """
     if version_cmd is None:
         version_cmd = [name, "--version"]
@@ -119,7 +261,7 @@ def install_tool(
             check=True,
         )
         version_output = result.stdout.strip() or result.stderr.strip()
-        print(f"OK: {name} already installed: {version_output}")
+        print(f"[OK] {name} already installed: {version_output}")
         return
 
     print(f"Installing {name}...")
@@ -127,20 +269,36 @@ def install_tool(
     print(f"Latest version: {version}")
 
     system = platform.system().lower()
-    if system == "darwin":
-        subprocess.run(["brew", "install", name], check=True)
-    elif system in asset_patterns:
-        download_github_release_binary(
-            repo=repo,
-            version=version,
-            asset_pattern=asset_patterns[system],
-            dest_name=name,
-        )
-    else:
-        print(f"Unsupported OS for {name}: {system}")
-        sys.exit(1)
 
-    print(f"OK: {name} installed.")
+    if system == "darwin" and prefer_brew and url_template is None:
+        subprocess.run(["brew", "install", name], check=True)
+    else:
+        if url_template is not None:
+            url = url_template.format(version=version, os=system, arch=_get_arch())
+        elif system in asset_patterns:
+            url = _build_github_release_url(repo, version, asset_patterns[system])
+        else:
+            print(f"Unsupported OS for {name}: {system}")
+            sys.exit(1)
+
+        if extract_binaries:
+            download_and_extract_archive(url, extract_binaries, get_install_dir())
+        else:
+            if url_template is not None:
+                install_dir = get_install_dir()
+                dest_path = install_dir / name
+                print(f"Downloading {url}...")
+                urllib.request.urlretrieve(url, dest_path)  # nosec B310 - URL from trusted caller template
+                dest_path.chmod(0o755)  # nosec B103 - executable bit required
+            else:
+                download_github_release_binary(
+                    repo=repo,
+                    version=version,
+                    asset_pattern=asset_patterns[system],
+                    dest_name=name,
+                )
+
+    print(f"[OK] {name} installed.")
     if post_install_message:
         print(post_install_message)
 
@@ -151,6 +309,9 @@ def create_install_task(
     asset_patterns: dict[str, str],
     version_cmd: list[str] | None = None,
     post_install_message: str | None = None,
+    extract_binaries: list[str] | None = None,
+    url_template: str | None = None,
+    prefer_brew: bool = True,
 ) -> dict[str, Any]:
     """Create a doit task dict for installing a tool from GitHub releases.
 
@@ -164,6 +325,12 @@ def create_install_task(
         asset_patterns: Mapping of platform names to asset filename patterns.
         version_cmd: Command list for version check. Defaults to [name, "--version"].
         post_install_message: Optional message printed after installation.
+        extract_binaries: Optional list of binary basenames to extract from
+            a downloaded archive. See :func:`install_tool`.
+        url_template: Optional download URL template with ``{version}``,
+            ``{os}``, ``{arch}`` placeholders. See :func:`install_tool`.
+        prefer_brew: Use brew on macOS when True (default). See
+            :func:`install_tool`.
 
     Returns:
         A doit task dictionary with actions and title.
@@ -176,6 +343,9 @@ def create_install_task(
             asset_patterns=asset_patterns,
             version_cmd=version_cmd,
             post_install_message=post_install_message,
+            extract_binaries=extract_binaries,
+            url_template=url_template,
+            prefer_brew=prefer_brew,
         )
 
     return {
@@ -217,24 +387,21 @@ def _install_age() -> None:
         print(f"Downloading {tar_url}...")
         urllib.request.urlretrieve(tar_url, tar_path)  # nosec B310
 
-        import tarfile
-
         with tarfile.open(tar_path, "r:gz") as tar:
             tar.extractall("/tmp")  # nosec B202 B108
 
         for binary in ["age", "age-keygen"]:
-            src = Path("/tmp/age") / binary
+            src = Path("/tmp/age") / binary  # nosec B108
             dst = install_dir / binary
             shutil.move(str(src), str(dst))
             dst.chmod(0o755)  # nosec B103
 
         tar_path.unlink()
-        shutil.rmtree("/tmp/age", ignore_errors=True)
+        shutil.rmtree("/tmp/age", ignore_errors=True)  # nosec B108
     elif system == "darwin":
         subprocess.run(["brew", "install", "age"], check=True)
     elif system == "windows":
         import glob
-        import zipfile
 
         zip_url = f"https://github.com/FiloSottile/age/releases/download/v{version}/age-v{version}-windows-amd64.zip"
         zip_path = Path(os.environ.get("TEMP", ".")) / "age.zip"

--- a/tools/doit/maintenance.py
+++ b/tools/doit/maintenance.py
@@ -145,7 +145,7 @@ def task_update_deps() -> dict[str, Any]:
         print()
         if check_result.returncode == 0:
             print("=" * 70)
-            print(" " * 20 + "✓ All checks passed!")
+            print(" " * 20 + "[OK] All checks passed!")
             print("=" * 70)
             print()
             print("Next steps:")

--- a/tools/doit/testing.py
+++ b/tools/doit/testing.py
@@ -36,12 +36,3 @@ def task_mutate() -> dict[str, Any]:
         "title": title_with_actions,
         "verbosity": 2,
     }
-
-
-def task_mutate_html() -> dict[str, Any]:
-    """Generate HTML report from mutmut results."""
-    return {
-        "actions": ["uv run mutmut html --html-dir tmp/mutmut"],
-        "title": title_with_actions,
-        "verbosity": 2,
-    }

--- a/tools/hooks/ai/block-dangerous-commands.py
+++ b/tools/hooks/ai/block-dangerous-commands.py
@@ -16,9 +16,11 @@ For full documentation, see: docs/development/ai/command-blocking.md
 """
 
 import json
+import os
 import shlex
 import subprocess  # nosec B404 - needed for git branch detection
 import sys
+from pathlib import Path
 
 # Protected branches - operations on these require extra scrutiny
 PROTECTED_BRANCHES = {"main", "master"}
@@ -126,6 +128,8 @@ def check_push_to_protected(tokens: list[str]) -> tuple[bool, str]:
 
     Blocks any git push when the current branch is a protected branch.
     Force pushes to protected branches are also blocked even from feature branches.
+
+    Scans all positions to handle chained commands (e.g., git status; git push --force).
     """
     tokens_lower = [t.lower() for t in tokens]
 
@@ -133,50 +137,61 @@ def check_push_to_protected(tokens: list[str]) -> tuple[bool, str]:
     if "git" not in tokens_lower or "push" not in tokens_lower:
         return False, ""
 
-    try:
-        git_idx = tokens_lower.index("git")
-    except ValueError:
-        return False, ""
+    # Find ALL positions where git + push appear as a pair
+    for git_idx in range(len(tokens_lower) - 1):
+        if tokens_lower[git_idx] != "git":
+            continue
 
-    # Ensure "push" is the git subcommand, not part of another command like "git stash push"
-    subcommand_idx = git_idx + 1
-    if subcommand_idx >= len(tokens_lower) or tokens_lower[subcommand_idx] != "push":
-        return False, ""
+        # Ensure "push" is the git subcommand, not part of another command like "git stash push"
+        subcommand_idx = git_idx + 1
+        if tokens_lower[subcommand_idx] != "push":
+            continue
 
-    # Check if any force flag is present
-    has_force_flag = any(flag in tokens for flag in FORCE_PUSH_FLAGS)
+        # Determine the end of this git push command (next git/doit/gh/uv token or end)
+        cmd_end = len(tokens)
+        for j in range(subcommand_idx + 1, len(tokens_lower)):
+            # A new command starts at a token that is a known command root
+            # Also handle shell operators that got merged with tokens (e.g., "status;")
+            if tokens_lower[j] in ("git", "doit", "gh", "uv"):
+                cmd_end = j
+                break
+        cmd_tokens = tokens[git_idx:cmd_end]
 
-    # Find the push index to look for branch/remote after it
-    push_idx = subcommand_idx
+        # Check if any force flag is present in this git push command
+        has_force_flag = any(flag in cmd_tokens for flag in FORCE_PUSH_FLAGS)
 
-    # Look for branch name in tokens after 'push'
-    # Skip flags (tokens starting with -)
-    after_push = [t for t in tokens[push_idx + 1 :] if not t.startswith("-")]
+        # Look for branch name in tokens after 'push'
+        # Skip flags (tokens starting with -)
+        push_idx = subcommand_idx
+        after_push = [t for t in tokens[push_idx + 1 : cmd_end] if not t.startswith("-")]
 
-    # Check if explicitly pushing to a protected branch
-    for token in after_push:
-        # Handle origin/main format
-        branch = token.split("/")[-1] if "/" in token else token
+        # Check if explicitly pushing to a protected branch
+        for token in after_push:
+            # Handle origin/main format
+            branch = token.split("/")[-1] if "/" in token else token
 
-        if branch.lower() in PROTECTED_BRANCHES:
+            if branch.lower() in PROTECTED_BRANCHES:
+                action = "Force push" if has_force_flag else "Push"
+                return True, f"{action} to protected branch '{branch}'"
+
+        # Check if currently on a protected branch (catches bare `git push`)
+        current_branch = get_current_branch()
+        if (
+            current_branch
+            and current_branch.lower() in PROTECTED_BRANCHES
+            and (not after_push or (len(after_push) == 1 and after_push[0] == "origin"))
+        ):
             action = "Force push" if has_force_flag else "Push"
-            return True, f"{action} to protected branch '{branch}'"
+            return True, (
+                f"{action} while on protected branch '{current_branch}'. "
+                f"Create a feature branch first"
+            )
 
-    # Check if currently on a protected branch (catches bare `git push`)
-    current_branch = get_current_branch()
-    if (
-        current_branch
-        and current_branch.lower() in PROTECTED_BRANCHES
-        and (not after_push or (len(after_push) == 1 and after_push[0] == "origin"))
-    ):
-        action = "Force push" if has_force_flag else "Push"
-        return True, (
-            f"{action} while on protected branch '{current_branch}'. Create a feature branch first"
-        )
-
-    # Force push without explicit branch from a feature branch — block as safety
-    if has_force_flag and (not after_push or (len(after_push) == 1 and after_push[0] == "origin")):
-        return True, "Force push without explicit branch (could affect protected branch)"
+        # Force push without explicit branch from a feature branch — block as safety
+        if has_force_flag and (
+            not after_push or (len(after_push) == 1 and after_push[0] == "origin")
+        ):
+            return True, "Force push without explicit branch (could affect protected branch)"
 
     return False, ""
 
@@ -190,30 +205,47 @@ def check_delete_protected_branch(tokens: list[str]) -> tuple[bool, str]:
     - git push origin :main
     - git branch -D main
     - git branch -d main
+
+    Scans all positions to handle chained commands (e.g., git log; git push origin --delete main).
     """
     tokens_lower = [t.lower() for t in tokens]
 
-    # Check for remote branch deletion: git push origin --delete main
-    if "git" in tokens_lower and "push" in tokens_lower and "--delete" in tokens_lower:
-        for token in tokens:
-            if token.lower() in PROTECTED_BRANCHES:
-                return True, f"Deleting protected remote branch '{token}'"
+    # Scan for all git token positions
+    for git_idx in range(len(tokens_lower)):
+        if tokens_lower[git_idx] != "git":
+            continue
 
-    # Check for remote branch deletion with colon syntax: git push origin :main
-    if "git" in tokens_lower and "push" in tokens_lower:
-        for token in tokens:
-            if token.startswith(":") and token[1:].lower() in PROTECTED_BRANCHES:
-                return True, f"Deleting protected remote branch '{token[1:]}'"
+        if git_idx + 1 >= len(tokens_lower):
+            continue
 
-    # Check for local branch deletion: git branch -D main or git branch -d main
-    if (
-        "git" in tokens_lower
-        and "branch" in tokens_lower
-        and ("-d" in tokens_lower or "-D" in tokens)
-    ):
-        for token in tokens:
-            if token.lower() in PROTECTED_BRANCHES:
-                return True, f"Deleting protected local branch '{token}'"
+        subcommand = tokens_lower[git_idx + 1]
+
+        # Determine the end of this git command (next command root or end)
+        cmd_end = len(tokens)
+        for j in range(git_idx + 2, len(tokens_lower)):
+            if tokens_lower[j] in ("git", "doit", "gh", "uv"):
+                cmd_end = j
+                break
+        cmd_tokens = tokens[git_idx:cmd_end]
+        cmd_tokens_lower = tokens_lower[git_idx:cmd_end]
+
+        # Check for remote branch deletion: git push origin --delete main
+        if subcommand == "push" and "--delete" in cmd_tokens_lower:
+            for token in cmd_tokens:
+                if token.lower() in PROTECTED_BRANCHES:
+                    return True, f"Deleting protected remote branch '{token}'"
+
+        # Check for remote branch deletion with colon syntax: git push origin :main
+        if subcommand == "push":
+            for token in cmd_tokens:
+                if token.startswith(":") and token[1:].lower() in PROTECTED_BRANCHES:
+                    return True, f"Deleting protected remote branch '{token[1:]}'"
+
+        # Check for local branch deletion: git branch -D main or git branch -d main
+        if subcommand == "branch" and ("-d" in cmd_tokens_lower or "-D" in cmd_tokens):
+            for token in cmd_tokens:
+                if token.lower() in PROTECTED_BRANCHES:
+                    return True, f"Deleting protected local branch '{token}'"
 
     return False, ""
 
@@ -243,13 +275,15 @@ def check_blocked_workflow_commands(tokens: list[str]) -> tuple[bool, str]:
     Check if command uses blocked workflow commands.
 
     These commands should use doit wrappers instead of direct gh commands.
+    Scans all positions to catch commands chained with && or ;.
     """
     tokens_lower = [t.lower() for t in tokens]
 
     for cmd_tuple, reason in BLOCKED_WORKFLOW_COMMANDS.items():
         cmd_len = len(cmd_tuple)
-        if len(tokens_lower) >= cmd_len and tuple(tokens_lower[:cmd_len]) == cmd_tuple:
-            return True, reason
+        for i in range(len(tokens_lower) - cmd_len + 1):
+            if tuple(tokens_lower[i : i + cmd_len]) == cmd_tuple:
+                return True, reason
     return False, ""
 
 
@@ -365,6 +399,54 @@ def check_command(command: str) -> tuple[bool, str]:
     return False, ""
 
 
+def _parse_input(input_data: dict) -> tuple[str, str]:
+    """
+    Parse tool name and command from hook input.
+
+    Handles two input formats:
+    - Claude/Gemini: {"tool_name": "Bash", "tool_input": {"command": "..."}}
+    - Copilot CLI:   {"toolName": "bash", "toolArgs": "{\"command\":\"...\"}"}
+
+    Returns:
+        (tool_name, command) tuple
+    """
+    # Copilot CLI format uses camelCase keys
+    if "toolName" in input_data:
+        tool_name = input_data.get("toolName", "")
+        tool_args_raw = input_data.get("toolArgs", "{}")
+        try:
+            tool_args = (
+                json.loads(tool_args_raw) if isinstance(tool_args_raw, str) else tool_args_raw
+            )
+        except json.JSONDecodeError:
+            tool_args = {}
+        return tool_name, tool_args.get("command", "")
+
+    # Claude/Gemini format uses snake_case keys
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+    return tool_name, tool_input.get("command", "")
+
+
+def _is_copilot_format(input_data: dict) -> bool:
+    """Return True if input uses Copilot CLI hook format (camelCase keys)."""
+    return "toolName" in input_data
+
+
+LOG_FILE = Path(__file__).parent / "hook-debug.jsonl"
+
+
+def _log(entry: dict) -> None:
+    """Append a JSON log entry. Only active when HOOK_DEBUG=1 is set."""
+    if not os.environ.get("HOOK_BLOCKCOMMAND_DEBUG"):
+        return
+    try:
+        with LOG_FILE.open("a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError:
+        pass  # Never fail due to logging
+
+
 def main() -> int:
     """Main entry point."""
     try:
@@ -373,28 +455,53 @@ def main() -> int:
         print(f"Invalid JSON input: {e}", file=sys.stderr)
         return 1
 
-    tool_name = input_data.get("tool_name", "")
-    tool_input = input_data.get("tool_input", {})
+    tool_name, command = _parse_input(input_data)
+    copilot_format = _is_copilot_format(input_data)
 
-    # Only check shell commands (Bash for Claude, run_shell_command for Gemini)
-    if tool_name not in ("Bash", "run_shell_command"):
+    _log(
+        {
+            "raw_input": input_data,
+            "tool_name": tool_name,
+            "command": command,
+            "copilot_format": copilot_format,
+        }
+    )
+
+    # Only check shell commands:
+    # - "Bash" for Claude
+    # - "run_shell_command" for Gemini
+    # - "bash" for Copilot CLI
+    if tool_name not in ("Bash", "run_shell_command", "bash"):
         return 0
 
-    command = tool_input.get("command", "")
     if not command:
         return 0
 
     is_dangerous, reason = check_command(command)
     if is_dangerous:
-        print(
-            f"BLOCKED: Command contains dangerous pattern.\n"
-            f"Reason: {reason}\n"
-            f"Command: {command}\n"
-            f"\n"
-            f"If this is intentional, ask the user to run it manually.",
-            file=sys.stderr,
-        )
-        return 2  # Exit 2 = Block and show stderr to Claude
+        if copilot_format:
+            # Copilot CLI: deny via JSON output to stdout
+            output = json.dumps(
+                {
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": (
+                        f"Blocked: {reason}. If intentional, ask the user to run it manually."
+                    ),
+                }
+            )
+            print(output)
+            return 0
+        else:
+            # Claude/Gemini: block via exit code 2 + stderr message
+            print(
+                f"BLOCKED: Command contains dangerous pattern.\n"
+                f"Reason: {reason}\n"
+                f"Command: {command}\n"
+                f"\n"
+                f"If this is intentional, ask the user to run it manually.",
+                file=sys.stderr,
+            )
+            return 2  # Exit 2 = Block and show stderr to Claude/Gemini
 
     return 0
 

--- a/tools/hooks/ai/ruff-fix-on-edit.py
+++ b/tools/hooks/ai/ruff-fix-on-edit.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Claude Code PostToolUse hook that runs ``ruff --fix`` on edited Python files.
+
+Triggered after ``Edit``/``Write``/``MultiEdit`` tool calls. When the touched
+file is a tracked Python source path, runs a fast ``ruff check --fix`` for
+unused imports/variables and import ordering, followed by ``ruff format``.
+
+The hook is best-effort: any failure (timeout, ruff missing, malformed payload)
+is swallowed and the hook exits 0 so it never blocks a tool call. The next
+``doit check`` will surface any genuine issue.
+
+For full documentation, see: docs/development/ai/ruff-fix-hook.md
+"""
+
+import json
+import os
+import subprocess  # nosec B404 - required to invoke ruff
+import sys
+from pathlib import Path
+
+# Path roots whose Python files are eligible for the auto-fix.
+# Mirrors the scope of ``doit format`` / ``doit lint``.
+ALLOWED_ROOTS: tuple[str, ...] = ("src/", "tests/", "tools/")
+
+# Specific files at the project root that are also eligible.
+# (pynetappfoundry does not ship a bootstrap.py; leave empty.)
+ALLOWED_FILES: tuple[str, ...] = ()
+
+# Ruff rule selectors restricted to deterministic, judgment-free fixes:
+#   F401 - unused imports
+#   F841 - unused local variables
+#   I    - import ordering
+SELECTED_RULES = "F401,F841,I"
+
+# Per-invocation timeout for ruff (covers both ``check`` and ``format`` calls).
+RUFF_TIMEOUT_SECONDS = 30
+
+
+def _is_in_scope(rel_path: str) -> bool:
+    """Return True iff *rel_path* is a Python file inside the auto-fix scope."""
+    if not rel_path.endswith(".py"):
+        return False
+    if rel_path in ALLOWED_FILES:
+        return True
+    return any(rel_path.startswith(root) for root in ALLOWED_ROOTS)
+
+
+def run_ruff(path: Path) -> None:
+    """Run ``ruff check --fix`` then ``ruff format`` on *path*.
+
+    Best-effort: every exception is swallowed. This function must never raise.
+    """
+    try:
+        subprocess.run(  # nosec B603 B607 - trusted ruff invocation
+            [
+                "uv",
+                "run",
+                "ruff",
+                "check",
+                "--fix",
+                "--select",
+                SELECTED_RULES,
+                "--quiet",
+                str(path),
+            ],
+            capture_output=True,
+            timeout=RUFF_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    except Exception:  # nosec B110 - hook must never raise; errors would block tool calls
+        pass
+
+    try:
+        subprocess.run(  # nosec B603 B607 - trusted ruff invocation
+            ["uv", "run", "ruff", "format", "--quiet", str(path)],
+            capture_output=True,
+            timeout=RUFF_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    except Exception:  # nosec B110 - hook must never raise; errors would block tool calls
+        pass
+
+
+def _normalize_path(raw_path: str, project_dir: str) -> str | None:
+    """Return *raw_path* as a project-relative POSIX-style string.
+
+    Returns None if the path is absolute and outside the project directory
+    (we never auto-fix files we don't own).
+    """
+    path = Path(raw_path)
+    if not path.is_absolute():
+        return raw_path
+
+    if not project_dir:
+        return None
+
+    try:
+        return path.relative_to(project_dir).as_posix()
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; tests call this directly."""
+    try:
+        try:
+            input_data = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0
+
+        if not isinstance(input_data, dict):
+            return 0
+
+        tool_input = input_data.get("tool_input")
+        if not isinstance(tool_input, dict):
+            return 0
+
+        raw_file_path = tool_input.get("file_path")
+        if not isinstance(raw_file_path, str) or not raw_file_path:
+            return 0
+
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+        rel_path = _normalize_path(raw_file_path, project_dir)
+        if rel_path is None:
+            return 0
+
+        if not _is_in_scope(rel_path):
+            return 0
+
+        # Resolve to an absolute path for the existence check and ruff call.
+        target = Path(project_dir) / rel_path if project_dir else Path(rel_path)
+        if not target.is_file():
+            return 0
+
+        run_ruff(target)
+    except Exception:  # hook must never raise
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/test_hook.py
+++ b/tools/hooks/ai/test_hook.py
@@ -119,6 +119,18 @@ EOF
     # === SHOULD ALLOW - Other labels ===
     ("gh pr edit 123 --add-label bug", "ALLOW", "add bug label"),
     ("gh pr edit 123 --add-label enhancement", "ALLOW", "add enhancement label"),
+    # === SHOULD BLOCK - Nested/chained commands ===
+    ("cd /path && doit release", "BLOCK", "chained doit release"),
+    ("cd /path && gh pr create --fill", "BLOCK", "chained gh pr create"),
+    ("cd /path && uv add requests", "BLOCK", "chained uv add"),
+    ("cd /path && git push --force origin main", "BLOCK", "chained force push main"),
+    ("git status; git push --force origin main", "BLOCK", "semicolon force push main"),
+    ("git status; git push origin --delete main", "BLOCK", "semicolon delete main"),
+    ("git log; git branch -D main", "BLOCK", "semicolon branch -D main"),
+    # === SHOULD ALLOW - Nested/chained safe commands ===
+    ("cd /path && doit check", "ALLOW", "chained doit check"),
+    ("cd /path && git status", "ALLOW", "chained git status"),
+    ("git status; git push origin feat/branch", "ALLOW", "semicolon push feature"),
     # === SHOULD ALLOW - Other gh commands ===
     ("gh issue list", "ALLOW", "gh issue list"),
     ("gh pr list", "ALLOW", "gh pr list"),

--- a/tools/pyproject_template/__init__.py
+++ b/tools/pyproject_template/__init__.py
@@ -14,6 +14,9 @@ from .configure import (
     load_defaults,
     run_configure,
 )
+from .migrate_existing_project import (
+    run_migrate,
+)
 from .settings import (
     ProjectContext,
     ProjectSettings,
@@ -43,14 +46,16 @@ __all__ = [
     "TemplateState",
     "get_template_commits_since",
     "get_template_latest_commit",
+    # Configure
+    "load_defaults",
+    "run_configure",
     # Check updates
     "compare_files",
     "download_template",
     "get_latest_release",
     "run_check_updates",
-    # Configure
-    "load_defaults",
-    "run_configure",
+    # Migrate
+    "run_migrate",
     # Utils
     "Colors",
     "GitHubCLI",

--- a/tools/pyproject_template/migrate_existing_project.py
+++ b/tools/pyproject_template/migrate_existing_project.py
@@ -1,0 +1,261 @@
+"""
+Helper script to apply this template onto an existing repository.
+
+Usage:
+    python tools/pyproject_template/migrate_existing_project.py --target /path/to/existing/repo
+    # Optional: download the template archive (no local checkout needed)
+    python tools/pyproject_template/migrate_existing_project.py --target /path/to/repo --download
+
+What it does:
+    - Optionally downloads the template (zip/tar) into target/tmp and extracts it
+    - Backs up any files/dirs it would overwrite into a timestamped backup folder
+      (under target/tmp/)
+    - Copies core template files (tooling, docs, workflows, editor config)
+    - Prints a summary of moved/backed-up items and next steps
+
+This does NOT run the interactive configurator or move your source code. After
+copying, you still need to:
+    - Run `python configure.py` in the target repo to set project/package info
+    - Move your code into src/<package_name>/ and fix imports
+    - Merge dependencies/metadata into the new pyproject.toml
+    - Regenerate uv.lock and rerun checks
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import shutil
+import sys
+from pathlib import Path
+
+# Support running as script or as module
+_script_dir = Path(__file__).parent
+if str(_script_dir) not in sys.path:
+    sys.path.insert(0, str(_script_dir))
+
+# Import shared utilities
+from utils import TEMPLATE_URL, Logger, download_and_extract_archive  # noqa: E402
+
+DEFAULT_ARCHIVE_URL = f"{TEMPLATE_URL}/archive/refs/heads/main.zip"
+
+
+TEMPLATE_REL_PATHS: tuple[str, ...] = (
+    # Config and tooling
+    "pyproject.toml",
+    "dodo.py",
+    "tools/pyproject_template/configure.py",
+    ".envrc",
+    ".envrc.local.example",
+    ".pre-commit-config.yaml",
+    ".python-version",
+    "mkdocs.yml",
+    ".editorconfig",
+    ".gitignore",
+    "src/package_name",
+    # Docs and guides
+    "AGENTS.md",
+    "CHANGELOG.md",
+    "docs",
+    "examples",
+    # Project scaffolding / automation
+    ".github",
+    ".devcontainer",
+    ".vscode",
+    ".claude",
+    ".codex",
+    ".gemini",
+    "tools",
+    "tmp/.gitkeep",
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Copy pyproject-template scaffolding into an existing repo with backups.",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        type=Path,
+        help="Path to the existing repository you want to update.",
+    )
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=None,
+        help="Path to the pyproject-template root (defaults to this script's "
+        "repo unless --download).",
+    )
+    parser.add_argument(
+        "--download",
+        action="store_true",
+        help="Download the template archive into target/tmp instead of using a local checkout.",
+    )
+    parser.add_argument(
+        "--archive-url",
+        type=str,
+        default=DEFAULT_ARCHIVE_URL,
+        help=f"URL to template archive (zip/tarball). Default: {DEFAULT_ARCHIVE_URL}",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be copied without making changes.",
+    )
+    return parser.parse_args(argv)
+
+
+def ensure_exists(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def run_migrate(
+    target: Path,
+    template: Path | None = None,
+    download: bool = False,
+    archive_url: str = DEFAULT_ARCHIVE_URL,
+    dry_run: bool = False,
+) -> int:
+    """Migrate an existing project to use pyproject-template.
+
+    Args:
+        target: Path to the existing repository to update.
+        template: Path to the pyproject-template root.
+        download: Download the template archive instead of using local checkout.
+        archive_url: URL to template archive.
+        dry_run: Show what would be done without making changes.
+
+    Returns:
+        Exit code (0 for success, non-zero for error).
+    """
+    target_root = target.resolve()
+
+    if download:
+        if dry_run:
+            Logger.info(f"Dry run: Would download template from {archive_url}")
+            template_root = Path(__file__).resolve().parent.parent.parent
+        else:
+            tmp_dir = target_root / "tmp"
+            ensure_exists(tmp_dir)
+            print(f"Downloading template archive from {archive_url} ...")
+
+            template_root = download_and_extract_archive(archive_url, tmp_dir)
+            Logger.success(f"Template downloaded to {template_root}")
+    else:
+        # Default to the root of the repo containing this script
+        # Script is at tools/pyproject_template/migrate_existing_project.py
+        # Root is ../../..
+        template_root = (template or Path(__file__).resolve().parent.parent.parent).resolve()
+
+    if not template_root.exists():
+        Logger.error(f"Template path does not exist: {template_root}")
+        return 1
+    if not target_root.exists():
+        Logger.error(f"Target path does not exist: {target_root}")
+        return 1
+
+    timestamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_root = target_root / "tmp" / f"template-migration-backup-{timestamp}"
+
+    backed_up: list[tuple[Path, Path]] = []
+    copied: list[Path] = []
+    skipped: list[Path] = []
+    would_backup: list[Path] = []
+
+    for rel in TEMPLATE_REL_PATHS:
+        src = template_root / rel
+        dst = target_root / rel
+
+        if not src.exists():
+            skipped.append(src)
+            continue
+
+        if dst.exists():
+            if dry_run:
+                would_backup.append(dst)
+            else:
+                backup_path = backup_root / rel
+                ensure_exists(backup_path.parent)
+                shutil.move(str(dst), str(backup_path))
+                backed_up.append((dst, backup_path))
+
+        if dry_run:
+            copied.append(dst)
+        else:
+            if src.is_dir():
+                shutil.copytree(src, dst)
+            else:
+                ensure_exists(dst.parent)
+                shutil.copy2(src, dst)
+            copied.append(dst)
+
+    print("\n=== Template Migration Helper ===")
+    print(f"Template: {template_root}")
+    print(f"Target  : {target_root}")
+    if dry_run:
+        print("Mode    : DRY RUN (no changes made)")
+    else:
+        print(f"Backup  : {backup_root}")
+    print()
+
+    if copied:
+        print("Would copy:" if dry_run else "Copied:")
+        for path in copied:
+            print(f"  - {path.relative_to(target_root)}")
+    else:
+        print("Copied: (none)")
+
+    print()
+    if dry_run and would_backup:
+        print("Would back up existing items before overwrite:")
+        for path in would_backup:
+            print(f"  - {path.relative_to(target_root)}")
+    elif backed_up:
+        print("Backed up existing items before overwrite:")
+        for original, backup in backed_up:
+            print(f"  - {original.relative_to(target_root)} -> {backup.relative_to(target_root)}")
+    else:
+        print("Backed up: (none needed)")
+
+    if skipped:
+        print()
+        print("Skipped (not present in template):")
+        for path in skipped:
+            print(f"  - {path.relative_to(template_root)}")
+
+    if dry_run:
+        print("\nDry run complete - no changes were made.")
+    else:
+        print("\nNext steps:")
+        print(" 1) Run: python tools/pyproject_template/configure.py")
+        print(" 2) Move your source code into src/<package_name>/ and fix imports")
+        print(" 3) Merge your dependencies into pyproject.toml")
+        print(" 4) Run: uv sync && doit check")
+        print(" 5) Review backed-up files and port any custom content")
+        print("\nFuture updates:")
+        print(" • Run: python tools/pyproject_template/check_template_updates.py")
+        print(" • This will show what changed in the template since migration")
+        print("\nDone.")
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for CLI usage."""
+    args = parse_args(argv)
+    return run_migrate(
+        target=args.target,
+        template=args.template,
+        download=args.download,
+        archive_url=args.archive_url,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    print("This script should not be run directly.")
+    print("Please use: python manage.py")
+    sys.exit(1)


### PR DESCRIPTION
## Description

Syncs the project with `endavis/pyproject-template` from commit `75cbe9b3` to `64c7aca0`. This is a pure maintenance/tooling sync — no runtime `src/pynetappfoundry/` code is touched and no public API changes. 80 files changed (+8038, -483) spread across template tooling, GitHub workflows, AI agent config, developer docs, and new template ADRs.

Template compare: https://github.com/endavis/pyproject-template/compare/75cbe9b3...64c7aca0

## Related Issue

Addresses #614

Related / complementary: #615 (pygments CVE bump follow-up cleanup).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement
- [x] Chore / template sync (tooling, workflows, AI agent config, developer docs)

## Changes Made

Delivered in 10 logically-scoped commits on top of `main`:

1. `c44aa982` — `chore(template): adopt new template files and dirs (614)`
2. `0f8b80b9` — `chore(workflows): sync GitHub Actions workflows (614)`
3. `cd660422` — `chore(doit): sync tools/doit task files (614)`
4. `6c5f19ab` — `chore(hooks): sync AI hooks and agent settings (614)`
5. `0b1f7453` — `chore(config): sync docs, mkdocs navigation, and .gitignore (614)`
6. `d1acd499` — `chore(pyproject): sync [tool.*] blocks with pyproject-template (614)`
7. `d3467e0c` — `chore(agents): merge new sections into AGENTS.md (614)`
8. `ac56d739` — `chore(template): bump sync pin to 64c7aca0 (614)`
9. `4dd27949` — `chore(template): adopt migrate_existing_project tooling (614)`
10. `09a71891` — `chore(template): adopt updated slash commands and github tests (614)`

Commits 9 and 10 are a small scope expansion discovered during final verification — they cover the `migrate_existing_project.py` tooling and updated slash commands + expanded `test_doit_github.py` (15 → 41 tests) that the original 8-commit plan missed.

### Preserved carve-outs (intentional divergences from upstream template)

These are project-specific settings that were **deliberately kept** during the sync. Reviewers should confirm each one is still in place:

- **`bootstrap.py` NOT added** — project-level carve-out. Stripped from `doit` lint/format/type-check/codespell/bandit target lists so the absence is not an error.
- **`.github/workflows/ci.yml`:**
  - SOPS install steps for Linux/macOS/Windows preserved.
  - `--ignore-vuln CVE-2026-4539` preserved.
  - `pip install --upgrade pip` preserved (CVE-2026-1703).
  - `pynetappfoundry` package references preserved.
  - Python 3.13 codecov filter preserved.
- **`.python-version` / `.github/python-versions.json`** — project keeps 3.13 as oldest supported (template is 3.12).
- **Benchmark/mutation workflows** — pinned to Python 3.13 (template uses 3.14).
- **`.github/workflows/breaking-change-detection.yml`** — unchanged. Retains `pynetappfoundry` refs, `_version.py` filter, and 64KB truncation.
- **`tools/doit/security.py`** — `--ignore-vuln CVE-2026-4539` preserved.
- **`tools/doit/install.py`** — `src/pynetappfoundry/_version.py` handling preserved.
- **`tools/doit/install_tools.py`** — custom `_install_age` with Windows `age.exe` handling preserved.
- **Project-only doit tasks untouched:** `audit_models.py`, `audit_nested.py`, `benchmark.py`, `codegen.py`, `template_clean.py`.
- **`AGENTS.md`** — Cache Schema Pitfalls section preserved.
- **`pyproject.toml` preserved blocks:**
  - `[project]` metadata
  - `[tool.hatch.*]`
  - Project-specific `[tool.ruff.lint.per-file-ignores]`
  - `[tool.mypy.overrides]`
  - `[tool.coverage.run].source`
  - `[tool.bandit].skips`
  - `[tool.codespell]`
  - `[tool.vulture].ignore_decorators`
  - `[dependency-groups]`

### Adopted upstream changes worth flagging

- `examples/` added to ruff `extend-exclude` with `force-exclude=true` so the new template-provided `examples/` tree doesn't break our strict ANN lint.
- `[tool.mutmut]` switched to the list format from the template.
- New template ADRs copied as-is under `docs/template/decisions/`:
  - `9014-use-click-for-application-cli.md`
  - `9015-install-tools-framework-archive-extraction-and-custom-urls.md`
- `test_doit_github.py` expanded from 15 to 41 tests.

## Testing

- [x] All existing tests pass (`doit check` — tests, lint, format, type-check, security, spell-check all green locally)
- [ ] Added new tests for new functionality — N/A for a template sync; template-provided test expansions come from upstream
- [x] Manually tested `doit check` (all sub-tasks passed)

No project runtime code was changed, so no new project-specific tests were required. Upstream test additions (e.g., the `test_doit_github.py` expansion) are adopted as-is from the template.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works (N/A — template sync; upstream-provided tests adopted)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (template-owned dev docs updated via the sync itself; no project-facing docs required changes)
- [ ] I have updated the CHANGELOG.md — N/A (chore; not user-visible)
- [x] My changes generate no new warnings

## Additional Notes

**ADR:** Issue #614 does not have the `needs-adr` label. No project-level ADR is required. The two new ADRs under `docs/template/decisions/` are **template** ADRs vendored in as-is — they document upstream decisions, not project decisions.

**Reviewer guidance:** Focus review on the carve-outs list above. The template sync itself is mechanical; the risk is in what we intentionally diverged from. If any carve-out looks wrong, flag it before merge.

**Follow-up:** Issue #615 (pygments CVE bump) is a related cleanup that can land independently of this PR.
