### PR TITLE
fix: split SBOMs into separate release artifact so twine accepts dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,24 @@ jobs:
       - name: Generate SBOM (XML)
         run: uv run cyclonedx-py environment --of XML -o dist/sbom.xml
 
+      # Split into two artifacts: ``dist`` for twine (wheels + sdist only)
+      # and ``sbom`` for the GitHub release. Mixing SBOM files into the
+      # publish artifact makes twine abort with InvalidDistribution. See
+      # issue #665.
       - uses: actions/upload-artifact@v7
         with:
           name: dist
-          path: dist
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: |
+            dist/sbom.json
+            dist/sbom.xml
           if-no-files-found: error
 
   publish-testpypi:
@@ -116,7 +130,7 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: dist
+          name: sbom
           path: dist
 
       - name: Upload SBOM assets to GitHub release

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -476,8 +476,8 @@ This produces two files in the `tmp/` directory:
 SBOMs are automatically generated and attached to every GitHub release:
 
 1. During the **build** job, `cyclonedx-py` generates both JSON and XML SBOMs
-2. The SBOM files are included in the `dist/` artifact alongside wheel and sdist packages
-3. After publishing to PyPI, the **github-release** job creates a GitHub release with auto-generated notes and attaches the SBOMs as release assets
+2. The SBOM files are uploaded as a separate `sbom` artifact (the `dist` artifact is wheels + sdist only, so twine in the publish jobs does not reject the SBOM files as `InvalidDistribution`)
+3. After publishing to PyPI, the **github-release** job downloads the `sbom` artifact and attaches both SBOMs to the GitHub release as downloadable assets
 
 Users can download the SBOM from the GitHub release page for any version.
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,76 @@
+"""Tests for the production Release publish workflow (issue #665).
+
+Structural asserts on `.github/workflows/release.yml`. The central regression
+guard is the artifact split: SBOM files (`sbom.json`, `sbom.xml`) must live
+in a separate `sbom` artifact from the wheels/sdist `dist` artifact, because
+twine (called by the publish jobs) inspects every file in `packages-dir` and
+rejects anything that isn't a `.whl` or `.tar.gz` with `InvalidDistribution`.
+
+These tests do not execute the workflow — they only verify its shape. Sibling
+file: `tests/test_testpypi_workflow.py`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "release.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the Release workflow YAML.
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is ``cp1252``.
+    """
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    data: dict[Any, Any] = yaml.safe_load(content)
+    return data
+
+
+def _upload_steps_for_job(job_name: str) -> list[dict[Any, Any]]:
+    """Return all upload-artifact steps for the named job."""
+    wf = _load_workflow()
+    jobs = wf.get("jobs")
+    assert isinstance(jobs, dict), "workflow must have a 'jobs' mapping"
+    job = jobs.get(job_name)
+    assert isinstance(job, dict), f"workflow must define job '{job_name}'"
+    steps = job.get("steps")
+    assert isinstance(steps, list), f"'{job_name}' must have a 'steps' list"
+    return [s for s in steps if isinstance(s, dict) and "upload-artifact" in str(s.get("uses", ""))]
+
+
+class TestBuildArtifactsSeparation:
+    """SBOMs must not be in the dist artifact (issue #665)."""
+
+    def test_dist_and_sbom_are_separate_uploads(self) -> None:
+        """build job must have two upload-artifact steps: 'dist' and 'sbom'."""
+        uploads = _upload_steps_for_job("build")
+        names = sorted(str(s.get("with", {}).get("name", "")) for s in uploads)
+        assert names == ["dist", "sbom"], (
+            f"build job must upload exactly 'dist' and 'sbom' artifacts; got {names}"
+        )
+
+    def test_dist_artifact_excludes_sbom(self) -> None:
+        """The 'dist' artifact's path must not include 'sbom' patterns.
+
+        Twine reads every file in dist/ and rejects sbom.json / sbom.xml
+        with InvalidDistribution, breaking publish-testpypi and publish.
+        """
+        uploads = _upload_steps_for_job("build")
+        dist_step = next(s for s in uploads if s.get("with", {}).get("name") == "dist")
+        path_value = str(dist_step["with"].get("path", ""))
+        assert "sbom" not in path_value.lower(), (
+            f"'dist' artifact path must not include sbom files; got {path_value!r}"
+        )
+
+    def test_sbom_artifact_includes_sbom_files(self) -> None:
+        """The 'sbom' artifact path must include sbom.json and sbom.xml."""
+        uploads = _upload_steps_for_job("build")
+        sbom_step = next(s for s in uploads if s.get("with", {}).get("name") == "sbom")
+        path_value = str(sbom_step["with"].get("path", ""))
+        assert "sbom.json" in path_value
+        assert "sbom.xml" in path_value


