### PR TITLE
feat: add -h short alias for --help in CLI

### DIFF
--- a/src/pynetappfoundry/cli/main.py
+++ b/src/pynetappfoundry/cli/main.py
@@ -16,7 +16,7 @@ from pynetappfoundry.cli.commands.reports import reports
 from pynetappfoundry.cli.commands.utils import utils
 
 
-@click.group()
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=__version__)
 @click.option(
     "--config-dir",

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,0 +1,85 @@
+"""Tests for the top-level `nf` CLI group, focusing on -h / --help equivalence."""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from pynetappfoundry.cli.main import nf
+
+
+class TestHelpShortAlias:
+    """Verify that -h is accepted everywhere --help is accepted."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    # ------------------------------------------------------------------
+    # Top-level group
+    # ------------------------------------------------------------------
+
+    def test_top_level_help_short_option_exit_code_zero(self, runner: CliRunner) -> None:
+        """`nf -h` exits with code 0."""
+        result = runner.invoke(nf, ["-h"])
+        assert result.exit_code == 0
+
+    def test_top_level_help_short_option_matches_long(self, runner: CliRunner) -> None:
+        """`nf -h` produces the same output as `nf --help`."""
+        short = runner.invoke(nf, ["-h"])
+        long = runner.invoke(nf, ["--help"])
+        assert short.exit_code == long.exit_code
+        assert short.output == long.output
+
+    # ------------------------------------------------------------------
+    # Subcommand: cache
+    # ------------------------------------------------------------------
+
+    def test_subcommand_cache_help_short_option_exit_code_zero(self, runner: CliRunner) -> None:
+        """`nf cache -h` exits with code 0."""
+        result = runner.invoke(nf, ["cache", "-h"])
+        assert result.exit_code == 0
+
+    def test_subcommand_cache_help_short_option_matches_long(self, runner: CliRunner) -> None:
+        """`nf cache -h` produces the same output as `nf cache --help`."""
+        short = runner.invoke(nf, ["cache", "-h"])
+        long = runner.invoke(nf, ["cache", "--help"])
+        assert short.exit_code == long.exit_code
+        assert short.output == long.output
+
+    # ------------------------------------------------------------------
+    # Subcommand: events
+    # ------------------------------------------------------------------
+
+    def test_subcommand_events_help_short_option_exit_code_zero(self, runner: CliRunner) -> None:
+        """`nf events -h` exits with code 0."""
+        result = runner.invoke(nf, ["events", "-h"])
+        assert result.exit_code == 0
+
+    def test_subcommand_events_help_short_option_matches_long(self, runner: CliRunner) -> None:
+        """`nf events -h` produces the same output as `nf events --help`."""
+        short = runner.invoke(nf, ["events", "-h"])
+        long = runner.invoke(nf, ["events", "--help"])
+        assert short.exit_code == long.exit_code
+        assert short.output == long.output
+
+    # ------------------------------------------------------------------
+    # Nested subcommand: cache show
+    # ------------------------------------------------------------------
+
+    def test_nested_subcommand_cache_show_help_short_option_exit_code_zero(
+        self, runner: CliRunner
+    ) -> None:
+        """`nf cache show -h` exits with code 0."""
+        result = runner.invoke(nf, ["cache", "show", "-h"])
+        assert result.exit_code == 0
+
+    def test_nested_subcommand_cache_show_help_short_option_matches_long(
+        self, runner: CliRunner
+    ) -> None:
+        """`nf cache show -h` produces the same output as `nf cache show --help`."""
+        short = runner.invoke(nf, ["cache", "show", "-h"])
+        long = runner.invoke(nf, ["cache", "show", "--help"])
+        assert short.exit_code == long.exit_code
+        assert short.output == long.output


### PR DESCRIPTION
## Description

Add `-h` as a short alias for `--help` across the entire `nf` CLI. This is a
near-universal convention for command-line tools and is a frequent source of
friction when users muscle-memory `-h` and get an error instead of help text.

The fix is a single-argument addition to the top-level `@click.group()` decorator:

```python
@click.group(context_settings={"help_option_names": ["-h", "--help"]})
```

Click propagates `context_settings` to every subcommand and nested group
automatically, so no per-command edits are needed.

This issue was split out of the Phase B template sync (PR #723) because the
upstream PR (#569) targeted a different file path than the one used in this
project.

## Related Issue

Addresses #719

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `src/pynetappfoundry/cli/main.py`: Add `context_settings={"help_option_names": ["-h", "--help"]}` to `@click.group()` — one line changed.
- `tests/unit/cli/test_main.py`: New test module with `TestHelpShortAlias` covering `-h` behavior at three levels of command nesting.

## Testing

- [ ] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`TestHelpShortAlias` (8 tests) covers:

| Scope | What is tested |
|---|---|
| Top-level `nf -h` | Exit code 0; output identical to `nf --help` |
| Subcommand `nf cache -h` | Exit code 0; output identical to `nf cache --help` |
| Subcommand `nf events -h` | Exit code 0; output identical to `nf events --help` |
| Nested `nf cache show -h` | Exit code 0; output identical to `nf cache show --help` |

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A

## Additional Notes

No documentation update is needed: existing docs reference `--help` by its long
form in option tables and examples, which remains correct. The alias does not
alter the long-form option name, so no reference becomes incorrect.

No ADR is needed: this is a minor CLI ergonomics change with no architectural
implications.
