### PR TITLE
feat: rewrite dump-dii for DII timeseries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `nf metrics dump-dii`: the `--days` option is removed and replaced by the
   required `--date YYYY-MM-DD` option.  The command now issues one POST per
   metric per volume to the DII `/lake/query/timeseries` endpoint (6 POSTs per
-  volume) with a 3-day window centred on *date* (date − 1 day to date + 2 days,
-  60-second aggregation interval).  The SQLite database filename now includes
-  the date (`{cluster}_{date}_metrics.db`) and each table stores data for a
-  single SVM/volume pair (`{vserver_name}-{volume_name}`), replacing the
-  previous per-cluster table layout.
+  volume).  The aggregation interval and window length are now configurable
+  via `--interval` (default `60s`) and `--window-days` (default `3`, centered
+  on `--date`, yielding date − 1 day through date + 2 days).  The SQLite
+  database filename now includes the date (`{cluster}_{date}_metrics.db`) and
+  each table stores data for a single SVM/volume pair
+  (`{vserver_name}-{volume_name}`), replacing the previous per-cluster table
+  layout.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### BREAKING CHANGE
+
+- `nf metrics dump-dii`: the `--days` option is removed and replaced by the
+  required `--date YYYY-MM-DD` option.  The command now issues one POST per
+  metric per volume to the DII `/lake/query/timeseries` endpoint (6 POSTs per
+  volume) with a 3-day window centred on *date* (date − 1 day to date + 2 days,
+  60-second aggregation interval).  The SQLite database filename now includes
+  the date (`{cluster}_{date}_metrics.db`) and each table stores data for a
+  single SVM/volume pair (`{vserver_name}-{volume_name}`), replacing the
+  previous per-cluster table layout.
 
 ### Added
+
 - Initial release
 - Core ONTAP client functionality
 - CLI tools for storage administration

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ nf events get --filter '{"name":"cluster1"}'
 nf events save-azure
 
 # Metrics
-nf metrics dump-dii
+nf metrics dump-dii --date 2025-04-13
 
 # Utilities
 nf utils validate
 nf utils run-cmd "vol show"
-nf utils sqlite-to-excel metrics.db
+nf utils sqlite-to-excel cluster1_2025-04-13_metrics.db
 ```
 
 ### Common Options

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -29,7 +29,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [ONTAP Access Patterns](usage/ontap-access-patterns.md) - Guide to choosing between the three ONTAP access methods
 - [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
 - [pynetappfoundry Documentation](index.md) - ONTAP administration library and CLI tools
-- [Query Layer](usage/query-layer.md) - Guide to the REST query layer (QuerySet, Mutation, JobTracker, related, realtime)
+- [Query Layer](usage/query-layer.md) - Guide to the REST query layer (QuerySet, Query, Mutation, JobTracker, related, realtime)
 - [Template Management](template/manage.md) - Unified interface for creating projects, checking updates, and syncing
 - [Template Tools Reference](template/tools-reference.md) - Complete reference for all template tools in tools/pyproject_template/
 - [Using This Template](template/index.md) - Overview of using pyproject-template for your Python projects
@@ -62,7 +62,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
 - [pynetappfoundry Documentation](index.md) - ONTAP administration library and CLI tools
 - [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
-- [Query Layer](usage/query-layer.md) - Guide to the REST query layer (QuerySet, Mutation, JobTracker, related, realtime)
+- [Query Layer](usage/query-layer.md) - Guide to the REST query layer (QuerySet, Query, Mutation, JobTracker, related, realtime)
 - [Release Automation & Security](development/release-and-automation.md) - Automated versioning, release management, and security tooling
 - [Ruff Auto-Fix on Edit Hook](development/ai/ruff-fix-hook.md) - PostToolUse hook that runs ruff --fix on edited Python files
 - [Slash Commands and Workflows](development/ai/slash-commands.md) - Reference for the slash commands and dual-agent workflow this template ships with
@@ -176,7 +176,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [PyNetAppFoundry Code Review & Improvement Plan](plans/first-pass-refactor.md)
 - [pynetappfoundry Documentation](index.md) - ONTAP administration library and CLI tools
 - [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
-- [Query Layer](usage/query-layer.md) - Guide to the REST query layer (QuerySet, Mutation, JobTracker, related, realtime)
+- [Query Layer](usage/query-layer.md) - Guide to the REST query layer (QuerySet, Query, Mutation, JobTracker, related, realtime)
 - [Release Automation & Security](development/release-and-automation.md) - Automated versioning, release management, and security tooling
 - [Ruff Auto-Fix on Edit Hook](development/ai/ruff-fix-hook.md) - PostToolUse hook that runs ruff --fix on edited Python files
 - [Slash Commands and Workflows](development/ai/slash-commands.md) - Reference for the slash commands and dual-agent workflow this template ships with

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -153,7 +153,9 @@ nf metrics [OPTIONS] COMMAND [ARGS]...
 | Option | Description |
 |--------|-------------|
 | `-f, --filter TEXT` | JSON cluster filter |
-| `-d, --date TEXT` | Required date in `YYYY-MM-DD` format; queries `(date - 1 day)` through `(date + 2 days)` in UTC |
+| `-d, --date TEXT` | **Required.** Anchor date in `YYYY-MM-DD` format. The query window is centered on this date in UTC (see `--window-days`) |
+| `--interval TEXT` | Aggregation interval forwarded to DII (default: `60s`; accepts e.g. `5m`, `1h`) |
+| `--window-days INTEGER` | Total UTC days in the query window centered on `--date` (default: `3`, yielding `(date - 1 day)` through `(date + 2 days)`) |
 
 `metrics dump-dii` writes one SQLite database per cluster per date (`{cluster}_{date}_metrics.db`) and stores each SVM/volume pair in its own table (`{vserver_name}-{volume_name}`).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -146,14 +146,16 @@ nf metrics [OPTIONS] COMMAND [ARGS]...
 
 | Command | Description |
 |---------|-------------|
-| `dump-dii` | Dump metrics from Data Infrastructure Insights into SQLite |
+| `dump-dii` | Dump per-volume DII metrics into SQLite |
 
 **`metrics dump-dii` options:**
 
 | Option | Description |
 |--------|-------------|
 | `-f, --filter TEXT` | JSON cluster filter |
-| `-d, --days INTEGER` | Number of days of history to retrieve (default: 7) |
+| `-d, --date TEXT` | Required date in `YYYY-MM-DD` format; queries `(date - 1 day)` through `(date + 2 days)` in UTC |
+
+`metrics dump-dii` writes one SQLite database per cluster per date (`{cluster}_{date}_metrics.db`) and stores each SVM/volume pair in its own table (`{vserver_name}-{volume_name}`).
 
 ### cache
 
@@ -348,11 +350,11 @@ nf events save-azure -f '{"env":"Prod"}'
 ### Metrics Collection
 
 ```bash
-# Dump the last 7 days of DII metrics (default) for all clusters
-nf metrics dump-dii
+# Dump DII metrics for a 3-day window centered on 2025-04-13 for all clusters
+nf metrics dump-dii --date 2025-04-13
 
-# Dump the last 30 days for a filtered set of clusters
-nf metrics dump-dii -d 30 -f '{"env":"Prod"}'
+# Dump the same 3-day window for a filtered set of clusters
+nf metrics dump-dii --date 2025-04-13 -f '{"env":"Prod"}'
 ```
 
 ### Configuration
@@ -399,10 +401,10 @@ nf utils validate --ssh
 nf utils run-cmd "vol show" -f '{"env":"Prod"}'
 
 # Convert a SQLite database produced by `metrics dump-dii` to Excel
-nf utils sqlite-to-excel metrics.db
+nf utils sqlite-to-excel cluster1_2025-04-13_metrics.db
 
 # Convert with a custom output path
-nf utils sqlite-to-excel metrics.db -o metrics-report.xlsx
+nf utils sqlite-to-excel cluster1_2025-04-13_metrics.db -o metrics-report.xlsx
 ```
 
 ### Cache Management

