### PR TITLE
docs: add ADR-0018 codifying cache-schema versioning and backward-compat policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,8 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 - **String Concatenation for Paths**: Use `Path` objects
 
 ### Cache Schema Pitfalls
+The contract behind these rules is in [ADR-0018](docs/decisions/0018-cache-schema-versioning-and-backward-compatibility-policy.md): the cache is rebuild-tolerant, downgrade is unsupported, and `SCHEMA_VERSION` is internal.
+
 - **Adding fields to cache models requires a DB migration**: If you add a field to any model stored in `CachedClusterMetadata` (e.g., `CloudMetadata`, `ClusterInfo`, `OntapNodeResponse`), existing SQLite databases won't have the column. You **must**:
   1. Bump `SCHEMA_VERSION` in `src/pynetappfoundry/cache/db.py`
   2. Add an `_upgrade_to_vN()` method that runs `ALTER TABLE <table> ADD COLUMN "<field>" <type>`

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -106,6 +106,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [ADR-0015: DII backend: live-only, bare-array envelope, offset/limit pagination](decisions/0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md)
 - [ADR-0016: PR-based release is the only supported flow](decisions/0016-pr-based-release-is-the-only-supported-flow.md)
 - [ADR-0017: where-expressions are cache-only (rationale)](decisions/0017-where-expressions-are-cache-only-rationale.md)
+- [ADR-0018: Cache schema versioning and backward-compatibility policy](decisions/0018-cache-schema-versioning-and-backward-compatibility-policy.md)
 - [ADR-9001: Use uv for package management](decisions/9001-use-uv-for-package-management.md)
 - [ADR-9001: Use uv for package management](template/decisions/9001-use-uv-for-package-management.md)
 - [ADR-9002: Use doit for task automation](decisions/9002-use-doit-for-task-automation.md)

