### PR TITLE
fix: refuse doit release --prerelease on tagless repos

### DIFF
--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -27,6 +27,7 @@ from tools.doit.release import (
     _build_cz_get_next_cmd,
     _extract_next_version_from_cz_output,
     _extract_version_from_release_pr,
+    _repo_has_version_tags,
     validate_merge_commits,
 )
 
@@ -598,3 +599,49 @@ class TestExtractNextVersionFromCzOutput:
         """
         stdout = "0.0.1\n0.0.2\n0.0.3\n"
         assert _extract_next_version_from_cz_output(stdout) == "0.0.3"
+
+
+class TestRepoHasVersionTags:
+    """Tests for ``_repo_has_version_tags`` (issue #644).
+
+    The helper shells out to ``git tag --list v*``. These tests monkeypatch
+    ``subprocess.run`` inside ``tools.doit.release`` so the git call returns
+    canned stdout.
+    """
+
+    @staticmethod
+    def _fake_tag_list(stdout: str, returncode: int = 0):
+        def fake(
+            cmd: list[str],
+            *_args: object,
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            assert cmd[:3] == ["git", "tag", "--list"]
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=returncode, stdout=stdout, stderr=""
+            )
+
+        return fake
+
+    def test_no_tags_returns_false(self, monkeypatch: MonkeyPatch) -> None:
+        """Empty ``git tag --list v*`` output → no tags → ``False``."""
+        monkeypatch.setattr("tools.doit.release.subprocess.run", self._fake_tag_list(""))
+        assert _repo_has_version_tags() is False
+
+    def test_whitespace_only_returns_false(self, monkeypatch: MonkeyPatch) -> None:
+        """Whitespace-only output counts as no tags."""
+        monkeypatch.setattr("tools.doit.release.subprocess.run", self._fake_tag_list("\n\n  \n"))
+        assert _repo_has_version_tags() is False
+
+    def test_one_tag_returns_true(self, monkeypatch: MonkeyPatch) -> None:
+        """A single ``v*`` tag present → ``True``."""
+        monkeypatch.setattr("tools.doit.release.subprocess.run", self._fake_tag_list("v0.0.0\n"))
+        assert _repo_has_version_tags() is True
+
+    def test_multiple_tags_returns_true(self, monkeypatch: MonkeyPatch) -> None:
+        """Multiple ``v*`` tags present → ``True``."""
+        monkeypatch.setattr(
+            "tools.doit.release.subprocess.run",
+            self._fake_tag_list("v0.0.0\nv0.1.0a0\nv0.1.0\n"),
+        )
+        assert _repo_has_version_tags() is True

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -207,6 +207,24 @@ def _build_cz_get_next_cmd(increment: str, prerelease: str) -> list[str]:
     return cmd
 
 
+def _repo_has_version_tags() -> bool:
+    """Return ``True`` if the repo has at least one ``v*`` tag.
+
+    Used by ``task_release`` to refuse the ``--prerelease`` combination on
+    a fresh repo: without an anchor tag, ``cz bump --get-next --yes
+    --prerelease alpha`` silently returns the production first-version
+    (``0.1.0``) and drops the ``--prerelease`` flag, producing a
+    production PR when a pre-release was requested (issue #644).
+    """
+    result = subprocess.run(  # nosec B603 B607
+        ["git", "tag", "--list", "v*"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return bool(result.stdout.strip())
+
+
 def _extract_next_version_from_cz_output(stdout: str) -> str | None:
     """Extract the next version from ``cz bump --get-next`` stdout.
 
@@ -284,6 +302,26 @@ def task_release(increment: str = "", prerelease: str = "") -> dict[str, Any]:
             console.print(
                 "[bold red]❌ Error: --prerelease and --increment "
                 "are mutually exclusive.[/bold red]"
+            )
+            sys.exit(1)
+
+        # prerelease on a tagless repo silently produces a production version
+        # because cz has no anchor to bump from. Refuse loudly instead.
+        if prerelease and not _repo_has_version_tags():
+            console.print(
+                "[bold red]❌ Error: --prerelease requested but this repo has "
+                "no version tags yet.[/bold red]"
+            )
+            console.print(
+                "[yellow]cz bump cannot compute a pre-release without an anchor "
+                "tag. Pick one of:[/yellow]\n"
+                "  [cyan]1.[/cyan] Seed a baseline tag and retry:\n"
+                "     [dim]git tag v0.0.0 <commit>[/dim]\n"
+                "     [dim]git push origin v0.0.0[/dim]\n"
+                "     [dim]doit release --prerelease=" + prerelease + "[/dim]\n"
+                "  [cyan]2.[/cyan] Drop --prerelease to cut a production first "
+                "release (v0.1.0):\n"
+                "     [dim]doit release[/dim]"
             )
             sys.exit(1)
 


### PR DESCRIPTION
## Description

`doit release --prerelease=alpha|beta|rc` on a repo with no `v*` tags silently
produced a **production** version instead of the requested pre-release. `cz bump
--get-next --yes --prerelease alpha` has no anchor tag to bump from, falls back
to the first-version default (`0.1.0`), and drops the `--prerelease` flag
entirely — so the task happily opens `release: v0.1.0`. If the user doesn't
notice, merging the release PR and running `doit release_tag` would push
straight to PyPI via `release.yml` instead of TestPyPI.

This PR adds a pre-flight guard: if `--prerelease` is set and the repo has no
`v*` tags, the task refuses with a red error banner and two-option guidance
instead of silently producing the wrong version.

## Related Issue

Addresses #644

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- **`tools/doit/release.py`**
  - New `_repo_has_version_tags() -> bool` helper. Shells out to
    `git tag --list v*` and returns `True` iff at least one version tag exists.
  - New guard in `task_release`, placed right after the existing `--prerelease`
    validations (allowed-values + mutual-exclusion with `--increment`): if
    `prerelease` is set AND `_repo_has_version_tags()` is `False`, print a red
    error banner plus yellow two-option guidance, then `sys.exit(1)`. The
    guidance echoes the user's prerelease type back in the suggested retry
    command.
  - Two suggested options in the error message:
    1. Seed a baseline tag (`git tag v0.0.0 <commit>; git push origin v0.0.0`)
       then retry `doit release --prerelease=<type>`.
    2. Drop `--prerelease` for a production first release (`doit release` →
       `v0.1.0`).

- **`tests/test_doit_release.py`**
  - New `TestRepoHasVersionTags` class with four cases using the same
    `subprocess.run` monkeypatch pattern introduced in #639:
    - empty stdout → `False` (the tagless first-release trap)
    - whitespace-only stdout → `False`
    - one tag → `True`
    - multiple tags → `True`
  - New import of `_repo_has_version_tags`.

## Before / After

**Before** (observed on this repo's first release attempt):

```
$ doit release --prerelease=alpha
# ... runs through check, cz bump --get-next --yes --prerelease alpha ...
# Silently creates release/v0.1.0 branch and opens "release: v0.1.0"
```

Evidence: PR #643 (`release: v0.1.0`) was created by exactly this invocation,
even though `--prerelease=alpha` was requested. The PR was closed unmerged and
its branch deleted.

**After**:

```
$ doit release --prerelease=alpha
❌ Error: --prerelease requested but this repo has no version tags yet.
cz bump cannot compute a pre-release without an anchor tag. Pick one of:
  1. Seed a baseline tag and retry:
     git tag v0.0.0 <commit>
     git push origin v0.0.0
     doit release --prerelease=alpha
  2. Drop --prerelease to cut a production first release (v0.1.0):
     doit release
# exit 1
```

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Test plan:
- 4 new parametrized tests in `TestRepoHasVersionTags` covering empty,
  whitespace-only, single-tag, and multi-tag outputs.
- Test count: 50 → 54.
- `doit check` green locally.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

No documentation update needed — existing docs (`docs/development/release-and-automation.md`,
`docs/development/doit-tasks-reference.md`) show pre-release examples that
assume an existing anchor tag; none promise a silent fallback for the tagless
case. `CHANGELOG.md` is auto-generated at release time from conventional
commits.

## Additional Notes

**Discovery context.** The trap was hit during end-to-end release verification
of the release-chain campaign (#631, #632, #639, #641). After #641 landed,
`doit release --prerelease=alpha` produced a clean `release/v0.1.0` branch and
PR #643 — but `v0.1.0` is a production tag, not the intended alpha. `cz`
silently ignored `--prerelease` because there was no anchor to bump from. PR
#643 was closed unmerged and its branch deleted; this issue was filed to make
the task refuse this case loudly instead of silently producing the wrong
version.

**Recovery path after merge.** Seed `v0.0.0` baseline tag → retry `doit release
--prerelease=alpha` → get `v0.1.0a0` PR.

**Template-heritage family.** Same family as #631, #632, #639, #641; destined
for the upstream `pyproject-template` port batch after downstream verification.
No `needs-adr` label, no architectural surface change — a defensive guard in
`task_release` keeps it in the fix family.
