### PR TITLE
feat: add Query for RPC-style POST endpoints

### DIFF
--- a/docs/usage/ontap-access-patterns.md
+++ b/docs/usage/ontap-access-patterns.md
@@ -164,11 +164,11 @@ The `--live` flag is wired through `@with_config`, which constructs `Config(no_c
 
 ---
 
-### 2. QuerySet + Mutation (Query Layer)
+### 2. QuerySet + Query + Mutation (Query Layer)
 
-`pynetappfoundry.query` is a thin, fluent layer over the ONTAP REST API that uses the project's `TypeMapping` metadata to translate model attribute filters into API requests and to parse responses back into Pydantic models. It covers reads (`QuerySet`), writes (`Mutation`), async job polling (`JobTracker`), relationship traversal (`related` / `related_one`), and on-demand realtime field access.
+`pynetappfoundry.query` is a thin, fluent layer over the ONTAP REST API that uses the project's `TypeMapping` metadata to translate model attribute filters into API requests and to parse responses back into Pydantic models. It covers collection reads (`QuerySet`), RPC-style POST reads (`Query`), writes (`Mutation`), async job polling (`JobTracker`), relationship traversal (`related` / `related_one`), and on-demand realtime field access.
 
-Choose `cluster_entry.ontap` for cached field-group reads with a `--live` bypass, and reach for `QuerySet` / `Mutation` whenever you need ad-hoc filtering, projection, or any write operation.
+Choose `cluster_entry.ontap` for cached field-group reads with a `--live` bypass, and reach for `QuerySet`, `Query`, or `Mutation` whenever you need ad-hoc filtering, POST-for-data RPC calls, or any write operation.
 
 See the dedicated [Query Layer](query-layer.md) guide for the full API reference, worked examples, and exception semantics.
 

--- a/docs/usage/query-layer.md
+++ b/docs/usage/query-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Query Layer
-description: Guide to the REST query layer (QuerySet, Mutation, JobTracker, related, realtime)
+description: Guide to the REST query layer (QuerySet, Query, Mutation, JobTracker, related, realtime)
 audience:
   - users
   - contributors
@@ -27,9 +27,10 @@ tags:
 
 `pynetappfoundry.query` is a thin, fluent layer on top of the ONTAP REST API client. It uses the same declarative `TypeMapping` metadata that drives the cache (see [ADR-0004](../decisions/0004-declarative-field-mapping-framework.md)) to translate model attribute names into API field paths and to parse responses back into Pydantic model instances.
 
-The layer ships five public surfaces:
+The layer ships six public surfaces:
 
-- `QuerySet` — fluent, lazy reads
+- `QuerySet` — fluent, lazy reads for collection-style GET endpoints
+- `Query` — RPC-style POST reads for endpoints that accept a request body and return data
 - `Mutation` — POST / PATCH / DELETE writes
 - `JobTracker` (and `JobError`) — polling for async ONTAP jobs
 - `related` / `related_one` — relationship-traversal sugar over `QuerySet`
@@ -40,6 +41,7 @@ The layer ships five public surfaces:
 | Use case | Use this |
 |----------|----------|
 | Type-safe ad-hoc reads with filters / projection / ordering | `QuerySet` |
+| Call a POST endpoint that returns data instead of mutating state | `Query` |
 | Create / update / delete a resource | `Mutation` |
 | Wait for an async ONTAP job | `JobTracker` (or `poll=True` shortcut on `Mutation`) |
 | Express "fetch related X for this Y" intent | `related` / `related_one` |
@@ -157,6 +159,19 @@ total = QuerySet(OntapVolume, client).filter(state="online").count()
     For complex predicates (`autosize.mode != 'grow_shrink'`, ranges, NOT, OR), the cache SQL query engine — used by `nf cache check` and `nf cache compliance` — is usually a better fit because it operates on the local SQLite cache without round-tripping to the cluster. `QuerySet` is the right tool when you want live data, single-cluster access, and the simple equality / wildcard semantics that ONTAP REST exposes natively.
 
     `nf cache check` also supports a `--live` flag that bypasses the cache and fetches data directly from each cluster via `DataSource(source="live")`. Note that `--live` and `--where` are mutually exclusive — SQL-like filter expressions are only supported on cached data.
+
+## Query RPC Reads
+
+`Query` is the lightweight companion to `Mutation` for endpoints that use POST as a query transport rather than as a write. It binds a client plus a fixed path, then forwards a JSON body to that path and returns the raw response payload.
+
+```python
+from pynetappfoundry.query import Query
+
+q = Query(client, "/lake/query/timeseries")
+results = q.invoke({"metric": "cpu", "interval": "1h"})
+```
+
+Use `Query` when the remote API expects a structured POST body for a read-style operation (for example, RPC-style analytics endpoints). Unlike `QuerySet`, it does not translate model fields or parse Pydantic models; unlike `Mutation`, it does not imply resource creation or lifecycle changes.
 
 ## Mutation Writes
 
@@ -375,6 +390,7 @@ The query layer and `ClusterEntry.ontap` are complementary, not competing:
 
 - Use **`cluster_entry.ontap`** for high-level reads of cached cluster metadata field groups (licenses, nodes, storage, network, ...). It serves sub-millisecond SQLite reads when the cache is populated and falls back to a live `DataSource` fetch on a miss. `--live` (`Config(no_cache=True)`) bypasses the cache without changing call sites.
 - Use **`QuerySet`** for ad-hoc reads that don't fit a pre-defined field group: arbitrary filters, custom projections, ordering / limit, or models the cache does not collect.
+- Use **`Query`** for RPC-style POST endpoints that return data rather than mutate resources.
 - Use **`Mutation`** for any write. There is no write surface on `ClusterEntry.ontap`.
 - Use **`fetch_realtime`** (and friends) for fields the cache deliberately excludes.
 

--- a/src/pynetappfoundry/query/__init__.py
+++ b/src/pynetappfoundry/query/__init__.py
@@ -7,6 +7,7 @@ ONTAP REST API using existing TypeMapping metadata.
 from pynetappfoundry.query.exceptions import MultipleResultsError, NotFoundError
 from pynetappfoundry.query.job import JobError, JobTracker
 from pynetappfoundry.query.mutation import Mutation
+from pynetappfoundry.query.query import Query
 from pynetappfoundry.query.queryset import QuerySet
 from pynetappfoundry.query.realtime import (
     compare_realtime,
@@ -22,6 +23,7 @@ __all__ = [
     "MultipleResultsError",
     "Mutation",
     "NotFoundError",
+    "Query",
     "QuerySet",
     "compare_realtime",
     "fetch_realtime",

--- a/src/pynetappfoundry/query/query.py
+++ b/src/pynetappfoundry/query/query.py
@@ -1,0 +1,72 @@
+"""RPC-style POST queries for data-returning endpoints.
+
+Provides :class:`Query`, a lightweight interface for invoking
+POST-for-data endpoints (e.g. ``/lake/query/timeseries``) that return
+results rather than mutating resources.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pynetappfoundry.clients.openapi import APIWrapper
+
+logger = logging.getLogger(__name__)
+
+
+class Query:
+    """Interface for RPC-style POST endpoints that return data.
+
+    Unlike :class:`~pynetappfoundry.query.mutation.Mutation`, which
+    manages resource lifecycle (create/update/delete), ``Query`` is
+    designed for POST-for-data endpoints where the body is a query
+    specification and the response is a result set.
+
+    Example::
+
+        q = Query(client, "/lake/query/timeseries")
+        results = q.invoke({"metric": "cpu", "interval": "1h"})
+    """
+
+    def __init__(self, client: APIWrapper, path: str) -> None:
+        """Initialise a ``Query`` bound to a specific endpoint path.
+
+        Args:
+            client: API client used to dispatch requests.
+            path: Endpoint path (e.g. ``"/lake/query/timeseries"``).
+        """
+        self._client = client
+        self._path = path
+
+    def invoke(
+        self,
+        body: dict[str, Any] | None = None,
+        *,
+        query_params: dict[str, Any] | None = None,
+    ) -> Any:
+        """Execute the query by POSTing *body* to the bound path.
+
+        RPC query endpoints are semantically idempotent reads, so retry is
+        enabled by default (unlike :meth:`Mutation.create`, which disables it).
+
+        Args:
+            body: Request payload to send as JSON.  ``None`` for endpoints
+                that accept no body.
+            query_params: Optional query string parameters forwarded to the
+                underlying ``call_endpoint`` (e.g. ``{"expand": "true"}``).
+
+        Returns:
+            Raw API response — a list of result records, a dict, or any other
+            shape returned by the endpoint.
+        """
+        logger.debug(
+            "Query.invoke: POST %s body=%s query_params=%s",
+            self._path,
+            body,
+            query_params,
+        )
+        kwargs: dict[str, Any] = {"method": "POST", "body": body}
+        if query_params is not None:
+            kwargs["query_params"] = query_params
+        return self._client.call_endpoint(self._path, **kwargs)

--- a/src/pynetappfoundry/query/query.py
+++ b/src/pynetappfoundry/query/query.py
@@ -66,7 +66,9 @@ class Query:
             body,
             query_params,
         )
-        kwargs: dict[str, Any] = {"method": "POST", "body": body}
-        if query_params is not None:
-            kwargs["query_params"] = query_params
-        return self._client.call_endpoint(self._path, **kwargs)
+        return self._client.call_endpoint(
+            self._path,
+            method="POST",
+            body=body,
+            query_params=query_params,
+        )

--- a/tests/unit/query/test_query.py
+++ b/tests/unit/query/test_query.py
@@ -74,7 +74,10 @@ class TestQueryInvoke:
         q = Query(mock_client, "/lake/query/timeseries")
         q.invoke({"metric": "cpu"})
         mock_client.call_endpoint.assert_called_once_with(
-            "/lake/query/timeseries", method="POST", body={"metric": "cpu"}
+            "/lake/query/timeseries",
+            method="POST",
+            body={"metric": "cpu"},
+            query_params=None,
         )
 
     def test_passes_body_through(self, mock_client: MagicMock) -> None:
@@ -91,7 +94,7 @@ class TestQueryInvoke:
         q = Query(mock_client, "/some/endpoint")
         q.invoke()
         mock_client.call_endpoint.assert_called_once_with(
-            "/some/endpoint", method="POST", body=None
+            "/some/endpoint", method="POST", body=None, query_params=None
         )
 
     def test_invoke_with_query_params(self, mock_client: MagicMock) -> None:
@@ -105,14 +108,6 @@ class TestQueryInvoke:
             body={"metric": "iops"},
             query_params={"expand": "true"},
         )
-
-    def test_invoke_without_query_params_omits_kwarg(self, mock_client: MagicMock) -> None:
-        """query_params is not forwarded when not provided."""
-        mock_client.call_endpoint.return_value = {}
-        q = Query(mock_client, "/some/endpoint")
-        q.invoke({"metric": "iops"})
-        call_kwargs = mock_client.call_endpoint.call_args[1]
-        assert "query_params" not in call_kwargs
 
     def test_invoke_does_not_disable_retry(self, mock_client: MagicMock) -> None:
         """Query.invoke does NOT disable retry (opposite of Mutation.create).
@@ -158,11 +153,3 @@ class TestQueryInvoke:
         assert mock_client.call_endpoint.call_count == 2
         for c in mock_client.call_endpoint.call_args_list:
             assert c[0][0] == "/fixed/path"
-
-    def test_works_with_any_mock_client(self) -> None:
-        """Query is not coupled to any specific client type."""
-        generic_client = MagicMock()
-        generic_client.call_endpoint.return_value = {"ok": True}
-        q = Query(generic_client, "/any/path")
-        result = q.invoke({"x": 1})
-        assert result == {"ok": True}

--- a/tests/unit/query/test_query.py
+++ b/tests/unit/query/test_query.py
@@ -1,0 +1,168 @@
+"""Tests for pynetappfoundry.query.query module."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pynetappfoundry.query import Query
+from pynetappfoundry.query.query import Query as QueryDirect
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_client() -> MagicMock:
+    """Return a mocked APIWrapper with call_endpoint."""
+    return MagicMock(spec=["call_endpoint"])
+
+
+# ---------------------------------------------------------------------------
+# Import / public API tests
+# ---------------------------------------------------------------------------
+
+
+class TestQueryImport:
+    """Query is importable from the top-level query package."""
+
+    def test_importable_from_package(self) -> None:
+        assert Query is QueryDirect
+
+    def test_present_in_all(self) -> None:
+        import pynetappfoundry.query as pkg
+
+        assert "Query" in pkg.__all__
+
+
+# ---------------------------------------------------------------------------
+# Constructor tests
+# ---------------------------------------------------------------------------
+
+
+class TestQueryInit:
+    """Tests for Query.__init__."""
+
+    def test_stores_client(self, mock_client: MagicMock) -> None:
+        q = Query(mock_client, "/lake/query/timeseries")
+        assert q._client is mock_client
+
+    def test_stores_path(self, mock_client: MagicMock) -> None:
+        q = Query(mock_client, "/lake/query/timeseries")
+        assert q._path == "/lake/query/timeseries"
+
+    def test_different_paths_stored_independently(self, mock_client: MagicMock) -> None:
+        q1 = Query(mock_client, "/path/one")
+        q2 = Query(mock_client, "/path/two")
+        assert q1._path == "/path/one"
+        assert q2._path == "/path/two"
+
+
+# ---------------------------------------------------------------------------
+# invoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestQueryInvoke:
+    """Tests for Query.invoke."""
+
+    def test_calls_post_on_correct_path(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = []
+        q = Query(mock_client, "/lake/query/timeseries")
+        q.invoke({"metric": "cpu"})
+        mock_client.call_endpoint.assert_called_once_with(
+            "/lake/query/timeseries", method="POST", body={"metric": "cpu"}
+        )
+
+    def test_passes_body_through(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = []
+        body: dict[str, Any] = {"metric": "iops", "interval": "5m", "filters": ["vol1"]}
+        q = Query(mock_client, "/some/endpoint")
+        q.invoke(body)
+        _, kwargs = mock_client.call_endpoint.call_args
+        assert kwargs["body"] == body
+
+    def test_invoke_with_no_body(self, mock_client: MagicMock) -> None:
+        """invoke() with no body sends body=None."""
+        mock_client.call_endpoint.return_value = []
+        q = Query(mock_client, "/some/endpoint")
+        q.invoke()
+        mock_client.call_endpoint.assert_called_once_with(
+            "/some/endpoint", method="POST", body=None
+        )
+
+    def test_invoke_with_query_params(self, mock_client: MagicMock) -> None:
+        """query_params kwarg is forwarded to call_endpoint."""
+        mock_client.call_endpoint.return_value = {}
+        q = Query(mock_client, "/some/endpoint")
+        q.invoke({"metric": "iops"}, query_params={"expand": "true"})
+        mock_client.call_endpoint.assert_called_once_with(
+            "/some/endpoint",
+            method="POST",
+            body={"metric": "iops"},
+            query_params={"expand": "true"},
+        )
+
+    def test_invoke_without_query_params_omits_kwarg(self, mock_client: MagicMock) -> None:
+        """query_params is not forwarded when not provided."""
+        mock_client.call_endpoint.return_value = {}
+        q = Query(mock_client, "/some/endpoint")
+        q.invoke({"metric": "iops"})
+        call_kwargs = mock_client.call_endpoint.call_args[1]
+        assert "query_params" not in call_kwargs
+
+    def test_invoke_does_not_disable_retry(self, mock_client: MagicMock) -> None:
+        """Query.invoke does NOT disable retry (opposite of Mutation.create).
+
+        RPC query endpoints are idempotent reads — the client default retry
+        config must be used unchanged.
+        """
+        from pynetappfoundry.core.models import RetryConfig
+
+        mock_client.call_endpoint.return_value = []
+        q = Query(mock_client, "/some/endpoint")
+        q.invoke({"x": 1})
+        call_kwargs = mock_client.call_endpoint.call_args[1]
+        assert "retry_config" not in call_kwargs or call_kwargs.get("retry_config") != RetryConfig(
+            enabled=False
+        )
+
+    def test_returns_list_response(self, mock_client: MagicMock) -> None:
+        expected: list[dict[str, Any]] = [{"ts": 1, "value": 42}, {"ts": 2, "value": 43}]
+        mock_client.call_endpoint.return_value = expected
+        q = Query(mock_client, "/lake/query/timeseries")
+        result = q.invoke({"metric": "cpu"})
+        assert result == expected
+
+    def test_returns_dict_response(self, mock_client: MagicMock) -> None:
+        expected: dict[str, Any] = {"total": 5, "records": [{"ts": 1}]}
+        mock_client.call_endpoint.return_value = expected
+        q = Query(mock_client, "/lake/query/summary")
+        result = q.invoke({"metric": "latency"})
+        assert result == expected
+
+    def test_returns_empty_list(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = []
+        q = Query(mock_client, "/lake/query/timeseries")
+        result = q.invoke({})
+        assert result == []
+
+    def test_uses_stored_path_on_each_call(self, mock_client: MagicMock) -> None:
+        mock_client.call_endpoint.return_value = []
+        q = Query(mock_client, "/fixed/path")
+        q.invoke({"a": 1})
+        q.invoke({"b": 2})
+        assert mock_client.call_endpoint.call_count == 2
+        for c in mock_client.call_endpoint.call_args_list:
+            assert c[0][0] == "/fixed/path"
+
+    def test_works_with_any_mock_client(self) -> None:
+        """Query is not coupled to any specific client type."""
+        generic_client = MagicMock()
+        generic_client.call_endpoint.return_value = {"ok": True}
+        q = Query(generic_client, "/any/path")
+        result = q.invoke({"x": 1})
+        assert result == {"ok": True}


### PR DESCRIPTION
## Description

Add a `Query` helper for RPC-style POST endpoints that return data, and document when to use it alongside the existing query-layer APIs.

## Related Issue

Addresses #688

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Add `pynetappfoundry.query.Query` as a lightweight wrapper for POST-for-data RPC endpoints
- Re-export `Query` from `pynetappfoundry.query.__init__` so it is part of the public query-layer API
- Add unit coverage for imports, initialization, POST dispatch, and list/dict response handling
- Update the query-layer and ONTAP access pattern docs to describe when to use `Query`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [ ] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A

## Additional Notes

`Query` intentionally complements `QuerySet` and `Mutation`: it is for POST endpoints that behave like reads and return raw data payloads rather than model-backed resources or lifecycle mutations.
