### PR TITLE
fix: wire release CLI params to action function (not closure)

### DIFF
--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -645,3 +645,51 @@ class TestRepoHasVersionTags:
             self._fake_tag_list("v0.0.0\nv0.1.0a0\nv0.1.0\n"),
         )
         assert _repo_has_version_tags() is True
+
+
+class TestTaskReleaseActionSignature:
+    """Regression tests for ``task_release`` CLI-param wiring (issue #650).
+
+    doit's ``params`` parsing populates values for the **action function**,
+    not the outer task-creator function. If the action doesn't accept the
+    param names as kwargs, doit silently drops the CLI values and the action
+    runs with closure-captured defaults. These tests pin the action signature
+    so a future refactor can't re-introduce the silent drop.
+    """
+
+    def test_action_accepts_params(self) -> None:
+        """The first action must accept ``increment`` and ``prerelease`` kwargs."""
+        import inspect
+
+        from tools.doit.release import task_release
+
+        result = task_release()
+        actions = result["actions"]
+        assert actions, "task_release must return at least one action"
+        action = actions[0]
+        sig = inspect.signature(action)
+        assert "increment" in sig.parameters, (
+            "create_release_pr must accept 'increment' for --increment CLI flag to reach it"
+        )
+        assert "prerelease" in sig.parameters, (
+            "create_release_pr must accept 'prerelease' for --prerelease CLI flag to reach it"
+        )
+
+    def test_params_names_match_action_signature(self) -> None:
+        """Every ``params[n]['name']`` must be a parameter of the action function.
+
+        Without this match, doit's parsed CLI values can't reach the action.
+        """
+        import inspect
+
+        from tools.doit.release import task_release
+
+        result = task_release()
+        action = result["actions"][0]
+        sig_params = set(inspect.signature(action).parameters)
+        cli_param_names = {p["name"] for p in result["params"]}
+        missing = cli_param_names - sig_params
+        assert not missing, (
+            f"params names {missing} have no matching kwarg in the action signature; "
+            "doit will silently drop their CLI values"
+        )

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -253,7 +253,7 @@ def _extract_next_version_from_cz_output(stdout: str) -> str | None:
     return None
 
 
-def task_release(increment: str = "", prerelease: str = "") -> dict[str, Any]:
+def task_release() -> dict[str, Any]:
     """Create a release PR with changelog updates (PR-based release flow).
 
     This is the single supported release entry point. It creates a release
@@ -261,13 +261,14 @@ def task_release(increment: str = "", prerelease: str = "") -> dict[str, Any]:
     reviewer merges the PR, run ``doit release_tag`` to tag ``main`` and
     trigger the publish workflow.
 
-    Args:
-        increment (str): Force version increment type (MAJOR, MINOR, PATCH). Auto-detects if empty.
-        prerelease (str): Pre-release type (alpha, beta, rc). Empty for a production release.
-            Mutually exclusive with ``increment``.
+    CLI params (see the ``params`` entry in the returned dict): ``--increment``
+    forces a version increment type; ``--prerelease`` produces a pre-release
+    (alpha/beta/rc). The action function ``create_release_pr`` accepts these
+    as keyword arguments so doit's param parsing reaches them — see #650 for
+    why the closure approach was wrong.
     """
 
-    def create_release_pr() -> None:
+    def create_release_pr(increment: str = "", prerelease: str = "") -> None:
         console = Console()
         console.print("=" * 70)
         console.print("[bold green]Starting PR-based release process...[/bold green]")


### PR DESCRIPTION
## Description

Fix a silent-drop bug in `task_release` that caused `doit release --prerelease=<kind>` and `doit release --increment=<level>` to behave as if no CLI flag had been passed. The advertised CLI surface was correct — the problem was a closure-vs-action-function wiring mistake inside `task_release`.

**User-facing symptom:** every release PR opened with `doit release --prerelease=alpha` came out as a production release instead of a pre-release. Concretely, PRs #643, #647, #648, and #649 were all titled `release: v0.1.0` despite being invoked with `--prerelease=alpha`. The expected title was `release: v0.1.0a0` and the expected `CHANGELOG.md` section was the alpha header.

