### PR TITLE
fix: accept release as a conventional type in PR and governance validators

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
-            const pattern = /^(feat|fix|refactor|docs|test|chore|ci|perf)(\(.+\))?:\s.+$/;
+            const pattern = /^(feat|fix|refactor|docs|test|chore|ci|perf|release)(\(.+\))?:\s.+$/;
 
             if (!pattern.test(title)) {
               core.setFailed(
@@ -22,11 +22,12 @@ jobs:
                 '   <type>: <subject>\n' +
                 '   or\n' +
                 '   <type>(<scope>): <subject>\n\n' +
-                'Valid types: feat, fix, refactor, docs, test, chore, ci, perf\n\n' +
+                'Valid types: feat, fix, refactor, docs, test, chore, ci, perf, release\n\n' +
                 'Examples:\n' +
                 '  ✅ feat: add user authentication\n' +
                 '  ✅ fix(api): handle null response\n' +
-                '  ✅ docs: update installation guide\n\n' +
+                '  ✅ docs: update installation guide\n' +
+                '  ✅ release: v0.1.0a0\n\n' +
                 `Current title: "${title}"`
               );
             } else {

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -550,7 +550,11 @@ This template enforces governance rules to ensure code quality and traceability.
 
 See [PR Merging](#pr-merging) for details.
 
-**Valid Types**: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf`
+**Valid Types**: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf`, `release`
+
+`release` is included so that merge commits from the release PRs that
+`doit release` opens (e.g. `release: v0.1.0a0 (merges PR #652)`) pass
+governance validation on the next release cut.
 
 **When It Runs**: During `doit release` (blocks on failure)
 

--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -525,6 +525,23 @@ class TestValidateMergeCommits:
 
         assert validate_merge_commits(self._silent_console()) is True
 
+    def test_release_type_merge_commit_passes(self, monkeypatch: MonkeyPatch) -> None:
+        """A release-PR merge commit (type=release) is accepted.
+
+        Regression test for #653: release PRs created by ``doit release``
+        merge as ``release: v<version> (merges PR #N)``. Without ``release``
+        in the allowed type set, governance validation on the next release
+        would fail on the prior release's merge commit.
+        """
+        _, fake = self._fake_run(
+            describe_returncode=0,
+            describe_stdout="v0.0.0\n",
+            log_stdout="abc1234 release: v0.1.0a0 (merges PR #652)",
+        )
+        monkeypatch.setattr("tools.doit.release.subprocess.run", fake)
+
+        assert validate_merge_commits(self._silent_console()) is True
+
     def test_invalid_merge_commit_fails(self, monkeypatch: MonkeyPatch) -> None:
         """A merge commit not matching the convention returns False."""
         _, fake = self._fake_run(

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -52,9 +52,11 @@ def validate_merge_commits(console: "ConsoleType") -> bool:
         console.print("[green]✓ No merge commits to validate.[/green]")
         return True
 
-    # Pattern: <type>: <subject> (merges PR #XX, addresses #YY) or (merges PR #XX)
+    # Pattern: <type>: <subject> (merges PR #XX, addresses #YY) or (merges PR #XX).
+    # `release` is an allowed type so release-PR merges (e.g. "release: v0.1.0a0
+    # (merges PR #652)") pass governance validation on the next release cut.
     merge_pattern = re.compile(
-        r"^[a-f0-9]+\s+(feat|fix|refactor|docs|test|chore|ci|perf):\s.+\s"
+        r"^[a-f0-9]+\s+(feat|fix|refactor|docs|test|chore|ci|perf|release):\s.+\s"
         r"\(merges PR #\d+(?:, addresses #\d+(?:, #\d+)*)?\)$"
     )
 


### PR DESCRIPTION
## Description

`doit release` generates release-PR titles of the form `release: v<version>`
(e.g. `release: v0.1.0a0`), but two separate validators in the repo treated
`release` as an unknown conventional-commit type, blocking the PR-based
release flow end-to-end.

This PR extends both validators to accept `release` as a valid type.

**The two validators fixed:**

1. **CI title check** (`.github/workflows/pr-checks.yml`) — the
   `Validate PR Title Format` job uses a regex restricted to the 8 standard
   types (`feat|fix|refactor|docs|test|chore|ci|perf`) and rejects release
   PR titles outright. PR #652 (the first `release: v0.1.0a0` PR cut after
   #650 landed) is blocked by this check right now.

2. **Governance check** (`tools/doit/release.py::validate_merge_commits`) —
   same 8-type regex. Even if the CI title check were worked around, the
   *next* `doit release` invocation would fail governance validation on the
   previously merged release PR's merge commit (`release: v0.1.0a0 (merges
   PR #652)`), because `release` isn't in the allowed set.

Both had to change together: fixing only the CI gate would unblock PR #652
but leave the next release cut broken on governance.

> **Note:** The `require-label` check that also failed on PR #652 is the
> normal `ready-to-merge` merge-gate, not this bug. That label is added
> manually by the maintainer when the PR is ready to merge; its failure on
> #652 is expected until then.

## Related Issue

Addresses #653

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `.github/workflows/pr-checks.yml`: extend the `Validate PR Title Format`
  regex and user-facing help text/examples to include `release` (with a
  `release: v0.1.0a0` example).
- `tools/doit/release.py`: extend `validate_merge_commits`'s merge-commit
  regex to accept `release`, with an inline comment explaining *why*
  (release-PR merges must pass governance on the next release cut).
- `tests/test_doit_release.py`: new regression test
  `test_release_type_merge_commit_passes` in `TestValidateMergeCommits`
  that monkeypatches git log to return a release-PR merge commit and
  asserts the validator returns `True`.
- `docs/development/release-and-automation.md`: update the governance
  validator's documented "Valid Types" list to include `release`, with a
  short note explaining why it is included.

Out of scope (deliberately): the `doit pr_merge` title validator in
`tools/doit/github.py` and the developer-facing "Commit Types" list in
`.github/CONTRIBUTING.md` are unchanged — `release` is a machine-generated
type used only by `doit release`, not a type contributors should use for
regular commits.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**Test plan:**

- Added `test_release_type_merge_commit_passes` as a regression test —
  simulates a release-PR merge commit (`release: v0.1.0a0 (merges PR
  #652)`) and asserts `validate_merge_commits` returns `True`.
- Test count: 56 → 57 in `tests/test_doit_release.py`.
- `doit check` passes end-to-end (format, lint, type-check, spell, tests,
  security).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

**Template-heritage family:** Same family as #631, #632, #639, #641, #644,
#650 — a defect inherited from the `pyproject-template` release chain.
Once this and the related fixes are verified downstream, the full set is
destined for upstream port to `pyproject-template` in one batch.

**Branch history note:** The branch was briefly based on
`release/v0.1.0a0` and picked up a `chore: update changelog for v0.1.0a0`
commit; that was reset back to `main` before this PR. The dropped
changelog commit remains on `release/v0.1.0a0` / PR #652.