### PR DESCRIPTION
## Description

Fixes the `Release` workflow so TestPyPI/PyPI publish no longer fails with
`InvalidDistribution`.

The build job generates both SBOM files (`sbom.json`, `sbom.xml`) and the
distribution artifacts (`*.whl`, `*.tar.gz`) into `dist/`, then uploaded the
whole directory as a single `dist` artifact. The downstream `publish-testpypi`
and `publish` jobs downloaded that artifact and handed `packages-dir: dist`
to `pypa/gh-action-pypi-publish`, which runs twine. Twine inspects every file
in `packages-dir` and aborts as soon as it sees a non-distribution file:

```
ERROR    InvalidDistribution: Unknown distribution format: 'sbom.json'
```

Production tag `v0.1.0` ran through this workflow and `publish-testpypi`
failed at the "Check dist/sbom.json" step in `pypa/gh-action-pypi-publish`.
`publish` and `github-release` were skipped because both `needs:` an upstream
job.

This PR splits the build job's output into two artifacts:

- `dist` — `dist/*.whl` + `dist/*.tar.gz` (wheels and sdist, consumed by
  `publish-testpypi` and `publish`)
- `sbom` — `dist/sbom.json` + `dist/sbom.xml` (consumed by `github-release`)

Both uploads set `if-no-files-found: error` so a future regression where
the SBOM generation or the build step stops producing its outputs fails
loudly instead of silently shipping an empty artifact.

The `github-release` job's `download-artifact` now pulls `sbom` (still into
`dist/`, so the existing `gh release upload "$tag" dist/sbom.json dist/sbom.xml`
line is unchanged). `publish-testpypi` and `publish` are unchanged — they
already only downloaded the `dist` artifact and now get a twine-clean payload.

## Related Issue

Addresses #665

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `.github/workflows/release.yml`: Split the build job's single `upload-artifact`
  into two artifacts (`dist` for the publish jobs, `sbom` for the GitHub
  release). Updated the `github-release` job's `download-artifact` to pull
  `sbom` instead of `dist` (it only needs the SBOM files, not the wheels).
- `tests/test_release_workflow.py` (new): 3 structural tests that load
  `.github/workflows/release.yml` with `yaml.safe_load` and assert: (1) the
  build job has exactly two `upload-artifact` steps named `dist` and `sbom`;
  (2) the `dist` artifact's `path` does not include `sbom`; (3) the `sbom`
  artifact's `path` includes both `sbom.json` and `sbom.xml`. Sibling of
  the existing `tests/test_testpypi_workflow.py`.
- `docs/development/release-and-automation.md`: Updated the "Release
  Integration" bullet that previously said SBOMs are included in the `dist/`
  artifact — now describes the two-artifact split and the twine rationale.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Verification:

- `doit check` passes locally (tests, lint, type, format, security, spell,
  coverage).
- `uv run pytest tests/test_release_workflow.py -v` — 3/3 pass. The tests
  pin the artifact split by parsing the workflow YAML directly, so any
  future change that re-merges SBOMs into the `dist` artifact will fail
  CI before a release attempt is made.
- Manual verification of the YAML structure via `git diff` confirms
  `publish-testpypi` and `publish` only reference `name: dist`, while
  `github-release` references `name: sbom`.

### Post-merge recovery

After this PR merges, the failed `release.yml` run for tag `v0.1.0` can be
recovered without retagging:

1. Go to **Actions** → **Release** → the failed run for `v0.1.0`.
2. Click **Re-run failed jobs**.

`skip-existing: true` is set on both `pypa/gh-action-pypi-publish` calls, so
any distribution already uploaded to TestPyPI or PyPI is tolerated. The
`github-release` job can re-upload the SBOM assets to the existing release —
`gh release upload ... --clobber` in that job already handles that case.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG.md is intentionally not updated — this repo's release flow
auto-generates changelog entries from conventional commit subjects during
`doit release`.

## Additional Notes

### Template heritage

This is the same family of release-flow defects as the template-inherited
bugs fixed in #631, #632, #639, #641, #644, #650, #653, #655, #657, #659,
and #661. `pyproject-template`'s `release.yml` has the same SBOM-in-dist
mistake, so this fix is destined for the upstream port batch.
