### PR TITLE
fix: align testpypi.yml tag trigger with PEP440 pre-release tags

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -384,7 +384,7 @@ This project uses **semantic versioning** derived automatically from git tags vi
 
 - **No manual version editing** - Version is determined by git tags
 - **Tag format:** `v<major>.<minor>.<patch>` (e.g., `v1.2.3`)
-- **Pre-release format:** `v<version>-<type><n>` (e.g., `v1.2.3-alpha0`, `v1.2.3-beta1`, `v1.2.3-rc0`)
+- **Pre-release format:** PEP440 `v<version><type><n>` (e.g., `v1.2.3a0`, `v1.2.3b1`, `v1.2.3rc0`, `v1.2.3.dev0`) — emitted by commitizen via `doit release --prerelease=...`
 
 Version bumping is handled by [commitizen](https://commitizen-tools.github.io/commitizen/) based on conventional commit history:
 
@@ -456,7 +456,7 @@ pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://
 
 | Workflow | Trigger | Destination |
 |----------|---------|-------------|
-| `testpypi.yml` | Tag matching `v*-[a-zA-Z]*` (e.g., `v1.0.0-alpha0`) | TestPyPI only |
+| `testpypi.yml` | PEP440 pre-release tags: `v*a[0-9]*`, `v*b[0-9]*`, `v*rc[0-9]*`, `v*.dev[0-9]*` (e.g., `v1.0.0a0`) | TestPyPI only |
 | `release.yml` | Tag matching `v[0-9]+.[0-9]+.[0-9]+` (e.g., `v1.0.0`) | TestPyPI → PyPI |
 
 ### Setting Up Release Permissions

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -2,9 +2,14 @@ name: Publish to TestPyPI
 
 on:
   workflow_dispatch:
+  # PEP440 pre-release tag patterns. commitizen (used by doit release) emits
+  # these forms, not semver-style v*-alpha.* tags. See #659.
   push:
     tags:
-      - "v*-[a-zA-Z]*"
+      - "v*a[0-9]*"       # alpha: v0.1.0a0
+      - "v*b[0-9]*"       # beta: v0.1.0b1
+      - "v*rc[0-9]*"      # rc: v0.1.0rc0
+      - "v*.dev[0-9]*"    # dev: v0.1.0.dev2
 
 permissions:
   contents: read

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -42,10 +42,11 @@ v1.0.0         # Major release
 v1.1.0         # Minor release (new features)
 v1.1.1         # Patch release (bug fixes)
 
-# Pre-releases (for TestPyPI)
-v1.0.0-alpha.1   # Alpha release
-v1.0.0-beta.1    # Beta release
-v1.0.0-rc.1      # Release candidate
+# Pre-releases (for TestPyPI) — PEP440 format emitted by commitizen
+v1.0.0a0         # Alpha release
+v1.0.0b1         # Beta release
+v1.0.0rc0        # Release candidate
+v1.0.0.dev2      # Development release
 ```
 
 ### Checking Current Version
@@ -146,8 +147,9 @@ Pass `--prerelease=<type>` to `doit release` to open a pre-release PR:
 | `beta` | Feature-complete but not yet stable |
 | `rc` | Release candidate; only fixes expected before the final release |
 
-Pre-release tags (e.g. `v1.2.0a0`, `v1.2.0-rc.1`) trigger the TestPyPI publish
-workflow; production tags (e.g. `v1.2.0`) trigger TestPyPI followed by PyPI.
+Pre-release tags (e.g. `v1.2.0a0`, `v1.2.0b1`, `v1.2.0rc0`, `v1.2.0.dev2`)
+trigger the TestPyPI publish workflow; production tags (e.g. `v1.2.0`) trigger
+TestPyPI followed by PyPI.
 See the [Workflow Triggers](../../.github/CONTRIBUTING.md#workflow-triggers)
 table in `CONTRIBUTING.md` for the full mapping.
 

--- a/tests/test_testpypi_workflow.py
+++ b/tests/test_testpypi_workflow.py
@@ -1,0 +1,73 @@
+"""Tests for the TestPyPI publish workflow (issue #659).
+
+Structural asserts on `.github/workflows/testpypi.yml`. The central regression
+guard is the `on.push.tags` glob list: it must cover the four PEP440
+pre-release shapes that `commitizen` (used by `doit release --prerelease=...`)
+actually emits, and it must NOT use the old semver-only pattern that missed
+every PEP440 tag this project produces.
+
+These tests do not execute the workflow — they only verify its shape. See
+`tests/test_codeql_workflow.py` for the sibling pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "testpypi.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the TestPyPI workflow YAML.
+
+    Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because PyYAML
+    parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is ``cp1252`` and chokes on any
+    non-ASCII content — see the sibling test file for #430 context.
+    """
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    data: dict[Any, Any] = yaml.safe_load(content)
+    return data
+
+
+class TestPushTagTriggers:
+    """The PEP440 pre-release tag patterns must be present; semver-only absent."""
+
+    def _tag_patterns(self) -> list[str]:
+        wf = _load_workflow()
+        # PyYAML parses bare 'on' as the boolean True.
+        on_section = wf.get("on") or wf.get(True)
+        assert isinstance(on_section, dict), "workflow must have an 'on' mapping"
+        push_section = on_section.get("push")
+        assert isinstance(push_section, dict), "workflow must have an 'on.push' mapping"
+        tags = push_section.get("tags")
+        assert isinstance(tags, list), "workflow must have an 'on.push.tags' list"
+        return [str(t) for t in tags]
+
+    def test_alpha_pattern_present(self) -> None:
+        """PEP440 alpha tags (e.g. v0.1.0a0) must trigger the workflow."""
+        assert "v*a[0-9]*" in self._tag_patterns()
+
+    def test_beta_pattern_present(self) -> None:
+        """PEP440 beta tags (e.g. v0.1.0b1) must trigger the workflow."""
+        assert "v*b[0-9]*" in self._tag_patterns()
+
+    def test_rc_pattern_present(self) -> None:
+        """PEP440 rc tags (e.g. v0.1.0rc0) must trigger the workflow."""
+        assert "v*rc[0-9]*" in self._tag_patterns()
+
+    def test_dev_pattern_present(self) -> None:
+        """PEP440 dev tags (e.g. v0.1.0.dev2) must trigger the workflow."""
+        assert "v*.dev[0-9]*" in self._tag_patterns()
+
+    def test_semver_only_pattern_absent(self) -> None:
+        """The old semver-style glob that missed all PEP440 tags must be gone."""
+        assert "v*-[a-zA-Z]*" not in self._tag_patterns(), (
+            "The old semver-only glob did not match commitizen's PEP440 pre-release "
+            "tags (e.g. v0.1.0a0) and must stay out to avoid regressing #659."
+        )


### PR DESCRIPTION
## Description

Align the TestPyPI publish workflow's tag trigger with the PEP440 tags that
`commitizen` actually produces.

`testpypi.yml`'s `on.push.tags` filter was `"v*-[a-zA-Z]*"` — a semver-style
glob that requires a literal dash before the pre-release type. `commitizen`
(driven by `doit release --prerelease=...`) emits PEP440-style tags with no
dash: `v0.1.0a0`, `v0.1.0b1`, `v0.1.0rc0`, `v0.1.0.dev2`. Net effect:
`doit release_tag` successfully pushed `v0.1.0a0`, but no workflow triggered
and nothing was published to TestPyPI.

### Decision: PEP440-only (not both formats)

- This is a Python project. PyPI/TestPyPI natively expect PEP440; semver-style
  pre-release tags aren't valid PEP440 and would be rejected/normalized.
- `commitizen` is our only tag source and emits PEP440 by default. The project
  never produces semver-style pre-release tags from its own tooling.
- One format means one simpler trigger and fewer edge cases.
- The upstream Phase-A extractor regex already accepts both shapes defensively
  on the *parse* side; that is orthogonal to what the *trigger* side must
  match and does not need to change here.
- Production tags (`v1.2.3`, no suffix) continue to be handled by
  `release.yml`, which is unchanged.

### Fix

Replace the single semver glob with four PEP440-style globs:

```yaml
tags:
  - "v*a[0-9]*"       # alpha: v0.1.0a0
  - "v*b[0-9]*"       # beta:  v0.1.0b1
  - "v*rc[0-9]*"      # rc:    v0.1.0rc0
  - "v*.dev[0-9]*"    # dev:   v0.1.0.dev2
```

## Related Issue

Addresses #659

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `.github/workflows/testpypi.yml`: drop the semver glob `"v*-[a-zA-Z]*"`; add
  four PEP440-style globs covering alpha/beta/rc/dev; add an inline comment
  referencing #659.
- `tests/test_testpypi_workflow.py` (new): 5 structural tests asserting each
  PEP440 glob is present and that the old semver-only glob is absent (sibling
  pattern to `test_codeql_workflow.py`).
- `.github/CONTRIBUTING.md`: update the pre-release tag format example and the
  "Workflow Triggers" table to reflect the PEP440 globs that are actually used.
- `docs/development/release-and-automation.md`: update pre-release tag
  examples from the hyphenated semver shape to the PEP440 shape commitizen
  actually emits, and drop a stale `v1.2.0-rc.1` example.

## Evidence

- Tag `v0.1.0a0` was pushed to `origin` by `doit release_tag`.
- No Actions run was created for that push — the old semver glob did not match.
- `release.yml` (which matches `v[0-9]+.[0-9]+.[0-9]+`) is unaffected and
  continues to handle production tags correctly.

## Post-Merge Recovery

Tag-push events don't re-fire when a workflow file later changes, so after
this PR merges, the TestPyPI publish for the already-pushed `v0.1.0a0` tag
must be triggered manually via `workflow_dispatch`:

- **Actions** → **Publish to TestPyPI** → **Run workflow** → select the
  `v0.1.0a0` tag.

Do **not** delete and re-push the tag — that would churn git history for an
already-published (or about-to-be-published) version.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` is green locally: `format_check`, `lint`, `type_check`,
`security`, `spell_check`, `test` all pass. The five new structural tests in
`tests/test_testpypi_workflow.py` assert each PEP440 pattern is present and
the old semver-only pattern is absent.

## Template Provenance

Same release-chain family as #631, #632, #639, #641, #644, #650, #653, #655,
#657 — template-heritage release-flow bug. Destined for upstream port batch
after downstream verification.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

No `needs-adr` label on #659 and no architectural decision is introduced, so
no ADR is required. `release.yml` is untouched; only the pre-release trigger
shape changes.
