### PR TITLE
fix: add --prerelease flag to release_pr for PR-based pre-releases

### DIFF
--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -3,9 +3,12 @@
 ``run_streamed`` / ``run_teed`` back the live-streaming output changes for
 the release tasks (issue #631). ``_extract_version_from_release_pr`` is the
 version-parsing helper factored out of ``task_release_tag`` to support
-PEP440 and semver-style pre-release suffixes (issue #632). The task
-functions themselves (``task_release``, etc.) have no existing test
-coverage and are out of scope per the plan.
+PEP440 and semver-style pre-release suffixes (issue #632 Phase A).
+``_build_cz_get_next_cmd`` is the command-list builder factored out of
+``task_release_pr`` so ``--prerelease`` can be threaded through to
+``cz bump --get-next`` (issue #632 Phase B). The task functions themselves
+(``task_release``, etc.) have no existing test coverage and are out of scope
+per the plan.
 """
 
 from __future__ import annotations
@@ -19,7 +22,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from tools.doit.base import run_streamed, run_teed
-from tools.doit.release import _extract_version_from_release_pr
+from tools.doit.release import _build_cz_get_next_cmd, _extract_version_from_release_pr
 
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
@@ -360,3 +363,73 @@ class TestExtractVersionFromReleasePR:
         """``release: vX.Y.Z`` with literal letters must not match — the regex
         requires digits."""
         assert _extract_version_from_release_pr("release: vX.Y.Z", "release/vX.Y.Z") is None
+
+
+class TestBuildCzGetNextCmd:
+    """Tests for ``_build_cz_get_next_cmd``.
+
+    The helper is a pure command-list builder: no validation, no I/O. These
+    tests pin the flag ordering, the uppercasing of ``--increment``, and the
+    verbatim pass-through of ``--prerelease`` (issue #632 Phase B).
+    """
+
+    @pytest.mark.parametrize(
+        ("increment", "prerelease", "expected"),
+        [
+            # No flags: base command only.
+            ("", "", ["uv", "run", "cz", "bump", "--get-next"]),
+            # Increment alone (lowercase input is uppercased).
+            (
+                "minor",
+                "",
+                ["uv", "run", "cz", "bump", "--get-next", "--increment", "MINOR"],
+            ),
+            # Increment alone (already uppercase stays uppercase).
+            (
+                "PATCH",
+                "",
+                ["uv", "run", "cz", "bump", "--get-next", "--increment", "PATCH"],
+            ),
+            # Prerelease alone: alpha.
+            (
+                "",
+                "alpha",
+                ["uv", "run", "cz", "bump", "--get-next", "--prerelease", "alpha"],
+            ),
+            # Prerelease alone: beta.
+            (
+                "",
+                "beta",
+                ["uv", "run", "cz", "bump", "--get-next", "--prerelease", "beta"],
+            ),
+            # Prerelease alone: rc.
+            (
+                "",
+                "rc",
+                ["uv", "run", "cz", "bump", "--get-next", "--prerelease", "rc"],
+            ),
+            # Both set: helper does NOT validate; the task is responsible for
+            # rejecting this combination. Helper just emits both flags in
+            # increment-then-prerelease order.
+            (
+                "minor",
+                "alpha",
+                [
+                    "uv",
+                    "run",
+                    "cz",
+                    "bump",
+                    "--get-next",
+                    "--increment",
+                    "MINOR",
+                    "--prerelease",
+                    "alpha",
+                ],
+            ),
+        ],
+    )
+    def test_builds_expected_command(
+        self, increment: str, prerelease: str, expected: list[str]
+    ) -> None:
+        """The emitted list matches the expected base + flags in order."""
+        assert _build_cz_get_next_cmd(increment, prerelease) == expected

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -176,6 +176,31 @@ def _extract_version_from_release_pr(pr_title: str, branch_name: str) -> str | N
     return None
 
 
+def _build_cz_get_next_cmd(increment: str, prerelease: str) -> list[str]:
+    """Build the ``cz bump --get-next`` command list with optional flags.
+
+    Pure helper: no validation, no I/O. Callers are responsible for validating
+    the ``increment`` and ``prerelease`` values before invoking this helper.
+
+    Args:
+        increment: Version increment type (e.g. ``"minor"``, ``"PATCH"``).
+            Uppercased before being passed to ``--increment``. Empty string
+            means no ``--increment`` flag is appended.
+        prerelease: Pre-release type (e.g. ``"alpha"``, ``"beta"``, ``"rc"``).
+            Passed verbatim to ``--prerelease``. Empty string means no
+            ``--prerelease`` flag is appended.
+
+    Returns:
+        The command list ready to hand to ``subprocess.run``.
+    """
+    cmd = ["uv", "run", "cz", "bump", "--get-next"]
+    if increment:
+        cmd.extend(["--increment", increment.upper()])
+    if prerelease:
+        cmd.extend(["--prerelease", prerelease])
+    return cmd
+
+
 def task_release_dev(type: str = "alpha") -> dict[str, Any]:
     """Create a pre-release (alpha/beta) tag for TestPyPI and push to GitHub.
 
@@ -439,7 +464,7 @@ def task_release(increment: str = "") -> dict[str, Any]:
     }
 
 
-def task_release_pr(increment: str = "") -> dict[str, Any]:
+def task_release_pr(increment: str = "", prerelease: str = "") -> dict[str, Any]:
     """Create a release PR with changelog updates (PR-based workflow).
 
     This task creates a release branch, updates the changelog, and opens a PR.
@@ -447,6 +472,8 @@ def task_release_pr(increment: str = "") -> dict[str, Any]:
 
     Args:
         increment (str): Force version increment type (MAJOR, MINOR, PATCH). Auto-detects if empty.
+        prerelease (str): Pre-release type (alpha, beta, rc). Empty for a production release.
+            Mutually exclusive with ``increment``.
     """
 
     def create_release_pr() -> None:
@@ -467,6 +494,23 @@ def task_release_pr(increment: str = "") -> dict[str, Any]:
             console.print(
                 f"[bold red]❌ Error: Must be on main branch "
                 f"(currently on {current_branch})[/bold red]"
+            )
+            sys.exit(1)
+
+        # Validate prerelease value
+        allowed_prerelease = {"", "alpha", "beta", "rc"}
+        if prerelease not in allowed_prerelease:
+            console.print(
+                f"[bold red]❌ Error: Invalid prerelease value '{prerelease}'. "
+                f"Allowed values: alpha, beta, rc (or empty for a production release).[/bold red]"
+            )
+            sys.exit(1)
+
+        # prerelease and increment are mutually exclusive
+        if prerelease and increment:
+            console.print(
+                "[bold red]❌ Error: --prerelease and --increment "
+                "are mutually exclusive.[/bold red]"
             )
             sys.exit(1)
 
@@ -521,10 +565,11 @@ def task_release_pr(increment: str = "") -> dict[str, Any]:
         # Get next version using commitizen
         console.print("\n[cyan]Determining next version...[/cyan]")
         try:
-            get_next_cmd = ["uv", "run", "cz", "bump", "--get-next"]
+            get_next_cmd = _build_cz_get_next_cmd(increment, prerelease)
             if increment:
-                get_next_cmd.extend(["--increment", increment.upper()])
                 console.print(f"[dim]Forcing {increment.upper()} version bump[/dim]")
+            if prerelease:
+                console.print(f"[dim]Pre-release type: {prerelease}[/dim]")
             result = subprocess.run(
                 get_next_cmd,
                 env={**os.environ, "UV_CACHE_DIR": UV_CACHE_DIR},
@@ -661,7 +706,14 @@ and trigger the release workflow.
                 "long": "increment",
                 "default": "",
                 "help": "Force increment (MAJOR, MINOR, PATCH). Auto-detects if empty.",
-            }
+            },
+            {
+                "name": "prerelease",
+                "short": "p",
+                "long": "prerelease",
+                "default": "",
+                "help": "Pre-release type (alpha, beta, rc). Empty for a production release.",
+            },
         ],
         "title": title_with_actions,
     }


### PR DESCRIPTION
## Description

**Phase B of 3** of the fix for #632 — the PR-based release flow now supports pre-releases (alpha/beta/rc) via a new `--prerelease` flag on `doit release_pr`.

Before this change, the PR-based workflow (`doit release_pr` → merge → `doit release_tag`) could only produce production releases. Pre-releases had to go through `doit release_dev`, which commits directly to `main` and is blocked by the `no-commit-to-main` pre-commit hook (the root of #632). This PR threads pre-release support through the PR-based path so alpha/beta/rc tags can also be produced without committing to `main`.

### Phase context

- **Phase A** — [PR #634](https://github.com/endavis/pynetappfoundry/pull/634) (merged): widened the `release_tag` version regex to accept PEP440 (`v0.1.0a0`) and semver (`v0.1.0-alpha.0`) pre-release suffixes. Without that, `release_tag` couldn't finish the flow that Phase B now kicks off.
- **Phase B (this PR)** — adds the `--prerelease` flag to `task_release_pr` so the same task can produce pre-release PRs.
- **Phase C (deferred)** — rename `task_release_pr` → `task_release`, delete the direct-to-main `task_release` and `task_release_dev`, and rewrite `docs/development/release-and-automation.md` to present the PR-based flow as the primary (and only) documented path. Kept separate because it is a user-facing rename + docs rewrite that deserves its own review. `release_dev` and direct-to-main `release` continue to exist after this PR for that reason.

## Related Issue

Addresses #632

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

Labelled as a bug fix because it unblocks the pre-release path called out in #632's acceptance criteria. The change itself is a pure API addition (`--prerelease` is opt-in, default is `""`), so it is non-breaking.

## Changes Made

- **`tools/doit/release.py`**
  - New pure helper `_build_cz_get_next_cmd(increment, prerelease) -> list[str]` that assembles the `cz bump --get-next` command list with optional `--increment` / `--prerelease` flags. No validation, no I/O — the task is responsible for rejecting bad combinations.
  - `task_release_pr` grew a new `prerelease: str = ""` parameter (short `-p`, long `--prerelease`) and a matching `doit` option entry so the flag is reachable from the CLI.
  - Task-entry validation rejects (a) `prerelease` values outside `{"", "alpha", "beta", "rc"}` and (b) `prerelease` + `increment` both set — both with a red banner and `sys.exit(1)` to match the existing validation style.
  - Reused the same helper in the existing `get_next_cmd` block so the new flag reaches `cz bump --get-next`.

- **`tests/test_doit_release.py`**
  - New `TestBuildCzGetNextCmd` parametrized class — 7 cases pinning flag ordering, the uppercasing of `--increment`, the verbatim pass-through of `--prerelease`, and the helper's deliberate non-validation of the mutually-exclusive case (task owns that guard).
  - File count: 28 → 35 tests.

Nothing else is touched. Phase C (the rename + direct-to-main removal + docs rewrite) is deliberately not in this PR.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**Test plan**
- New `TestBuildCzGetNextCmd` parametrized class covers the 7 command-shape cases for the new helper (empty, increment-only lowercase + uppercase, each prerelease type, and the both-set case that the helper intentionally emits without validating).
- `doit check` green on the current branch state (format, lint, mypy, bandit, codespell, pytest — all 35 tests in `tests/test_doit_release.py` pass).
- No new behavioural tests for `task_release_pr` itself: the pre-existing task functions (`task_release`, `task_release_pr`, etc.) have no existing test coverage and are out of scope per the plan. The new logic is concentrated in the pure helper, which is fully covered.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

**Docs note:** User-facing documentation is intentionally **deferred to Phase C**. The `--prerelease` flag is a new internal API surface that Phase C will expose to users alongside the `task_release_pr` → `task_release` rename and the `docs/development/release-and-automation.md` rewrite. Documenting it now would produce churn: the entry would be rewritten again one PR later. `docs/development/doit-tasks-reference.md` describes `release_pr` at a summary level (no per-flag options table), so it did not need an edit for this PR either. CHANGELOG.md is maintained by commitizen during release and is not touched here.

**ADR note:** No ADR changes — issue is labelled `bug` / `needs-triage` (no `needs-adr`), and this is an API addition inside an existing architectural pattern rather than a new architectural decision.

## Additional Notes

After Phase B merges, the pre-release path works end-to-end on a template-default repo with `no-commit-to-main` enabled:

```
doit release_pr --prerelease=alpha   # creates release/vX.Y.Z branch + PR
# (merge the PR via the normal flow)
doit release_tag                     # creates v0.1.0a0 tag on main, triggers TestPyPI
```

Phase C will then remove the now-redundant `release_dev` and direct-to-main `release` tasks and promote this path to the default.