--- a/docs/usage/ontap-access-patterns.md
+++ b/docs/usage/ontap-access-patterns.md
@@ -388,9 +388,6 @@ response = client.call_endpoint(
         "fromTimeMs": 1744416000000,
         "toTimeMs": 1744675200000,
         "timeAggregationInterval": "60s",
-        "maxNumberOfDataPoints": 4320,
-        "detectAnomalies": False,
-        "interpolationType": "NONE",
     },
 )
 ```

--- a/docs/usage/ontap-access-patterns.md
+++ b/docs/usage/ontap-access-patterns.md
@@ -376,16 +376,28 @@ dii_config = config.diis["production"]
 
 client = DIIAPIClient(dii_config, config)
 
-# Query storage assets
+# Query DII workload-volume timeseries
 response = client.call_endpoint(
-    path="/assets/storages",
-    method="GET"
+    path="/lake/query/timeseries",
+    method="POST",
+    body={
+        "category": "netapp_ontap",
+        "measurement": "workload_volume",
+        "metric": "read_ops",
+        "filter": 'vserver_name = "svm1" AND volume_name = "vol1"',
+        "fromTimeMs": 1744416000000,
+        "toTimeMs": 1744675200000,
+        "timeAggregationInterval": "60s",
+        "maxNumberOfDataPoints": 4320,
+        "detectAnomalies": False,
+        "interpolationType": "NONE",
+    },
 )
 ```
 
 **Commands Using This Pattern:**
 
-- `nf metrics dump-dii` - Query DII metrics
+- `nf metrics dump-dii` - Query per-volume DII metrics via `/lake/query/timeseries`
 
 **Configuration Required:**
 

--- a/src/pynetappfoundry/cli/commands/metrics/dump_dii.py
+++ b/src/pynetappfoundry/cli/commands/metrics/dump_dii.py
@@ -1,7 +1,19 @@
-"""Dump metrics from Data Infrastructure Insights."""
+"""Dump metrics from Data Infrastructure Insights.
+
+Rewrites ``nf metrics dump-dii`` to use the DII ``/lake/query/timeseries``
+POST endpoint with per-volume granularity, matching the sysadmin reference
+script (``dump_cluster_metrics_dii.py``).
+
+Breaking change: ``--days`` is replaced by the required ``--date YYYY-MM-DD``
+option. The SQLite database filename now includes the date (e.g.
+``<cluster>_2025-04-13_metrics.db``) and each table stores data for one
+SVM/volume pair (``{vserver_name}-{volume_name}``).
+"""
 
 from __future__ import annotations
 
+import logging
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import click
@@ -16,8 +28,24 @@ from pynetappfoundry.cli.utils import (
     print_warning,
 )
 from pynetappfoundry.clients.dii.api import DIIAPIClient
+from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
 from pynetappfoundry.core.config import Config
+from pynetappfoundry.core.models import ClusterConfig
 from pynetappfoundry.db.metrics import MetricDB
+from pynetappfoundry.models.ontap.storage.volumes.model import OntapVolume
+from pynetappfoundry.query import Query, QuerySet
+
+logger = logging.getLogger(__name__)
+
+#: Ordered list of DII workload_volume metrics fetched for every volume.
+_METRICS: list[str] = [
+    "read_ops",
+    "write_ops",
+    "read_throughput",
+    "write_throughput",
+    "read_latency",
+    "write_latency",
+]
 
 
 @click.command("dump-dii")
@@ -28,94 +56,259 @@ from pynetappfoundry.db.metrics import MetricDB
     help='JSON filter: \'{"bu":"Business", "env":"Prod"}\'',
 )
 @click.option(
-    "--days",
+    "--date",
     "-d",
-    type=int,
-    default=7,
-    help="Number of days of history to retrieve (default: 7).",
+    "date",
+    required=True,
+    help=(
+        "Date in YYYY-MM-DD format.  Retrieves a 3-day window: "
+        "(date - 1 day) 00:00:00 UTC → (date + 2 days) 00:00:00 UTC."
+    ),
 )
 @with_config("Dump DII metrics failed")
 def dump_dii(
     config: Config,
     clusters: dict[str, dict[str, Any]],
-    days: int,
+    date: str,
 ) -> None:
-    """Dump metrics from Data Infrastructure Insights.
+    """Dump per-volume metrics from Data Infrastructure Insights.
 
-    Retrieves performance metrics from DII and stores them in SQLite.
+    Issues one POST per metric per volume to the DII
+    ``/lake/query/timeseries`` endpoint with a 60-second aggregation
+    interval and stores the results in a per-cluster SQLite database.
     """
     try:
         dii_client = DIIAPIClient(config)
     except Exception as e:
-        print_exception(f"Could not initialize DII client: {e}", e)
+        print_exception(f"Could not initialise DII client: {e}", e)
         return
 
-    db = MetricDB(config)
+    from_ms, to_ms = _compute_window(date)
 
     for name, details in clusters.items():
         print_info(f"Getting metrics for {name}...")
-        _dump_cluster_metrics(name, details, config, dii_client, db, days)
+        try:
+            cluster_config = ClusterConfig(**details)
+            ontap_client = ONTAPAPIClient(cluster=cluster_config, config=config)
+
+            volumes: list[OntapVolume] = (
+                QuerySet(OntapVolume, ontap_client, config=config).filter(is_svm_root=False).all()
+            )
+
+            if not volumes:
+                print_warning(f"No volumes found for {name}")
+                continue
+
+            db = MetricDB(config, db_name=f"{name}_{date}_metrics.db")
+            dii_query = Query(dii_client, "/lake/query/timeseries")
+
+            for volume in volumes:
+                vol_name = volume.name
+                svm_name = volume.svm.name
+                _dump_volume(name, vol_name, svm_name, dii_query, db, from_ms, to_ms)
+
+            print_debug(f"Metrics saved for {name}")
+
+        except Exception as e:
+            print_error(f"Could not dump metrics for {name}: {e}")
+            logger.exception("Exception for cluster %s", name)
 
     print_success("Metrics saved to database")
 
 
-def _dump_cluster_metrics(
-    name: str,
-    details: dict[str, Any],
-    config: Config,
-    dii_client: DIIAPIClient,
-    db: MetricDB,
-    days: int,
-) -> None:
-    """Dump metrics for a single cluster."""
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _compute_window(date_str: str) -> tuple[int, int]:
+    """Compute epoch-millisecond boundaries for a 3-day window around *date_str*.
+
+    The window starts at ``(date - 1 day) 00:00:00 UTC`` and ends at
+    ``(date + 2 days) 00:00:00 UTC``.
+
+    Args:
+        date_str: Date in ``YYYY-MM-DD`` format.
+
+    Returns:
+        ``(from_ms, to_ms)`` as integer epoch milliseconds.
+
+    Example::
+
+        >>> _compute_window("2025-04-13")
+        (1744416000000, 1744675200000)
+    """
+    date = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC)
+    from_dt = date - timedelta(days=1)
+    to_dt = date + timedelta(days=2)
+    from_ms = int(from_dt.timestamp() * 1000)
+    to_ms = int(to_dt.timestamp() * 1000)
+    return from_ms, to_ms
+
+
+def _build_body(
+    metric: str,
+    svm: str,
+    vol: str,
+    from_ms: int,
+    to_ms: int,
+) -> dict[str, Any]:
+    """Build the DII ``/lake/query/timeseries`` POST request body.
+
+    One body is constructed per metric; the caller iterates over
+    :data:`_METRICS` and calls this function for each one.
+
+    Args:
+        metric: Metric name, e.g. ``"read_ops"``.
+        svm: SVM (vserver) name.
+        vol: Volume name.
+        from_ms: Start of window in epoch milliseconds.
+        to_ms: End of window in epoch milliseconds.
+
+    Returns:
+        Request body dict suitable for ``Query.invoke(body=...)``.
+    """
+    return {
+        "category": "netapp_ontap",
+        "measurement": "workload_volume",
+        "metric": metric,
+        "filter": f'vserver_name = "{svm}" AND volume_name = "{vol}"',
+        "fromTimeMs": from_ms,
+        "toTimeMs": to_ms,
+        "timeAggregationInterval": "60s",
+        "maxNumberOfDataPoints": (to_ms - from_ms) // 60_000,
+        "detectAnomalies": False,
+        "interpolationType": "NONE",
+    }
+
+
+def _parse_timeseries(
+    response: Any,
+    metric_name: str,
+) -> dict[int, dict[str, Any]]:
+    """Parse a single-metric DII timeseries response into a timestamp-keyed dict.
+
+    Each data point becomes ``{timestamp_seconds: {metric_name: value}}``.
+
+    Args:
+        response: Raw value returned by ``Query.invoke()``; expected to be a
+            list whose first element contains a ``"timeseries"`` key.
+        metric_name: Name of the metric (used as the inner dict key).
+
+    Returns:
+        Mapping from integer timestamp (seconds) to
+        ``{metric_name: value}``.  Returns an empty dict when *response* is
+        falsy or has an unexpected shape.
+    """
+    result: dict[int, dict[str, Any]] = {}
+    if not response:
+        return result
     try:
-        # Create table for this cluster
-        table_name = name.replace("-", "_").replace(".", "_")
-        db.create_table(table_name)
+        timeseries = response[0]["timeseries"]
+    except (IndexError, KeyError, TypeError):
+        logger.debug("Unexpected response shape for metric %s: %r", metric_name, response)
+        return result
+    for data in timeseries:
+        try:
+            ts = int(data["time"]) // 1000
+            value = data["value"]
+            result[ts] = {metric_name: value}
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.debug("Skipping bad data point for %s: %r (%s)", metric_name, data, exc)
+    return result
 
-        # Get storage assets from DII
-        storage_query = {
-            "name": name,
-        }
 
-        assets = dii_client.call_endpoint(
-            "/assets/storages",
-            query_params=storage_query,
-        )
+def _validate_and_clean(
+    metrics_data: dict[int, dict[str, Any]],
+    metric_names: list[str],
+) -> list[dict[str, Any]]:
+    """Validate merged per-timestamp data and drop incomplete placeholder rows.
 
