### PR TITLE
docs: add ADR-0017 rationale for where-expressions being cache-only

### DIFF
--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -105,6 +105,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [ADR-0014: Parallel Cluster Refresh](decisions/0014-parallel-cluster-refresh.md)
 - [ADR-0015: DII backend: live-only, bare-array envelope, offset/limit pagination](decisions/0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md)
 - [ADR-0016: PR-based release is the only supported flow](decisions/0016-pr-based-release-is-the-only-supported-flow.md)
+- [ADR-0017: where-expressions are cache-only (rationale)](decisions/0017-where-expressions-are-cache-only-rationale.md)
 - [ADR-9001: Use uv for package management](decisions/9001-use-uv-for-package-management.md)
 - [ADR-9001: Use uv for package management](template/decisions/9001-use-uv-for-package-management.md)
 - [ADR-9002: Use doit for task automation](decisions/9002-use-doit-for-task-automation.md)

--- a/docs/decisions/0012-unified-datasource-accessor.md
+++ b/docs/decisions/0012-unified-datasource-accessor.md
@@ -46,7 +46,7 @@ Add a `_fetched_fields: set[str]` instance attribute on `OntapModel` (`src/pynet
 
 `DataSource.query(OntapVolume).filter({"svm.name": "vs1", "autosize.mode": "grow"})` is the canonical form: a positional `dict[str, Any]` whose keys are dotted API paths. `**kwargs` (`filter(name="vol1", state="online")`) remains supported for top-level scalar fields as a convenience. The dunder-to-dot rewrite from today's `QuerySet.filter._attr_to_api_path` is **not** carried forward into `DataSource`. Existing `QuerySet` keeps the rewrite for backwards compatibility during migration and has it removed during Phase 4. This resolves issue #487.
 
-String filter expressions beyond equality land via `DataSource.QueryBuilder.where(*expressions: str)` (issue #512) — e.g. `.where("size > 1000000000", "state != 'offline'")` — which the cache backend concatenates with the dict-derived equality fragments and hands to `ClusterMetadataDB.query_with_filters` as a single ANDed list. v1 supports `.where()` on cache-backed routes only. As of issue #618, obviously incompatible cases fail early: `source="live"` on `OntapBackend` and any backend with `supports_where_expressions=False` raise `ValueError` at chain time. Partial-fetch routes still raise `NotImplementedError` when execution resolves to a mixed cache+live plan. The typed field-reference DSL (e.g. `OntapVolume.svm.name == "vs1"`) remains deferred as issue #497 and will eventually compile down to the same string-expression shape that `.where()` already accepts.
+String filter expressions beyond equality land via `DataSource.QueryBuilder.where(*expressions: str)` (issue #512) — e.g. `.where("size > 1000000000", "state != 'offline'")` — which the cache backend concatenates with the dict-derived equality fragments and hands to `ClusterMetadataDB.query_with_filters` as a single ANDed list. v1 supports `.where()` on cache-backed routes only. As of issue #618, obviously incompatible cases fail early: `source="live"` on `OntapBackend` and any backend with `supports_where_expressions=False` raise `ValueError` at chain time. Partial-fetch routes still raise `NotImplementedError` when execution resolves to a mixed cache+live plan. The typed field-reference DSL (e.g. `OntapVolume.svm.name == "vs1"`) remains deferred as issue #497 and will eventually compile down to the same string-expression shape that `.where()` already accepts. See [ADR-0017](0017-where-expressions-are-cache-only-rationale.md) for the rationale behind the cache-only restriction.
 
 ### 4. Per-call source override
 
@@ -180,6 +180,7 @@ Known limitations:
 - [ADR-0006: Generalize field mapping for multi-API](0006-generalize-field-mapping-for-multi-api.md)
 - [ADR-0010: ClusterEntry and namespace access pattern](0010-clusterentry-and-namespace-access-pattern.md) (partially superseded by this ADR)
 - [ADR-0011: Nested models to replace flat model pattern](0011-nested-models-to-replace-flat-model-pattern.md)
+- [ADR-0017: where-expressions are cache-only (rationale)](0017-where-expressions-are-cache-only-rationale.md)
 - Source: `src/pynetappfoundry/cache/field_mapping.py`
 - Source: `src/pynetappfoundry/cache/_registry.py`
 - Source: `src/pynetappfoundry/cache/_lazy.py`

--- a/docs/decisions/0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md
+++ b/docs/decisions/0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md
@@ -14,7 +14,7 @@ Add a DII (Data Infrastructure Insights) backend to the DataSource framework. Di
 
 3. **Offset/limit pagination.** DII uses `offset` + `limit` query parameters for pagination, not ONTAP's `_links.next.href` HAL convention. The DII API client handles pagination at the client layer.
 
-4. **Deferred `where_expressions`.** SQL-like cache filter expressions are not supported since there is no cache. As of issue #618, the public `QueryBuilder` surface rejects `.where()` and non-equality typed DSL operators with `ValueError` at chain time; `DiiBackend.query()` still raises `NotImplementedError` if `where_expressions` is passed directly.
+4. **Deferred `where_expressions`.** SQL-like cache filter expressions are not supported since there is no cache. As of issue #618, the public `QueryBuilder` surface rejects `.where()` and non-equality typed DSL operators with `ValueError` at chain time; `DiiBackend.query()` still raises `NotImplementedError` if `where_expressions` is passed directly. See [ADR-0017](0017-where-expressions-are-cache-only-rationale.md) for the rationale behind the cache-only restriction.
 
 The full DII surface (191 endpoints) is generated via the existing OpenAPI codegen pipeline (ADR-0008), producing 191 model files under `models/dii/` and 191 mapping files under `cache/dii/`. DiiBackend is registered in `_BACKENDS` under the key `"dii"`, consistent with the backend registry pattern from ADR-0013.
 
@@ -35,4 +35,5 @@ The bare-array envelope is a DII-specific quirk that the existing `parse_api_res
 - [ADR-0006: Generalize field mapping for multi-API](0006-generalize-field-mapping-for-multi-api.md) -- multi-API TypeMapping generalization that DII relies on
 - [ADR-0008: OpenAPI codegen for model generation](0008-openapi-codegen-for-model-generation.md) -- codegen pipeline that generated the 191 DII models and mappings
 - [ADR-0013: DataSource as a Thin Facade](0013-datasource-as-a-thin-facade-over-the-collector.md) -- backend registry and routing architecture
+- [ADR-0017: where-expressions are cache-only (rationale)](0017-where-expressions-are-cache-only-rationale.md) -- rationale for the cache-only restriction on `.where()` and non-equality typed DSL operators
 - [Adding a New API Backend](../development/adding-backends.md) -- developer guide updated with DII-specific section

--- a/docs/decisions/0017-where-expressions-are-cache-only-rationale.md
+++ b/docs/decisions/0017-where-expressions-are-cache-only-rationale.md
@@ -1,0 +1,46 @@
+# ADR-0017: where-expressions are cache-only (rationale)
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-0012 §49 and ADR-0015 §17 both state that `.where()`-string expressions and the non-equality typed DSL operators that compile to them (`<`, `>`, `!=`, `.in_()`, `.is_null()`, etc.) are supported only on the cache path. Live and partial-fetch paths reject them at chain time (`ValueError`) for cases the chain knows about, and at iteration (`NotImplementedError`) as defense-in-depth. Issue #618 (already merged) added the early `ValueError` validation so callers fail fast at construction rather than at iteration.
+
+Neither existing ADR captures **why** the live paths are not expected to grow comparison support. The position keeps getting re-litigated whenever a caller hits the asymmetry, so this ADR records the rationale once and points future challenges at it.
+
+## Decision
+
+`.where()`-string expressions and the non-equality typed DSL operators that compile to them are supported only on the cache path. Live and partial-fetch paths reject them at chain time (`ValueError`) for cases the chain knows about, and at iteration (`NotImplementedError`) as defense-in-depth. The DII backend rejects them regardless of `source=` since it has no cache substrate.
+
+## Rationale
+
+The position is **"not yet implemented; no fundamental objection."** Specifically:
+
+- There is no architectural objection to extending where-expression evaluation to live and partial-fetch paths. The current position is "no one has done the work," not "we have decided this is wrong."
+- Translating where-expressions to ONTAP/DII filter syntax is an implementable problem. A well-designed PR that handles all current backends (and accepts the per-backend translation cost) would be accepted.
+- The cache path is privileged today simply because SQLite already evaluates the full expression grammar. Adding a second evaluator for each live backend is work that nobody has chosen to do.
+
+Because the position is "not yet implemented" rather than "rejected," issue #618 added early `ValueError` at chain time as the operational consequence: callers fail fast when constructing an incompatible query rather than discovering the gap mid-iteration. The early validation surfaces the asymmetry without committing to closing it.
+
+This is intentionally an honest "soft" position rather than a hard architectural one. The cache-only constraint is a description of current implementation reality, not a principled rejection of the feature.
+
+## Conditions for revisiting
+
+A repeated, demonstrated pattern of caller pain — where the early-validation messages aren't enough and callers need real expression evaluation on live paths — is the most likely catalyst for revisiting this position.
+
+This ADR does not enumerate an exhaustive list of triggers. Any future challenge to this position gets its own ADR with its own context and decision.
+
+## Related Issues
+
+- Issue #619: docs: ADR documenting why where-expressions are cache-only (this ADR)
+- Issue #618: feat: early validation for where()/typed-DSL + incompatible source mode (operational consequence of this position)
+- Issue #512: feat: `.where()` SQL-like cache filter expressions (original feature)
+- Issue #497: feat: typed field-reference DSL (deferred typed front door that compiles to the same shape)
+
+## Related Documentation
+
+- [ADR-0012: Unified DataSource Accessor](0012-unified-datasource-accessor.md) -- §49 states the cache-only position for `.where()`
+- [ADR-0015: DII backend live-only](0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md) -- §17 states the cache-only position for the DII backend
+- [DataSource user guide](../usage/data-source.md) -- "Cache-only constraint" section documents the user-facing behavior

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -117,3 +117,4 @@ The Issue contains the full discussion; the ADR summarizes the outcome.
 | [0014](0014-parallel-cluster-refresh.md) | Parallel Cluster Refresh | Accepted |
 | [0015](0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md) | DII backend: live-only, bare-array envelope, offset/limit pagination | Accepted |
 | [0016](0016-pr-based-release-is-the-only-supported-flow.md) | PR-based release is the only supported flow | Accepted |
+| [0017](0017-where-expressions-are-cache-only-rationale.md) | where-expressions are cache-only (rationale) | Accepted |

--- a/docs/usage/data-source.md
+++ b/docs/usage/data-source.md
@@ -187,6 +187,8 @@ On `OntapBackend`, this incompatibility is detected before iteration. Partial-fe
 
 The DII backend rejects `.where()` and non-equality DSL expressions **regardless of `source=`** since it has no cache substrate (see [ADR-0015](../decisions/0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md) §4). Any `.where()` against a DII-backed query now raises `ValueError` at chain time.
 
+See [ADR-0017](../decisions/0017-where-expressions-are-cache-only-rationale.md) for the rationale behind the cache-only restriction.
+
 ### Field Projection with `.fields()`
 
 `.fields()` restricts which fields are populated on the returned models. Use it to reduce response size and parsing cost on large collections.


### PR DESCRIPTION
## Description

Adds ADR-0017 capturing the rationale for `.where()`-string expressions and non-equality typed DSL operators being cache-only. This is a documentation-only change: no code paths or behaviors are modified.

The chosen rationale is **"not yet implemented; no fundamental objection."** That is, the cache path is privileged today simply because SQLite already evaluates the full expression grammar; live and partial-fetch paths reject these expressions because nobody has written a translator to ONTAP/DII filter syntax — not because the project has decided the feature is wrong. A well-designed PR that handles all current backends would be accepted.

The operational consequence of this position is the early `ValueError` validation added by issue #618 (already merged): callers fail fast at chain time rather than mid-iteration, surfacing the asymmetry without committing to closing it.

ADR-0012 §49 and ADR-0015 §17 (which both already stated the cache-only restriction) now cross-link to ADR-0017 for the rationale, and the "Cache-only constraint" section of the DataSource user guide does the same.

## Related Issue

Addresses #619

## Type of Change

- [x] Documentation update

## Changes Made

- Add `docs/decisions/0017-where-expressions-are-cache-only-rationale.md` documenting the "not yet implemented; no fundamental objection" rationale, conditions for revisiting, and links to related issues (#618 / #512 / #497) and docs.
- Cross-link ADR-0012 §49 (inline + Related Documentation) to ADR-0017.
- Cross-link ADR-0015 §17 (inline + Related Documentation) to ADR-0017.
- Add a cross-link from the "Cache-only constraint" section of `docs/usage/data-source.md` to ADR-0017.
- Register ADR-0017 in the project-level index in `docs/decisions/README.md`.

## Testing

- [x] All existing tests pass (`doit check` passes locally)
- [ ] Added new tests for new functionality (N/A — documentation-only change, no code paths modified)
- [x] Manually tested the changes (verified all cross-links resolve and ADR follows the project ADR template)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — documentation-only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (N/A — generated from conventional commits at release time)
- [x] My changes generate no new warnings

## Additional Notes

- Issue #619 was filed as `documentation` rather than carrying the `needs-adr` label, but the deliverable itself is the ADR. ADR creation is the substance of the change.
- All success criteria from issue #619 are satisfied: status `Accepted`, rationale captured, ADR-0012 §49 cross-linked, ADR-0015 §17 cross-linked, and a user-facing doc (`docs/usage/data-source.md`) links to the new ADR.
- No code paths changed, so no behavior tests are required. The early-validation operational consequence referenced in ADR-0017 is already implemented and tested under issue #618.