--- a/docs/decisions/0001-use-sqlite-for-cluster-metadata-caching.md
+++ b/docs/decisions/0001-use-sqlite-for-cluster-metadata-caching.md
@@ -47,3 +47,4 @@ changed to enable SQL-level queries and per-field indexing.
 - CLI commands: `nf cache refresh`, `nf cache show`, `nf cache query`, `nf cache schema`, `nf cache status`, `nf cache clear`
 - CLI Reference: [docs/reference/cli.md](../reference/cli.md#cache)
 - Usage Guide: [docs/usage/basics.md](../usage/basics.md#cluster-metadata-caching)
+- [ADR-0018: Cache schema versioning and backward-compatibility policy](0018-cache-schema-versioning-and-backward-compatibility-policy.md)

--- a/docs/decisions/0003-use-base-sqlitedb-class-with-version-based-migrations.md
+++ b/docs/decisions/0003-use-base-sqlitedb-class-with-version-based-migrations.md
@@ -62,3 +62,4 @@ class SQLiteDB(ABC):
 
 - Database module: `src/pynetappfoundry/db/`
 - Cache module: `src/pynetappfoundry/cache/`
+- [ADR-0018: Cache schema versioning and backward-compatibility policy](0018-cache-schema-versioning-and-backward-compatibility-policy.md)

--- a/docs/decisions/0018-cache-schema-versioning-and-backward-compatibility-policy.md
+++ b/docs/decisions/0018-cache-schema-versioning-and-backward-compatibility-policy.md
@@ -1,0 +1,68 @@
+# ADR-0018: Cache schema versioning and backward-compatibility policy
+
+## Status
+
+Accepted
+
+## Context
+
+[ADR-0001](0001-use-sqlite-for-cluster-metadata-caching.md) established SQLite as the cache substrate for cluster metadata, and [ADR-0003](0003-use-base-sqlitedb-class-with-version-based-migrations.md) established the version-based migration mechanism (the `_schema_version` table and the convention-based `_upgrade_to_v{N}()` methods on the shared `SQLiteDB` base class). Together they document the **mechanism** but not the **contract**: what migrations may do, what users must accept, and what downgrade means.
+
+The cache is a derived store. Its on-disk shape changes whenever cached models are refactored — the v3 → v4 migration that accompanied the nested-model refactor ([ADR-0011](0011-nested-models-to-replace-flat-model-pattern.md)) dropped and recreated every per-model table, losing cached data on upgrade. That precedent has not been written down anywhere as policy, so each new cache-touching change re-litigates "what are we allowed to do here?"
+
+This ADR records the contract behind the mechanism so future cache-schema changes (and reviewers) have something to point to.
+
+Scope: this ADR covers the on-disk SQLite schema version (`SCHEMA_VERSION` in `cache/db.py`, currently `5`). The snapshot-level `METADATA_SCHEMA_VERSION` (`cache/_base.py`) is a separate mechanism with its own contract documented in [Cache System Reference](../reference/cache.md); it is out of scope here.
+
+## Decision
+
+1. **Compatibility contract: rebuild-tolerant.** The cache is a derived store. Deleting `{config_dir}/.cache/cluster_metadata.db` and running `nf cache refresh` is an acceptable contributor or user fallback for any migration concern. The project does not promise formal cross-upgrade preservation of cached data.
+
+2. **Column lifecycle.**
+   - **Add a column:** bump `SCHEMA_VERSION` and write an idempotent `_upgrade_to_v{N}()` that runs `ALTER TABLE … ADD COLUMN`. Idempotency is required because earlier migration chains may have recreated the table with the current DDL, so the migration must check `PRAGMA table_info` before issuing the `ALTER`.
+   - **Rename or remove a column:** drop and recreate the affected table(s). Cached data for that table is lost on upgrade. The v3 → v4 migration ([ADR-0011](0011-nested-models-to-replace-flat-model-pattern.md), issue #444) is the precedent. Clear the affected envelope row(s) so collectors detect missing data and trigger a refresh.
+   - Deprecate-in-place is **not** the default. Cache rebuild is preferred over carrying dead columns forward.
+
+3. **Migration atomicity.** Each version upgrade runs in a transaction (already established by [ADR-0003](0003-use-base-sqlitedb-class-with-version-based-migrations.md)). Interrupted migrations roll back and the database stays at the prior version. Migrations must be safe to re-run from any prior version; the migration chain is replayed in sequence on every open.
+
+4. **Downgrade: not supported.** Opening a database whose recorded version exceeds the code's `SCHEMA_VERSION` raises `SchemaUpgradeError` (`db/base.py`). Users who downgrade `pynetappfoundry` must manually delete the cache database. This matches the no-downgrade stance already taken by [ADR-0003](0003-use-base-sqlitedb-class-with-version-based-migrations.md).
+
+5. **Visibility: internal.** `SCHEMA_VERSION` is an implementation detail. It is not surfaced in CLI output, log messages, or release notes. Users observe migration effects only as side effects (e.g. an empty cache after a destructive migration). Adding migration logging is a possible future enhancement, not part of this contract.
+
+6. **Out of scope.** `METADATA_SCHEMA_VERSION` (snapshot-level) is a separate mechanism with its own contract documented in [Cache System Reference](../reference/cache.md). This ADR covers only the on-disk SQLite schema version.
+
+## Rationale
+
+- **The cache is derived, so promising preservation costs more than it gives.** Cached data can be reconstructed from the live ONTAP API at any time via `nf cache refresh`. Promising cross-upgrade preservation would constrain contributors (forcing in-place column transforms, multi-step migrations, compatibility shims) for negligible user benefit. Users who want preservation can refresh.
+
+- **Drop-and-recreate is simpler than transforming 50+ models in place.** When a refactor changes the shape of cached models (as ADR-0011 did), the on-disk transform problem grows with the model count. The v3 → v4 migration validated the trade-off: a single destructive migration plus a `nf cache refresh` is cheaper to write, review, and maintain than a per-model in-place column transform.
+
+- **No-downgrade is the standard practice for embedded migration frameworks.** [ADR-0003](0003-use-base-sqlitedb-class-with-version-based-migrations.md) already takes this position to keep the migration framework simple. Carrying down-migrations would double the maintenance burden for a fallback (cache delete) that already exists.
+
+- **Internal visibility matches the scope of the contract.** Surfacing `SCHEMA_VERSION` in CLI output or release notes would invite users to expect a stability guarantee the project does not provide. Keeping it internal aligns visibility with the actual contract.
+
+## Consequences
+
+- Contributors may propose data-destructive cache migrations without a preservation justification. The bar is "is this the right shape going forward?" not "can we preserve the data?"
+
+- Users have no formal cache-continuity guarantee across upgrades. They get continuity when migrations happen to be additive (`ALTER TABLE … ADD COLUMN`) and lose cached data when migrations are destructive (drop and recreate). In all cases, `nf cache refresh` restores the cache.
+
+- Migration logging is not required by this contract but may be added as a future enhancement (e.g. a one-line log when a migration runs, surfacing the destructive case to the user).
+
+- The "Cache Schema Pitfalls" section in `AGENTS.md` remains the operational checklist for contributors adding fields to cached models. This ADR provides its policy basis.
+
+## Related Issues
+
+- Issue #620: doc: ADR codifying cache-schema versioning and backward-compat policy (this ADR)
+- Issue #444: refactor: nested-model layout for cached ONTAP models (v3 → v4 destructive precedent)
+- Issue #111: feat: add base SQLiteDB class with version-based migrations (the migration mechanism)
+- Issue #32: feat: add cluster metadata cache for ONTAP clusters (the original cache decision)
+
+## Related Documentation
+
+- [ADR-0001: Use SQLite for cluster metadata caching](0001-use-sqlite-for-cluster-metadata-caching.md) -- the cache substrate decision
+- [ADR-0003: Use base SQLiteDB class with version-based migrations](0003-use-base-sqlitedb-class-with-version-based-migrations.md) -- the migration mechanism
+- [ADR-0009: Per-Model SQL Table Storage for Cache Layer](0009-sql-table-storage.md) -- the per-model table layout that migrations evolve
+- [ADR-0011: Nested models to replace flat model pattern](0011-nested-models-to-replace-flat-model-pattern.md) -- the v3 → v4 destructive migration precedent
+- [Cache System Reference](../reference/cache.md) -- "SQLite database schema versioning" section, plus the snapshot-level `METADATA_SCHEMA_VERSION` contract that this ADR explicitly does not cover
+- `AGENTS.md` "Cache Schema Pitfalls" -- operational checklist for contributors adding fields to cached models

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -118,3 +118,4 @@ The Issue contains the full discussion; the ADR summarizes the outcome.
 | [0015](0015-dii-backend-live-only-bare-array-envelope-offsetlimit-pagination.md) | DII backend: live-only, bare-array envelope, offset/limit pagination | Accepted |
 | [0016](0016-pr-based-release-is-the-only-supported-flow.md) | PR-based release is the only supported flow | Accepted |
 | [0017](0017-where-expressions-are-cache-only-rationale.md) | where-expressions are cache-only (rationale) | Accepted |
+| [0018](0018-cache-schema-versioning-and-backward-compatibility-policy.md) | Cache schema versioning and backward-compatibility policy | Accepted |

--- a/docs/development/cache-models.md
+++ b/docs/development/cache-models.md
@@ -498,11 +498,21 @@ If you add a field to a Pydantic model stored in `CachedClusterMetadata`:
 3. **Table names**: Lowercased model class name (e.g., `CloudMetadata` →
    `cloudmetadata`)
 
-#### Removing a field from a cache model
+#### Removing or renaming a field on a cache model
 
-The column remains in the SQL table (SQLite doesn't support `DROP COLUMN`
-before 3.35). The column is ignored on read since `_row_to_model()` only
-reads fields defined on the model. No migration is needed.
+Per [ADR-0018](../decisions/0018-cache-schema-versioning-and-backward-compatibility-policy.md),
+the cache is rebuild-tolerant and deprecate-in-place is not the default —
+remove or rename a field by dropping and recreating the affected table(s)
+in a schema migration. Cached data for that table is lost on upgrade and
+the next `nf cache refresh` repopulates it.
+
+1. Bump `SCHEMA_VERSION` in `src/pynetappfoundry/cache/db.py`.
+2. Add an `_upgrade_to_vN()` method that drops and recreates the affected
+   table(s) using the current DDL (the v3 → v4 migration is the reference
+   example for a destructive recreate). Clear the affected envelope row(s)
+   so collectors detect missing data and trigger a refresh.
+3. Add a test in `tests/unit/cache/test_db.py`.
+4. Update any existing migration tests that assert the schema version.
 
 ---
 

--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -191,6 +191,12 @@ deserialised against the current Pydantic models.
 
 ### SQLite database schema versioning
 
+The contract for what migrations may do — additive vs. destructive, downgrade
+behavior, visibility — is recorded in
+[ADR-0018](../decisions/0018-cache-schema-versioning-and-backward-compatibility-policy.md).
+The cache is rebuild-tolerant: destructive migrations are allowed, and
+`nf cache refresh` is the documented fallback.
+
 In addition to the `cache_version` stamped into each snapshot,
 `ClusterMetadataDB` tracks the **on-disk SQLite schema** version through the
 shared `SQLiteDB` base class. The current value is `SCHEMA_VERSION = 4`, and
@@ -1121,3 +1127,4 @@ nf cache refresh cluster1 -v
 - ADR-0005 — UUID index for cache cross-references.
 - ADR-0009 — Per-model SQL table storage for the cache layer.
 - ADR-0011 — Nested models to replace the flat model pattern.
+- ADR-0018 — Cache schema versioning and backward-compatibility policy.


### PR DESCRIPTION
## Description

Adds **ADR-0018: Cache schema versioning and backward-compatibility policy**, which codifies the contract behind the cache-schema migration mechanism documented in ADR-0001 (cache substrate) and ADR-0003 (migration mechanism). The ADR records what migrations may do, what users must accept, and what downgrade means — answers contributors previously had to infer from precedent.

The contract: the cache is **rebuild-tolerant**, column-rename/remove **drops and recreates the table**, downgrade is **not supported**, and `SCHEMA_VERSION` is **internal**. The v3 → v4 migration (ADR-0011, issue #444) is cited as the destructive precedent. Snapshot-level `METADATA_SCHEMA_VERSION` is explicitly out of scope.

Cross-links added so the policy is reachable from every place the mechanism is described:

- `AGENTS.md` "Cache Schema Pitfalls" — leading sentence linking ADR-0018
- `docs/reference/cache.md` "SQLite database schema versioning" + "See Also" — leading sentence and bullet linking ADR-0018
- `docs/decisions/0001-...` and `docs/decisions/0003-...` — "Related Documentation" cross-link
- `docs/decisions/README.md` — index row
- `docs/TABLE_OF_CONTENTS.md` — index row

This is **policy documentation only.** No code changes, no behavior changes.

## Related Issue

Addresses #620

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- **Added** `docs/decisions/0018-cache-schema-versioning-and-backward-compatibility-policy.md` — full ADR (Status, Context, Decision with 6 numbered points, Rationale, Consequences, Related Issues, Related Documentation).
- **Updated** `AGENTS.md` — leading sentence in "Cache Schema Pitfalls" pointing to ADR-0018 for the contract behind the rules.
- **Updated** `docs/reference/cache.md` — leading sentence in "SQLite database schema versioning" plus a "See Also" entry for ADR-0018.
- **Updated** `docs/decisions/0001-use-sqlite-for-cluster-metadata-caching.md` — "Related Documentation" cross-link to ADR-0018.
- **Updated** `docs/decisions/0003-use-base-sqlitedb-class-with-version-based-migrations.md` — "Related Documentation" cross-link to ADR-0018.
- **Updated** `docs/decisions/README.md` — ADR-0018 row in the project-level ADR index.
- **Updated** `docs/TABLE_OF_CONTENTS.md` — ADR-0018 entry in the alphabetical index.
- **Updated** `docs/development/cache-models.md` — "Removing a field from a cache model" rewritten to align with ADR-0018's drop-and-recreate policy (was previously recommending orphan-column / no-migration, which contradicted the ADR).

## Issue #620 Success Criteria

- [x] New ADR drafted with status `Accepted`
- [x] Contract explicitly stated (rebuild-tolerant vs. preserve) — Decision §1
- [x] Column lifecycle policy documented — Decision §2 (add / rename / remove)
- [x] Downgrade behavior documented — Decision §4 (`SchemaUpgradeError`, manual delete)
- [x] ADR-0001 cross-links to the new ADR
- [x] ADR-0003 cross-links to the new ADR
- [x] `.claude/CLAUDE.md` "Cache Schema Pitfalls" cross-links to the new ADR — note: this section now lives in `AGENTS.md`, where the cross-link was added (the project's `.claude/CLAUDE.md` includes `AGENTS.md` via `@../AGENTS.md`).
- [x] ADR linked from the relevant docs in `docs/` (per AGENTS.md ADR rule) — `docs/reference/cache.md` (the user-facing surface for cache schema versioning), `docs/decisions/0001`, `docs/decisions/0003`, `docs/decisions/README.md`, `docs/TABLE_OF_CONTENTS.md`.

## Out of Scope (flagged for separate follow-up)

While editing `docs/reference/cache.md`, two pre-existing inaccuracies were noticed but **not** fixed in this PR (to keep the policy-documentation scope clean):

- `docs/reference/cache.md:202` claims `SCHEMA_VERSION = 4`. The actual value in `src/pynetappfoundry/cache/db.py` is `5`.
- The migration table in the same section is missing the `v4 → v5` row.

These should be addressed in a separate `docs:` issue.

## Testing

- [x] All existing tests pass — `doit check` passes (format, lint, type-check, security, spell-check, full pytest suite). No code changes, so no new tests are required.
- [ ] Added new tests for new functionality — N/A (documentation-only)
- [x] Manually tested the changes — `doit docs_build` was run by the implementing agent and succeeded.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`) — N/A (docs-only); `doit check` includes format check.
- [x] I have run linting checks (`doit lint`) — included in `doit check`.
- [x] I have run type checking (`doit type_check`) — included in `doit check`.
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (documentation-only PR).
- [x] All new and existing tests pass (`doit test`) — included in `doit check`.
- [x] I have updated the documentation accordingly — this PR *is* the documentation update.
- [ ] I have updated the CHANGELOG.md — N/A; CHANGELOG is auto-generated from conventional commits at release time.
- [x] My changes generate no new warnings.

## Additional Notes

- `doit check` and `doit docs_build` both pass.
- This ADR is `Accepted` because it codifies the **already-practiced** policy (rebuild-tolerant, no-downgrade, internal versioning, drop-and-recreate for destructive migrations as exercised in v3 → v4). It is not proposing a change of practice.
- The ADR scope is deliberately limited to the on-disk SQLite schema version (`SCHEMA_VERSION` in `cache/db.py`). The snapshot-level `METADATA_SCHEMA_VERSION` (`cache/_base.py`) is a separate mechanism with its own contract documented in `docs/reference/cache.md` and is explicitly marked out of scope in the ADR.