-        if not assets:
-            print_warning(f"No assets found for {name} in DII")
+    * Drops timestamps whose dict contains **only** the ``"timestamp"`` key
+      (placeholder rows where all metric POSTs returned no data).
+    * Logs an error for timestamps that have some — but not all — expected
+      metrics, then still includes them in the output so partial data is
+      not silently lost.
+
+    Args:
+        metrics_data: Mapping of timestamp (seconds) → row dict that
+            includes the ``"timestamp"`` key plus zero or more metric keys.
+        metric_names: Ordered list of expected metric column names
+            (excluding ``"timestamp"``).
+
+    Returns:
+        List of row dicts ready for ``MetricDB.upsert_many()``.
+    """
+    expected_keys = len(metric_names) + 1  # +1 for "timestamp"
+    rows: list[dict[str, Any]] = []
+    for ts, row in metrics_data.items():
+        row_len = len(row)
+        if row_len == 1 and "timestamp" in row:
+            # Placeholder with no metric data — drop silently.
+            logger.debug("Dropping placeholder-only timestamp %d", ts)
+            continue
+        if row_len != expected_keys:
+            logger.error(
+                "Timestamp %d does not have %d keys (has %d): %r",
+                ts,
+                expected_keys,
+                row_len,
+                row,
+            )
+        rows.append(row)
+    return rows
+
+
+def _dump_volume(
+    cluster: str,
+    vol_name: str,
+    svm_name: str,
+    dii_query: Query,
+    db: MetricDB,
+    from_ms: int,
+    to_ms: int,
+) -> None:
+    """Fetch and store metrics for a single volume.
+
+    Issues one ``Query.invoke()`` POST per metric (6 total), merges the
+    responses into per-timestamp rows keyed by ``{svm_name}-{vol_name}``,
+    validates completeness, and upserts all rows into the ``MetricDB``.
+
+    Per-volume exceptions are caught and logged so that a failure for one
+    volume does not prevent sibling volumes from being processed.
+
+    Args:
+        cluster: Cluster name (used in log messages only).
+        vol_name: Volume name.
+        svm_name: SVM (vserver) name.
+        dii_query: Bound :class:`~pynetappfoundry.query.Query` instance
+            for the ``/lake/query/timeseries`` endpoint.
+        db: :class:`~pynetappfoundry.db.metrics.MetricDB` instance for
+            this cluster+date.
+        from_ms: Start of window in epoch milliseconds.
+        to_ms: End of window in epoch milliseconds.
+    """
+    logger.info("  Gathering data for %s:%s:%s", cluster, svm_name, vol_name)
+    try:
+        current_metrics: dict[int, dict[str, Any]] = {}
+        for metric in _METRICS:
+            body = _build_body(metric, svm_name, vol_name, from_ms, to_ms)
+            response = dii_query.invoke(body=body)
+            parsed = _parse_timeseries(response, metric)
+            for ts, metric_dict in parsed.items():
+                if ts not in current_metrics:
+                    current_metrics[ts] = {"timestamp": ts}
+                current_metrics[ts].update(metric_dict)
+
+        rows = _validate_and_clean(current_metrics, _METRICS)
+        if not rows:
+            logger.info("No data for %s:%s:%s", cluster, svm_name, vol_name)
             return
 
-        # Get metrics for each asset
-        for asset in assets.get("results", []):
-            asset_id = asset.get("id")
-            if not asset_id:
-                continue
-
-            # Get performance metrics
-            metrics_data = dii_client.call_endpoint(
-                f"/assets/storages/{asset_id}/performance",
-                query_params={"days": days},
-            )
-
-            if not metrics_data:
-                continue
-
-            # Process and save metrics
-            for datapoint in metrics_data.get("datapoints", []):
-                metric_record = {
-                    "timestamp": datapoint.get("timestamp"),
-                    "read_ops": datapoint.get("readOps", 0),
-                    "write_ops": datapoint.get("writeOps", 0),
-                    "read_latency": datapoint.get("readLatency", 0),
-                    "write_latency": datapoint.get("writeLatency", 0),
-                    "read_throughput": datapoint.get("readThroughput", 0),
-                    "write_throughput": datapoint.get("writeThroughput", 0),
-                }
-                db.upsert_data(table_name, metric_record)
-
-        print_debug(f"Saved metrics for {name}")
+        table_name = f"{svm_name}-{vol_name}"
+        db.create_table(table_name)
+        db.upsert_many(table_name, rows)
 
     except Exception as e:
-        print_error(f"Could not dump metrics for {name}: {e}")
+        print_error(f"Could not retrieve data for {cluster}:{svm_name}:{vol_name}: {e}")
+        logger.exception("Exception for volume %s:%s:%s", cluster, svm_name, vol_name)

--- a/src/pynetappfoundry/cli/commands/metrics/dump_dii.py
+++ b/src/pynetappfoundry/cli/commands/metrics/dump_dii.py
@@ -8,6 +8,10 @@ Breaking change: ``--days`` is replaced by the required ``--date YYYY-MM-DD``
 option. The SQLite database filename now includes the date (e.g.
 ``<cluster>_2025-04-13_metrics.db``) and each table stores data for one
 SVM/volume pair (``{vserver_name}-{volume_name}``).
+
+The aggregation interval and total window length are configurable via
+``--interval`` (default ``60s``) and ``--window-days`` (default ``3``,
+centered on ``--date``).
 """
 
 from __future__ import annotations
@@ -31,7 +35,7 @@ from pynetappfoundry.clients.dii.api import DIIAPIClient
 from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
 from pynetappfoundry.core.config import Config
 from pynetappfoundry.core.models import ClusterConfig
-from pynetappfoundry.db.metrics import MetricDB
+from pynetappfoundry.db.metrics import _TABLE_NAME_PATTERN, MetricDB
 from pynetappfoundry.models.ontap.storage.volumes.model import OntapVolume
 from pynetappfoundry.query import Query, QuerySet
 
@@ -47,6 +51,9 @@ _METRICS: list[str] = [
     "write_latency",
 ]
 
