### PR TITLE
chore: add docs/decisions/README.md to sync-exclude.toml

### DIFF
--- a/.config/pyproject_template/sync-exclude.toml
+++ b/.config/pyproject_template/sync-exclude.toml
@@ -52,6 +52,12 @@ exclude = [
     "docs/getting-started/installation.md",
     "docs/reference/api.md",
     "docs/usage/basics.md",
+    # docs/decisions/README.md: project owns the "Project-level ADRs
+    # (0001+)" table. Upstream ships a generic placeholder
+    # ("_(No project-level ADRs yet.)_") that, if synced, clobbers the
+    # project's ADR-0001..ADR-NNNN list. Surfaced as a rebase conflict
+    # in PR #715 after Phase B sync (#723).
+    "docs/decisions/README.md",
 
     # tests/template/test_properties.py — Hypothesis property tests for
     # upstream's example `package_name.core.greet` (which we exclude). The


### PR DESCRIPTION
## Description

Adds `docs/decisions/README.md` to `.config/pyproject_template/sync-exclude.toml` so future pyproject-template syncs do not clobber the project's "Project-level ADRs (0001+)" table.

**Why this is needed:** Phase B's bulk-copy sync (#723) applied upstream's version of `docs/decisions/README.md` over the project's version. Upstream ships a generic placeholder for the project-level ADRs section:

```
_(No project-level ADRs yet.)_
```

The project's version contains the full ADR-0001 → ADR-NNNN table. The clobber surfaced as a rebase conflict on PR #715 (which laid ADR-0019 on top of the pre-Phase-B README). The PR #715 merge restored the project ADR table to `main`, but the sync-exclude rule was still missing — so the next template sync would clobber it again.

This PR adds the missing exclude entry. Same pattern as the eight pages added in Phase B's tail commit `ad2ebfd6` (`docs/index.md`, `docs/reference/api.md`, etc.).

## Related Issue

Addresses #725

## Type of Change

- [x] Code refactoring — sync-exclude config; no runtime behavior change

## Changes Made

- `.config/pyproject_template/sync-exclude.toml`: add one entry for `docs/decisions/README.md` with a comment explaining the project-vs-upstream content split.

## Testing

- [x] `doit check` passes
- [x] Manually verified: `python tools/pyproject_template/manage.py --show-excluded check` now lists `docs/decisions/README.md` under "Skipped per project policy" (count went from 55 → 56; "different" count dropped from 10 → 9... actually 11 → 10 since the README itself stops being flagged as drift)

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (N/A — TOML only)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Context

Sibling Phase-B-clobber follow-ons:
- **#726** — `breaking-change-detection.yml` `package_name` → `pynetappfoundry` (merged as #727 / `04cb9525`).
- **#725** — this PR.

Both stem from the same root cause: the Phase B bulk-overwrite didn't enumerate all project-customized files. The sync-exclude mechanism is the right place to encode these.
