### PR TITLE
fix: use bracket access for HA detection in azevents

### DIFF
--- a/src/pynetappfoundry/cli/commands/events/azevents.py
+++ b/src/pynetappfoundry/cli/commands/events/azevents.py
@@ -282,7 +282,7 @@ class ClusterData:
             ):
                 # Detect CVO vs CVO HA
                 nodes = list(Node.get_collection(fields="ha"))
-                if len(nodes) > 1 and nodes[0].to_dict().get("ha", {}).get("enabled"):
+                if len(nodes) > 1 and nodes[0]["ha"]["enabled"]:
                     self.cluster_type = "CVO HA"
                 else:
                     self.cluster_type = "CVO"

--- a/tests/unit/cli/commands/events/test_azevents.py
+++ b/tests/unit/cli/commands/events/test_azevents.py
@@ -275,7 +275,8 @@ class TestClusterDataGatherData:
         )
 
         mock_node = MagicMock()
-        mock_node.to_dict.return_value = {"ha": {"enabled": False}}
+        ha_data = {"ha": {"enabled": False}}
+        mock_node.__getitem__ = MagicMock(side_effect=ha_data.__getitem__)
 
         with patch("netapp_ontap.HostConnection") as mock_conn:
             mock_conn.return_value.__enter__ = MagicMock(return_value=None)
@@ -307,9 +308,11 @@ class TestClusterDataGatherData:
         )
 
         mock_node1 = MagicMock()
-        mock_node1.to_dict.return_value = {"ha": {"enabled": True}}
+        ha_data1 = {"ha": {"enabled": True}}
+        mock_node1.__getitem__ = MagicMock(side_effect=ha_data1.__getitem__)
         mock_node2 = MagicMock()
-        mock_node2.to_dict.return_value = {"ha": {"enabled": True}}
+        ha_data2 = {"ha": {"enabled": True}}
+        mock_node2.__getitem__ = MagicMock(side_effect=ha_data2.__getitem__)
 
         with patch("netapp_ontap.HostConnection") as mock_conn:
             mock_conn.return_value.__enter__ = MagicMock(return_value=None)


### PR DESCRIPTION
## Description

Use bracket access for HA detection in `save-azure` so the command matches the ONTAP resource access pattern already used elsewhere in `azevents`.

## Related Issue

Addresses #92

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Switched HA detection from `.to_dict()` access to bracket access on node resources
- Updated HA detection unit tests to mock `__getitem__` instead of `to_dict()`
- Verified the branch with `doit check`

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A

## Additional Notes

This is a small consistency fix with no intended user-facing behavior change.