### PR TITLE
fix: QueryBuilder.filter() leaves partial state on early-validation rejection

### DIFF
--- a/src/pynetappfoundry/cache/_registry.py
+++ b/src/pynetappfoundry/cache/_registry.py
@@ -102,6 +102,21 @@ class ModelRegistry:
         self._mappings[name] = mapping
         self._mappings_by_class[mapping.model_class] = mapping
 
+    def unregister_mapping(self, name: str) -> None:
+        """Remove a mapping from both indexes by name.
+
+        Idempotent: silently ignores names that are not registered.
+        Primarily intended for test fixtures that register a mapping
+        for the duration of one test and need to tear it down without
+        reaching into the private indexes.
+
+        Args:
+            name: Identifier of the mapping to remove.
+        """
+        mapping = self._mappings.pop(name, None)
+        if mapping is not None:
+            self._mappings_by_class.pop(mapping.model_class, None)
+
     def get_mapping(self, name: str) -> TypeMapping | None:
         """Look up a type mapping by name.
 

--- a/src/pynetappfoundry/data/source.py
+++ b/src/pynetappfoundry/data/source.py
@@ -250,6 +250,12 @@ class QueryBuilder[T: BaseModel]:
            cannot be evaluated. Use ``source="cache"`` to opt into the
            cache-only path. See ADR-0012 §49.
 
+        Reads the capability flag off the registered backend **class** rather
+        than instantiating it, so chain-time validation does not eagerly
+        construct a backend instance. Backends with no entry in
+        :data:`_BACKENDS` are deferred to iteration time, where
+        :meth:`DataSource._get_backend` raises a clear ``ValueError``.
+
         Args:
             context: Human-readable label for the call site, used in the
                 error message (e.g. ``"where()"`` or ``"filter()"``).
@@ -258,9 +264,11 @@ class QueryBuilder[T: BaseModel]:
             ValueError: If the current backend or source mode is incompatible
                 with where-expressions.
         """
