### PR TITLE
fix: point breaking-change-detection workflow at pynetappfoundry module

### DIFF
--- a/.github/workflows/breaking-change-detection.yml
+++ b/.github/workflows/breaking-change-detection.yml
@@ -35,7 +35,7 @@ jobs:
         id: griffe
         run: |
           set +e
-          OUTPUT=$(griffe check package_name \
+          OUTPUT=$(griffe check pynetappfoundry \
             --against "origin/${{ github.base_ref }}" \
             --search src \
             --verbose 2>&1)


### PR DESCRIPTION
## Description

The Phase B template sync (#723 / `951f31dc`) bulk-overwrote `.github/workflows/breaking-change-detection.yml` from upstream without applying the `package_name` → `pynetappfoundry` mapping. The workflow then invoked `griffe check package_name` on every PR and failed with:

```
ModuleNotFoundError: package_name
ImportError: With sys.path = [.../src], accessing 'package_name' raises
  ModuleNotFoundError: No module named 'package_name'
```

This surfaced as a false-positive "Breaking changes detected but not documented!" gate. First reproduced on PR #715 post-rebase.

## Related Issue

Addresses #726

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `.github/workflows/breaking-change-detection.yml`: change `griffe check package_name` → `griffe check pynetappfoundry` (line 38).

**Not adopting a sync-exclude entry for this file.** The project-specific override is a single line; future upstream improvements (newer griffe flags, better diff handling, security fixes) are worth not silencing. The next template sync will flag this file as drift and the one-line module-name override will be re-applied in the hand-merge pass (same pattern as `ci.yml`, `AGENTS.md`, `.pre-commit-config.yaml`).

A potentially cleaner long-term fix would be an upstream feature request to read the module name from `pyproject.toml` / `settings.toml` — left for a separate effort.

## Testing

- [x] All existing tests pass (`doit check` green prior to and after this change)
- [x] Manually verified:
  - `yaml.safe_load(open('.github/workflows/breaking-change-detection.yml'))` parses cleanly.
  - `import pynetappfoundry` resolves locally — `griffe check pynetappfoundry` will have a real module to introspect.
- [ ] Final verification: this PR's own `Detect API Breaking Changes` check should now run cleanly instead of erroring on import.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (N/A — YAML + TOML only)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Context

Sibling Phase-B-clobber follow-on: **#725** — adds `docs/decisions/README.md` to `sync-exclude.toml` after PR #715 restores its content. Both issues stem from the same root cause: bulk-overwrite during Phase B did not enumerate all project-customized files.

Phase B PR: #723 (merged as `951f31dc`).

