### PR TITLE
fix: use message.severity filter and default to wildcard

### DIFF
--- a/src/pynetappfoundry/cli/commands/events/get.py
+++ b/src/pynetappfoundry/cli/commands/events/get.py
@@ -149,10 +149,11 @@ def _get_cluster_events(
             password=password,
             verify=False,
         ):
-            query_params: dict[str, Any] = {"max_records": limit, "fields": "*"}
-
-            if severity:
-                query_params["severity"] = severity
+            query_params: dict[str, Any] = {
+                "max_records": limit,
+                "fields": "*",
+                "message.severity": severity if severity else "*",
+            }
 
             if event_names:
                 query_params["message.name"] = ",".join(event_names)

--- a/tests/unit/cli/commands/events/test_get.py
+++ b/tests/unit/cli/commands/events/test_get.py
@@ -230,7 +230,7 @@ class TestGetClusterEvents:
         mock_config: MagicMock,
         sample_cluster_details: dict[str, Any],
     ) -> None:
-        """Test that severity filter is passed to API."""
+        """Test that severity filter is passed as message.severity to API."""
         with patch("pynetappfoundry.cli.commands.events.get.HostConnection") as mock_conn:
             mock_conn.return_value.__enter__ = MagicMock(return_value=None)
             mock_conn.return_value.__exit__ = MagicMock(return_value=None)
@@ -248,9 +248,35 @@ class TestGetClusterEvents:
                     limit=50,
                 )
 
-            # Check that severity was passed
+            # Check that severity was passed as message.severity
             call_kwargs = mock_event_class.get_collection.call_args[1]
-            assert call_kwargs["severity"] == "error"
+            assert call_kwargs["message.severity"] == "error"
+
+    def test_default_severity_wildcard_passed_to_api(
+        self,
+        mock_config: MagicMock,
+        sample_cluster_details: dict[str, Any],
+    ) -> None:
+        """Test that message.severity defaults to '*' to include debug events."""
+        with patch("pynetappfoundry.cli.commands.events.get.HostConnection") as mock_conn:
+            mock_conn.return_value.__enter__ = MagicMock(return_value=None)
+            mock_conn.return_value.__exit__ = MagicMock(return_value=None)
+
+            with patch("pynetappfoundry.cli.commands.events.get.EmsEvent") as mock_event_class:
+                mock_event_class.get_collection.return_value = []
+
+                _get_cluster_events(
+                    "cluster1",
+                    sample_cluster_details,
+                    mock_config,
+                    severity=None,
+                    event_names=(),
+                    sort="time",
+                    limit=50,
+                )
+
+            call_kwargs = mock_event_class.get_collection.call_args[1]
+            assert call_kwargs["message.severity"] == "*"
 
     def test_event_names_filter_passed_to_api(
         self,


### PR DESCRIPTION
## Description

Fix severity filter API parameter key and default to fetch all severities including debug, matching sysadmin `get_event.py` behaviour.

## Related Issue
Addresses #108
Follow-up to #108 (discovered via output comparison after #685 merged).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Change severity API param key from `severity` to `message.severity` (correct ONTAP EMS API parameter)
- Default `message.severity` to `*` when no `--severity` given, so debug events are included — matching the sysadmin `get_event.py` pattern (```{'message.severity': '*'}```)
- Add test for wildcard default; update existing severity filter test to assert `message.severity` key

## Testing

- [x] All existing tests pass
- [x] Added new test: `test_default_severity_wildcard_passed_to_api`
- [x] Manually verified: output row count matches sysadmin script (4096 vs 4096)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings