### PR TITLE
fix: bound validate_merge_commits walk when no tags exist

### DIFF
--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -20,9 +20,14 @@ import sys
 from typing import TYPE_CHECKING
 
 import pytest
+from rich.console import Console
 
 from tools.doit.base import run_streamed, run_teed
-from tools.doit.release import _build_cz_get_next_cmd, _extract_version_from_release_pr
+from tools.doit.release import (
+    _build_cz_get_next_cmd,
+    _extract_version_from_release_pr,
+    validate_merge_commits,
+)
 
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
@@ -433,3 +438,97 @@ class TestBuildCzGetNextCmd:
     ) -> None:
         """The emitted list matches the expected base + flags in order."""
         assert _build_cz_get_next_cmd(increment, prerelease) == expected
+
+
+class TestValidateMergeCommits:
+    """Tests for ``validate_merge_commits`` (issue #639).
+
+    The helper shells out to ``git describe`` and ``git log --merges``; the
+    tests monkeypatch ``subprocess.run`` inside ``tools.doit.release`` so the
+    git calls return canned results and the ``range_spec`` argument to the
+    second call can be asserted on.
+    """
+
+    @staticmethod
+    def _silent_console() -> Console:
+        return Console(file=io.StringIO(), force_terminal=False)
+
+    @staticmethod
+    def _fake_run(
+        describe_returncode: int,
+        describe_stdout: str,
+        log_stdout: str,
+    ) -> tuple[list[list[str]], object]:
+        """Build a fake ``subprocess.run`` that captures calls.
+
+        Returns ``(captured_calls, fake_run)``. The first git-describe call
+        yields a ``CompletedProcess`` with the given ``describe_returncode``
+        and ``describe_stdout``; the second git-log call yields ``log_stdout``
+        with returncode 0. ``captured_calls`` is appended to on each call.
+        """
+        calls: list[list[str]] = []
+
+        def fake(
+            cmd: list[str],
+            *_args: object,
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            calls.append(cmd)
+            if "describe" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=describe_returncode, stdout=describe_stdout, stderr=""
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=log_stdout, stderr="")
+
+        return calls, fake
+
+    def test_no_tags_falls_back_to_last_10_commits(self, monkeypatch: MonkeyPatch) -> None:
+        """When ``git describe`` fails (no tags), range_spec is ``HEAD~10..HEAD``.
+
+        Regression test for #639: the previous fallback was ``HEAD``, which
+        walked full history and surfaced merges from unrelated pre-project
+        ancestors on any fresh repo.
+        """
+        calls, fake = self._fake_run(describe_returncode=128, describe_stdout="", log_stdout="")
+        monkeypatch.setattr("tools.doit.release.subprocess.run", fake)
+
+        assert validate_merge_commits(self._silent_console()) is True
+
+        log_cmds = [c for c in calls if "log" in c]
+        assert len(log_cmds) == 1
+        assert log_cmds[0][-1] == "HEAD~10..HEAD"
+
+    def test_with_tag_uses_tag_range(self, monkeypatch: MonkeyPatch) -> None:
+        """When a tag exists, range_spec is ``<last_tag>..HEAD``."""
+        calls, fake = self._fake_run(
+            describe_returncode=0, describe_stdout="v0.1.0\n", log_stdout=""
+        )
+        monkeypatch.setattr("tools.doit.release.subprocess.run", fake)
+
+        assert validate_merge_commits(self._silent_console()) is True
+
+        log_cmds = [c for c in calls if "log" in c]
+        assert len(log_cmds) == 1
+        assert log_cmds[0][-1] == "v0.1.0..HEAD"
+
+    def test_valid_merge_commit_passes(self, monkeypatch: MonkeyPatch) -> None:
+        """A merge commit matching the convention returns True."""
+        _, fake = self._fake_run(
+            describe_returncode=0,
+            describe_stdout="v0.1.0\n",
+            log_stdout="abc1234 fix: handle null (merges PR #42, addresses #41)",
+        )
+        monkeypatch.setattr("tools.doit.release.subprocess.run", fake)
+
+        assert validate_merge_commits(self._silent_console()) is True
+
+    def test_invalid_merge_commit_fails(self, monkeypatch: MonkeyPatch) -> None:
+        """A merge commit not matching the convention returns False."""
+        _, fake = self._fake_run(
+            describe_returncode=0,
+            describe_stdout="v0.1.0\n",
+            log_stdout="abc1234 Merge branch 'master' of https://example.com/repo",
+        )
+        monkeypatch.setattr("tools.doit.release.subprocess.run", fake)
+
+        assert validate_merge_commits(self._silent_console()) is False

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -32,7 +32,10 @@ def validate_merge_commits(console: "ConsoleType") -> bool:
             text=True,
         )
         last_tag = result.stdout.strip() if result.returncode == 0 else ""
