### PR TITLE
fix: pass --yes to cz bump --get-next and parse its output defensively

### DIFF
--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -25,6 +25,7 @@ from rich.console import Console
 from tools.doit.base import run_streamed, run_teed
 from tools.doit.release import (
     _build_cz_get_next_cmd,
+    _extract_next_version_from_cz_output,
     _extract_version_from_release_pr,
     validate_merge_commits,
 )
@@ -382,36 +383,36 @@ class TestBuildCzGetNextCmd:
         ("increment", "prerelease", "expected"),
         [
             # No flags: base command only.
-            ("", "", ["uv", "run", "cz", "bump", "--get-next"]),
+            ("", "", ["uv", "run", "cz", "bump", "--get-next", "--yes"]),
             # Increment alone (lowercase input is uppercased).
             (
                 "minor",
                 "",
-                ["uv", "run", "cz", "bump", "--get-next", "--increment", "MINOR"],
+                ["uv", "run", "cz", "bump", "--get-next", "--yes", "--increment", "MINOR"],
             ),
             # Increment alone (already uppercase stays uppercase).
             (
                 "PATCH",
                 "",
-                ["uv", "run", "cz", "bump", "--get-next", "--increment", "PATCH"],
+                ["uv", "run", "cz", "bump", "--get-next", "--yes", "--increment", "PATCH"],
             ),
             # Prerelease alone: alpha.
             (
                 "",
                 "alpha",
-                ["uv", "run", "cz", "bump", "--get-next", "--prerelease", "alpha"],
+                ["uv", "run", "cz", "bump", "--get-next", "--yes", "--prerelease", "alpha"],
             ),
             # Prerelease alone: beta.
             (
                 "",
                 "beta",
-                ["uv", "run", "cz", "bump", "--get-next", "--prerelease", "beta"],
+                ["uv", "run", "cz", "bump", "--get-next", "--yes", "--prerelease", "beta"],
             ),
             # Prerelease alone: rc.
             (
                 "",
                 "rc",
-                ["uv", "run", "cz", "bump", "--get-next", "--prerelease", "rc"],
+                ["uv", "run", "cz", "bump", "--get-next", "--yes", "--prerelease", "rc"],
             ),
             # Both set: helper does NOT validate; the task is responsible for
             # rejecting this combination. Helper just emits both flags in
@@ -425,6 +426,7 @@ class TestBuildCzGetNextCmd:
                     "cz",
                     "bump",
                     "--get-next",
+                    "--yes",
                     "--increment",
                     "MINOR",
                     "--prerelease",
@@ -532,3 +534,67 @@ class TestValidateMergeCommits:
         monkeypatch.setattr("tools.doit.release.subprocess.run", fake)
 
         assert validate_merge_commits(self._silent_console()) is False
+
+
+class TestExtractNextVersionFromCzOutput:
+    """Tests for ``_extract_next_version_from_cz_output`` (issue #641).
+
+    Scans the captured stdout of ``cz bump --get-next --yes`` and returns
+    the last line that matches a semver-ish version pattern. Must tolerate
+    leading diagnostic noise (on a tagless repo, cz prints a multi-line
+    "No tag matching configuration could be found" block before emitting
+    the version) and reject strings that merely contain a version substring.
+    """
+
+    @pytest.mark.parametrize(
+        ("stdout", "expected"),
+        [
+            # Clean production-release output.
+            ("1.2.3\n", "1.2.3"),
+            # Clean pre-release output (PEP440).
+            ("0.1.0a0\n", "0.1.0a0"),
+            ("0.1.0b1\n", "0.1.0b1"),
+            ("0.1.0rc0\n", "0.1.0rc0"),
+            # Clean pre-release output (semver style).
+            ("0.1.0-alpha.0\n", "0.1.0-alpha.0"),
+            # Leading 'v' accepted and stripped.
+            ("v0.2.0\n", "0.2.0"),
+            # Tagless-repo case: diagnostic noise precedes the version.
+            # Regression case that this helper exists to fix.
+            (
+                "No tag matching configuration could be found.\n"
+                "Possible causes:\n"
+                "- version in configuration is not the current version\n"
+                "- tag_format or legacy_tag_formats is missing\n"
+                "\n"
+                "0.1.0a0\n",
+                "0.1.0a0",
+            ),
+            # Trailing blank lines are ignored; the version is still found.
+            ("0.1.0\n\n\n", "0.1.0"),
+        ],
+    )
+    def test_returns_trailing_version_line(self, stdout: str, expected: str) -> None:
+        assert _extract_next_version_from_cz_output(stdout) == expected
+
+    def test_returns_none_when_no_version_line(self) -> None:
+        """Output with zero version-shaped lines returns ``None``."""
+        assert _extract_next_version_from_cz_output("totally unrelated output\n") is None
+
+    def test_rejects_line_that_only_contains_a_version_substring(self) -> None:
+        """The pattern is anchored to the whole line.
+
+        A diagnostic line like ``"error at 1.2.3 somewhere"`` must not
+        be mistaken for the version output.
+        """
+        stdout = "something broke near 1.2.3 in the build\n"
+        assert _extract_next_version_from_cz_output(stdout) is None
+
+    def test_returns_last_version_when_multiple(self) -> None:
+        """When multiple version-shaped lines are present, take the last.
+
+        cz may print intermediate version hints in diagnostic output; the
+        trailing line is the authoritative one.
+        """
+        stdout = "0.0.1\n0.0.2\n0.0.3\n"
+        assert _extract_next_version_from_cz_output(stdout) == "0.0.3"

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -196,12 +196,43 @@ def _build_cz_get_next_cmd(increment: str, prerelease: str) -> list[str]:
     Returns:
         The command list ready to hand to ``subprocess.run``.
     """
-    cmd = ["uv", "run", "cz", "bump", "--get-next"]
+    # --yes auto-answers cz's interactive prompts (e.g. "Is this the first
+    # tag created?" on a tagless repo). Without it, cz hangs or prints
+    # "Cancelled by user" into the stdout we capture for version parsing.
+    cmd = ["uv", "run", "cz", "bump", "--get-next", "--yes"]
     if increment:
         cmd.extend(["--increment", increment.upper()])
     if prerelease:
         cmd.extend(["--prerelease", prerelease])
     return cmd
+
+
+def _extract_next_version_from_cz_output(stdout: str) -> str | None:
+    """Extract the next version from ``cz bump --get-next`` stdout.
+
+    On a tagless repo, cz emits diagnostic lines before the version (e.g.
+    ``"No tag matching configuration could be found."``). Scan from the
+    last line backward and return the first line that matches
+    ``_VERSION_PATTERN``. The match must cover the entire line so noisy
+    diagnostics that happen to contain a version substring don't fool it.
+
+    Args:
+        stdout: The captured stdout from ``cz bump --get-next``.
+
+    Returns:
+        The bare version string (no leading ``v``) from the last
+        version-looking line, or ``None`` if no line matches.
+    """
+    # Anchor the pattern so it must span the whole (stripped) line.
+    whole_line = re.compile(rf"^{_VERSION_PATTERN}$")
+    for line in reversed(stdout.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        match = whole_line.match(stripped)
+        if match:
+            return match.group(1)
+    return None
 
 
 def task_release(increment: str = "", prerelease: str = "") -> dict[str, Any]:
@@ -319,7 +350,15 @@ def task_release(increment: str = "", prerelease: str = "") -> dict[str, Any]:
                 capture_output=True,
                 text=True,
             )
-            next_version = result.stdout.strip()
+            next_version = _extract_next_version_from_cz_output(result.stdout)
+            if next_version is None:
+                console.print(
+                    "[bold red]❌ Could not extract a version from "
+                    "cz bump --get-next output.[/bold red]"
+                )
+                console.print(f"[red]Stdout: {result.stdout}[/red]")
+                console.print(f"[red]Stderr: {result.stderr}[/red]")
+                sys.exit(1)
             console.print(f"[green]✓ Next version: {next_version}[/green]")
         except subprocess.CalledProcessError as e:
             console.print("[bold red]❌ Failed to determine next version.[/bold red]")


### PR DESCRIPTION
## Description

Fix `doit release` failing on tagless repos. Two stacked defects in the
same code path are addressed together (defense in depth):

1. **`cz bump --get-next` was running without `--yes`.** On a repo with
   zero tags, cz raises an interactive "Is this the first tag created?
   (Y/n)" prompt before emitting the version. With `capture_output=True`
   the prompt can't reach stdin, so cz prints `Cancelled by user` plus a
   multi-line diagnostic block to stdout and exits 0.

2. **The version was being parsed with `result.stdout.strip()`.** When
   the diagnostic block above is captured, the whole blob is then
   interpolated into the `release/vX.Y.Z` branch name, producing things
   like:

   ```
   release/vNo tag matching configuration could be found.
   Possible causes:
   ...
   0.1.0a0
   ```

   git rejects the malformed branch name and the release task aborts in
   a confusing state.

This is another template-heritage bug in the same release-task family as
#631 / #632 / #639 — worth porting back to `pyproject-template`.

## Related Issue

Addresses #641

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `_build_cz_get_next_cmd` now always emits `--yes`, auto-answering the
  first-tag prompt (and any future interactive prompts cz adds).
- New helper `_extract_next_version_from_cz_output(stdout) -> str | None`
  scans the captured stdout from the last line backward and returns the
  first line that matches `_VERSION_PATTERN` anchored to the **whole
  line**. A diagnostic line that merely contains a version substring
  (e.g. `"error at 1.2.3 somewhere"`) is rejected.
- `task_release` calls the new extractor instead of `result.stdout.strip()`.
  If the extractor returns `None`, the task prints a red error banner with
  the full captured stdout and stderr and exits 1 so a future change in
  cz's output shape fails loudly instead of silently polluting the branch
  name.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` is green on the branch.

Test coverage delta (`tests/test_doit_release.py` 39 → 50, +11):

- `TestBuildCzGetNextCmd` — existing 7 parametrized cases updated to
  expect `--yes` in the emitted command list.
- `TestExtractNextVersionFromCzOutput` — **new** class with 11 cases:
  - Clean production output (`"1.2.3\n"` → `"1.2.3"`).
  - PEP440 pre-releases: `0.1.0a0`, `0.1.0b1`, `0.1.0rc0`.
  - Semver pre-release: `0.1.0-alpha.0`.
  - Leading `v` stripped (`"v0.2.0\n"` → `"0.2.0"`).
  - **#641 regression case:** multi-line "No tag matching configuration
    could be found." diagnostic block followed by `0.1.0a0` → extractor
    still returns `"0.1.0a0"`.
  - Trailing blank lines tolerated.
  - `None` when no version-shaped line is present.
  - `None` when a diagnostic line merely contains a version substring
    (whole-line-anchor test).
  - Last-of-multiple version lines wins (takes the trailing line).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly <!-- no user-facing behavior change; the external CLI surface is unchanged -->
- [ ] I have updated the CHANGELOG.md <!-- commitizen owns CHANGELOG.md on release -->
- [x] My changes generate no new warnings

## Additional Notes

Template-heritage bug, same family as #631 / #632 / #639. Destined for
the upstream `pyproject-template` port batch.