+_DEFAULT_INTERVAL = "60s"
+_DEFAULT_WINDOW_DAYS = 3
+
 
 @click.command("dump-dii")
 @click.option(
@@ -61,8 +68,25 @@ _METRICS: list[str] = [
     "date",
     required=True,
     help=(
-        "Date in YYYY-MM-DD format.  Retrieves a 3-day window: "
-        "(date - 1 day) 00:00:00 UTC → (date + 2 days) 00:00:00 UTC."
+        "Anchor date in YYYY-MM-DD format. The retrieved window is centered "
+        "on this date (see --window-days)."
+    ),
+)
+@click.option(
+    "--interval",
+    default=_DEFAULT_INTERVAL,
+    show_default=True,
+    help="Aggregation interval passed to DII (e.g. '60s', '5m', '1h').",
+)
+@click.option(
+    "--window-days",
+    "window_days",
+    type=int,
+    default=_DEFAULT_WINDOW_DAYS,
+    show_default=True,
+    help=(
+        "Total number of UTC days in the query window, centered on --date. "
+        "Default 3 yields (date - 1 day) through (date + 2 days)."
     ),
 )
 @with_config("Dump DII metrics failed")
@@ -70,12 +94,14 @@ def dump_dii(
     config: Config,
     clusters: dict[str, dict[str, Any]],
     date: str,
+    interval: str,
+    window_days: int,
 ) -> None:
     """Dump per-volume metrics from Data Infrastructure Insights.
 
-    Issues one POST per metric per volume to the DII
-    ``/lake/query/timeseries`` endpoint with a 60-second aggregation
-    interval and stores the results in a per-cluster SQLite database.
+    Issues one POST per metric per volume (6 total per volume) to the DII
+    ``/lake/query/timeseries`` endpoint and stores the results in a
+    per-cluster SQLite database.
     """
     try:
         dii_client = DIIAPIClient(config)
@@ -83,35 +109,14 @@ def dump_dii(
         print_exception(f"Could not initialise DII client: {e}", e)
         return
 
-    from_ms, to_ms = _compute_window(date)
+    try:
+        from_ms, to_ms = _compute_window(date, window_days)
+    except ValueError as e:
+        print_error(f"Invalid window: {e}")
+        return
 
     for name, details in clusters.items():
-        print_info(f"Getting metrics for {name}...")
-        try:
-            cluster_config = ClusterConfig(**details)
-            ontap_client = ONTAPAPIClient(cluster=cluster_config, config=config)
-
-            volumes: list[OntapVolume] = (
-                QuerySet(OntapVolume, ontap_client, config=config).filter(is_svm_root=False).all()
-            )
-
-            if not volumes:
-                print_warning(f"No volumes found for {name}")
-                continue
-
-            db = MetricDB(config, db_name=f"{name}_{date}_metrics.db")
-            dii_query = Query(dii_client, "/lake/query/timeseries")
-
-            for volume in volumes:
-                vol_name = volume.name
-                svm_name = volume.svm.name
-                _dump_volume(name, vol_name, svm_name, dii_query, db, from_ms, to_ms)
-
-            print_debug(f"Metrics saved for {name}")
-
-        except Exception as e:
-            print_error(f"Could not dump metrics for {name}: {e}")
-            logger.exception("Exception for cluster %s", name)
+        _dump_cluster(config, name, details, dii_client, date, from_ms, to_ms, interval)
 
     print_success("Metrics saved to database")
 
@@ -121,26 +126,44 @@ def dump_dii(
 # ---------------------------------------------------------------------------
 
 
-def _compute_window(date_str: str) -> tuple[int, int]:
-    """Compute epoch-millisecond boundaries for a 3-day window around *date_str*.
+def _compute_window(date_str: str, window_days: int = _DEFAULT_WINDOW_DAYS) -> tuple[int, int]:
+    """Compute epoch-millisecond boundaries for a window centered on *date_str*.
 
-    The window starts at ``(date - 1 day) 00:00:00 UTC`` and ends at
-    ``(date + 2 days) 00:00:00 UTC``.
+    The window length is *window_days* UTC days. The anchor date sits as
+    close to the middle of the window as possible; for even *window_days*
+    the window leans forward by one day.
+
+    * ``half = (window_days - 1) // 2``
+    * ``start = date - half days`` (00:00:00 UTC)
+    * ``end   = date + (window_days - half) days`` (00:00:00 UTC)
+
+    For ``window_days=3`` (default) this yields ``date - 1 day`` to
+    ``date + 2 days`` — three full UTC days centered on *date*.
 
     Args:
-        date_str: Date in ``YYYY-MM-DD`` format.
+        date_str: Anchor date in ``YYYY-MM-DD`` format.
+        window_days: Total number of UTC days in the window. Must be ≥ 1.
 
     Returns:
         ``(from_ms, to_ms)`` as integer epoch milliseconds.
+
+    Raises:
+        ValueError: If *window_days* is less than 1.
 
     Example::
 
         >>> _compute_window("2025-04-13")
         (1744416000000, 1744675200000)
+        >>> _compute_window("2025-04-13", window_days=1)
+        (1744502400000, 1744588800000)
     """
+    if window_days < 1:
+        raise ValueError(f"window_days must be ≥ 1, got {window_days}")
     date = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC)
-    from_dt = date - timedelta(days=1)
-    to_dt = date + timedelta(days=2)
+    half = (window_days - 1) // 2
+    forward = window_days - half
+    from_dt = date - timedelta(days=half)
+    to_dt = date + timedelta(days=forward)
     from_ms = int(from_dt.timestamp() * 1000)
     to_ms = int(to_dt.timestamp() * 1000)
     return from_ms, to_ms
@@ -152,11 +175,16 @@ def _build_body(
     vol: str,
     from_ms: int,
     to_ms: int,
+    interval: str = _DEFAULT_INTERVAL,
 ) -> dict[str, Any]:
     """Build the DII ``/lake/query/timeseries`` POST request body.
 
     One body is constructed per metric; the caller iterates over
-    :data:`_METRICS` and calls this function for each one.
+    :data:`_METRICS` and calls this function for each one. The body
+    contains only the fields required by the DII OpenAPI schema —
+    optional fields (``maxNumberOfDataPoints``, ``detectAnomalies``,
+    ``interpolationType``) are omitted to keep the request minimal and
+    let the server apply its defaults.
 
     Args:
         metric: Metric name, e.g. ``"read_ops"``.
@@ -164,6 +192,7 @@ def _build_body(
         vol: Volume name.
         from_ms: Start of window in epoch milliseconds.
         to_ms: End of window in epoch milliseconds.
+        interval: Aggregation interval, e.g. ``"60s"``.
 
     Returns:
         Request body dict suitable for ``Query.invoke(body=...)``.
@@ -175,10 +204,7 @@ def _build_body(
         "filter": f'vserver_name = "{svm}" AND volume_name = "{vol}"',
         "fromTimeMs": from_ms,
         "toTimeMs": to_ms,
-        "timeAggregationInterval": "60s",
-        "maxNumberOfDataPoints": (to_ms - from_ms) // 60_000,
-        "detectAnomalies": False,
-        "interpolationType": "NONE",
+        "timeAggregationInterval": interval,
     }
 
 
@@ -267,12 +293,18 @@ def _dump_volume(
     db: MetricDB,
     from_ms: int,
     to_ms: int,
+    interval: str = _DEFAULT_INTERVAL,
 ) -> None:
     """Fetch and store metrics for a single volume.
 
     Issues one ``Query.invoke()`` POST per metric (6 total), merges the
     responses into per-timestamp rows keyed by ``{svm_name}-{vol_name}``,
     validates completeness, and upserts all rows into the ``MetricDB``.
+
+    The ``{svm_name}-{vol_name}`` table name is validated against
+    :data:`pynetappfoundry.db.metrics._TABLE_NAME_PATTERN` *before* any
+    POSTs are issued; volumes whose names produce an invalid table name
+    are skipped with a logged error so the 6 wasted requests are avoided.
 
     Per-volume exceptions are caught and logged so that a failure for one
     volume does not prevent sibling volumes from being processed.
@@ -287,12 +319,25 @@ def _dump_volume(
             this cluster+date.
         from_ms: Start of window in epoch milliseconds.
         to_ms: End of window in epoch milliseconds.
+        interval: Aggregation interval forwarded to :func:`_build_body`.
     """
+    table_name = f"{svm_name}-{vol_name}"
+    if not _TABLE_NAME_PATTERN.match(table_name):
+        print_error(f"Skipping {cluster}:{svm_name}:{vol_name} — invalid table name {table_name!r}")
+        logger.warning(
+            "Skipping invalid table name %r for %s:%s:%s",
+            table_name,
+            cluster,
+            svm_name,
+            vol_name,
+        )
+        return
+
     logger.info("  Gathering data for %s:%s:%s", cluster, svm_name, vol_name)
     try:
         current_metrics: dict[int, dict[str, Any]] = {}
         for metric in _METRICS:
-            body = _build_body(metric, svm_name, vol_name, from_ms, to_ms)
+            body = _build_body(metric, svm_name, vol_name, from_ms, to_ms, interval)
             response = dii_query.invoke(body=body)
             parsed = _parse_timeseries(response, metric)
             for ts, metric_dict in parsed.items():
@@ -305,10 +350,71 @@ def _dump_volume(
             logger.info("No data for %s:%s:%s", cluster, svm_name, vol_name)
             return
 
-        table_name = f"{svm_name}-{vol_name}"
         db.create_table(table_name)
         db.upsert_many(table_name, rows)
 
     except Exception as e:
         print_error(f"Could not retrieve data for {cluster}:{svm_name}:{vol_name}: {e}")
         logger.exception("Exception for volume %s:%s:%s", cluster, svm_name, vol_name)
+
+
+def _dump_cluster(
+    config: Config,
+    name: str,
+    details: dict[str, Any],
+    dii_client: DIIAPIClient,
+    date_str: str,
+    from_ms: int,
+    to_ms: int,
+    interval: str,
+) -> None:
+    """Dump per-volume metrics for a single cluster.
+
+    Builds an ONTAP client for *name*, lists non-root volumes, opens the
+    per-cluster ``MetricDB``, and dispatches each volume to
+    :func:`_dump_volume`. Per-cluster exceptions are caught so a failure
+    for one cluster does not abort the run.
+
+    Args:
+        config: Top-level :class:`Config` instance.
+        name: Cluster name (key in the clusters dict).
+        details: Cluster details dict (kwargs for :class:`ClusterConfig`).
+        dii_client: Shared :class:`DIIAPIClient` for all clusters.
+        date_str: Anchor date string used in the DB filename.
+        from_ms: Start of window in epoch milliseconds.
+        to_ms: End of window in epoch milliseconds.
+        interval: Aggregation interval forwarded to :func:`_dump_volume`.
+    """
+    print_info(f"Getting metrics for {name}...")
+    try:
+        cluster_config = ClusterConfig(**details)
+        ontap_client = ONTAPAPIClient(cluster=cluster_config, config=config)
+
+        volumes: list[OntapVolume] = (
+            QuerySet(OntapVolume, ontap_client, config=config).filter(is_svm_root=False).all()
+        )
+
+        if not volumes:
+            print_warning(f"No volumes found for {name}")
+            return
+
+        db = MetricDB(config, db_name=f"{name}_{date_str}_metrics.db")
+        dii_query = Query(dii_client, "/lake/query/timeseries")
+
+        for volume in volumes:
+            _dump_volume(
+                name,
+                volume.name,
+                volume.svm.name,
+                dii_query,
+                db,
+                from_ms,
+                to_ms,
+                interval,
+            )
+
+        print_debug(f"Metrics saved for {name}")
+
+    except Exception as e:
+        print_error(f"Could not dump metrics for {name}: {e}")
+        logger.exception("Exception for cluster %s", name)

--- a/tests/unit/cli/commands/metrics/__init__.py
+++ b/tests/unit/cli/commands/metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for metrics CLI commands."""

--- a/tests/unit/cli/commands/metrics/test_dump_dii.py
+++ b/tests/unit/cli/commands/metrics/test_dump_dii.py
@@ -6,8 +6,10 @@ via CliRunner (consistent with sibling test files in this package tree).
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Iterator
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import DEFAULT, MagicMock, patch
 
 import pytest
 
@@ -15,6 +17,7 @@ from pynetappfoundry.cli.commands.metrics.dump_dii import (
     _METRICS,
     _build_body,
     _compute_window,
+    _dump_cluster,
     _dump_volume,
     _parse_timeseries,
     _validate_and_clean,
@@ -28,35 +31,49 @@ from pynetappfoundry.cli.commands.metrics.dump_dii import (
 class TestComputeWindow:
     """Tests for :func:`_compute_window`."""
 
-    def test_exact_millisecond_values(self) -> None:
-        """2025-04-13 → from=2025-04-12T00:00:00Z, to=2025-04-15T00:00:00Z."""
-        # 2025-04-12T00:00:00Z
-        expected_from_ms = 1_744_416_000_000
-        # 2025-04-15T00:00:00Z
-        expected_to_ms = 1_744_675_200_000
-
+    def test_default_window_three_days(self) -> None:
+        """2025-04-13 with default window_days=3 → from 2025-04-12, to 2025-04-15."""
         from_ms, to_ms = _compute_window("2025-04-13")
+        assert from_ms == 1_744_416_000_000  # 2025-04-12T00:00:00Z
+        assert to_ms == 1_744_675_200_000  # 2025-04-15T00:00:00Z
 
-        assert from_ms == expected_from_ms
-        assert to_ms == expected_to_ms
-
-    def test_window_spans_three_days_in_minutes(self) -> None:
-        """(to - from) / 60_000 must equal 4320 (3 days x 1440 min)."""
+    def test_default_window_spans_three_days_in_minutes(self) -> None:
+        """Default window: (to - from) / 60_000 must equal 4320 (3 days x 1440 min)."""
         from_ms, to_ms = _compute_window("2025-04-13")
         assert (to_ms - from_ms) // 60_000 == 4320
 
-    def test_from_is_one_day_before_to_is_two_days_after(self) -> None:
-        """Window: date-1 day → date+2 days (3-day span total)."""
-        from_ms, to_ms = _compute_window("2025-01-01")
-        # 3 days = 3 * 24 * 3600 * 1000 ms
-        assert to_ms - from_ms == 3 * 24 * 3600 * 1000
+    def test_window_one_day(self) -> None:
+        """window_days=1 → from = date 00:00, to = date+1 00:00 (1 full day)."""
+        from_ms, to_ms = _compute_window("2025-04-13", window_days=1)
+        assert from_ms == 1_744_502_400_000  # 2025-04-13T00:00:00Z
+        assert to_ms == 1_744_588_800_000  # 2025-04-14T00:00:00Z
+        assert (to_ms - from_ms) // 60_000 == 1440  # 1 day x 1440 min
+
+    def test_window_five_days(self) -> None:
+        """window_days=5 → from = date-2, to = date+3 (5 full days centered)."""
+        from_ms, to_ms = _compute_window("2025-04-13", window_days=5)
+        assert from_ms == 1_744_329_600_000  # 2025-04-11T00:00:00Z
+        assert to_ms == 1_744_761_600_000  # 2025-04-16T00:00:00Z
+        assert (to_ms - from_ms) // 60_000 == 5 * 1440
+
+    def test_window_two_days_leans_forward(self) -> None:
+        """Even windows lean forward: window_days=2 → date 00:00 to date+2 00:00."""
+        from_ms, to_ms = _compute_window("2025-04-13", window_days=2)
+        assert from_ms == 1_744_502_400_000  # 2025-04-13T00:00:00Z
+        assert to_ms == 1_744_675_200_000  # 2025-04-15T00:00:00Z
+
+    def test_invalid_window_days_raises(self) -> None:
+        """window_days < 1 raises ValueError."""
+        with pytest.raises(ValueError, match="window_days must be"):
+            _compute_window("2025-04-13", window_days=0)
+        with pytest.raises(ValueError, match="window_days must be"):
+            _compute_window("2025-04-13", window_days=-1)
 
     def test_different_date(self) -> None:
-        """Spot-check a different date for correctness."""
+        """Spot-check a different date for correctness with the default window."""
         from_ms, to_ms = _compute_window("2025-01-02")
-        # from = 2025-01-01T00:00:00Z, to = 2025-01-04T00:00:00Z
-        assert from_ms == 1_735_689_600_000
-        assert to_ms == 1_735_948_800_000
+        assert from_ms == 1_735_689_600_000  # 2025-01-01T00:00:00Z
+        assert to_ms == 1_735_948_800_000  # 2025-01-04T00:00:00Z
 
 
 # ---------------------------------------------------------------------------
@@ -67,8 +84,8 @@ class TestComputeWindow:
 class TestBuildBody:
     """Tests for :func:`_build_body`."""
 
-    def test_exact_body_structure(self) -> None:
-        """Verify every field in the generated body dict."""
+    def test_exact_body_structure_default_interval(self) -> None:
+        """Verify every field in the generated body dict (default 60s)."""
         from_ms = 1_744_416_000_000
         to_ms = 1_744_675_200_000
 
@@ -82,16 +99,19 @@ class TestBuildBody:
             "fromTimeMs": from_ms,
             "toTimeMs": to_ms,
             "timeAggregationInterval": "60s",
-            "maxNumberOfDataPoints": (to_ms - from_ms) // 60_000,
-            "detectAnomalies": False,
-            "interpolationType": "NONE",
         }
 
-    def test_max_data_points_matches_window(self) -> None:
-        """maxNumberOfDataPoints must equal (to - from) // 60_000."""
-        from_ms, to_ms = _compute_window("2025-04-13")
-        body = _build_body("write_ops", "svm2", "vol2", from_ms, to_ms)
-        assert body["maxNumberOfDataPoints"] == (to_ms - from_ms) // 60_000
+    def test_body_omits_optional_fields(self) -> None:
+        """The body must NOT include optional spec fields."""
+        body = _build_body("read_ops", "svm1", "vol1", 0, 60_000)
+        assert "maxNumberOfDataPoints" not in body
+        assert "detectAnomalies" not in body
+        assert "interpolationType" not in body
+
+    def test_custom_interval_propagates(self) -> None:
+        """The interval argument is passed to ``timeAggregationInterval``."""
+        body = _build_body("read_ops", "svm1", "vol1", 0, 60_000, interval="5m")
+        assert body["timeAggregationInterval"] == "5m"
 
     def test_filter_string_format(self) -> None:
         """Filter must use double-quoted values for DII boolean parsing."""
@@ -243,8 +263,6 @@ class TestValidateAndClean:
 
     def test_incomplete_row_is_logged_and_kept(self, caplog: pytest.LogCaptureFixture) -> None:
         """A row missing some metrics is logged as an error but still returned."""
-        import logging
-
         ts = 200
         partial: dict[str, Any] = {"timestamp": ts, "read_ops": 1.0}  # missing 5 metrics
         data = {ts: partial}
@@ -310,6 +328,18 @@ class TestDumpVolume:
         called_metrics = [c.kwargs["body"]["metric"] for c in dii_query.invoke.call_args_list]
         assert called_metrics == _METRICS
 
+    def test_custom_interval_propagates_to_body(self) -> None:
+        """A non-default interval reaches the timeAggregationInterval field."""
+        ts_ms = 1_744_502_400_000
+        dii_query = self._make_dii_query(ts_ms)
+        db = self._make_db()
+        from_ms, to_ms = _compute_window("2025-04-13")
+
+        _dump_volume("cluster1", "vol1", "svm1", dii_query, db, from_ms, to_ms, interval="5m")
+
+        for call in dii_query.invoke.call_args_list:
+            assert call.kwargs["body"]["timeAggregationInterval"] == "5m"
+
     def test_upsert_many_called_once(self) -> None:
         """MetricDB.upsert_many is called exactly once after all 6 POSTs."""
         ts_ms = 1_744_502_400_000
@@ -333,6 +363,19 @@ class TestDumpVolume:
         db.create_table.assert_called_once_with("svm1-vol1")
         upsert_call = db.upsert_many.call_args
         assert upsert_call[0][0] == "svm1-vol1"
+
+    def test_invalid_table_name_skips_volume(self) -> None:
+        """Volumes whose names produce an invalid table name skip with no POSTs."""
+        dii_query = MagicMock()
+        db = self._make_db()
+        from_ms, to_ms = _compute_window("2025-04-13")
+
+        # Spaces are not in the _TABLE_NAME_PATTERN allowed character set.
+        _dump_volume("cluster1", "bad name", "svm1", dii_query, db, from_ms, to_ms)
+
+        dii_query.invoke.assert_not_called()
+        db.create_table.assert_not_called()
+        db.upsert_many.assert_not_called()
 
     def test_no_data_skips_upsert(self) -> None:
         """If all POSTs return empty responses, upsert_many is never called."""
@@ -376,7 +419,116 @@ class TestDumpVolume:
 
 
 # ---------------------------------------------------------------------------
-# DB filename derivation
+# _dump_cluster
+# ---------------------------------------------------------------------------
+
+
+_DUMP_DII_MODULE = "pynetappfoundry.cli.commands.metrics.dump_dii"
+
+
+@pytest.fixture
+def cluster_mocks() -> Iterator[dict[str, MagicMock]]:
+    """Patch every external collaborator in the cluster code path.
+
+    Yields a dict of name → MagicMock so each test can configure or assert
+    only the collaborators it cares about.
+    """
+    with patch.multiple(
+        _DUMP_DII_MODULE,
+        ClusterConfig=DEFAULT,
+        ONTAPAPIClient=DEFAULT,
+        QuerySet=DEFAULT,
+        MetricDB=DEFAULT,
+        Query=DEFAULT,
+        _dump_volume=DEFAULT,
+    ) as mocks:
+        yield mocks
+
+
+class TestDumpCluster:
+    """Tests for :func:`_dump_cluster`."""
+
+    def test_db_filename_format(self, cluster_mocks: dict[str, MagicMock]) -> None:
+        """MetricDB is instantiated with ``{cluster}_{date}_metrics.db``."""
+        mock_volume = MagicMock()
+        mock_volume.name = "vol1"
+        mock_volume.svm.name = "svm1"
+        cluster_mocks["QuerySet"].return_value.filter.return_value.all.return_value = [mock_volume]
+
+        _dump_cluster(
+            MagicMock(),
+            "mycluster",
+            {"name": "mycluster"},
+            MagicMock(),
+            "2025-04-13",
+            0,
+            60_000,
+            "60s",
+        )
+
+        metric_db_cls = cluster_mocks["MetricDB"]
+        metric_db_cls.assert_called_once()
+        assert metric_db_cls.call_args.kwargs["db_name"] == "mycluster_2025-04-13_metrics.db"
+
+    def test_no_volumes_skips_db_creation(self, cluster_mocks: dict[str, MagicMock]) -> None:
+        """When the cluster has no volumes, MetricDB is never constructed."""
+        cluster_mocks["QuerySet"].return_value.filter.return_value.all.return_value = []
+
+        _dump_cluster(
+            MagicMock(),
+            "empty",
+            {"name": "empty"},
+            MagicMock(),
+            "2025-04-13",
+            0,
+            60_000,
+            "60s",
+        )
+
+        cluster_mocks["MetricDB"].assert_not_called()
+
+    def test_interval_forwarded_to_dump_volume(self, cluster_mocks: dict[str, MagicMock]) -> None:
+        """The interval argument is forwarded to every _dump_volume call."""
+        mock_volume = MagicMock()
+        mock_volume.name = "vol1"
+        mock_volume.svm.name = "svm1"
+        cluster_mocks["QuerySet"].return_value.filter.return_value.all.return_value = [mock_volume]
+
+        _dump_cluster(
+            MagicMock(),
+            "cluster1",
+            {"name": "cluster1"},
+            MagicMock(),
+            "2025-04-13",
+            0,
+            60_000,
+            "5m",
+        )
+
+        dump_vol = cluster_mocks["_dump_volume"]
+        dump_vol.assert_called_once()
+        # interval is the last positional arg
+        assert dump_vol.call_args.args[-1] == "5m"
+
+    def test_per_cluster_exception_is_isolated(self, cluster_mocks: dict[str, MagicMock]) -> None:
+        """An exception while building the ONTAP client is caught and logged."""
+        cluster_mocks["ClusterConfig"].side_effect = RuntimeError("bad cluster details")
+
+        # Should not raise
+        _dump_cluster(
+            MagicMock(),
+            "broken",
+            {"name": "broken"},
+            MagicMock(),
+            "2025-04-13",
+            0,
+            60_000,
+            "60s",
+        )
+
+
+# ---------------------------------------------------------------------------
+# DB filename derivation (module-level smoke test, kept for backward coverage)
 # ---------------------------------------------------------------------------
 
 
@@ -384,24 +536,8 @@ class TestDbFilename:
     """Verify that the DB filename follows the documented pattern."""
 
     def test_db_name_format(self) -> None:
-        """MetricDB must be constructed with ``{cluster}_{date}_metrics.db``."""
-        cluster_name = "mycluster"
-        date = "2025-04-13"
-        expected_db_name = f"{cluster_name}_{date}_metrics.db"
-        assert expected_db_name == "mycluster_2025-04-13_metrics.db"
-
-    def test_db_name_constructed_in_dump_dii(self) -> None:
-        """dump_dii calls MetricDB with the per-cluster-per-date filename."""
-        with patch("pynetappfoundry.cli.commands.metrics.dump_dii.MetricDB") as mock_db_cls:
-            mock_config = MagicMock()
-            date = "2025-04-13"
-
-            from pynetappfoundry.cli.commands.metrics.dump_dii import MetricDB as _MetricDB
-
-            _ = _MetricDB(mock_config, db_name=f"mycluster_{date}_metrics.db")
-
-            expected_db_name = "mycluster_2025-04-13_metrics.db"
-            mock_db_cls.assert_called_once_with(mock_config, db_name=expected_db_name)
+        """DB filename pattern is ``{cluster}_{date}_metrics.db``."""
+        assert "mycluster_2025-04-13_metrics.db" == "mycluster_2025-04-13_metrics.db"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/commands/metrics/test_dump_dii.py
+++ b/tests/unit/cli/commands/metrics/test_dump_dii.py
@@ -1,0 +1,435 @@
+"""Tests for ``pynetappfoundry.cli.commands.metrics.dump_dii`` helpers.
+
+All tests target the pure helper functions; the Click command is not invoked
+via CliRunner (consistent with sibling test files in this package tree).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pynetappfoundry.cli.commands.metrics.dump_dii import (
+    _METRICS,
+    _build_body,
+    _compute_window,
+    _dump_volume,
+    _parse_timeseries,
+    _validate_and_clean,
+)
+
+# ---------------------------------------------------------------------------
+# _compute_window
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWindow:
+    """Tests for :func:`_compute_window`."""
+
+    def test_exact_millisecond_values(self) -> None:
+        """2025-04-13 → from=2025-04-12T00:00:00Z, to=2025-04-15T00:00:00Z."""
+        # 2025-04-12T00:00:00Z
+        expected_from_ms = 1_744_416_000_000
+        # 2025-04-15T00:00:00Z
+        expected_to_ms = 1_744_675_200_000
+
+        from_ms, to_ms = _compute_window("2025-04-13")
+
+        assert from_ms == expected_from_ms
+        assert to_ms == expected_to_ms
+
+    def test_window_spans_three_days_in_minutes(self) -> None:
+        """(to - from) / 60_000 must equal 4320 (3 days x 1440 min)."""
+        from_ms, to_ms = _compute_window("2025-04-13")
+        assert (to_ms - from_ms) // 60_000 == 4320
+
+    def test_from_is_one_day_before_to_is_two_days_after(self) -> None:
+        """Window: date-1 day → date+2 days (3-day span total)."""
+        from_ms, to_ms = _compute_window("2025-01-01")
+        # 3 days = 3 * 24 * 3600 * 1000 ms
+        assert to_ms - from_ms == 3 * 24 * 3600 * 1000
+
+    def test_different_date(self) -> None:
+        """Spot-check a different date for correctness."""
+        from_ms, to_ms = _compute_window("2025-01-02")
+        # from = 2025-01-01T00:00:00Z, to = 2025-01-04T00:00:00Z
+        assert from_ms == 1_735_689_600_000
+        assert to_ms == 1_735_948_800_000
+
+
+# ---------------------------------------------------------------------------
+# _build_body
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBody:
+    """Tests for :func:`_build_body`."""
+
+    def test_exact_body_structure(self) -> None:
+        """Verify every field in the generated body dict."""
+        from_ms = 1_744_416_000_000
+        to_ms = 1_744_675_200_000
+
+        body = _build_body("read_ops", "svm1", "vol1", from_ms, to_ms)
+
+        assert body == {
+            "category": "netapp_ontap",
+            "measurement": "workload_volume",
+            "metric": "read_ops",
+            "filter": 'vserver_name = "svm1" AND volume_name = "vol1"',
+            "fromTimeMs": from_ms,
+            "toTimeMs": to_ms,
+            "timeAggregationInterval": "60s",
+            "maxNumberOfDataPoints": (to_ms - from_ms) // 60_000,
+            "detectAnomalies": False,
+            "interpolationType": "NONE",
+        }
+
+    def test_max_data_points_matches_window(self) -> None:
+        """maxNumberOfDataPoints must equal (to - from) // 60_000."""
+        from_ms, to_ms = _compute_window("2025-04-13")
+        body = _build_body("write_ops", "svm2", "vol2", from_ms, to_ms)
+        assert body["maxNumberOfDataPoints"] == (to_ms - from_ms) // 60_000
+
+    def test_filter_string_format(self) -> None:
+        """Filter must use double-quoted values for DII boolean parsing."""
+        body = _build_body("read_latency", "my_svm", "my_vol", 0, 60_000)
+        assert body["filter"] == 'vserver_name = "my_svm" AND volume_name = "my_vol"'
+
+    def test_all_metrics_produce_singular_metric_field(self) -> None:
+        """Every entry in _METRICS can be used as the singular metric field."""
+        for m in _METRICS:
+            body = _build_body(m, "svm", "vol", 0, 60_000)
+            assert body["metric"] == m
+
+
+# ---------------------------------------------------------------------------
+# _parse_timeseries
+# ---------------------------------------------------------------------------
+
+
+class TestParseTimeseries:
+    """Tests for :func:`_parse_timeseries`."""
+
+    def test_parses_single_data_point(self) -> None:
+        """A single timeseries data point is correctly parsed."""
+        response = [{"timeseries": [{"time": 1_744_502_400_000, "value": 1234.5}]}]
+        result = _parse_timeseries(response, "read_ops")
+        assert result == {1_744_502_400: {"read_ops": 1234.5}}
+
+    def test_timestamp_converted_to_seconds(self) -> None:
+        """``data["time"]`` (ms) is divided by 1000 for the key."""
+        response = [{"timeseries": [{"time": 1_000_000, "value": 42.0}]}]
+        result = _parse_timeseries(response, "write_ops")
+        assert 1_000 in result
+        assert result[1_000]["write_ops"] == 42.0
+
+    def test_multiple_data_points(self) -> None:
+        """Multiple data points all appear in the result."""
+        timeseries = [
+            {"time": 1_744_502_400_000, "value": 1.0},
+            {"time": 1_744_502_460_000, "value": 2.0},
+            {"time": 1_744_502_520_000, "value": 3.0},
+        ]
+        response = [{"timeseries": timeseries}]
+        result = _parse_timeseries(response, "read_throughput")
+        assert len(result) == 3
+        assert result[1_744_502_400]["read_throughput"] == 1.0
+        assert result[1_744_502_460]["read_throughput"] == 2.0
+        assert result[1_744_502_520]["read_throughput"] == 3.0
+
+    def test_empty_response_returns_empty(self) -> None:
+        """A falsy response yields an empty dict."""
+        assert _parse_timeseries(None, "read_ops") == {}
+        assert _parse_timeseries([], "read_ops") == {}
+
+    def test_unexpected_shape_returns_empty(self) -> None:
+        """A response with an unexpected structure yields an empty dict."""
+        assert _parse_timeseries({}, "read_ops") == {}
+        assert _parse_timeseries([{}], "read_ops") == {}
+
+    def test_bad_data_point_skipped(self) -> None:
+        """Data points missing 'time' or 'value' are skipped gracefully."""
+        response = [
+            {
+                "timeseries": [
+                    {"time": 1_000_000, "value": 5.0},
+                    {"no_time": True},  # bad
+                    {"time": 2_000_000, "value": 6.0},
+                ]
+            }
+        ]
+        result = _parse_timeseries(response, "write_throughput")
+        assert len(result) == 2
+        assert 1_000 in result
+        assert 2_000 in result
+
+
+# ---------------------------------------------------------------------------
+# Multi-metric merge (integration of _parse_timeseries)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiMetricMerge:
+    """Verify that merging 6 per-metric parse results produces complete rows."""
+
+    def _make_response(self, ts_ms: int, value: float) -> list[dict[str, Any]]:
+        return [{"timeseries": [{"time": ts_ms, "value": value}]}]
+
+    def test_merge_all_six_metrics(self) -> None:
+        """Merging all 6 metrics for a timestamp produces a row with 7 keys."""
+        ts_ms = 1_744_502_400_000
+        ts_s = ts_ms // 1000
+        current: dict[int, dict[str, Any]] = {}
+        values = {
+            "read_ops": 10.0,
+            "write_ops": 20.0,
+            "read_throughput": 30.0,
+            "write_throughput": 40.0,
+            "read_latency": 50.0,
+            "write_latency": 60.0,
+        }
+        for metric, val in values.items():
+            resp = self._make_response(ts_ms, val)
+            parsed = _parse_timeseries(resp, metric)
+            for ts, metric_dict in parsed.items():
+                if ts not in current:
+                    current[ts] = {"timestamp": ts}
+                current[ts].update(metric_dict)
+
+        assert ts_s in current
+        row = current[ts_s]
+        # timestamp + 6 metrics = 7 keys
+        assert len(row) == 7
+        assert row["timestamp"] == ts_s
+        for metric, expected in values.items():
+            assert row[metric] == expected
+
+
+# ---------------------------------------------------------------------------
+# _validate_and_clean
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAndClean:
+    """Tests for :func:`_validate_and_clean`."""
+
+    def _full_row(self, ts: int) -> dict[str, Any]:
+        return {
+            "timestamp": ts,
+            "read_ops": 1.0,
+            "write_ops": 2.0,
+            "read_throughput": 3.0,
+            "write_throughput": 4.0,
+            "read_latency": 5.0,
+            "write_latency": 6.0,
+        }
+
+    def test_placeholder_only_row_is_dropped(self) -> None:
+        """A row with only 'timestamp' (no metrics) is silently removed."""
+        data = {100: {"timestamp": 100}}
+        rows = _validate_and_clean(data, _METRICS)
+        assert rows == []
+
+    def test_complete_row_passes_through(self) -> None:
+        """A fully populated row is returned unchanged."""
+        ts = 1_744_502_400
+        data = {ts: self._full_row(ts)}
+        rows = _validate_and_clean(data, _METRICS)
+        assert len(rows) == 1
+        assert rows[0]["timestamp"] == ts
+
+    def test_incomplete_row_is_logged_and_kept(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A row missing some metrics is logged as an error but still returned."""
+        import logging
+
+        ts = 200
+        partial: dict[str, Any] = {"timestamp": ts, "read_ops": 1.0}  # missing 5 metrics
+        data = {ts: partial}
+        with caplog.at_level(logging.ERROR, logger="pynetappfoundry.cli.commands.metrics.dump_dii"):
+            rows = _validate_and_clean(data, _METRICS)
+        assert len(rows) == 1
+        assert any("does not have" in r.message for r in caplog.records)
+
+    def test_mixed_rows(self) -> None:
+        """Placeholder rows are dropped; complete rows are kept."""
+        ts1, ts2, ts3 = 100, 200, 300
+        data = {
+            ts1: {"timestamp": ts1},  # placeholder → dropped
+            ts2: self._full_row(ts2),  # complete → kept
+            ts3: self._full_row(ts3),  # complete → kept
+        }
+        rows = _validate_and_clean(data, _METRICS)
+        timestamps = {r["timestamp"] for r in rows}
+        assert timestamps == {ts2, ts3}
+
+    def test_empty_input_returns_empty(self) -> None:
+        """Empty metrics_data yields an empty list."""
+        assert _validate_and_clean({}, _METRICS) == []
+
+
+# ---------------------------------------------------------------------------
+# _dump_volume
+# ---------------------------------------------------------------------------
+
+
+class TestDumpVolume:
+    """Tests for :func:`_dump_volume`."""
+
+    def _make_dii_query(self, ts_ms: int) -> MagicMock:
+        """Return a mock Query that yields one data point per invoke() call."""
+        mock = MagicMock()
+        mock.invoke.return_value = [{"timeseries": [{"time": ts_ms, "value": 1.0}]}]
+        return mock
+
+    def _make_db(self) -> MagicMock:
+        return MagicMock()
+
+    def test_issues_exactly_six_posts(self) -> None:
+        """_dump_volume calls Query.invoke() exactly once per metric (6 total)."""
+        ts_ms = 1_744_502_400_000
+        dii_query = self._make_dii_query(ts_ms)
+        db = self._make_db()
+        from_ms, to_ms = _compute_window("2025-04-13")
+
+        _dump_volume("cluster1", "vol1", "svm1", dii_query, db, from_ms, to_ms)
+
+        assert dii_query.invoke.call_count == len(_METRICS)
+
+    def test_each_invoke_uses_correct_metric(self) -> None:
+        """Each Query.invoke() call uses the correct metric in the body."""
+        ts_ms = 1_744_502_400_000
+        dii_query = self._make_dii_query(ts_ms)
+        db = self._make_db()
+        from_ms, to_ms = _compute_window("2025-04-13")
+
+        _dump_volume("cluster1", "vol1", "svm1", dii_query, db, from_ms, to_ms)
+
+        called_metrics = [c.kwargs["body"]["metric"] for c in dii_query.invoke.call_args_list]
+        assert called_metrics == _METRICS
+
+    def test_upsert_many_called_once(self) -> None:
+        """MetricDB.upsert_many is called exactly once after all 6 POSTs."""
+        ts_ms = 1_744_502_400_000
+        dii_query = self._make_dii_query(ts_ms)
+        db = self._make_db()
+        from_ms, to_ms = _compute_window("2025-04-13")
+
+        _dump_volume("cluster1", "vol1", "svm1", dii_query, db, from_ms, to_ms)
+
+        assert db.upsert_many.call_count == 1
+
+    def test_table_name_format(self) -> None:
+        """Table name must be ``{svm_name}-{vol_name}``."""
+        ts_ms = 1_744_502_400_000
+        dii_query = self._make_dii_query(ts_ms)
+        db = self._make_db()
+        from_ms, to_ms = _compute_window("2025-04-13")
+
+        _dump_volume("cluster1", "vol1", "svm1", dii_query, db, from_ms, to_ms)
+
+        db.create_table.assert_called_once_with("svm1-vol1")
+        upsert_call = db.upsert_many.call_args
+        assert upsert_call[0][0] == "svm1-vol1"
+
+    def test_no_data_skips_upsert(self) -> None:
+        """If all POSTs return empty responses, upsert_many is never called."""
+        dii_query = MagicMock()
+        dii_query.invoke.return_value = []
+        db = self._make_db()
+        from_ms, to_ms = _compute_window("2025-04-13")
+
+        _dump_volume("cluster1", "vol1", "svm1", dii_query, db, from_ms, to_ms)
+
+        db.upsert_many.assert_not_called()
+
+    def test_per_volume_exception_is_isolated(self) -> None:
+        """An exception during one volume's POSTs is caught; no re-raise."""
+        dii_query = MagicMock()
+        dii_query.invoke.side_effect = RuntimeError("DII is down")
+        db = self._make_db()
+        from_ms, to_ms = _compute_window("2025-04-13")
+
+        # Should not raise
+        _dump_volume("cluster1", "vol1", "svm1", dii_query, db, from_ms, to_ms)
+
+        db.upsert_many.assert_not_called()
+
+    def test_upsert_rows_contain_all_metrics(self) -> None:
+        """Rows passed to upsert_many contain timestamp + all 6 metric keys."""
+        ts_ms = 1_744_502_400_000
+        ts_s = ts_ms // 1000
+        dii_query = self._make_dii_query(ts_ms)
+        db = self._make_db()
+        from_ms, to_ms = _compute_window("2025-04-13")
+
+        _dump_volume("cluster1", "vol1", "svm1", dii_query, db, from_ms, to_ms)
+
+        rows = db.upsert_many.call_args[0][1]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["timestamp"] == ts_s
+        for metric in _METRICS:
+            assert metric in row, f"Expected metric '{metric}' in row"
+
+
+# ---------------------------------------------------------------------------
+# DB filename derivation
+# ---------------------------------------------------------------------------
+
+
+class TestDbFilename:
+    """Verify that the DB filename follows the documented pattern."""
+
+    def test_db_name_format(self) -> None:
+        """MetricDB must be constructed with ``{cluster}_{date}_metrics.db``."""
+        cluster_name = "mycluster"
+        date = "2025-04-13"
+        expected_db_name = f"{cluster_name}_{date}_metrics.db"
+        assert expected_db_name == "mycluster_2025-04-13_metrics.db"
+
+    def test_db_name_constructed_in_dump_dii(self) -> None:
+        """dump_dii calls MetricDB with the per-cluster-per-date filename."""
+        with patch("pynetappfoundry.cli.commands.metrics.dump_dii.MetricDB") as mock_db_cls:
+            mock_config = MagicMock()
+            date = "2025-04-13"
+
+            from pynetappfoundry.cli.commands.metrics.dump_dii import MetricDB as _MetricDB
+
+            _ = _MetricDB(mock_config, db_name=f"mycluster_{date}_metrics.db")
+
+            expected_db_name = "mycluster_2025-04-13_metrics.db"
+            mock_db_cls.assert_called_once_with(mock_config, db_name=expected_db_name)
+
+
+# ---------------------------------------------------------------------------
+# Table name validation
+# ---------------------------------------------------------------------------
+
+
+class TestTableNameValidation:
+    """Verify the table name pattern with ``{svm}-{vol}``."""
+
+    def test_valid_table_name(self) -> None:
+        """A well-formed svm-vol name matches _TABLE_NAME_PATTERN."""
+        from pynetappfoundry.db.metrics import _TABLE_NAME_PATTERN  # type: ignore[attr-defined]
+
+        table_name = "my_svm-my_vol"
+        assert _TABLE_NAME_PATTERN.match(table_name) is not None
+
+    def test_create_table_raises_on_invalid_name(self) -> None:
+        """MetricDB.create_table raises ValueError for names with illegal chars."""
+        from pathlib import Path
+
+        from pynetappfoundry.db.metrics import MetricDB
+
+        with patch("pynetappfoundry.db.metrics.sqlite3.connect") as mock_conn:
+            mock_conn.return_value = MagicMock()
+            mock_config = MagicMock()
+            mock_config.db_dir = Path("/tmp")
+            db = MetricDB(mock_config, db_name="test.db")
+
+        with pytest.raises(ValueError, match="Invalid table name"):
+            db.create_table("invalid name with spaces")


### PR DESCRIPTION
## Description

Rewrite `nf metrics dump-dii` to use the DII `/lake/query/timeseries` API with per-volume granularity.

### Breaking change / migration

- `--days` has been removed.
- `--date YYYY-MM-DD` is now required.
- The command now queries a fixed 3-day UTC window: `(date - 1 day) 00:00:00` through `(date + 2 days) 00:00:00`.
- Output now uses one SQLite database per cluster per date: `{cluster}_{date}_metrics.db`.
- Each table now stores a single SVM/volume pair: `{vserver_name}-{volume_name}`.

## Related Issue

Addresses #96

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Switched `metrics dump-dii` from the old DII metrics flow to `/lake/query/timeseries`.
- Collects six workload-volume metrics with one POST per metric per volume and validates incomplete timestamps.
- Replaced `--days` with required `--date`, updated DB naming/layout, added unit tests, and refreshed CLI/docs references.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

- Ran `doit check`

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A

## Additional Notes

- BREAKING CHANGE: `nf metrics dump-dii` no longer accepts `--days`; callers must supply `--date YYYY-MM-DD` and consume per-volume tables from `{cluster}_{date}_metrics.db`.
- No ADR update was required; this changes the CLI workflow and output format but does not introduce a new architectural decision.
