### PR TITLE
docs: call out where() cache-only footgun in DataSource user guide

### DIFF
--- a/docs/usage/data-source.md
+++ b/docs/usage/data-source.md
@@ -141,7 +141,7 @@ ds.query(OntapVolume, cluster="prod1").filter(
 | `expr1 & expr2` | `And` | Both expressions ANDed |
 
 !!! warning "Non-equality operators are cache-only"
-    Only `==` (equality) expressions work on both cache and live paths. All other operators (`!=`, `<`, `>`, `in_()`, etc.) compile to where-expression strings that are evaluated by the cache query engine. Use `source="cache"` when using non-equality operators.
+    Only `==` (equality) expressions work on both cache and live paths. All other operators (`!=`, `<`, `>`, `in_()`, etc.) compile to where-expression strings that are evaluated by the cache query engine. Use `source="cache"` when using non-equality operators. See the [footgun callout](#cache-only-constraint-footgun) below the `.where()` section for the exact failure shape.
 
 ### SQL-like Expressions with `.where()`
 
@@ -158,6 +158,37 @@ for vol in large_vols:
 
 !!! warning "Cache-only"
     `.where()` expressions are evaluated by the cache query engine and are only supported when the routing decision uses the cache path. Use `source="cache"` to opt in explicitly. Combining `.where()` with `source="live"` raises `NotImplementedError` at iteration time.
+
+#### Cache-only constraint footgun
+
+The cache-only constraint applies equally to `.where()` string expressions and to non-equality typed DSL operators (`>`, `<`, `!=`, `.in_()`, etc.). Both compile to the same where-expression shape and share the same failure mode: a query constructs cleanly and only raises `NotImplementedError` once you start iterating.
+
+```python
+# Bad: constructs without error, raises NotImplementedError at the first `for` / list()
+query = (
+    ds.query(OntapVolume, cluster="prod1", source="live")
+    .filter(OntapVolume.F.size > 1_073_741_824)
+)
+for vol in query:   # <-- NotImplementedError raised here
+    ...
+
+# Also bad: string-expression variant of the same mistake
+query = (
+    ds.query(OntapVolume, cluster="prod1", source="live")
+    .where("size > 1073741824")
+)
+list(query)         # <-- NotImplementedError raised here
+
+# Good: opt into the cache path explicitly
+query = (
+    ds.query(OntapVolume, cluster="prod1", source="cache")
+    .filter(OntapVolume.F.size > 1_073_741_824)
+)
+```
+
+The DII backend rejects `.where()` and non-equality DSL expressions **regardless of `source=`** since it has no cache substrate (see [ADR-0015](../decisions/0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md) §4). Any `.where()` against a DII-backed query raises `NotImplementedError` at iteration.
+
+Early construction-time validation for this asymmetry is tracked in [#618](https://github.com/endavis/pynetappfoundry/issues/618). Until that lands, verify `source=` and `.where()`/DSL-comparison combinations during review.
 
 ### Field Projection with `.fields()`
 


### PR DESCRIPTION
## Description

Expand the existing "Cache-only" admonition in the DataSource user guide's `.where()` section into a dedicated `Cache-only constraint footgun` subsection with concrete good/bad code examples. Clarifies the shared failure mode of `.where()` strings and non-equality typed DSL operators (both compile to the same where-expression shape and raise `NotImplementedError` at iteration time, not at construction) and calls out the DII-backend constraint that rejects `.where()` regardless of `source=`.

## Related Issue

Addresses #621

## Type of Change

- [x] Documentation update

## Changes Made

- Added `#### Cache-only constraint footgun` subsection under `.where()` in `docs/usage/data-source.md` with three worked examples (two bad, one good) covering both typed DSL and string-expression variants.
- Called out the DII backend's unconditional rejection of `.where()` with a pointer to ADR-0015 §4.
- Pointed readers at #618 for the tracked early-validation feature and set review-time expectations until it lands.
- Added a one-line cross-reference from the existing typed-DSL "Non-equality operators are cache-only" warning to the new footgun subsection.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

Test plan: N/A — doc-only change; `doit check` passes locally. Optional manual `doit docs_serve` render to eyeball anchor navigation; not blocking.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Companion issues (context, not blockers):

- **#618** — tracks the early construction-time validation feature that would surface this asymmetry at `.filter()`/`.where()` call time instead of iteration time.
- **#619** — tracks the companion ADR documenting the rationale for cache-only non-equality/`where()` evaluation; intentionally not introduced in this branch.

No ADR required for this PR: issue #621 has no `needs-adr` label, the change is a pure doc clarification, and the architectural rationale is tracked separately under #619.
