### PR TITLE
fix: bump urllib3 to 2.7.0 to resolve CVE-2026-44431/44432

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2747,11 +2747,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Bumps `urllib3` 2.6.3 → 2.7.0 in `uv.lock` to resolve two known CVEs reported by `pip-audit`:

- **CVE-2026-44431**
- **CVE-2026-44432**

Both vulnerabilities are fixed in urllib3 2.7.0. `urllib3` is a transitive dependency — no `pyproject.toml` change is required. `uv lock --upgrade-package urllib3` cleanly resolves to 2.7.0 with no other package movement.

The CVEs were failing the `Run dependency audit` step of `.github/workflows/ci.yml` across every OS × Python combination, blocking PR **#720** (Phase A of the pyproject-template sync). Landing this first unblocks #720 via a clean rebase.

## Related Issue

Addresses #721

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue) — security CVE remediation

## Changes Made

- `uv.lock`: `urllib3` 2.6.3 → 2.7.0 (only package movement; verified via `git diff uv.lock | grep -E "^[+-](name|version)"`).

## Testing

- [x] All existing tests pass (`doit check` green: tests, lint, type-check, security, spell-check)
- [x] Manually verified `uv run pip-audit --skip-editable --ignore-vuln GHSA-r374-rxx8-8654` reports `No known vulnerabilities found, 1 ignored` (the 1 ignored is the unchanged paramiko CVE tracked in #701).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works (N/A — dependency-version bump, behavior verified via `pip-audit`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (N/A — internal dependency)
- [ ] I have updated the CHANGELOG.md (N/A — internal dependency bump)
- [x] My changes generate no new warnings

## Additional Context

Unlike the paramiko CVE (`GHSA-r374-rxx8-8654`, tracked in #701) where no upstream-fixed release exists yet and CI suppresses the finding via `--ignore-vuln`, urllib3 has the fix already published — so the right action is to upgrade rather than add another suppression entry.
