### PR TITLE
feat: stream subprocess output during release tasks instead of silent capture

### DIFF
--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -10,6 +10,7 @@ behavior is actually verified.
 from __future__ import annotations
 
 import io
+import os
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -75,12 +76,30 @@ class TestRunStreamed:
         out = capfd.readouterr().out
         assert "NO_PATH" in out
 
+    def test_pythonunbuffered_is_set_by_default(self, capfd: pytest.CaptureFixture[str]) -> None:
+        """``PYTHONUNBUFFERED=1`` is injected into the child env so Python
+        descendants flush stdout line-by-line to pipes, not on process exit."""
+        run_streamed(
+            [
+                sys.executable,
+                "-c",
+                "import os; print(os.environ.get('PYTHONUNBUFFERED', 'unset'))",
+            ]
+        )
+        assert capfd.readouterr().out.strip() == "1"
+
 
 class TestRunTeed:
     """Tests for ``run_teed``."""
 
     def test_streams_and_captures_stdout(self, monkeypatch: MonkeyPatch) -> None:
-        """Each line of stdout is both written live and captured in the buffer."""
+        """Each line of stdout is both written live and captured in the buffer.
+
+        The child deliberately does NOT call ``sys.stdout.flush()`` — real
+        tools (cz, pytest, mypy) don't, and an earlier version of this test
+        did which masked a PYTHONUNBUFFERED bug. We rely on the helper's
+        ``PYTHONUNBUFFERED=1`` env override for the child to line-buffer.
+        """
         fake_stdout = io.StringIO()
         monkeypatch.setattr(sys, "stdout", fake_stdout)
 
@@ -88,7 +107,7 @@ class TestRunTeed:
             [
                 sys.executable,
                 "-c",
-                "import sys\nfor i in (1, 2, 3):\n    print(i)\n    sys.stdout.flush()\n",
+                "for i in (1, 2, 3):\n    print(i)\n",
             ]
         )
 
@@ -200,3 +219,97 @@ class TestRunTeed:
         # getcwd() in the child should resolve to tmp_path.
         captured = result.stdout.strip()
         assert Path(captured).resolve() == tmp_path.resolve()
+
+    def test_pythonunbuffered_is_set_by_default(self, monkeypatch: MonkeyPatch) -> None:
+        """``PYTHONUNBUFFERED=1`` is injected into the child env so Python
+        descendants flush stdout line-by-line to pipes, not on process exit."""
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        result = run_teed(
+            [
+                sys.executable,
+                "-c",
+                "import os; print(os.environ.get('PYTHONUNBUFFERED', 'unset'))",
+            ]
+        )
+        assert result.stdout.strip() == "1"
+
+    def test_pythonunbuffered_caller_override_respected(self, monkeypatch: MonkeyPatch) -> None:
+        """A caller-supplied ``PYTHONUNBUFFERED`` wins; the helper only
+        provides it as a default."""
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        result = run_teed(
+            [
+                sys.executable,
+                "-c",
+                "import os; print(os.environ.get('PYTHONUNBUFFERED', 'unset'))",
+            ],
+            env={**os.environ, "PYTHONUNBUFFERED": "0"},
+        )
+        assert result.stdout.strip() == "0"
+
+    def test_streams_line_by_line_without_child_flush(self, monkeypatch: MonkeyPatch) -> None:
+        """Regression test for PR #633 review Issue 2: a Python child that
+        does NOT call ``sys.stdout.flush()`` after each print (which is what
+        real tools do) still delivers lines to the parent as they are
+        printed — not batched at process exit — thanks to
+        ``PYTHONUNBUFFERED=1``. Without that env override, all three writes
+        would arrive together at ~0.45s when the child terminates.
+        """
+        import time
+
+        received: list[tuple[float, str]] = []
+        start = time.monotonic()
+
+        class TimestampingStdout:
+            def write(self, s: str) -> int:
+                received.append((time.monotonic() - start, s))
+                return len(s)
+
+            def flush(self) -> None:
+                pass
+
+        monkeypatch.setattr(sys, "stdout", TimestampingStdout())
+
+        # Child prints 3 lines with 150ms gaps. Total runtime ~0.45s. No flush.
+        run_teed(
+            [
+                sys.executable,
+                "-c",
+                "import time\nfor i in (1, 2, 3):\n    print(i)\n    time.sleep(0.15)\n",
+            ]
+        )
+
+        content_writes = [(t, s) for t, s in received if s.strip()]
+        assert len(content_writes) >= 3, f"expected >=3 content writes, got {content_writes}"
+
+        first_write_time = content_writes[0][0]
+        # Generous threshold: first line should arrive by ~0.15s under live
+        # streaming; child's full runtime is ~0.45s. 0.3s gives margin for
+        # slow CI without masking a regression where everything arrives at
+        # process exit.
+        assert first_write_time < 0.3, (
+            f"first content write at {first_write_time:.3f}s "
+            f"(child runs ~0.45s). Output appears buffered — "
+            f"regression of PR #633 review Issue 2 fix (PYTHONUNBUFFERED)."
+        )
+
+    def test_raising_write_triggers_child_cleanup(self, monkeypatch: MonkeyPatch) -> None:
+        """Regression test for PR #633 review Issue 1: if the stdout-write
+        loop raises, the helper still calls ``process.kill()`` and
+        ``wait()`` so the child is reaped and the pipe is closed — no
+        lingering child, no deadlock on a full pipe."""
+
+        class FailingStdout:
+            def write(self, s: str) -> int:
+                raise OSError(f"broken stdout (refused {len(s)} chars)")
+
+            def flush(self) -> None:
+                pass
+
+        monkeypatch.setattr(sys, "stdout", FailingStdout())
+
+        # The child prints a line; our write will raise on the first line.
+        # Primary assertion: the exception propagates out (rather than the
+        # helper swallowing it and hanging on wait()).
+        with pytest.raises(OSError, match="broken stdout"):
+            run_teed([sys.executable, "-c", "print('hi')"])

