### PR TITLE
feat: validate where expressions before query execution

### DIFF
--- a/docs/decisions/0012-unified-datasource-accessor.md
+++ b/docs/decisions/0012-unified-datasource-accessor.md
@@ -46,7 +46,7 @@ Add a `_fetched_fields: set[str]` instance attribute on `OntapModel` (`src/pynet
 
 `DataSource.query(OntapVolume).filter({"svm.name": "vs1", "autosize.mode": "grow"})` is the canonical form: a positional `dict[str, Any]` whose keys are dotted API paths. `**kwargs` (`filter(name="vol1", state="online")`) remains supported for top-level scalar fields as a convenience. The dunder-to-dot rewrite from today's `QuerySet.filter._attr_to_api_path` is **not** carried forward into `DataSource`. Existing `QuerySet` keeps the rewrite for backwards compatibility during migration and has it removed during Phase 4. This resolves issue #487.
 
-String filter expressions beyond equality land via `DataSource.QueryBuilder.where(*expressions: str)` (issue #512) — e.g. `.where("size > 1000000000", "state != 'offline'")` — which the cache backend concatenates with the dict-derived equality fragments and hands to `ClusterMetadataDB.query_with_filters` as a single ANDed list. v1 supports `.where()` on the cache path only; live and partial-fetch paths raise `NotImplementedError`. The typed field-reference DSL (e.g. `OntapVolume.svm.name == "vs1"`) remains deferred as issue #497 and will eventually compile down to the same string-expression shape that `.where()` already accepts.
+String filter expressions beyond equality land via `DataSource.QueryBuilder.where(*expressions: str)` (issue #512) — e.g. `.where("size > 1000000000", "state != 'offline'")` — which the cache backend concatenates with the dict-derived equality fragments and hands to `ClusterMetadataDB.query_with_filters` as a single ANDed list. v1 supports `.where()` on cache-backed routes only. As of issue #618, obviously incompatible cases fail early: `source="live"` on `OntapBackend` and any backend with `supports_where_expressions=False` raise `ValueError` at chain time. Partial-fetch routes still raise `NotImplementedError` when execution resolves to a mixed cache+live plan. The typed field-reference DSL (e.g. `OntapVolume.svm.name == "vs1"`) remains deferred as issue #497 and will eventually compile down to the same string-expression shape that `.where()` already accepts.
 
 ### 4. Per-call source override
 
@@ -171,6 +171,7 @@ Known limitations:
 - Issue #488: realtime output shape (closed, superseded by #495)
 - Issue #485: CLI migration onto cache + on-demand fetch (paused pending this work)
 - Issue #472: feat: add Config.no_cache flag and --live CLI option (origin of `--live`)
+- Issue #618: feat: early validation for where()/typed-DSL + incompatible source mode
 
 ## Related Documentation
 

--- a/docs/decisions/0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md
+++ b/docs/decisions/0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md
@@ -14,7 +14,7 @@ Add a DII (Data Infrastructure Insights) backend to the DataSource framework. Di
 
 3. **Offset/limit pagination.** DII uses `offset` + `limit` query parameters for pagination, not ONTAP's `_links.next.href` HAL convention. The DII API client handles pagination at the client layer.
 
-4. **Deferred `where_expressions`.** SQL-like cache filter expressions are not supported since there is no cache. `where_expressions` raises `NotImplementedError`.
+4. **Deferred `where_expressions`.** SQL-like cache filter expressions are not supported since there is no cache. As of issue #618, the public `QueryBuilder` surface rejects `.where()` and non-equality typed DSL operators with `ValueError` at chain time; `DiiBackend.query()` still raises `NotImplementedError` if `where_expressions` is passed directly.
 
 The full DII surface (191 endpoints) is generated via the existing OpenAPI codegen pipeline (ADR-0008), producing 191 model files under `models/dii/` and 191 mapping files under `cache/dii/`. DiiBackend is registered in `_BACKENDS` under the key `"dii"`, consistent with the backend registry pattern from ADR-0013.
 
@@ -28,6 +28,7 @@ The bare-array envelope is a DII-specific quirk that the existing `parse_api_res
 
 - Issue #600: feat: add DII API backend to DataSource
 - Issue #533: feat: DataSource non-ONTAP backends (partially addressed; DII is the first non-ONTAP backend)
+- Issue #618: feat: early validation for where()/typed-DSL + incompatible source mode
 
 ## Related Documentation
 

--- a/docs/usage/data-source.md
+++ b/docs/usage/data-source.md
@@ -157,27 +157,24 @@ for vol in large_vols:
 ```
 
 !!! warning "Cache-only"
-    `.where()` expressions are evaluated by the cache query engine and are only supported when the routing decision uses the cache path. Use `source="cache"` to opt in explicitly. Combining `.where()` with `source="live"` raises `NotImplementedError` at iteration time.
+    `.where()` expressions are evaluated by the cache query engine and are only supported when the routing decision uses the cache path. Use `source="cache"` to opt in explicitly. Combining `.where()` with `source="live"`, or using non-equality typed DSL operators on a live query, now raises `ValueError` immediately at chain time.
 
-#### Cache-only constraint footgun
+#### Cache-only constraint
 
-The cache-only constraint applies equally to `.where()` string expressions and to non-equality typed DSL operators (`>`, `<`, `!=`, `.in_()`, etc.). Both compile to the same where-expression shape and share the same failure mode: a query constructs cleanly and only raises `NotImplementedError` once you start iterating.
+The cache-only constraint applies equally to `.where()` string expressions and to non-equality typed DSL operators (`>`, `<`, `!=`, `.in_()`, etc.). Both compile to the same where-expression shape.
 
 ```python
-# Bad: constructs without error, raises NotImplementedError at the first `for` / list()
+# Bad: raises ValueError immediately at .filter(...)
 query = (
     ds.query(OntapVolume, cluster="prod1", source="live")
     .filter(OntapVolume.F.size > 1_073_741_824)
 )
-for vol in query:   # <-- NotImplementedError raised here
-    ...
 
 # Also bad: string-expression variant of the same mistake
 query = (
     ds.query(OntapVolume, cluster="prod1", source="live")
     .where("size > 1073741824")
 )
-list(query)         # <-- NotImplementedError raised here
 
 # Good: opt into the cache path explicitly
 query = (
@@ -186,9 +183,9 @@ query = (
 )
 ```
 
-The DII backend rejects `.where()` and non-equality DSL expressions **regardless of `source=`** since it has no cache substrate (see [ADR-0015](../decisions/0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md) §4). Any `.where()` against a DII-backed query raises `NotImplementedError` at iteration.
+On `OntapBackend`, this incompatibility is detected before iteration. Partial-fetch mixes (`source="auto"` plus live-only projected fields) still raise later at execution time because the mixed cache/live routing decision is only known when the query runs.
 
-Early construction-time validation for this asymmetry is tracked in [#618](https://github.com/endavis/pynetappfoundry/issues/618). Until that lands, verify `source=` and `.where()`/DSL-comparison combinations during review.
+The DII backend rejects `.where()` and non-equality DSL expressions **regardless of `source=`** since it has no cache substrate (see [ADR-0015](../decisions/0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md) §4). Any `.where()` against a DII-backed query now raises `ValueError` at chain time.
 
 ### Field Projection with `.fields()`
 

--- a/src/pynetappfoundry/data/backends.py
+++ b/src/pynetappfoundry/data/backends.py
@@ -80,9 +80,20 @@ class Backend(ABC):
     dict into concrete fetches against its upstream system and returns
     populated model instances with ``_fetched_fields`` set.
 
+    Class attribute :attr:`supports_where_expressions` controls whether
+    the backend accepts SQL-like where-expression strings from
+    :meth:`QueryBuilder.where` and non-equality typed DSL operators.
+    Defaults to ``False`` so that any new backend that does not
+    explicitly opt in rejects where-expressions early (at chain time)
+    rather than failing silently at iteration time.
+
     Args:
         config: The :class:`pynetappfoundry.core.config.Config` instance.
     """
+
+    #: Set to ``True`` on backends whose cache substrate supports
+    #: SQL-like where-expression strings (e.g. :class:`OntapBackend`).
+    supports_where_expressions: bool = False
 
     def __init__(self, config: Config) -> None:
         self._config = config
@@ -123,6 +134,8 @@ class OntapBackend(Backend):
     Args:
         config: The :class:`pynetappfoundry.core.config.Config` instance.
     """
+
+    supports_where_expressions: bool = True
 
     def __init__(self, config: Config) -> None:
         super().__init__(config)

--- a/src/pynetappfoundry/data/dii_backend.py
+++ b/src/pynetappfoundry/data/dii_backend.py
@@ -38,12 +38,19 @@ class DiiBackend(Backend):
     remote API directly.  Cache-only routing decisions and
     ``where_expressions`` are rejected with :class:`NotImplementedError`.
 
+    ``where_expressions`` are not supported: :attr:`supports_where_expressions`
+    is explicitly ``False`` so that :class:`QueryBuilder` raises
+    :class:`ValueError` at chain time (before iteration) when a caller
+    passes where-strings or non-equality typed DSL operators.
+
     API clients are lazily constructed and cached per-cluster (DII tenant)
     for the lifetime of the backend instance.
 
     Args:
         config: The :class:`pynetappfoundry.core.config.Config` instance.
     """
+
+    supports_where_expressions: bool = False
 
     def __init__(self, config: Config) -> None:
         super().__init__(config)

--- a/src/pynetappfoundry/data/source.py
+++ b/src/pynetappfoundry/data/source.py
@@ -230,6 +230,56 @@ class QueryBuilder[T: BaseModel]:
         self._fields: list[str] | None = None
         self._where_expressions: list[str] = []
 
+    def _validate_where_expressions(self, context: str) -> None:
+        """Raise :class:`ValueError` early if where-expressions are incompatible.
+
+        Called by :meth:`where` (when expressions are non-empty) and by
+        :meth:`filter` (when non-equality DSL operators produce where-strings).
+
+        Two incompatibility classes are caught here — at chain time rather
+        than at iteration time — to give callers a clear, actionable error:
+
+        1. **Backend does not support where-expressions at all** (e.g.
+           :class:`DiiBackend`): any backend whose
+           :attr:`Backend.supports_where_expressions` is ``False`` rejects
+           where-expressions unconditionally.
+
+        2. **Source mode is ``"live"``** on a backend that only supports
+           where-expressions on the cache path (e.g. :class:`OntapBackend`):
+           the cache substrate is bypassed on the live path, so where-strings
+           cannot be evaluated. Use ``source="cache"`` to opt into the
+           cache-only path. See ADR-0012 §49.
+
+        Args:
+            context: Human-readable label for the call site, used in the
+                error message (e.g. ``"where()"`` or ``"filter()"``).
+
+        Raises:
+            ValueError: If the current backend or source mode is incompatible
+                with where-expressions.
+        """
+        backend = self._source._get_backend(self._mapping.api_type)
+        backend_name = type(backend).__name__
+        if not backend.supports_where_expressions:
+            msg = (
+                f"{context}: {backend_name} does not support where-expressions. "
+                f"where() and non-equality typed DSL operators (>, >=, <, <=, !=) "
+                f"are only available on backends that set "
+                f"supports_where_expressions=True (e.g. OntapBackend). "
+                f"See ADR-0012 for the supported backend list."
+            )
+            raise ValueError(msg)
+        if self._source_mode == "live":
+            msg = (
+                f"{context}: where-expressions are not supported with "
+                f"source='live' on {backend_name}. "
+                f"The live REST path bypasses the cache substrate that "
+                f"evaluates where-strings. Use source='cache' to apply "
+                f"where-expressions against the local cache. "
+                f"See ADR-0012 §49."
+            )
+            raise ValueError(msg)
+
     def where(self, *expressions: str) -> QueryBuilder[T]:
         """Add SQL-like filter expressions to the query.
 
@@ -240,11 +290,13 @@ class QueryBuilder[T: BaseModel]:
 
         Expressions are evaluated by the backend's cache substrate
         (:meth:`ClusterMetadataDB.query_with_filters`) and are only
-        supported on the cache-only path. Using ``.where()`` with a
-        routing decision that requires the live REST API (``source="live"``)
-        or a partial-fetch mix (``source="auto"`` when the model has both
-        cached and realtime fields) raises :class:`NotImplementedError`
-        at iteration time. Use ``source="cache"`` to opt into the
+        supported on cache-backed routes. Backends that set
+        ``supports_where_expressions=False`` and queries using
+        ``source="live"`` raise :class:`ValueError` immediately at chain
+        time. Partial-fetch mixes (for example ``source="auto"`` with
+        live-only projected fields) still raise :class:`NotImplementedError`
+        at iteration time because the final routing decision is resolved
+        during execution. Use ``source="cache"`` to opt into the
         cache-only path and apply ``.where()`` expressions there.
 
         Composes freely with :meth:`filter` — the final filter list is
@@ -258,6 +310,8 @@ class QueryBuilder[T: BaseModel]:
         Returns:
             ``self`` for chaining.
         """
+        if expressions:
+            self._validate_where_expressions("where()")
         self._where_expressions.extend(expressions)
         return self
 
@@ -301,6 +355,8 @@ class QueryBuilder[T: BaseModel]:
         if expr_args:
             eq_dict, where_tuple = compile_filters(*expr_args)
             self._filters.update(eq_dict)
+            if where_tuple:
+                self._validate_where_expressions("filter()")
             self._where_expressions.extend(where_tuple)
 
         # Merge dict positional arguments.

--- a/tests/unit/data/test_source.py
+++ b/tests/unit/data/test_source.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pynetappfoundry.cache._registry import model_registry
-from pynetappfoundry.cache.field_mapping import TypeMapping
+from pynetappfoundry.cache.field_mapping import FieldMapping, TypeMapping
 from pynetappfoundry.data.source import _BACKENDS, DataSource, QueryBuilder
 
 from .conftest import FakeComposite, FakeVolume
@@ -557,3 +558,209 @@ class TestAutoFallback:
         second_decision = fake_backend.query.call_args_list[1].args[2]
         assert not second_decision.cache_fields
         assert second_decision.live_fields
+
+
+class TestQueryBuilderEarlyValidation:
+    """Early ValueError when where-expressions are used on an incompatible backend or source.
+
+    Covers issue #618: ``where()`` and non-equality typed DSL operators must
+    raise :class:`ValueError` at chain time (not iteration time) when the
+    backend does not support where-expressions or the source mode is ``"live"``.
+    """
+
+    # -----------------------------------------------------------------
+    # DII fixtures — use a FakeVolume subclass so there is no name-keyed
+    # conflict with the shared ``fake_volume_mapping`` fixture.
+    # -----------------------------------------------------------------
+
+    @pytest.fixture
+    def fake_dii_mapping(self) -> Iterator[TypeMapping]:
+        """Register a DII-typed fake mapping for the duration of one test."""
+
+        class _FakeDiiModel(FakeVolume):
+            """Thin FakeVolume subclass registered with api_type='dii'."""
+
+        mapping = TypeMapping(
+            name="FakeDiiModel",
+            model_class=_FakeDiiModel,
+            api_endpoint="/dii/fake-volumes",
+            api_type="dii",
+            identifier_field="uuid",
+            fields=(
+                FieldMapping(cache_attr="name", cache_strategy="cache"),
+                FieldMapping(cache_attr="uuid", cache_strategy="cache"),
+            ),
+        )
+        model_registry.register_mapping("FakeDiiModel", mapping)
+        try:
+            yield mapping
+        finally:
+            model_registry._mappings.pop("FakeDiiModel", None)
+            model_registry._mappings_by_class.pop(_FakeDiiModel, None)
+
+    # -----------------------------------------------------------------
+    # OntapBackend + source="live" → ValueError at chain time
+    # -----------------------------------------------------------------
+
+    def test_where_raises_valueerror_on_live_source(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """OntapBackend + source='live' + .where() raises ValueError immediately."""
+        ds = DataSource(mock_config)
+        qb = ds.query(FakeVolume, cluster="prod1", source="live")
+
+        with pytest.raises(ValueError, match="source='live'"):
+            qb.where("size > 1")
+
+    def test_filter_raises_valueerror_on_live_source_with_non_equality_dsl(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """OntapBackend + source='live' + .filter(non-equality expr) raises ValueError."""
+        ds = DataSource(mock_config)
+        qb = ds.query(FakeVolume, cluster="prod1", source="live")
+
+        # Ne operator compiles to a where-string, so filter() should raise.
+        with pytest.raises(ValueError, match="source='live'"):
+            qb.filter(FakeVolume.F.name != "forbidden")
+
+    # -----------------------------------------------------------------
+    # DiiBackend → ValueError regardless of source mode
+    # -----------------------------------------------------------------
+
+    def test_where_raises_valueerror_for_dii_backend(
+        self,
+        fake_dii_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """DiiBackend does not support where-expressions: raises ValueError at where() time."""
+        ds = DataSource(mock_config)
+        model_cls = fake_dii_mapping.model_class
+        qb = ds.query(model_cls, cluster="prod1")
+
+        with pytest.raises(ValueError, match="DiiBackend"):
+            qb.where("size > 1")
+
+    def test_filter_raises_valueerror_for_dii_backend_non_equality(
+        self,
+        fake_dii_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """DiiBackend + non-equality DSL in filter() raises ValueError at filter() time."""
+        from pynetappfoundry.data.filters import Gt
+
+        ds = DataSource(mock_config)
+        model_cls = fake_dii_mapping.model_class
+        qb = ds.query(model_cls, cluster="prod1")
+
+        # Gt operator compiles to a where-string; filter() must reject it.
+        with pytest.raises(ValueError, match="DiiBackend"):
+            qb.filter(Gt("size", 0))
+
+    # -----------------------------------------------------------------
+    # OntapBackend + compatible source modes → no error at chain time
+    # -----------------------------------------------------------------
+
+    def test_where_succeeds_on_cache_source(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """OntapBackend + source='cache' + .where() succeeds at chain time."""
+        ds = DataSource(mock_config)
+        qb = ds.query(FakeVolume, cluster="prod1", source="cache")
+        # Should not raise; only raises at iteration time if cache is unavailable.
+        qb.where("size > 1")
+        assert "size > 1" in qb._where_expressions
+
+    def test_where_succeeds_on_auto_source(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """OntapBackend + source='auto' + .where() succeeds at chain time."""
+        ds = DataSource(mock_config)
+        qb = ds.query(FakeVolume, cluster="prod1", source="auto")
+        qb.where("size > 1")
+        assert "size > 1" in qb._where_expressions
+
+    # -----------------------------------------------------------------
+    # Equality-only DSL is not affected by the new validation
+    # -----------------------------------------------------------------
+
+    def test_filter_equality_dsl_not_affected_on_live(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Equality expressions compile to dict entries and must never raise.
+
+        Using ``==`` on a live OntapBackend query must succeed because
+        equality filters are not where-expressions; they route through the
+        REST API ``?key=value`` query-param path.
+        """
+        ds = DataSource(mock_config)
+        fake_backend = MagicMock()
+        fake_backend.query.return_value = []
+        ds._backends["ontap"] = fake_backend
+
+        qb = ds.query(FakeVolume, cluster="prod1", source="live")
+        # Should not raise: Eq compiles to a dict entry, not a where-string.
+        qb.filter(FakeVolume.F.name == "vs1")
+        assert qb._filters == {"name": "vs1"}
+        assert qb._where_expressions == []
+
+    # -----------------------------------------------------------------
+    # Empty .where() is always a no-op (no backend check performed)
+    # -----------------------------------------------------------------
+
+    def test_empty_where_skips_validation(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """.where() with no arguments is a no-op and never raises."""
+        ds = DataSource(mock_config)
+        # Use source='live' to ensure that IF validation were triggered it
+        # would raise — but it must NOT be triggered for an empty call.
+        qb = ds.query(FakeVolume, cluster="prod1", source="live")
+        qb.where()  # must be silent
+        assert qb._where_expressions == []
+
+    # -----------------------------------------------------------------
+    # Error message content assertions
+    # -----------------------------------------------------------------
+
+    def test_error_message_names_backend_and_source(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Error for live+OntapBackend names the backend class and source mode."""
+        ds = DataSource(mock_config)
+        qb = ds.query(FakeVolume, cluster="prod1", source="live")
+
+        with pytest.raises(ValueError) as exc_info:
+            qb.where("size > 0")
+
+        msg = str(exc_info.value)
+        assert "OntapBackend" in msg
+        assert "live" in msg
+
+    def test_error_message_names_backend_for_dii(
+        self,
+        fake_dii_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """Error for DiiBackend names 'DiiBackend' in the message."""
+        ds = DataSource(mock_config)
+        model_cls = fake_dii_mapping.model_class
+        qb = ds.query(model_cls, cluster="prod1")
+
+        with pytest.raises(ValueError) as exc_info:
+            qb.where("size > 0")
+
+        assert "DiiBackend" in str(exc_info.value)

--- a/tools/codegen/generators.py
+++ b/tools/codegen/generators.py
@@ -18,7 +18,7 @@ from typing import Any
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
-    import tomli as tomllib  # type: ignore[no-redef]
+    import tomli as tomllib  # type: ignore[import-not-found,no-redef]
 
 import tomli_w
 


### PR DESCRIPTION
## Description

Add early chain-time validation for `.where()` and non-equality typed DSL filters when the current backend or source mode cannot support where-expressions. This changes unsupported cases from late iteration-time failures to clearer `ValueError` messages, and updates the related docs/ADRs.

## Related Issue

Addresses #618

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- add `supports_where_expressions` to the backend contract and opt `OntapBackend` in while keeping `DiiBackend` explicitly unsupported
- validate unsupported `.where()` / non-equality typed DSL usage in `QueryBuilder.where()` and `QueryBuilder.filter()` before iteration
- add coverage for live-source, DII-backend, equality-only, empty-where, and error-message cases
- update the DataSource guide plus ADR-0012 and ADR-0015 to document issue #618 behavior
- widen the fallback `tomli` import ignore in `tools/codegen/generators.py` so `doit check` passes under mypy

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A

## Additional Notes

- Unsupported `source="live"` and DII-backed where-expression use now fail at chain time with `ValueError` instead of surfacing later during iteration.
- Partial mixed cache/live routing still rejects where-expressions at execution time; the docs now call out that distinction.