-        range_spec = f"{last_tag}..HEAD" if last_tag else "HEAD"
+        # When no tag exists yet (first release), bound the walk to the last
+        # 10 commits — matches validate_issue_links below. Walking full HEAD
+        # can surface merges from unrelated pre-project history.
+        range_spec = f"{last_tag}..HEAD" if last_tag else "HEAD~10..HEAD"
 
         result = subprocess.run(
             ["git", "log", "--merges", "--pretty=format:%h %s", range_spec],


### PR DESCRIPTION
## Description

`validate_merge_commits` in `tools/doit/release.py` had a no-tag fallback of
`range_spec = "HEAD"`, which walks the entire git history. On any repo that
had a pre-project ancestor (or a fresh release before the first tag), this
surfaced unrelated merge commits and blocked `doit release`.

The fix mirrors the sibling `validate_issue_links` helper (one function
below, at line 96): fall back to `HEAD~10..HEAD` so only the last 10
commits are scanned when no tag exists yet.

This was discovered during end-to-end verification of the #632 pre-release
fix. Running `doit release --prerelease=alpha` on a tagless branch surfaced
two 2017 merge commits from a pre-project ancestor repo (`endavis/sysadmin`)
because the fallback walked full history.

## Related Issue

Addresses #639

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `tools/doit/release.py`: change the no-tag fallback in
  `validate_merge_commits` from `range_spec = "HEAD"` to
  `range_spec = "HEAD~10..HEAD"`. Added a short comment explaining why.
- `tests/test_doit_release.py`: new `TestValidateMergeCommits` class with
  four tests:
  - `test_no_tags_falls_back_to_last_10_commits` — regression test for
    #639, pins the fallback string to `HEAD~10..HEAD` when `git describe`
    returns non-zero.
  - `test_with_tag_uses_tag_range` — asserts `<tag>..HEAD` is used when a
    tag exists.
  - `test_valid_merge_commit_passes` — conventional-format merge commit
    returns True.
  - `test_invalid_merge_commit_fails` — non-conforming merge commit
    returns False.
  - Uses a local `_fake_run` helper that monkeypatches
    `tools.doit.release.subprocess.run`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Test plan:

- `doit check` is green on this branch.
- `tests/test_doit_release.py` goes from 35 → 39 tests.
- The regression test (`test_no_tags_falls_back_to_last_10_commits`) pins
  the exact fallback string, which is the defect.
- Tests-not-mocks verification isn't feasible here because the bug depends
  on repo state (presence of an unrelated-ancestor merge with no tags).
  The pinned-string regression test is the actual defect.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — N/A, internal validator fix
- [ ] I have updated the CHANGELOG.md — handled by release automation
- [x] My changes generate no new warnings

## Additional Notes

This is another template-heritage bug (same shape as #631 and #632) in the
`doit release*` tasks. After this fix is verified end-to-end downstream, it
will be ported back to `pyproject-template` as part of a later batch
alongside #631 and #632.