--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -1,0 +1,202 @@
+"""Tests for the ``run_streamed`` / ``run_teed`` helpers in tools.doit.base.
+
+The helpers back the live-streaming output changes for the release tasks
+(issue #631). The task functions themselves (``task_release``, etc.) have no
+existing test coverage and are out of scope per the plan. These tests exercise
+the two helpers only, using real child processes so the tee / streaming
+behavior is actually verified.
+"""
+
+from __future__ import annotations
+
+import io
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tools.doit.base import run_streamed, run_teed
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+class TestRunStreamed:
+    """Tests for ``run_streamed``."""
+
+    def test_success_returns_none(self) -> None:
+        """A zero-exit command returns ``None`` and does not raise."""
+        result = run_streamed([sys.executable, "-c", "print('hi')"])
+        assert result is None
+
+    def test_failure_with_check_true_raises(self) -> None:
+        """Non-zero exit with ``check=True`` raises ``CalledProcessError``."""
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            run_streamed([sys.executable, "-c", "import sys; sys.exit(2)"])
+        assert excinfo.value.returncode == 2
+
+    def test_failure_with_check_false_does_not_raise(self) -> None:
+        """Non-zero exit with ``check=False`` returns without raising."""
+        # Must not raise.
+        result = run_streamed(
+            [sys.executable, "-c", "import sys; sys.exit(3)"],
+            check=False,
+        )
+        assert result is None
+
+    def test_env_is_threaded_through(self, capfd: pytest.CaptureFixture[str]) -> None:
+        """The ``env`` mapping is forwarded to the child process."""
+        # Use a sentinel env var the child will echo to stdout.
+        run_streamed(
+            [
+                sys.executable,
+                "-c",
+                "import os; print(os.environ.get('RUN_STREAMED_TEST', ''))",
+            ],
+            env={"RUN_STREAMED_TEST": "threaded-value"},
+        )
+        out = capfd.readouterr().out
+        assert "threaded-value" in out
+
+    def test_empty_env_isolates_child(self, capfd: pytest.CaptureFixture[str]) -> None:
+        """Passing a tightly-scoped env actually replaces (not extends) the parent env."""
+        # A var the parent likely has — confirm the child doesn't see it when
+        # we pass a minimal env. We still need PATH for the interpreter lookup
+        # on some platforms; use the interpreter's absolute path to avoid that.
+        run_streamed(
+            [
+                sys.executable,
+                "-c",
+                "import os; print(os.environ.get('PATH', 'NO_PATH'))",
+            ],
+            env={"OTHER": "x"},
+        )
+        out = capfd.readouterr().out
+        assert "NO_PATH" in out
+
+
+class TestRunTeed:
+    """Tests for ``run_teed``."""
+
+    def test_streams_and_captures_stdout(self, monkeypatch: MonkeyPatch) -> None:
+        """Each line of stdout is both written live and captured in the buffer."""
+        fake_stdout = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", fake_stdout)
+
+        result = run_teed(
+            [
+                sys.executable,
+                "-c",
+                "import sys\nfor i in (1, 2, 3):\n    print(i)\n    sys.stdout.flush()\n",
+            ]
+        )
+
+        streamed = fake_stdout.getvalue()
+        # All three lines must appear in the live-streamed output.
+        assert "1\n" in streamed
+        assert "2\n" in streamed
+        assert "3\n" in streamed
+        # And also in the returned captured stdout.
+        assert result.stdout == "1\n2\n3\n"
+        assert result.stderr == ""
+        assert result.returncode == 0
+
+    def test_stderr_merges_into_stdout(self, monkeypatch: MonkeyPatch) -> None:
+        """Content written to stderr is captured in ``.stdout`` (merged stream)."""
+        fake_stdout = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", fake_stdout)
+
+        result = run_teed(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.stderr.write('err-line\\n'); sys.stderr.flush()",
+            ]
+        )
+
+        assert "err-line" in result.stdout
+        assert "err-line" in fake_stdout.getvalue()
+        assert result.stderr == ""
+        assert result.returncode == 0
+
+    def test_returncode_reflects_success(self, monkeypatch: MonkeyPatch) -> None:
+        """A zero-exit command returns a ``CompletedProcess`` with ``returncode=0``."""
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        result = run_teed([sys.executable, "-c", "print('ok')"])
+        assert result.returncode == 0
+        assert "ok" in result.stdout
+
+    def test_failure_with_check_true_raises_with_stdout(self, monkeypatch: MonkeyPatch) -> None:
+        """Non-zero exit under ``check=True`` raises with captured ``stdout``.
+
+        This preserves the old error-path semantics — callers that logged
+        ``e.stdout`` still see output even though live streaming already
+        showed it to the user.
+        """
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            run_teed(
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys; print('partial output'); sys.exit(5)",
+                ]
+            )
+
+        err = excinfo.value
+        assert err.returncode == 5
+        assert err.stdout is not None
+        assert "partial output" in err.stdout
+
+    def test_failure_with_check_false_returns_completedprocess(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Non-zero exit under ``check=False`` returns a ``CompletedProcess``."""
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+
+        result = run_teed(
+            [
+                sys.executable,
+                "-c",
+                "import sys; print('still captured'); sys.exit(7)",
+            ],
+            check=False,
+        )
+
+        assert result.returncode == 7
+        assert "still captured" in result.stdout
+        assert result.stderr == ""
+
+    def test_env_is_threaded_through(self, monkeypatch: MonkeyPatch) -> None:
+        """The ``env`` mapping is forwarded to the child process."""
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+
+        result = run_teed(
+            [
+                sys.executable,
+                "-c",
+                "import os; print(os.environ.get('RUN_TEED_TEST', ''))",
+            ],
+            env={"RUN_TEED_TEST": "teed-value"},
+        )
+
+        assert "teed-value" in result.stdout
+
+    def test_cwd_is_threaded_through(self, monkeypatch: MonkeyPatch, tmp_path: object) -> None:
+        """The ``cwd`` parameter is forwarded to the child process."""
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+
+        # tmp_path is a pathlib.Path fixture; reify to str for the child.
+        from pathlib import Path
+
+        assert isinstance(tmp_path, Path)
+        result = run_teed(
+            [sys.executable, "-c", "import os; print(os.getcwd())"],
+            cwd=str(tmp_path),
+        )
+
+        # getcwd() in the child should resolve to tmp_path.
+        captured = result.stdout.strip()
+        assert Path(captured).resolve() == tmp_path.resolve()

--- a/tools/doit/base.py
+++ b/tools/doit/base.py
@@ -1,6 +1,9 @@
 """Base utilities and configuration for doit tasks."""
 
 import os
+import subprocess  # nosec B404 - subprocess is required to run doit sub-tasks
+import sys
+from collections.abc import Mapping
 
 from rich.console import Console
 from rich.panel import Panel
@@ -27,3 +30,117 @@ def success_message() -> None:
         )
     )
     console.print()
+
+
+def run_streamed(
+    cmd: list[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    check: bool = True,
+    cwd: str | os.PathLike[str] | None = None,
+) -> None:
+    """Run a subprocess with stdout/stderr inherited from the parent.
+
+    Unlike ``subprocess.run(..., capture_output=True)``, this function does not
+    buffer output: the child process writes directly to the parent's stdout and
+    stderr so the user sees progress live. This is the right choice for long-
+    running steps whose output we do not need to parse (``doit check``,
+    ``git pull``, ``git push``, ``git commit``, ``gh pr create``).
+
+    Args:
+        cmd: Command to run, as a list of args (no shell expansion).
+        env: Optional environment mapping. If ``None``, the child inherits the
+            parent's environment.
+        check: When ``True`` (default), a non-zero exit raises
+            ``subprocess.CalledProcessError``.
+        cwd: Optional working directory for the child process.
+
+    Raises:
+        subprocess.CalledProcessError: If ``check`` is ``True`` and the child
+            exits with a non-zero return code.
+    """
+    subprocess.run(  # nosec B603 B607
+        cmd,
+        env=dict(env) if env is not None else None,
+        check=check,
+        cwd=cwd,
+    )
+
+
+def run_teed(
+    cmd: list[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    check: bool = True,
+    cwd: str | os.PathLike[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess, streaming output to stdout while also capturing it.
+
+    Merges stderr into stdout (so the captured buffer reflects interleaved
+    output as a user would see it), streams each line to ``sys.stdout`` as it
+    arrives, and returns a ``CompletedProcess`` whose ``stdout`` contains the
+    full captured output. ``stderr`` is always empty because it was merged.
+
+    This is the right choice when the caller both needs live output (long step,
+    hooks, etc.) *and* needs to parse the output afterwards (e.g. regex-extract
+    the version printed by ``cz bump``).
+
+    On non-zero exit with ``check=True``, raises ``CalledProcessError`` with
+    ``stdout`` populated so existing error-path logging keeps working.
+
+    Args:
+        cmd: Command to run, as a list of args (no shell expansion).
+        env: Optional environment mapping. If ``None``, the child inherits the
+            parent's environment.
+        check: When ``True`` (default), a non-zero exit raises
+            ``subprocess.CalledProcessError``.
+        cwd: Optional working directory for the child process.
+
+    Returns:
+        ``subprocess.CompletedProcess[str]`` with ``stdout`` set to the full
+        captured output and ``stderr`` set to ``""``.
+
+    Raises:
+        subprocess.CalledProcessError: If ``check`` is ``True`` and the child
+            exits with a non-zero return code. The exception's ``stdout``
+            attribute contains the captured output.
+    """
+    # Popen with stdout piped and stderr merged into stdout. We read lines
+    # from the pipe, echo each to sys.stdout (so the user sees live output),
+    # and buffer them for the caller.
+    process = subprocess.Popen(  # nosec B603 B607
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=dict(env) if env is not None else None,
+        cwd=cwd,
+        text=True,
+        bufsize=1,  # line buffered
+    )
+
+    buffer: list[str] = []
+    # process.stdout is non-None because we asked for subprocess.PIPE.
+    assert process.stdout is not None  # nosec B101 - invariant from Popen args
+    for line in process.stdout:
+        buffer.append(line)
+        sys.stdout.write(line)
+        sys.stdout.flush()
+    process.stdout.close()
+
+    returncode = process.wait()
+    captured = "".join(buffer)
+
+    if check and returncode != 0:
+        raise subprocess.CalledProcessError(
+            returncode=returncode,
+            cmd=cmd,
+            output=captured,
+            stderr="",
+        )
+
+    return subprocess.CompletedProcess(
+        args=cmd,
+        returncode=returncode,
+        stdout=captured,
+        stderr="",
+    )

--- a/tools/doit/base.py
+++ b/tools/doit/base.py
@@ -32,6 +32,22 @@ def success_message() -> None:
     console.print()
 
 
+def _child_env(env: Mapping[str, str] | None) -> dict[str, str]:
+    """Build the environment for a child process spawned by a streaming helper.
+
+    Always sets ``PYTHONUNBUFFERED=1`` so Python children (including descendants
+    like ``pytest``, ``mypy``, ``cz``) flush stdout line-by-line to pipes instead
+    of block-buffering to process exit. Without this, streaming appears to work
+    in tests that explicitly flush, but real tools — whose output is the whole
+    point of streaming — deliver everything in one burst at process end.
+
+    A caller-supplied ``PYTHONUNBUFFERED`` is respected.
+    """
+    merged = dict(env if env is not None else os.environ)
+    merged.setdefault("PYTHONUNBUFFERED", "1")
+    return merged
+
+
 def run_streamed(
     cmd: list[str],
     *,
@@ -61,7 +77,7 @@ def run_streamed(
     """
     subprocess.run(  # nosec B603 B607
         cmd,
-        env=dict(env) if env is not None else None,
+        env=_child_env(env),
         check=check,
         cwd=cwd,
     )
@@ -112,22 +128,34 @@ def run_teed(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        env=dict(env) if env is not None else None,
+        env=_child_env(env),
         cwd=cwd,
         text=True,
-        bufsize=1,  # line buffered
+        # bufsize=1 configures only the parent-side TextIOWrapper for reading
+        # the pipe. Child-side flushing is controlled via PYTHONUNBUFFERED=1
+        # in _child_env() — without it, Python children block-buffer to pipes.
+        bufsize=1,
     )
 
     buffer: list[str] = []
     # process.stdout is non-None because we asked for subprocess.PIPE.
     assert process.stdout is not None  # nosec B101 - invariant from Popen args
-    for line in process.stdout:
-        buffer.append(line)
-        sys.stdout.write(line)
-        sys.stdout.flush()
-    process.stdout.close()
+    try:
+        for line in process.stdout:
+            buffer.append(line)
+            sys.stdout.write(line)
+            sys.stdout.flush()
+    except BaseException:
+        # Streaming raised (broken parent stdout, KeyboardInterrupt, etc.).
+        # Kill the child so wait() below doesn't hang waiting for a process
+        # that may be blocked on a full pipe buffer.
+        process.kill()
+        raise
+    finally:
+        process.stdout.close()
+        process.wait()
 
-    returncode = process.wait()
+    returncode = process.returncode
     captured = "".join(buffer)
 
     if check and returncode != 0:

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from doit.tools import title_with_actions
 from rich.console import Console
 
-from .base import UV_CACHE_DIR
+from .base import UV_CACHE_DIR, run_streamed, run_teed
 
 if TYPE_CHECKING:
     from rich.console import Console as ConsoleType
@@ -183,64 +183,48 @@ def task_release_dev(type: str = "alpha") -> dict[str, Any]:
         # Pull latest changes
         console.print("\n[cyan]Pulling latest changes...[/cyan]")
         try:
-            subprocess.run(["git", "pull"], check=True, capture_output=True, text=True)
+            run_streamed(["git", "pull"])
             console.print("[green]✓ Git pull successful.[/green]")
-        except subprocess.CalledProcessError as e:
-            console.print("[bold red]❌ Error pulling latest changes:[/bold red]")
-            console.print(f"[red]Stdout: {e.stdout}[/red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
+        except subprocess.CalledProcessError:
+            console.print("[bold red]❌ Error pulling latest changes.[/bold red]")
             sys.exit(1)
 
         # Run checks
         console.print("\n[cyan]Running all pre-release checks...[/cyan]")
         try:
-            subprocess.run(["doit", "check"], check=True, capture_output=True, text=True)
+            run_streamed(["doit", "check"])
             console.print("[green]✓ All checks passed.[/green]")
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             console.print(
                 "[bold red]❌ Pre-release checks failed! "
                 "Please fix issues before tagging.[/bold red]"
             )
-            console.print(f"[red]Stdout: {e.stdout}[/red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
             sys.exit(1)
 
         # Automated version bump and tagging
         console.print(f"\n[cyan]Bumping version ({type}) and updating changelog...[/cyan]")
         try:
-            # Use cz bump --prerelease <type> --changelog
-            result = subprocess.run(
+            # Use cz bump --prerelease <type> --changelog; tee so we can still
+            # parse the printed "Bumping to version X.Y.Z" line.
+            result = run_teed(
                 ["uv", "run", "cz", "bump", "--prerelease", type, "--changelog"],
                 env={**os.environ, "UV_CACHE_DIR": UV_CACHE_DIR},
-                check=True,
-                capture_output=True,
-                text=True,
             )
             console.print(f"[green]✓ Version bumped to {type}.[/green]")
-            console.print(f"[dim]{result.stdout}[/dim]")
             # Extract new version
             version_match = re.search(r"Bumping to version (\d+\.\d+\.\d+[^\s]*)", result.stdout)
             new_version = version_match.group(1) if version_match else "unknown"
 
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             console.print("[bold red]❌ commitizen bump failed![/bold red]")
-            console.print(f"[red]Stdout: {e.stdout}[/red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
             sys.exit(1)
 
         console.print(f"\n[cyan]Pushing tag v{new_version} to origin...[/cyan]")
         try:
-            subprocess.run(
-                ["git", "push", "--follow-tags", "origin", current_branch],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
+            run_streamed(["git", "push", "--follow-tags", "origin", current_branch])
             console.print("[green]✓ Tags pushed to origin.[/green]")
-        except subprocess.CalledProcessError as e:
-            console.print("[bold red]❌ Error pushing tag to origin:[/bold red]")
-            console.print(f"[red]Stdout: {e.stdout}[/red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
+        except subprocess.CalledProcessError:
+            console.print("[bold red]❌ Error pushing tag to origin.[/bold red]")
             sys.exit(1)
 
         console.print("\n" + "=" * 70)
@@ -311,12 +295,10 @@ def task_release(increment: str = "") -> dict[str, Any]:
         # Pull latest changes
         console.print("\n[cyan]Pulling latest changes...[/cyan]")
         try:
-            subprocess.run(["git", "pull"], check=True, capture_output=True, text=True)
+            run_streamed(["git", "pull"])
             console.print("[green]✓ Git pull successful.[/green]")
-        except subprocess.CalledProcessError as e:
-            console.print("[bold red]❌ Error pulling latest changes:[/bold red]")
-            console.print(f"[red]Stdout: {e.stdout}[/red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
+        except subprocess.CalledProcessError:
+            console.print("[bold red]❌ Error pulling latest changes.[/bold red]")
             sys.exit(1)
 
         # Governance validation
@@ -337,15 +319,13 @@ def task_release(increment: str = "") -> dict[str, Any]:
         # Run all checks
         console.print("\n[cyan]Running all pre-release checks...[/cyan]")
         try:
-            subprocess.run(["doit", "check"], check=True, capture_output=True, text=True)
+            run_streamed(["doit", "check"])
             console.print("[green]✓ All checks passed.[/green]")
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             console.print(
                 "[bold red]❌ Pre-release checks failed! "
                 "Please fix issues before releasing.[/bold red]"
             )
-            console.print(f"[red]Stdout: {e.stdout}[/red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
             sys.exit(1)
 
         # Automated version bump and CHANGELOG generation using commitizen
@@ -353,34 +333,29 @@ def task_release(increment: str = "") -> dict[str, Any]:
         try:
             # Use cz bump --changelog --merge-prerelease to update version,
             # changelog, commit, and tag. This consolidates pre-release changes
-            # into the final release entry
+            # into the final release entry. Tee so we can still parse the
+            # "Bumping to version X.Y.Z" line.
             bump_cmd = ["uv", "run", "cz", "bump", "--changelog", "--merge-prerelease"]
             if increment:
                 bump_cmd.extend(["--increment", increment.upper()])
                 console.print(f"[dim]Forcing {increment.upper()} version bump[/dim]")
-            result = subprocess.run(
+            result = run_teed(
                 bump_cmd,
                 env={**os.environ, "UV_CACHE_DIR": UV_CACHE_DIR},
-                check=True,
-                capture_output=True,
-                text=True,
             )
             console.print(
                 "[green]✓ Version bumped and CHANGELOG updated (merged pre-releases).[/green]"
             )
-            console.print(f"[dim]{result.stdout}[/dim]")
             # Extract new version from cz output (example: "Bumping to version 1.0.0")
             version_match = re.search(r"Bumping to version (\d+\.\d+\.\d+)", result.stdout)
             # Fallback to "unknown" if regex fails
             new_version = version_match.group(1) if version_match else "unknown"
 
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             console.print(
                 "[bold red]❌ commitizen bump failed! "
                 "Ensure your commit history is conventional.[/bold red]"
             )
-            console.print(f"[red]Stdout: {e.stdout}[/red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
             sys.exit(1)
         except Exception as e:
             console.print(
@@ -391,17 +366,10 @@ def task_release(increment: str = "") -> dict[str, Any]:
         # Push commits and tags to GitHub
         console.print("\n[cyan]Pushing commits and tags to GitHub...[/cyan]")
         try:
-            subprocess.run(
-                ["git", "push", "--follow-tags", "origin", current_branch],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
+            run_streamed(["git", "push", "--follow-tags", "origin", current_branch])
             console.print("[green]✓ Pushed new commits and tags to GitHub.[/green]")
-        except subprocess.CalledProcessError as e:
-            console.print("[bold red]❌ Error pushing to GitHub:[/bold red]")
-            console.print(f"[red]Stdout: {e.stdout}[/red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
+        except subprocess.CalledProcessError:
+            console.print("[bold red]❌ Error pushing to GitHub.[/bold red]")
             sys.exit(1)
 
         console.print("\n" + "=" * 70)
@@ -478,12 +446,10 @@ def task_release_pr(increment: str = "") -> dict[str, Any]:
         # Pull latest changes
         console.print("\n[cyan]Pulling latest changes...[/cyan]")
         try:
-            subprocess.run(["git", "pull"], check=True, capture_output=True, text=True)
+            run_streamed(["git", "pull"])
             console.print("[green]✓ Git pull successful.[/green]")
-        except subprocess.CalledProcessError as e:
-            console.print("[bold red]❌ Error pulling latest changes:[/bold red]")
-            console.print(f"[red]Stdout: {e.stdout}[/red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
+        except subprocess.CalledProcessError:
+            console.print("[bold red]❌ Error pulling latest changes.[/bold red]")
             sys.exit(1)
 
         # Governance validation
@@ -504,15 +470,13 @@ def task_release_pr(increment: str = "") -> dict[str, Any]:
         # Run all checks
         console.print("\n[cyan]Running all pre-release checks...[/cyan]")
         try:
-            subprocess.run(["doit", "check"], check=True, capture_output=True, text=True)
+            run_streamed(["doit", "check"])
             console.print("[green]✓ All checks passed.[/green]")
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             console.print(
                 "[bold red]❌ Pre-release checks failed! "
                 "Please fix issues before releasing.[/bold red]"
             )
-            console.print(f"[red]Stdout: {e.stdout}[/red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
             sys.exit(1)
 
         # Get next version using commitizen
@@ -557,18 +521,13 @@ def task_release_pr(increment: str = "") -> dict[str, Any]:
         console.print("\n[cyan]Updating CHANGELOG.md...[/cyan]")
         try:
             changelog_cmd = ["uv", "run", "cz", "changelog", "--incremental"]
-            subprocess.run(
+            run_streamed(
                 changelog_cmd,
                 env={**os.environ, "UV_CACHE_DIR": UV_CACHE_DIR},
-                check=True,
-                capture_output=True,
-                text=True,
             )
             console.print("[green]✓ CHANGELOG.md updated.[/green]")
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             console.print("[bold red]❌ Failed to update changelog.[/bold red]")
-            console.print(f"[red]Stdout: {e.stdout}[/red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
             # Cleanup: go back to main
             subprocess.run(["git", "checkout", "main"], capture_output=True)
             subprocess.run(["git", "branch", "-D", branch_name], capture_output=True)
@@ -583,16 +542,12 @@ def task_release_pr(increment: str = "") -> dict[str, Any]:
                 capture_output=True,
                 text=True,
             )
-            subprocess.run(
+            run_streamed(
                 ["git", "commit", "-m", f"chore: update changelog for v{next_version}"],
-                check=True,
-                capture_output=True,
-                text=True,
             )
             console.print("[green]✓ Changelog committed.[/green]")
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             console.print("[bold red]❌ Failed to commit changelog.[/bold red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
             # Cleanup
             subprocess.run(["git", "checkout", "main"], capture_output=True)
             subprocess.run(["git", "branch", "-D", branch_name], capture_output=True)
@@ -601,16 +556,10 @@ def task_release_pr(increment: str = "") -> dict[str, Any]:
         # Push branch
         console.print(f"\n[cyan]Pushing branch {branch_name}...[/cyan]")
         try:
-            subprocess.run(
-                ["git", "push", "-u", "origin", branch_name],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
+            run_streamed(["git", "push", "-u", "origin", branch_name])
             console.print("[green]✓ Branch pushed.[/green]")
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             console.print("[bold red]❌ Failed to push branch.[/bold red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
             sys.exit(1)
 
         # Create PR using doit pr
@@ -641,7 +590,7 @@ After this PR is merged, run `doit release_tag` to create the version tag
 and trigger the release workflow.
 """
             # Use gh CLI directly since we're in a non-interactive context
-            subprocess.run(
+            run_streamed(
                 [
                     "gh",
                     "pr",
@@ -651,14 +600,10 @@ and trigger the release workflow.
                     "--body",
                     pr_body,
                 ],
-                check=True,
-                capture_output=True,
-                text=True,
             )
             console.print("[green]✓ Pull request created.[/green]")
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             console.print("[bold red]❌ Failed to create PR.[/bold red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
             sys.exit(1)
 
         console.print("\n" + "=" * 70)
@@ -714,11 +659,10 @@ def task_release_tag() -> dict[str, Any]:
         # Pull latest changes
         console.print("\n[cyan]Pulling latest changes...[/cyan]")
         try:
-            subprocess.run(["git", "pull"], check=True, capture_output=True, text=True)
+            run_streamed(["git", "pull"])
             console.print("[green]✓ Git pull successful.[/green]")
-        except subprocess.CalledProcessError as e:
-            console.print("[bold red]❌ Error pulling latest changes:[/bold red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
+        except subprocess.CalledProcessError:
+            console.print("[bold red]❌ Error pulling latest changes.[/bold red]")
             sys.exit(1)
 
         # Find the most recently merged release PR
@@ -804,16 +748,10 @@ def task_release_tag() -> dict[str, Any]:
         # Push tag
         console.print(f"\n[cyan]Pushing tag {tag_name}...[/cyan]")
         try:
-            subprocess.run(
-                ["git", "push", "origin", tag_name],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
+            run_streamed(["git", "push", "origin", tag_name])
             console.print(f"[green]✓ Tag {tag_name} pushed.[/green]")
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             console.print("[bold red]❌ Failed to push tag.[/bold red]")
-            console.print(f"[red]Stderr: {e.stderr}[/red]")
             sys.exit(1)
 
         console.print("\n" + "=" * 70)


### PR DESCRIPTION
## Description

Replace silent `capture_output=True` subprocess calls in the release tasks
with live-streamed output so users can see progress during long-running
steps. During a first-time TestPyPI bootstrap, `doit check` and `cz bump`
each ran silently for minutes — and because `cz bump` triggers pre-commit
hooks that re-run much of `doit check`, the "silence" stacked. For a
first-time releaser, this is indistinguishable from a hang. It also means
any interactive prompt that lands in a captured pipe (git credentials,
pre-commit pauses, commitizen confirmations) blocks the task forever with
no visible indication of what it is waiting on.

Two new helpers in `tools/doit/base.py` fix this:

- `run_streamed` — child inherits the parent's stdout/stderr. Right for
  steps whose output we never parse (`git pull`, `doit check`, `git push`,
  `git commit`, `gh pr create`, `cz changelog`).
- `run_teed` — streams each line to `sys.stdout` as it arrives while also
  buffering the full output. Right for steps where we need live visibility
  *and* need to parse the output afterwards (`cz bump`, which prints
  `Bumping to version X.Y.Z` that we regex-extract).

`release.py` swaps every long-running `subprocess.run(..., capture_output=True)`
call for the appropriate helper per a simple matrix (stream vs. tee based on
whether the output is parsed). Read-only queries used purely for branch /
commit inspection (`git rev-parse`, `git status --porcelain`,
`gh pr list --json`, `cz bump --get-next`, cleanup calls inside error paths)
are left unchanged — those are fast, their output is data, and they should
stay silent.

## Related Issue

Addresses #631

Upstream cross-reference: endavis/pyproject-template#425. This lands here
first, then ports back to the template.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Add `run_streamed(cmd, *, env=None, check=True, cwd=None) -> None` to
  `tools/doit/base.py`. Thin wrapper around `subprocess.run` with stdout and
  stderr inherited from the parent so output streams live.
- Add `run_teed(cmd, *, env=None, check=True, cwd=None) -> CompletedProcess[str]`
  to `tools/doit/base.py`. Uses `Popen` with a pipe + reader loop, echoes each
  line to `sys.stdout` as it arrives, merges stderr into stdout, and returns
  the full captured buffer. On non-zero exit with `check=True`, raises
  `CalledProcessError` with `output` populated so existing error-path logging
  keeps working.
- `tools/doit/release.py`: replace `capture_output=True` calls in
  `task_release_dev`, `task_release`, `task_release_pr`, and `task_release_tag`
  with the appropriate helper:
  - `run_streamed` for `git pull`, `doit check`, `git push [--follow-tags]`,
    `git commit`, `gh pr create`, `cz changelog --incremental`.
  - `run_teed` for the two `cz bump ...` calls whose stdout we regex-parse to
    extract the new version.
- Trim the error-path `console.print(f"[red]Stdout: {e.stdout}[/red]")` /
  `...stderr...` lines that are now redundant — users already saw that output
  live.
- Leave read-only inspection subprocesses unchanged (`git rev-parse`,
  `git status --porcelain`, `gh pr list`, `cz bump --get-next`, cleanup
  fallbacks).

## Testing

- New `tests/test_doit_release.py` — 12 tests covering both helpers end-to-end
  with real child processes (not mocks) so the streaming and tee behavior is
  actually exercised:
  - `run_streamed`: success path, `check=True` raising on non-zero, `check=False`
    returning on non-zero, `env` forwarded to child, `env` replaces (not extends)
    parent env.
  - `run_teed`: lines streamed live *and* captured, stderr merges into captured
    stdout, `returncode=0` on success, `check=True` raises `CalledProcessError`
    with captured `output`, `check=False` returns a `CompletedProcess` with
    captured output, `env` forwarded, `cwd` forwarded.
- `doit check` green (format, lint, type_check, security, spell_check, test).
- The four release tasks themselves have no existing test coverage and are
  out of scope for this change; only the new helpers are tested.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

No documentation update needed: the release-automation guide never claimed
subprocess output was silent, so there's nothing stale to correct. The
behavior change is a strict improvement to the in-terminal experience of
existing commands. CHANGELOG is generated by commitizen from the conventional
commit subject at release time.

## Additional Notes

- This is a behavior change only in what the user sees on their terminal —
  exit codes, return values, and parsed outputs are all preserved. `cz bump`
  stdout is still captured and regex-parsed for the version string; the only
  difference is the user now sees the output as it happens rather than after
  the fact.
- The helpers live in `tools/doit/base.py` specifically so they are available
  to other `doit` tasks that may want the same treatment in the future (e.g.
  `doit pr`, `doit issue`). No such callers are added in this PR — scope is
  the release tasks only.
- Cross-repo: this implementation will port back to the upstream
  pyproject-template (endavis/pyproject-template#425) after landing here.