-        backend = self._source._get_backend(self._mapping.api_type)
-        backend_name = type(backend).__name__
-        if not backend.supports_where_expressions:
+        backend_cls = _BACKENDS.get(self._mapping.api_type)
+        if backend_cls is None:
+            return
+        backend_name = backend_cls.__name__
+        if not backend_cls.supports_where_expressions:
             msg = (
                 f"{context}: {backend_name} does not support where-expressions. "
                 f"where() and non-equality typed DSL operators (>, >=, <, <=, !=) "
@@ -352,11 +360,13 @@ class QueryBuilder[T: BaseModel]:
                 raise TypeError(msg)
 
         # Compile typed expressions into equality dict + where strings.
+        # Validate before mutating state so a rejected call leaves the
+        # builder unchanged.
         if expr_args:
             eq_dict, where_tuple = compile_filters(*expr_args)
-            self._filters.update(eq_dict)
             if where_tuple:
                 self._validate_where_expressions("filter()")
+            self._filters.update(eq_dict)
             self._where_expressions.extend(where_tuple)
 
         # Merge dict positional arguments.

--- a/tests/unit/cache/test_registry.py
+++ b/tests/unit/cache/test_registry.py
@@ -29,6 +29,29 @@ class TestModelRegistry:
         registry = ModelRegistry()
         assert registry.get_mapping("MISSING") is None
 
+    def test_unregister_mapping_removes_from_both_indexes(self) -> None:
+        from pynetappfoundry.cache.field_mapping import TypeMapping
+
+        registry = ModelRegistry()
+
+        class Baz(BaseModel):
+            pass
+
+        mapping = TypeMapping(name="Baz", model_class=Baz, api_endpoint="/baz")
+        registry.register_mapping("BAZ", mapping)
+        assert registry.get_mapping("BAZ") is mapping
+        assert registry.get_mapping_by_model_class(Baz) is mapping
+
+        registry.unregister_mapping("BAZ")
+        assert registry.get_mapping("BAZ") is None
+        assert registry.get_mapping_by_model_class(Baz) is None
+
+    def test_unregister_mapping_is_idempotent(self) -> None:
+        registry = ModelRegistry()
+        # Must not raise on a name that was never registered.
+        registry.unregister_mapping("NEVER_REGISTERED")
+        registry.unregister_mapping("NEVER_REGISTERED")
+
     def test_mappings_property_returns_copy(self) -> None:
         from pynetappfoundry.cache.field_mapping import TypeMapping
 

--- a/tests/unit/data/test_source.py
+++ b/tests/unit/data/test_source.py
@@ -595,8 +595,7 @@ class TestQueryBuilderEarlyValidation:
         try:
             yield mapping
         finally:
-            model_registry._mappings.pop("FakeDiiModel", None)
-            model_registry._mappings_by_class.pop(_FakeDiiModel, None)
+            model_registry.unregister_mapping("FakeDiiModel")
 
     # -----------------------------------------------------------------
     # OntapBackend + source="live" → ValueError at chain time
@@ -712,6 +711,38 @@ class TestQueryBuilderEarlyValidation:
         qb.filter(FakeVolume.F.name == "vs1")
         assert qb._filters == {"name": "vs1"}
         assert qb._where_expressions == []
+
+    # -----------------------------------------------------------------
+    # filter() must not mutate state when validation rejects
+    # -----------------------------------------------------------------
+
+    def test_filter_rejection_leaves_builder_state_untouched(
+        self,
+        fake_volume_mapping: TypeMapping,
+        mock_config: Any,
+    ) -> None:
+        """A filter() call that raises must not leave _filters partially mutated.
+
+        When a single filter() invocation mixes equality and non-equality DSL
+        expressions, validation must run before any state mutation so that
+        catching the ValueError leaves the builder in its prior state.
+        """
+        ds = DataSource(mock_config)
+        qb = ds.query(FakeVolume, cluster="prod1", source="live")
+        qb.filter(FakeVolume.F.name == "starting")  # baseline
+        baseline_filters = dict(qb._filters)
+        baseline_where = list(qb._where_expressions)
+
+        with pytest.raises(ValueError, match="source='live'"):
+            # Eq compiles to a dict entry; Ne compiles to a where-string and
+            # must trip validation before either is applied.
+            qb.filter(
+                FakeVolume.F.name == "second",
+                FakeVolume.F.name != "forbidden",
+            )
+
+        assert qb._filters == baseline_filters
+        assert qb._where_expressions == baseline_where
 
     # -----------------------------------------------------------------
     # Empty .where() is always a no-op (no backend check performed)

--- a/tools/codegen/generators.py
+++ b/tools/codegen/generators.py
@@ -18,7 +18,7 @@ from typing import Any
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
-    import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+    import tomli as tomllib  # type: ignore[import-not-found,no-redef,unused-ignore]
 
 import tomli_w
 


### PR DESCRIPTION
## Description

Polish for the early `where`-expression validation shipped in #682. Addresses three review-feedback items in one focused PR plus a small CI/local portability fix.

## Related Issue

Addresses #683.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Test improvement

## Changes Made

- `QueryBuilder.filter()` now validates **before** mutating `self._filters`, so a rejected call (mixed equality + non-equality DSL on a backend/source that rejects where-strings) leaves the builder in its prior state.
- `_validate_where_expressions` reads `supports_where_expressions` off the registered backend **class** via `_BACKENDS` instead of calling `_get_backend()`. This avoids eager backend instantiation at chain time and removes the `type(backend).__name__` fragility in error messages.
- `ModelRegistry.unregister_mapping(name)` added as a small public API; new DII test fixture uses it instead of poking `_mappings` / `_mappings_by_class` directly. Existing fixtures untouched (no scope creep).
- `tools/codegen/generators.py`: tomli `type: ignore` now includes `unused-ignore` so `doit check` passes both in CI (no tomli installed → `import-not-found` is needed) and locally (tomli installed → `import-not-found` would otherwise be flagged unused under `warn_unused_ignores=true`).

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

New tests:

- `tests/unit/data/test_source.py::test_filter_rejection_leaves_builder_state_untouched` — locks in the new validation-before-mutation ordering by mixing `Eq` and `Ne` and asserting the builder snapshot is unchanged after the rejected call.
- `tests/unit/cache/test_registry.py::test_unregister_mapping_removes_from_both_indexes`
- `tests/unit/cache/test_registry.py::test_unregister_mapping_is_idempotent`

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

`#682` was merged with the original `where()` validation; this PR polishes that work based on review feedback. No public API/behavior changes beyond the new `unregister_mapping()` helper.