**Root cause:** `task_release(increment="", prerelease="")` declared `increment` and `prerelease` as arguments of the outer task-creator function, and the inner action was a no-arg closure that captured those names:

```python
def task_release(increment: str = "", prerelease: str = "") -> dict[str, Any]:
    def create_release_pr() -> None:
        # uses `increment` / `prerelease` captured from the outer scope
```

doit's `params` parsing populates the **action function's** kwargs, not the outer task-creator's parameters. Because `create_release_pr` took no parameters, doit had nowhere to deliver the parsed values, so it silently dropped them. The closure then always read the outer function's empty-string defaults. No warning, no error, no log — the action simply ran as if the flag had never been passed.

This is why #644's tag guard never fired on the broken pre-release attempts: that guard read `prerelease` from the same empty closure, so it saw `""` on every call and skipped the guard.

**Code fix shape (`tools/doit/release.py`):**

Before:

```python
def task_release(increment: str = "", prerelease: str = "") -> dict[str, Any]:
    def create_release_pr() -> None:
        # `increment` / `prerelease` captured from the outer scope (always "")
```

After:

```python
def task_release() -> dict[str, Any]:
    def create_release_pr(increment: str = "", prerelease: str = "") -> None:
        # kwargs match `params[n]["name"]`, so doit delivers CLI values here
```

The param `name` entries already were `increment` and `prerelease`; the fix is to move the kwargs onto the action function where doit actually looks for them. The docstring was updated to describe the params and point readers at #650 for the closure-capture rationale.

## Related Issue

Addresses #650

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `tools/doit/release.py`: drop `increment` / `prerelease` from `task_release`'s signature; add them as kwargs on the inner `create_release_pr` action so doit's `params` parsing can populate them. Docstring updated to describe the CLI params and reference #650.
- `tests/test_doit_release.py`: new `TestTaskReleaseActionSignature` class with two regression tests that pin the wiring so this bug can't silently recur:
  - `test_action_accepts_params` — asserts the first action returned by `task_release()` accepts `increment` and `prerelease` kwargs.
  - `test_params_names_match_action_signature` — generic consistency check: every `params[n]["name"]` must exist as a kwarg on the action function. Catches future drift on any future flag, not just these two.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**Test plan:**

- 2 new regression tests pin the action-function signature and the generic params-to-signature consistency rule (see "Changes Made" above for names).
- `doit check` is green.
- `tests/test_doit_release.py` goes from 54 → 56 tests.

## Discovery context

The bug was discovered during end-to-end release verification after #641 and #644 merged. `doit release --prerelease=alpha` consistently produced release PRs titled `release: v0.1.0` instead of the expected `release: v0.1.0a0`.

Diagnosis ran `cz bump --get-next --prerelease=alpha` stand-alone, in a direct python-subprocess replica of the doit call path, and via a dedicated `doit diagnose_641` task that mirrored `task_release`'s full pre-cz sequence. In every case where cz received `--prerelease=alpha`, **cz correctly emitted `0.1.0a0`**. Only `doit release` itself produced `0.1.0`, which ruled out commitizen, git state, and the surrounding shell environment.

Adding `console.print(f"prerelease={prerelease!r}")` at the top of `create_release_pr` showed the captured value on a run invoked with `--prerelease=alpha`:

```
prerelease=''
```

The closure was reading the outer function's default. That's the whole bug.

## Template-heritage note

Same class of defect as #631, #632, #639, #641, and #644 — defects inherited from the shared pyproject-template `release.py`. The `--increment` flag has been broken in the template since it was first added (pre-Phase-B), and Phase B's `--prerelease` inherited the same structural mistake. This fix is destined for the upstream port batch so the template and every downstream project pick it up.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- **No docs change required.** The user-facing CLI surface is unchanged — `--prerelease` and `--increment` were already documented as working in `docs/development/release-and-automation.md` and `docs/development/doit-tasks-reference.md`. Users just weren't getting the advertised behavior.
- **No ADR required.** No `needs-adr` label; this is a bug fix inside an existing task — no architectural decision involved.
- **CHANGELOG.md unchecked:** changelog is generated from conventional commits by `doit release` on the next release cut, not edited by hand.
