### PR TITLE
fix: use head:release/ in release_tag gh pr search

### DIFF
--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -710,3 +710,27 @@ class TestTaskReleaseActionSignature:
             f"params names {missing} have no matching kwarg in the action signature; "
             "doit will silently drop their CLI values"
         )
+
+
+class TestReleaseTagGhSearch:
+    """Regression test for ``task_release_tag``'s gh pr list search (issue #657).
+
+    GitHub's search parses ``release: v in:title`` with the colon as a
+    qualifier separator (like ``head:``, ``author:``), returning zero results
+    for literal title substrings containing colons. ``head:release/`` is
+    GitHub's intended syntax and matches the head-branch naming convention
+    ``doit release`` uses for release branches.
+    """
+
+    def test_gh_search_uses_head_prefix_not_title_colon_substring(self) -> None:
+        """Source must use head:release/ and not the broken title-colon search."""
+        import pathlib
+
+        src = pathlib.Path("tools/doit/release.py").read_text()
+        assert "release: v in:title" not in src, (
+            "The broken colon-in-search pattern returns zero results from gh "
+            "pr list and must not recur"
+        )
+        assert '"head:release/"' in src, (
+            "task_release_tag must use head:release/ to find merged release PRs"
+        )

--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -726,7 +726,9 @@ class TestReleaseTagGhSearch:
         """Source must use head:release/ and not the broken title-colon search."""
         import pathlib
 
-        src = pathlib.Path("tools/doit/release.py").read_text()
+        # Windows read_text() defaults to cp1252 which can't decode non-ASCII
+        # characters like ❌ in release.py's error banners — always specify utf-8.
+        src = pathlib.Path("tools/doit/release.py").read_text(encoding="utf-8")
         assert "release: v in:title" not in src, (
             "The broken colon-in-search pattern returns zero results from gh "
             "pr list and must not recur"

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -581,6 +581,12 @@ def task_release_tag() -> dict[str, Any]:
         # Find the most recently merged release PR
         console.print("\n[cyan]Finding merged release PR...[/cyan]")
         try:
+            # Match PRs whose head branch starts with ``release/`` — the naming
+            # convention ``doit release`` uses. Do NOT use a title-substring
+            # search that includes the literal "release" prefix plus a colon
+            # and space: GitHub's search parses the colon as a qualifier
+            # separator (like ``head:``, ``author:``) and returns zero
+            # results. See #657.
             result = subprocess.run(
                 [
                     "gh",
@@ -589,7 +595,7 @@ def task_release_tag() -> dict[str, Any]:
                     "--state",
                     "merged",
                     "--search",
-                    "release: v in:title",
+                    "head:release/",
                     "--limit",
                     "1",
                     "--json",


### PR DESCRIPTION
## Description

Fix `doit release_tag` so it actually finds the merged release PR after a
successful `doit release` run. The `gh pr list` lookup used a search expression
starting with `release: v ...`, which GitHub's search parser interprets as a
qualifier prefix (the colon is treated like `head:`, `author:`, `base:`), so
the query returned zero results even when a matching merged PR existed.

Switched the search to `head:release/` — GitHub's built-in head-branch prefix
qualifier. `doit release` always names release branches `release/v<version>`,
so this is a precise filter and sidesteps the colon-parsing trap entirely.
The downstream `_extract_version_from_release_pr` check still validates the
PR title / branch shape, so any misnamed `release/*` branch still errors
clearly instead of producing a bad tag.

## Related Issue

Addresses #657

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `tools/doit/release.py` (`task_release_tag`): replace the
  `"release: v in:title"` search argument with `"head:release/"` in the
  `gh pr list` invocation that finds the most recently merged release PR.
  Add an explanatory comment (phrased so it does not contain the literal
  broken substring the regression test asserts absent).
- `tests/test_doit_release.py`: add `TestReleaseTagGhSearch` with
  `test_gh_search_uses_head_prefix_not_title_colon_substring`, a
  string-in-source regression test that asserts the broken pattern is
  absent and the fixed `"head:release/"` pattern is present.

## Root Cause and Evidence

With PR #652 (`release: v0.1.0a0`) sitting in the merged list, running
`doit release_tag` on `main` aborted with:

```
❌ No merged release PR found.
Ensure a release PR with title 'release: vX.Y.Z' was merged.
```

Reproducing the internal query directly confirmed the parser behavior:

```
$ gh pr list --state merged --search "release: v in:title" --limit 1 --json title
[]

$ gh pr list --state merged --search "head:release/"   --limit 1 --json title,headRefName
[{"headRefName":"release/v0.1.0a0","title":"release: v0.1.0a0"}]
```

The colon in `release:` is interpreted as a qualifier separator, so the old
search expression was never a literal-substring match — it quietly looked
like `release:` + `v in:title`, matched nothing, and fell through to the
error path.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Test count: 57 → 58 (`tests/test_doit_release.py`).

`doit check` green locally (format, lint, type_check, security, spell_check,
test).

Manually verified the replacement search expression against the real
`gh pr list` API (output above) — it returns the expected merged release PR.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

Documentation: no update required. `docs/development/release-and-automation.md`
and `docs/development/doit-tasks-reference.md` describe `doit release_tag`
only at the behavioral level (tag `main`, trigger publish); they don't
reference the internal `gh pr list` search expression, so they remain
accurate.

CHANGELOG: generated from conventional-commit history at release time — no
manual edit.

## Additional Notes

Template-heritage: same release-chain family as #631, #632, #639, #641, #644,
#650, #653, #655 — template-inherited release-flow bug that only surfaces
running the full release end-to-end. Destined for the upstream
`pyproject-template` port batch.
