### PR TITLE
fix: widen release_tag version regex to accept PEP440 and semver pre-releases

### DIFF
--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -1,10 +1,11 @@
-"""Tests for the ``run_streamed`` / ``run_teed`` helpers in tools.doit.base.
+"""Tests for helpers in tools.doit.base and tools.doit.release.
 
-The helpers back the live-streaming output changes for the release tasks
-(issue #631). The task functions themselves (``task_release``, etc.) have no
-existing test coverage and are out of scope per the plan. These tests exercise
-the two helpers only, using real child processes so the tee / streaming
-behavior is actually verified.
+``run_streamed`` / ``run_teed`` back the live-streaming output changes for
+the release tasks (issue #631). ``_extract_version_from_release_pr`` is the
+version-parsing helper factored out of ``task_release_tag`` to support
+PEP440 and semver-style pre-release suffixes (issue #632). The task
+functions themselves (``task_release``, etc.) have no existing test
+coverage and are out of scope per the plan.
 """
 
 from __future__ import annotations
@@ -18,6 +19,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from tools.doit.base import run_streamed, run_teed
+from tools.doit.release import _extract_version_from_release_pr
 
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
@@ -313,3 +315,48 @@ class TestRunTeed:
         # helper swallowing it and hanging on wait()).
         with pytest.raises(OSError, match="broken stdout"):
             run_teed([sys.executable, "-c", "print('hi')"])
+
+
+class TestExtractVersionFromReleasePR:
+    """Tests for ``_extract_version_from_release_pr``.
+
+    Covers the PR-title / branch-name shapes produced by ``task_release_pr``
+    (and the shapes a maintainer might hand-write), including PEP440 and
+    semver-style pre-release suffixes that the previous regex in
+    ``task_release_tag`` rejected (issue #632).
+    """
+
+    @pytest.mark.parametrize(
+        ("pr_title", "expected"),
+        [
+            # Production release (what was already supported before #632).
+            ("release: v1.0.0", "1.0.0"),
+            # PEP440 pre-release shapes (cz bump --prerelease output).
+            ("release: v0.1.0a0", "0.1.0a0"),
+            ("release: v0.2.0b1", "0.2.0b1"),
+            ("release: v1.5.0rc0", "1.5.0rc0"),
+            ("release: v0.1.0.dev2", "0.1.0.dev2"),
+            # Semver-style pre-release shapes (hand-written / alternate tooling).
+            ("release: v0.1.0-alpha.0", "0.1.0-alpha.0"),
+            ("release: v0.1.0-beta.1", "0.1.0-beta.1"),
+            ("release: v0.1.0-rc.0", "0.1.0-rc.0"),
+        ],
+    )
+    def test_extracts_from_pr_title(self, pr_title: str, expected: str) -> None:
+        """The PR title is the primary source; the captured group is the bare version."""
+        # Branch name is deliberately unrelated so the title match is the only
+        # thing that can succeed.
+        assert _extract_version_from_release_pr(pr_title, "unrelated/branch") == expected
+
+    def test_falls_back_to_branch_name(self) -> None:
+        """When the PR title doesn't match, the branch name is consulted."""
+        assert _extract_version_from_release_pr("unrelated: fix", "release/v0.1.0a0") == "0.1.0a0"
+
+    def test_returns_none_when_neither_matches(self) -> None:
+        """Neither input matches -> ``None`` (caller handles the error path)."""
+        assert _extract_version_from_release_pr("fix: bug", "fix/123-thing") is None
+
+    def test_returns_none_for_non_numeric_version(self) -> None:
+        """``release: vX.Y.Z`` with literal letters must not match — the regex
+        requires digits."""
+        assert _extract_version_from_release_pr("release: vX.Y.Z", "release/vX.Y.Z") is None

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -137,6 +137,45 @@ def validate_issue_links(console: "ConsoleType") -> bool:
     return True  # Warning only, don't block release
 
 
+# Version pattern covering:
+#   - Production releases:       1.0.0
+#   - PEP440 pre-releases:       0.1.0a0, 0.1.0b1, 0.1.0rc0, 0.1.0.dev2
+#   - Semver-style pre-releases: 0.1.0-alpha.0, 0.1.0-beta.1, 0.1.0-rc.0
+# The optional leading 'v' is stripped; the captured group is the bare version.
+_VERSION_PATTERN = r"v?(\d+\.\d+\.\d+(?:[ab]\d+|rc\d+|\.dev\d+|-(?:alpha|beta|rc)\.\d+)?)"
+
+
+def _extract_version_from_release_pr(pr_title: str, branch_name: str) -> str | None:
+    """Extract a release version from a PR title or fall back to the branch name.
+
+    Recognizes the shapes produced by ``task_release_pr`` (and by hand):
+      - PR title: ``release: v<version>``
+      - Branch:   ``release/v<version>``
+
+    The version portion may be a production release (``1.0.0``), a PEP440
+    pre-release (``0.1.0a0``, ``0.1.0b1``, ``0.1.0rc0``, ``0.1.0.dev2``), or a
+    semver-style pre-release (``0.1.0-alpha.0``, ``0.1.0-beta.1``,
+    ``0.1.0-rc.0``).
+
+    Args:
+        pr_title: The PR title to inspect first.
+        branch_name: The PR head branch name, used as a fallback.
+
+    Returns:
+        The captured version string without the leading ``v`` (e.g. ``"1.0.0"``,
+        ``"0.1.0a0"``, ``"0.1.0-alpha.0"``), or ``None`` if neither input matches.
+    """
+    # Try the PR title first (format: "release: vX.Y.Z[suffix]").
+    match = re.search(rf"release:\s*{_VERSION_PATTERN}", pr_title)
+    if match:
+        return match.group(1)
+    # Fall back to the branch name (format: "release/vX.Y.Z[suffix]").
+    match = re.search(rf"release/{_VERSION_PATTERN}", branch_name)
+    if match:
+        return match.group(1)
+    return None
+
+
 def task_release_dev(type: str = "alpha") -> dict[str, Any]:
     """Create a pre-release (alpha/beta) tag for TestPyPI and push to GitHub.
 
@@ -698,19 +737,15 @@ def task_release_tag() -> dict[str, Any]:
             pr_title = pr["title"]
             branch_name = pr["headRefName"]
 
-            # Extract version from PR title (format: "release: vX.Y.Z")
-            version_match = re.search(r"release:\s*v?(\d+\.\d+\.\d+)", pr_title)
-            if not version_match:
-                # Try extracting from branch name (format: "release/vX.Y.Z")
-                version_match = re.search(r"release/v?(\d+\.\d+\.\d+)", branch_name)
-
-            if not version_match:
+            # Extract version from PR title (format: "release: vX.Y.Z[suffix]"),
+            # falling back to the branch name (format: "release/vX.Y.Z[suffix]").
+            version = _extract_version_from_release_pr(pr_title, branch_name)
+            if version is None:
                 console.print("[bold red]❌ Could not extract version from PR.[/bold red]")
                 console.print(f"[yellow]PR title: {pr_title}[/yellow]")
                 console.print(f"[yellow]Branch: {branch_name}[/yellow]")
                 sys.exit(1)
 
-            version = version_match.group(1)
             tag_name = f"v{version}"
             console.print(f"[green]✓ Found release PR: {pr_title}[/green]")
             console.print(f"[green]✓ Version to tag: {tag_name}[/green]")


### PR DESCRIPTION
## Description

**Phase A of 3** for issue #632. This PR widens the version-matching regex in `task_release_tag` so the PR-based release path can recognize pre-release versions.

Per the [plan comment on #632](https://github.com/endavis/pynetappfoundry/issues/632#issuecomment-4280911183), the full fix is split into three PRs against the same issue:

- **Phase A (this PR):** Widen the regex in `task_release_tag` and extract it into a pure helper. Internal refactor only; no user-visible behavior change yet.
- **Phase B (follow-up):** Add a `--prerelease` flag / pre-release path to `task_release_pr` so pre-releases actually flow through a PR (rather than committing directly to `main`). The widened regex here is what makes that PR's tag step work.
- **Phase C (follow-up):** Consolidate `release_dev` into `release_pr --prerelease` and rewrite `docs/development/release-and-automation.md`.

The issue remains open after this PR merges; it will be closed when Phase C lands.

### Why

`task_release_tag` extracts the version from a merged release PR's title (or branch name) and creates the corresponding `vX.Y.Z` tag. The previous regex was `release:\s*v?(\d+\.\d+\.\d+)`, which only matches bare production versions. It rejects every pre-release shape:

- PEP440 (cz bump's native output): `v0.1.0a0`, `v0.1.0b1`, `v0.1.0rc0`, `v0.1.0.dev2`
- Semver-style (alternate tooling / hand-written): `v0.1.0-alpha.0`, `v0.1.0-beta.1`, `v0.1.0-rc.0`

Once Phase B introduces a pre-release path through `release_pr`, `release_tag` has to recognize those titles. Landing the regex change first, with tests, keeps Phase B focused and reviewable.

### How

- New module-level constant `_VERSION_PATTERN` in `tools/doit/release.py` covering production releases, PEP440 pre-releases, and semver-style pre-releases.
- New pure helper `_extract_version_from_release_pr(pr_title, branch_name) -> str | None` that tries the PR title first (`release: v<version>`), then falls back to the branch name (`release/v<version>`), and returns the bare version string or `None`.
- `task_release_tag` now calls the helper instead of matching the regex inline. The error path (title + branch logged, `sys.exit(1)`) is preserved.

## Related Issue

Addresses #632

Upstream template issue: [pyproject-template#426](https://github.com/endavis/pyproject-template/issues/426).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `_VERSION_PATTERN` constant in `tools/doit/release.py` that accepts production releases (`1.0.0`), PEP440 pre-releases (`0.1.0a0`, `0.1.0b1`, `0.1.0rc0`, `0.1.0.dev2`), and semver-style pre-releases (`0.1.0-alpha.0`, `0.1.0-beta.1`, `0.1.0-rc.0`).
- Added helper `_extract_version_from_release_pr` that encapsulates the PR-title-then-branch-name lookup and returns the bare version string (no leading `v`).
- Replaced the inline regex in `task_release_tag` with a call to the new helper.
- Added 11 new tests in `tests/test_doit_release.py` under a new `TestExtractVersionFromReleasePR` class (8 parametrized PR-title cases, plus branch-name fallback, neither-matches, and non-numeric-version cases). Updated the module docstring to reference issue #632.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes locally (format, lint, type-check, security, spell-check, all 28 tests in `tests/test_doit_release.py` green — 17 pre-existing + 11 new).

The helper is pure, so the new tests are direct assertions on return values across the version shapes listed above. The task function itself remains untested (existing coverage gap called out in the file's module docstring; explicitly out of scope per the plan).

## Scope Boundaries

This PR intentionally does **not**:

- Change the behavior of `task_release_dev` or `task_release` (Phase C will consolidate them).
- Add a pre-release path to `task_release_pr` (Phase B).
- Update `docs/development/release-and-automation.md` (Phase C rewrite covers it; the widened regex is not reachable end-to-end until Phase B ships).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (no user-facing docs are affected by Phase A; see Scope Boundaries)
- [ ] I have updated the CHANGELOG.md (auto-generated from conventional commits at release time)
- [x] My changes generate no new warnings

## Additional Notes

No ADR changes — issue #632 does not carry the `needs-adr` label, and no existing ADR references `release_tag`, the release tooling, or version parsing.
