### PR TITLE
chore: suppress paramiko CVE-2026-44405 until upstream 4.0.1 ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,11 @@ jobs:
         run: uv pip install --upgrade pip
 
       - name: Run dependency audit
-        run: uv run pip-audit --skip-editable
+        # GHSA-r374-rxx8-8654 / CVE-2026-44405: paramiko rsakey.py SHA-1 acceptance.
+        # All released paramiko (<=4.0.0) is affected; upstream fix landed in commit
+        # a4489456 but no tagged release exists yet. Remove --ignore-vuln when
+        # paramiko 4.0.1+ ships. Tracked in issue #701.
+        run: uv run pip-audit --skip-editable --ignore-vuln GHSA-r374-rxx8-8654
 
       - name: Run tests with coverage
         run: uv run pytest --cov=pynetappfoundry --cov-report=xml:tmp/coverage.xml --cov-report=term -v

--- a/tools/doit/security.py
+++ b/tools/doit/security.py
@@ -6,12 +6,19 @@ from doit.tools import title_with_actions
 
 from .base import optional_root_files
 
+# GHSA-r374-rxx8-8654 / CVE-2026-44405: paramiko rsakey.py allows the SHA-1 algorithm.
+# Affects all released paramiko versions (<=4.0.0). Fix landed upstream in commit
+# a4489456b6f65281e172380cc4826cee5e851dbb but no tagged release exists yet.
+# Suppress until paramiko 4.0.1+ ships — see issue #701.
+_AUDIT_IGNORED_VULNS = ("GHSA-r374-rxx8-8654",)
+
 
 def task_audit() -> dict[str, Any]:
     """Run security audit with pip-audit (requires security extras)."""
+    ignore_args = " ".join(f"--ignore-vuln {vid}" for vid in _AUDIT_IGNORED_VULNS)
     return {
         "actions": [
-            "uv run pip-audit --skip-editable || "
+            f"uv run pip-audit --skip-editable {ignore_args} || "
             "echo 'pip-audit not installed. Run: uv sync --extra security'"
         ],
         "title": title_with_actions,


### PR DESCRIPTION
## Description

Suppresses CVE-2026-44405 / GHSA-r374-rxx8-8654 in `pip-audit` so CI's audit
step stops blocking PRs. **No paramiko version bump** because no fixed
release exists yet.

### Why not bump paramiko

Issue #701's "Proposed Changes" assumed a patched release was available. OSV
confirms otherwise — the advisory affects every released paramiko version
(`introduced: 0`, `last_affected: 4.0.0`). The upstream fix landed in
commit [`a4489456`](https://github.com/paramiko/paramiko/commit/a4489456b6f65281e172380cc4826cee5e851dbb)
but is not in a tagged release. Pinning to a git ref or downgrading does not
help.

### What this PR does

- `.github/workflows/ci.yml` — adds `--ignore-vuln GHSA-r374-rxx8-8654` to
  the `Run dependency audit` step, with an inline comment pointing at the
  upstream fix and a TODO to remove when paramiko 4.0.1+ ships.
- `tools/doit/security.py` — mirrors the suppression in the local `doit
  audit` task using a `_AUDIT_IGNORED_VULNS` tuple, so local and CI audit
  behaviour match. Same comment + TODO.

### Risk assessment

The advisory is "paramiko's `rsakey.py` accepts the SHA-1 algorithm." This is
a defense-in-depth issue (chosen-prefix collision attacks against SSH RSA
signatures, expensive in practice), not an RCE. Our paramiko consumer
(`src/pynetappfoundry/clients/ontap/cli.py`) connects to managed ONTAP
clusters, not arbitrary internet hosts. A documented temporary suppression
with a clear remove-on-release trail is the right tactical fix; the
alternative (CI broken across every PR for an unknown number of weeks) is
worse for security posture overall.

## Related Issue

Addresses #701

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement
- [x] Other: dependency / CI maintenance (chore)

## Changes Made

- Two-line suppression in CI workflow (audit step) with rationale comment.
- Mirroring suppression in `doit audit` via a small `_AUDIT_IGNORED_VULNS`
  tuple, so adding/removing future suppressions touches one structure rather
  than CLI string mangling.

## Testing

- [x] All existing tests pass
- [x] No new functionality (no new tests required)
- [x] Manually verified

`doit check` passes locally. `doit audit` runs with the suppression and
reports `Found 2 known vulnerabilities, ignored 1 in 1 package` — the
remaining two are unrelated `pip` CVEs that CI works around in a separate
step (`Upgrade pip (CVE-2026-1703)` at `.github/workflows/ci.yml:152-153`).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] No tests added (no new functional code)
- [x] All existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (inline comments document the rationale)
- [ ] I have updated the CHANGELOG.md (auto-generated by commitizen at release time)
- [x] My changes generate no new warnings

## Follow-up

When paramiko 4.0.1+ is released:

1. Bump the `paramiko>=` floor in `pyproject.toml` past 4.0.0.
2. `uv sync` to refresh `uv.lock`.
3. Remove `--ignore-vuln GHSA-r374-rxx8-8654` from `.github/workflows/ci.yml`.
4. Remove `GHSA-r374-rxx8-8654` from `_AUDIT_IGNORED_VULNS` in `tools/doit/security.py`.
5. Confirm `doit audit` and CI's audit step are clean.
