### PR TITLE
refactor(codegen): remove dead datamodel-code-generator call

### DIFF
--- a/tools/codegen/adapters.py
+++ b/tools/codegen/adapters.py
@@ -3,9 +3,6 @@
 Parses OpenAPI 3.0 specs (all API specs are pre-converted to OpenAPI 3.0
 by the ``doit convert_specs`` task) and produces normalized
 :class:`ParsedEndpoint` and :class:`ParsedField` dataclasses.
-
-Uses ``datamodel-code-generator`` for ``$ref`` resolution and type mapping,
-then extracts the resolved field structure for nested model generation.
 """
 
 from __future__ import annotations
@@ -14,8 +11,6 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-
-from datamodel_code_generator.parser.openapi import OpenAPIParser
 
 from tools.codegen.expensive_fields import extract_expensive_patterns, is_field_expensive
 
@@ -452,10 +447,6 @@ def parse_openapi_spec(
     with open(spec_path, encoding="utf-8") as f:
         spec = json.load(f)
 
-    # Run datamodel-code-generator parser for $ref resolution and type cross-reference.
-    # The resolved models are available for future type validation enhancements.
-    _parse_with_datamodel_codegen(spec_path)
-
     endpoints: list[ParsedEndpoint] = []
     paths = spec.get("paths", {})
 
@@ -573,46 +564,3 @@ def detect_shared_schemas(endpoints: list[ParsedEndpoint]) -> set[str]:
             continue
         counts[ep.schema_name] = counts.get(ep.schema_name, 0) + 1
     return {name for name, count in counts.items() if count > 1}
-
-
-def _parse_with_datamodel_codegen(spec_path: Path) -> dict[str, Any]:
-    """Use datamodel-code-generator to parse and resolve schemas.
-
-    This leverages the library's ``$ref`` resolution and type mapping
-    capabilities.  The results are used to cross-reference type information
-    when our own flattening logic needs confirmation.
-
-    Args:
-        spec_path: Path to the OpenAPI 3.0 JSON spec.
-
-    Returns:
-        Dict mapping model name to parsed model info.
-    """
-    try:
-        parser = OpenAPIParser(
-            source=spec_path,
-        )
-        parser.parse()
-
-        models: dict[str, Any] = {}
-        for result in parser.results:
-            name = getattr(result, "name", None)
-            if name and hasattr(result, "fields"):
-                field_info = {}
-                for f in result.fields:
-                    dt = f.data_type
-                    ref_name = None
-                    if hasattr(dt, "reference") and dt.reference:
-                        ref_name = dt.reference.name
-                    prim_type = getattr(dt, "type", None)
-                    field_info[f.name] = {
-                        "type_hint": getattr(f, "type_hint", ""),
-                        "required": f.required,
-                        "reference": ref_name,
-                        "primitive_type": str(prim_type) if prim_type else None,
-                    }
-                models[name] = {"fields": field_info}
-        return models
-    except Exception:
-        # Non-fatal: we can still generate from our own parsing
-        return {}


### PR DESCRIPTION
## Description

Removes a dead call inside `parse_openapi_spec` (`tools/codegen/adapters.py`) that ran `datamodel-code-generator`'s `OpenAPIParser` — including a black-format pass over the entire generated Pydantic model — and threw away the return value. The dict it built was never read by any caller, test, or downstream tool. Speculative scaffolding for a "type cross-reference" feature that was never wired up.

cProfile breakdown of the previous round-trip test setup (~30s):

```
40.7s  parse_openapi_spec (called twice — ontap + dii)
40.5s  └── _parse_with_datamodel_codegen
39.9s      └── OpenAPIParser.parse
26.5s          └── _generate_module_output
25.9s              └── format_code
25.2s                  └── apply_black
22.9s                      └── black.format_str (built-in)
```

Local timings before/after on this branch:

| Test | Before | After |
|---|---|---|
| `tests/unit/codegen/test_roundtrip.py` | 33s | 3.2s |
| `parse_openapi_spec(ontap)` direct call | ~20s | ~0.16s |
| `parse_openapi_spec(dii)` direct call | ~0.5s | ~0.02s |

Equivalent CI savings compound across the OS × Python matrix.

## Related Issue

Addresses #692

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Performance improvement
- [ ] Test improvement

## Changes Made

- Removed the `_parse_with_datamodel_codegen(spec_path)` call site from `parse_openapi_spec`.
- Removed the `_parse_with_datamodel_codegen` function (~40 lines).
- Removed the now-unused `from datamodel_code_generator.parser.openapi import OpenAPIParser` import.
- Updated the module docstring to drop the stale `datamodel-code-generator` reference.

## Testing

- [x] All existing tests pass (`doit check`)
- [x] `tests/unit/codegen/test_roundtrip.py` still produces byte-identical output for all 6 endpoints
- [x] `tests/unit/codegen/test_adapters.py` (9 tests calling `parse_openapi_spec`) still pass
- [ ] Manually tested the changes (no manual testing applicable — this is dead-code removal)

## Why this is safe

- `_parse_with_datamodel_codegen` was referenced exactly twice in the repo: its definition and the (now-removed) call site.
- The model files users consume are written by `write_endpoint_files` in `tools/codegen/generators.py`, using our own `_flatten_schema` parser — not by datamodel-code-generator.
- `test_codegen_round_trip` remains the canonical end-to-end safety net: parse → generate → format → byte-compare against on-disk fixtures. Any regression in `_flatten_schema`'s `$ref` handling would surface as a diff in the generated `model.py` or `mapping.py`.

## Follow-up

`datamodel-code-generator` is now an unused dependency in `pyproject.toml`. Removing it is a separate decision (potentially pinned by other tooling expectations); deferring to the maintainer.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works (N/A — dead-code removal; existing tests prove no regression)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (module docstring updated)
- [ ] I have updated the CHANGELOG.md (N/A — internal tooling change, no user-facing impact)
- [x] My changes generate no new warnings
