### PR TITLE
feat: add Console SaaS v1 runtime client and cache integration

### DIFF
--- a/docs/decisions/0019-console-runtime-client-architecture-org-scoped-access-and-per-token-type-wrapper-isolation.md
+++ b/docs/decisions/0019-console-runtime-client-architecture-org-scoped-access-and-per-token-type-wrapper-isolation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed. Will be marked Accepted once issue #713 ships the v1 implementation.
+Accepted. v1 implementation landed in issue #713.
 
 ## Context
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -119,4 +119,4 @@ The Issue contains the full discussion; the ADR summarizes the outcome.
 | [0016](0016-pr-based-release-is-the-only-supported-flow.md) | PR-based release is the only supported flow | Accepted |
 | [0017](0017-where-expressions-are-cache-only-rationale.md) | where-expressions are cache-only (rationale) | Accepted |
 | [0018](0018-cache-schema-versioning-and-backward-compatibility-policy.md) | Cache schema versioning and backward-compatibility policy | Accepted |
-| [0019](0019-console-runtime-client-architecture-org-scoped-access-and-per-token-type-wrapper-isolation.md) | Console runtime client architecture: org-scoped access and per-token-type wrapper isolation | Proposed |
+| [0019](0019-console-runtime-client-architecture-org-scoped-access-and-per-token-type-wrapper-isolation.md) | Console runtime client architecture: org-scoped access and per-token-type wrapper isolation | Accepted |

--- a/docs/example-config/apis/console/consoleapi.toml
+++ b/docs/example-config/apis/console/consoleapi.toml
@@ -1,0 +1,20 @@
+[general]
+# Console SaaS (BlueXP) API settings.
+#
+# v1 supports static tokens only (no OAuth refresh flow yet).
+# See notes.txt for how to obtain the user_token (and optional service_token).
+
+user_token = 'paste-user-jwt-here'
+
+# Optional. Lazy-validated: ConsoleAPIClient only constructs the service-token
+# APIWrapper when this is present. Calling a service-typed endpoint without
+# a service_token raises ConsoleServiceTokenMissingError.
+# service_token = 'paste-service-account-jwt-here'
+
+base_url = 'https://api.bluexp.netapp.com'
+base_api_path = '/'
+
+# Default organization id. Can be overridden per Console(...) instance.
+org_id = 'your-org-id'
+
+timeout = 30.0

--- a/docs/example-config/apis/console/notes.txt
+++ b/docs/example-config/apis/console/notes.txt
@@ -1,1 +1,39 @@
-Unknown as of this time
+Console SaaS (BlueXP) runtime client setup.
+
+1. OpenAPI schema:
+   Copy tools/console_openapi/generated/console_openapi.yaml from the repo into
+   this directory:
+
+       cp tools/console_openapi/generated/console_openapi.yaml \
+          ~/.config/pynetappfoundry/apis/console/
+
+   The runtime client (ConsoleAPIClient) loads the spec from
+   config.get_schema_location("console") / "console_openapi.yaml".
+
+2. Auth tokens (v1 = static tokens only):
+
+   user_token (required):
+   - Log into BlueXP at https://console.bluexp.netapp.com
+   - Open browser devtools -> Application -> Local Storage / Cookies
+   - Copy the JWT-shaped Bearer access token used in Authorization headers
+   - Paste into consoleapi.toml [general].user_token
+
+   service_token (optional, only needed for service-typed endpoints):
+   - Provision a service account in BlueXP
+   - Use its refresh token to obtain an access JWT
+   - Paste the access JWT into consoleapi.toml [general].service_token
+
+   The OAuth refresh-token grant flow is intentionally out of scope for v1
+   (ADR-0019). Tokens must be obtained out-of-band and pasted directly.
+
+3. Test it:
+
+       uv run python -c "
+       from pynetappfoundry.core.config import Config
+       from pynetappfoundry.console import Console
+
+       config = Config(config_dir='~/.config/pynetappfoundry')
+       console = Console(config)
+       org = console.get_organization()
+       print(f'{org.id}: {org.name}')
+       "

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -30,6 +30,7 @@ config/
 ├── users.toml           # Credentials for resource types
 ├── ontapapi.toml        # ONTAP REST API settings
 ├── diiapi.toml          # Data Infrastructure Insights API settings
+├── consoleapi.toml      # Console SaaS (BlueXP) API settings
 ├── monitoring.toml      # Monitoring thresholds (optional)
 ├── environments/        # Data files (clusters, connectors, etc.)
 │   ├── prod.toml
@@ -38,8 +39,10 @@ config/
 └── apis/                # API specifications (OpenAPI/Swagger)
     ├── ontap/
     │   └── all.json
-    └── dii/
-        └── all.json
+    ├── dii/
+    │   └── all.json
+    └── console/
+        └── console_openapi.yaml
 ```
 
 ### How Configuration Loading Works
@@ -169,6 +172,35 @@ base_api_path = "/rest/v1"                 # Optional: Base API path (default: "
 | `api_ro_token` | string | Yes | - | Read-only API token for DII authentication |
 | `base_url` | string | Yes | - | Base URL for your DII tenant |
 | `base_api_path` | string | No | `"/rest/v1"` | Base path for DII REST API endpoints |
+
+---
+
+### consoleapi.toml
+
+Console SaaS (BlueXP) API settings. Loaded into `config.settings["consoleapi"]`.
+
+v1 supports static tokens only. See `docs/example-config/apis/console/notes.txt` for how to obtain the tokens.
+
+```toml
+[general]
+user_token = "paste-user-jwt-here"          # Required: User JWT from the BlueXP UI
+# service_token = "paste-service-account-jwt-here"  # Optional: service-account JWT
+base_url = "https://api.bluexp.netapp.com"  # Required: Console API base URL
+org_id = "your-org-id"                      # Optional: Default organization ID
+base_api_path = "/"                          # Optional: Base API path (default: "/")
+timeout = 30.0                               # Optional: Request timeout in seconds (default: 30.0)
+```
+
+#### Console API Settings Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `user_token` | string | Yes | - | User JWT obtained from the BlueXP UI |
+| `service_token` | string | No | `null` | Service-account JWT. Lazy-validated: raises `ConsoleServiceTokenMissingError` if absent when a service-typed endpoint is called |
+| `base_url` | string | Yes | - | Base URL for the Console API |
+| `org_id` | string | No | `null` | Default organization ID. Can be overridden per `Console(config, org_id=...)` call |
+| `base_api_path` | string | No | `"/"` | Base path for Console API endpoints |
+| `timeout` | float | No | `30.0` | HTTP request timeout in seconds |
 
 ---
 

--- a/src/pynetappfoundry/cache/_lazy.py
+++ b/src/pynetappfoundry/cache/_lazy.py
@@ -41,6 +41,7 @@ _DATA_FIELDS = frozenset(
         "mediator",
         "relationships",
         "protocols",
+        "console",
     }
 )
 

--- a/src/pynetappfoundry/cache/_metadata.py
+++ b/src/pynetappfoundry/cache/_metadata.py
@@ -18,6 +18,7 @@ from pynetappfoundry.cache._base import (
     HasUUID,
     _utcnow,
 )
+from pynetappfoundry.models.console.types import Organization
 from pynetappfoundry.models.ontap.cloud.metadata.model import CloudMetadata
 from pynetappfoundry.models.ontap.cluster.licensing.licenses.model import (
     OntapLicensePackageResponse,
@@ -32,6 +33,12 @@ from pynetappfoundry.models.ontap.snapmirror.relationships.model import (
 )
 from pynetappfoundry.models.ontap.storage.model import StorageInfo
 from pynetappfoundry.models.ontap.svm.peers.model import OntapSvmPeer
+
+
+class ConsoleInfo(CacheModel):
+    """Console SaaS data cached for the cluster's owning org."""
+
+    organization: Organization | None = None
 
 
 class RelationshipsInfo(CacheModel):
@@ -88,6 +95,7 @@ class CachedClusterMetadata(CacheModel):
     mediator: OntapMediatorResponse = Field(default_factory=OntapMediatorResponse)
     relationships: RelationshipsInfo = Field(default_factory=RelationshipsInfo)
     protocols: ProtocolsInfo = Field(default_factory=ProtocolsInfo)
+    console: ConsoleInfo = Field(default_factory=ConsoleInfo)
 
     def is_stale(self, ttl_days: int = 30) -> bool:
         """Check if the cache is stale based on TTL.

--- a/src/pynetappfoundry/cache/db.py
+++ b/src/pynetappfoundry/cache/db.py
@@ -269,7 +269,7 @@ class ClusterMetadataDB(SQLiteDB):
     for data safety and isolation.
     """
 
-    SCHEMA_VERSION: ClassVar[int] = 5
+    SCHEMA_VERSION: ClassVar[int] = 6
     TABLE_NAME: ClassVar[str] = "cluster_metadata"
 
     def __init__(
@@ -418,6 +418,27 @@ class ClusterMetadataDB(SQLiteDB):
         existing_cols = {row[1] for row in cursor.fetchall()}
         if "vm_name" not in existing_cols:
             self.conn.execute('ALTER TABLE cloudmetadata ADD COLUMN "vm_name" TEXT')
+
+    # ------------------------------------------------------------------
+    # Migration v5 → v6
+    # ------------------------------------------------------------------
+
+    def _upgrade_to_v6(self) -> None:
+        """Create the consoleinfo table for the Console cache wrapper (#713).
+
+        v6 adds ``CachedClusterMetadata.console: ConsoleInfo`` to support
+        cluster-scoped Console SaaS data (ADR-0019).  Existing v5 databases
+        have no ``consoleinfo`` table; create it via the same DDL generator
+        used in ``_create_schema``.  Idempotent via ``sqlite_master`` check.
+        """
+        from pynetappfoundry.cache._metadata import ConsoleInfo
+
+        cursor = self.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='consoleinfo'"
+        )
+        if cursor.fetchone() is None:
+            self.conn.execute(generate_table_ddl("consoleinfo", ConsoleInfo))
+            self.conn.execute(generate_cluster_name_index_ddl("consoleinfo"))
 
     # ------------------------------------------------------------------
     # Internal: decompose metadata into tables

--- a/src/pynetappfoundry/clients/console/__init__.py
+++ b/src/pynetappfoundry/clients/console/__init__.py
@@ -1,0 +1,5 @@
+"""Console SaaS client modules."""
+
+from pynetappfoundry.clients.console.api import ConsoleAPIClient, ConsoleServiceTokenMissingError
+
+__all__ = ["ConsoleAPIClient", "ConsoleServiceTokenMissingError"]

--- a/src/pynetappfoundry/clients/console/api.py
+++ b/src/pynetappfoundry/clients/console/api.py
@@ -1,0 +1,108 @@
+"""Console SaaS API client with per-token-type wrapper isolation (ADR-0019)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pynetappfoundry.clients.openapi import APIWrapper
+from pynetappfoundry.models.console.types import Organization
+
+if TYPE_CHECKING:
+    from pynetappfoundry.core.config import Config
+
+
+class ConsoleServiceTokenMissingError(RuntimeError):
+    """Raised when a service-token endpoint is called without a configured service token."""
+
+
+class ConsoleAPIClient:
+    """Console SaaS API client with per-token-type wrapper isolation (ADR-0019).
+
+    Wraps two internal ``APIWrapper`` instances — one for user-token endpoints
+    and one (optional) for service-token endpoints.  ``APIWrapper``'s static
+    ``auth_header`` contract is preserved; token selection is resolved at
+    construction time, not per-call.
+    """
+
+    def __init__(self, config: Config) -> None:
+        """Initialize the Console API client.
+
+        Args:
+            config: Configuration object with Console API settings.
+        """
+        self.config = config
+        settings = config.get_console_api_settings()
+        spec_path = str(config.get_schema_location("console") / "console_openapi.yaml")
+
+        self._user = APIWrapper(
+            api_json_file=spec_path,
+            base_url=settings.base_url,
+            auth_header={"Authorization": f"Bearer {settings.user_token}"},
+            base_api_path=settings.base_api_path,
+            timeout=settings.timeout,
+            name="console-user",
+        )
+
+        if settings.service_token:
+            self._service: APIWrapper | None = APIWrapper(
+                api_json_file=spec_path,
+                base_url=settings.base_url,
+                auth_header={"Authorization": f"Bearer {settings.service_token}"},
+                base_api_path=settings.base_api_path,
+                timeout=settings.timeout,
+                name="console-service",
+            )
+        else:
+            self._service = None
+
+    def _require_service(self) -> APIWrapper:
+        """Return the service-token wrapper, or raise if not configured.
+
+        Returns:
+            The service-token ``APIWrapper``.
+
+        Raises:
+            ConsoleServiceTokenMissingError: If no service_token was provided.
+        """
+        if self._service is None:
+            raise ConsoleServiceTokenMissingError(
+                "This Console endpoint requires a service token, but no "
+                "service_token was provided in settings. Add service_token to "
+                "consoleapi.toml [general]."
+            )
+        return self._service
+
+    def get_organization(self, organization_id: str) -> Organization:
+        """GET /organizations/{organization_id} (user-token endpoint).
+
+        Args:
+            organization_id: The organization UUID.
+
+        Returns:
+            Compact Organization instance.
+        """
+        response: Any = self._user.call_endpoint(
+            method="GET",
+            path_template="/organizations/{organization_id}",
+            path_params={"organization_id": organization_id},
+        )
+        return Organization.model_validate(response)
+
+    def list_organizations(self) -> list[Organization]:
+        """GET /organizations (user-token endpoint).
+
+        Returns all organizations the bound user can see.  Pagination
+        (the ``continue`` cursor) is out of scope for v1.
+
+        Returns:
+            List of compact Organization instances.
+        """
+        response: Any = self._user.call_endpoint(
+            method="GET",
+            path_template="/organizations",
+        )
+        items: list[Any] = response.get("items", [])
+        return [Organization.model_validate(item) for item in items]
+
+
+__all__ = ["ConsoleAPIClient", "ConsoleServiceTokenMissingError"]

--- a/src/pynetappfoundry/console/__init__.py
+++ b/src/pynetappfoundry/console/__init__.py
@@ -1,0 +1,68 @@
+"""Org-scoped Console SaaS facade (ADR-0019).
+
+Primary entry point for callers:
+
+    from pynetappfoundry.console import Console
+
+    console = Console(config, org_id="org-abc123")
+    org = console.get_organization()
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pynetappfoundry.clients.console import ConsoleAPIClient, ConsoleServiceTokenMissingError
+from pynetappfoundry.models.console.types import Organization
+
+if TYPE_CHECKING:
+    from pynetappfoundry.core.config import Config
+
+
+class Console:
+    """Org-scoped facade for the Console SaaS API (ADR-0019).
+
+    Per ADR-0019 §1, Console primary access is *org-scoped*.  Instantiate
+    with an org_id (either directly or via consoleapi.toml ``org_id``).
+    There is intentionally no ``ClusterEntry.console`` accessor in v1.
+    """
+
+    def __init__(self, config: Config, org_id: str | None = None) -> None:
+        """Initialize the org-scoped Console facade.
+
+        Args:
+            config: Configuration object.
+            org_id: The organization UUID to bind to.  If omitted, falls back
+                    to ``org_id`` from ``consoleapi.toml [general]``.
+
+        Raises:
+            ValueError: If no org_id is available from either source.
+        """
+        self._client = ConsoleAPIClient(config)
+        settings = config.get_console_api_settings()
+        resolved = org_id or settings.org_id
+        if not resolved:
+            raise ValueError(
+                "Console requires an org_id either as a constructor argument "
+                "or in consoleapi.toml [general] as 'org_id'."
+            )
+        self.org_id: str = resolved
+
+    def get_organization(self) -> Organization:
+        """Get the organization bound to this Console instance.
+
+        Returns:
+            The Organization for ``self.org_id``.
+        """
+        return self._client.get_organization(self.org_id)
+
+    def list_organizations(self) -> list[Organization]:
+        """List all organizations the bound user can see.
+
+        Returns:
+            List of Organization instances.
+        """
+        return self._client.list_organizations()
+
+
+__all__ = ["Console", "ConsoleAPIClient", "ConsoleServiceTokenMissingError", "Organization"]

--- a/src/pynetappfoundry/core/config.py
+++ b/src/pynetappfoundry/core/config.py
@@ -47,6 +47,7 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 from pynetappfoundry.core.models import (
+    ConsoleAPISettings,
     DIIAPISettings,
     LicensingSettings,
     ONTAPAPISettings,
@@ -259,6 +260,27 @@ class Config:
                 f"Invalid DII API configuration: {e}. "
                 "Ensure settings.toml has a valid [diiapi.general] section with "
                 "'api_ro_token', 'base_url', and 'base_api_path' fields."
+            ) from e
+
+    def get_console_api_settings(self) -> ConsoleAPISettings:
+        """Get Console SaaS API settings.
+
+        Returns:
+            ConsoleAPISettings object with API configuration.
+
+        Raises:
+            ConfigurationError: If Console API settings are not configured.
+        """
+        try:
+            console_data = self.get_setting("consoleapi", "general")
+            return ConsoleAPISettings.model_validate(console_data)
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            raise ConfigurationError(
+                f"Invalid Console API configuration: {e}. "
+                "Ensure consoleapi.toml has a valid [general] section with "
+                "'user_token' and 'base_url' fields."
             ) from e
 
     def get_licensing_settings(self) -> LicensingSettings | None:

--- a/src/pynetappfoundry/core/models.py
+++ b/src/pynetappfoundry/core/models.py
@@ -110,6 +110,24 @@ class DIIAPISettings(BaseModel):
     timeout: float = 30.0
 
 
+class ConsoleAPISettings(BaseModel):
+    """Console SaaS API settings.
+
+    user_token is required (a user JWT from the BlueXP UI).
+    service_token is optional; operations that require it will raise
+    ConsoleServiceTokenMissingError if it is absent.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    user_token: str
+    service_token: str | None = None
+    base_url: str
+    org_id: str | None = None
+    base_api_path: str = "/"
+    timeout: float = 30.0
+
+
 class SearchableKeysConfig(BaseModel):
     """Searchable keys configuration for a resource type."""
 

--- a/src/pynetappfoundry/models/console/types.py
+++ b/src/pynetappfoundry/models/console/types.py
@@ -1,0 +1,52 @@
+"""Hand-authored compact Console types for cache use.
+
+These classes are intentionally *not* generated — they stay stable across
+codegen runs so the cache field types don't change under us.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from pynetappfoundry.models.console.tenancyv4.get_organizations import (
+        Resource10GetResponseBody,
+    )
+
+
+class Organization(BaseModel):
+    """Compact view of a Console organization for cache use.
+
+    Hand-authored (not generated) so the cache field type stays stable
+    across codegen runs and the cached JSON stays small. Source schema:
+    Resource10GetResponseBody in
+    pynetappfoundry.models.console.tenancyv4.get_organizations.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    name: str
+    resource_class: str = Field(alias="resourceClass")
+    resource_type: str = Field(alias="resourceType")
+    owner_organization_id: str | None = Field(default=None, alias="ownerOrganizationId")
+    parent_id: str | None = Field(default=None, alias="parentId")
+    description: str | None = None
+    state: str | None = None
+
+    @classmethod
+    def from_resource(cls, resource: Resource10GetResponseBody) -> Organization:
+        """Convert a generated Resource10GetResponseBody to the compact form.
+
+        Args:
+            resource: Generated model from tenancyv4/get_organizations.
+
+        Returns:
+            Compact Organization instance.
+        """
+        return cls.model_validate(resource.model_dump())
+
+
+__all__ = ["Organization"]

--- a/tests/unit/cache/test_db.py
+++ b/tests/unit/cache/test_db.py
@@ -860,9 +860,9 @@ class TestClusterMetadataDBMigrationV3:
         )
         assert cursor.fetchone() is None
 
-        # Verify schema version is 5 (v4 drops/recreates, v5 adds vm_name)
+        # Verify schema version is the current SCHEMA_VERSION (migrations run forward)
         cursor = db.conn.execute("SELECT version FROM _schema_version")
-        assert cursor.fetchone()[0] == 5
+        assert cursor.fetchone()[0] == ClusterMetadataDB.SCHEMA_VERSION
 
         # v4 clears envelope data (nested model refactoring)
         got = db.get("test-cluster")
@@ -924,17 +924,74 @@ class TestClusterMetadataDBMigrationV3:
         conn.commit()
         conn.close()
 
-        # Open with current code — should trigger v4→v5 migration
+        # Open with current code — should trigger v4→v5 (→...) migrations
         db = ClusterMetadataDB(db_path=db_path)
 
-        # Verify schema version is 5
+        # Verify schema version is the current SCHEMA_VERSION (migrations run forward)
         cursor = db.conn.execute("SELECT version FROM _schema_version")
-        assert cursor.fetchone()[0] == 5
+        assert cursor.fetchone()[0] == ClusterMetadataDB.SCHEMA_VERSION
 
         # Verify vm_name column exists
         cursor = db.conn.execute("PRAGMA table_info(cloudmetadata)")
         columns = {row[1] for row in cursor.fetchall()}
         assert "vm_name" in columns
+
+        db.close()
+
+    def test_upgrade_v5_to_v6_creates_consoleinfo_table(self, tmp_path: Path) -> None:
+        """v5→v6 migration creates the consoleinfo table for ADR-0019 / #713."""
+        db_path = tmp_path / "v5.db"
+        conn = sqlite3.connect(db_path)
+
+        # Create a v5 schema: envelope + per-model tables (excluding consoleinfo)
+        conn.execute(
+            "CREATE TABLE cluster_metadata ("
+            "    cluster_name TEXT PRIMARY KEY,"
+            "    cached_at TEXT NOT NULL,"
+            "    cache_version TEXT NOT NULL"
+            ")"
+        )
+        conn.execute("CREATE TABLE _schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO _schema_version (version) VALUES (5)")
+
+        # Create remaining model tables except consoleinfo (simulates pre-#713 state)
+        from pynetappfoundry.cache.db_schema import (
+            _ensure_registry,
+            generate_cluster_name_index_ddl,
+            generate_table_ddl,
+            generate_uuid_column_index_ddl,
+        )
+
+        registry = _ensure_registry()
+        for spec in registry.values():
+            if spec.table_name == "consoleinfo":
+                continue  # v5 had no consoleinfo table — that's what v6 adds
+            ddl = generate_table_ddl(spec.table_name, spec.model_class)
+            conn.execute(ddl)
+            conn.execute(generate_cluster_name_index_ddl(spec.table_name))
+            if spec.has_uuid:
+                conn.execute(generate_uuid_column_index_ddl(spec.table_name))
+
+        conn.commit()
+        conn.close()
+
+        # Open with current code — should trigger v5→v6 migration
+        db = ClusterMetadataDB(db_path=db_path)
+
+        # Verify schema version is the current SCHEMA_VERSION
+        cursor = db.conn.execute("SELECT version FROM _schema_version")
+        assert cursor.fetchone()[0] == ClusterMetadataDB.SCHEMA_VERSION
+
+        # Verify consoleinfo table exists with an organization column
+        cursor = db.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='consoleinfo'"
+        )
+        assert cursor.fetchone() is not None
+
+        cursor = db.conn.execute("PRAGMA table_info(consoleinfo)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "organization" in columns
+        assert "cluster_name" in columns
 
         db.close()
 

--- a/tests/unit/clients/console/test_console_client.py
+++ b/tests/unit/clients/console/test_console_client.py
@@ -1,0 +1,221 @@
+"""Tests for ConsoleAPIClient (ADR-0019 runtime client)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pynetappfoundry.clients.console.api import (
+    ConsoleAPIClient,
+    ConsoleServiceTokenMissingError,
+)
+from pynetappfoundry.core.models import ConsoleAPISettings
+from pynetappfoundry.models.console.types import Organization
+
+
+@pytest.fixture
+def base_settings() -> ConsoleAPISettings:
+    """Settings with only the user_token populated (service_token absent)."""
+    return ConsoleAPISettings(
+        user_token="user-jwt",
+        base_url="https://api.bluexp.netapp.com",
+        base_api_path="/",
+        timeout=15.0,
+    )
+
+
+@pytest.fixture
+def both_tokens_settings() -> ConsoleAPISettings:
+    """Settings with both user_token and service_token populated."""
+    return ConsoleAPISettings(
+        user_token="user-jwt",
+        service_token="service-jwt",
+        base_url="https://api.bluexp.netapp.com",
+        base_api_path="/",
+        timeout=15.0,
+    )
+
+
+def _make_config(settings: ConsoleAPISettings, tmp_path: Any) -> MagicMock:
+    """Build a stub Config object that returns the given settings and a writable schema path."""
+    config = MagicMock()
+    config.get_console_api_settings.return_value = settings
+    # The Console client calls config.get_schema_location("console") / "console_openapi.yaml".
+    # Point at a non-existent path; APIWrapper is mocked below so the file is never read.
+    config.get_schema_location.return_value = tmp_path
+    return config
+
+
+class TestConsoleAPIClientConstruction:
+    """Two-wrapper composition per ADR-0019."""
+
+    def test_constructs_user_wrapper_only_when_service_token_absent(
+        self,
+        base_settings: ConsoleAPISettings,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`_service` is None when service_token is omitted."""
+        wrapper_mock = MagicMock()
+        monkeypatch.setattr(
+            "pynetappfoundry.clients.console.api.APIWrapper",
+            wrapper_mock,
+        )
+        client = ConsoleAPIClient(_make_config(base_settings, tmp_path))
+
+        assert wrapper_mock.call_count == 1
+        assert client._service is None
+        # User wrapper was constructed with the user-token bearer header
+        user_call_kwargs = wrapper_mock.call_args_list[0].kwargs
+        assert user_call_kwargs["auth_header"] == {"Authorization": "Bearer user-jwt"}
+        assert user_call_kwargs["name"] == "console-user"
+
+    def test_constructs_both_wrappers_when_service_token_present(
+        self,
+        both_tokens_settings: ConsoleAPISettings,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Both `_user` and `_service` wrappers exist when both tokens are configured."""
+        wrapper_mock = MagicMock()
+        monkeypatch.setattr(
+            "pynetappfoundry.clients.console.api.APIWrapper",
+            wrapper_mock,
+        )
+        client = ConsoleAPIClient(_make_config(both_tokens_settings, tmp_path))
+
+        assert wrapper_mock.call_count == 2
+        assert client._service is not None
+        service_call_kwargs = wrapper_mock.call_args_list[1].kwargs
+        assert service_call_kwargs["auth_header"] == {"Authorization": "Bearer service-jwt"}
+        assert service_call_kwargs["name"] == "console-service"
+
+
+class TestServiceTokenLazyValidation:
+    """`_require_service` raises only when callers reach for the missing wrapper."""
+
+    def test_require_service_raises_when_missing(
+        self,
+        base_settings: ConsoleAPISettings,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pynetappfoundry.clients.console.api.APIWrapper",
+            MagicMock(),
+        )
+        client = ConsoleAPIClient(_make_config(base_settings, tmp_path))
+
+        with pytest.raises(ConsoleServiceTokenMissingError, match="service_token"):
+            client._require_service()
+
+    def test_require_service_returns_wrapper_when_present(
+        self,
+        both_tokens_settings: ConsoleAPISettings,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        wrapper_mock = MagicMock()
+        monkeypatch.setattr(
+            "pynetappfoundry.clients.console.api.APIWrapper",
+            wrapper_mock,
+        )
+        client = ConsoleAPIClient(_make_config(both_tokens_settings, tmp_path))
+
+        assert client._require_service() is client._service
+
+
+class TestHandAuthoredOperations:
+    """v1 hand-authored methods route to `_user` and parse the compact Organization type."""
+
+    def test_get_organization_calls_user_wrapper(
+        self,
+        base_settings: ConsoleAPISettings,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        wrapper_instance = MagicMock()
+        wrapper_instance.call_endpoint.return_value = {
+            "id": "org-abc",
+            "name": "Test Org",
+            "resourceClass": "tenancyv4",
+            "resourceType": "organization",
+        }
+        wrapper_factory = MagicMock(return_value=wrapper_instance)
+        monkeypatch.setattr(
+            "pynetappfoundry.clients.console.api.APIWrapper",
+            wrapper_factory,
+        )
+
+        client = ConsoleAPIClient(_make_config(base_settings, tmp_path))
+        org = client.get_organization("org-abc")
+
+        assert isinstance(org, Organization)
+        assert org.id == "org-abc"
+        assert org.resource_class == "tenancyv4"
+
+        wrapper_instance.call_endpoint.assert_called_once_with(
+            method="GET",
+            path_template="/organizations/{organization_id}",
+            path_params={"organization_id": "org-abc"},
+        )
+
+    def test_list_organizations_parses_items(
+        self,
+        base_settings: ConsoleAPISettings,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        wrapper_instance = MagicMock()
+        wrapper_instance.call_endpoint.return_value = {
+            "items": [
+                {
+                    "id": "org-1",
+                    "name": "Org One",
+                    "resourceClass": "tenancyv4",
+                    "resourceType": "organization",
+                },
+                {
+                    "id": "org-2",
+                    "name": "Org Two",
+                    "resourceClass": "tenancyv4",
+                    "resourceType": "organization",
+                },
+            ],
+            "count": 2,
+        }
+        wrapper_factory = MagicMock(return_value=wrapper_instance)
+        monkeypatch.setattr(
+            "pynetappfoundry.clients.console.api.APIWrapper",
+            wrapper_factory,
+        )
+
+        client = ConsoleAPIClient(_make_config(base_settings, tmp_path))
+        orgs = client.list_organizations()
+
+        assert len(orgs) == 2
+        assert {o.id for o in orgs} == {"org-1", "org-2"}
+
+        wrapper_instance.call_endpoint.assert_called_once_with(
+            method="GET",
+            path_template="/organizations",
+        )
+
+    def test_list_organizations_handles_empty_response(
+        self,
+        base_settings: ConsoleAPISettings,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        wrapper_instance = MagicMock()
+        wrapper_instance.call_endpoint.return_value = {"count": 0}  # no "items" key
+        wrapper_factory = MagicMock(return_value=wrapper_instance)
+        monkeypatch.setattr(
+            "pynetappfoundry.clients.console.api.APIWrapper",
+            wrapper_factory,
+        )
+
+        client = ConsoleAPIClient(_make_config(base_settings, tmp_path))
+        assert client.list_organizations() == []

--- a/tests/unit/console/test_console_facade.py
+++ b/tests/unit/console/test_console_facade.py
@@ -1,0 +1,114 @@
+"""Tests for the org-scoped Console facade (ADR-0019 §1)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pynetappfoundry.console import Console
+from pynetappfoundry.core.models import ConsoleAPISettings
+from pynetappfoundry.models.console.types import Organization
+
+
+def _make_config(settings: ConsoleAPISettings, tmp_path: Any) -> MagicMock:
+    config = MagicMock()
+    config.get_console_api_settings.return_value = settings
+    config.get_schema_location.return_value = tmp_path
+    return config
+
+
+@pytest.fixture
+def settings_with_default_org() -> ConsoleAPISettings:
+    return ConsoleAPISettings(
+        user_token="user-jwt",
+        base_url="https://api.bluexp.netapp.com",
+        base_api_path="/",
+        org_id="org-default",
+    )
+
+
+@pytest.fixture
+def settings_without_org() -> ConsoleAPISettings:
+    return ConsoleAPISettings(
+        user_token="user-jwt",
+        base_url="https://api.bluexp.netapp.com",
+        base_api_path="/",
+    )
+
+
+class TestConsoleOrgBinding:
+    """org_id resolution from constructor argument vs. settings default."""
+
+    def test_constructor_arg_wins_over_settings_default(
+        self,
+        settings_with_default_org: ConsoleAPISettings,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pynetappfoundry.clients.console.api.APIWrapper",
+            MagicMock(),
+        )
+        console = Console(_make_config(settings_with_default_org, tmp_path), org_id="org-explicit")
+        assert console.org_id == "org-explicit"
+
+    def test_settings_default_used_when_no_arg(
+        self,
+        settings_with_default_org: ConsoleAPISettings,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pynetappfoundry.clients.console.api.APIWrapper",
+            MagicMock(),
+        )
+        console = Console(_make_config(settings_with_default_org, tmp_path))
+        assert console.org_id == "org-default"
+
+    def test_raises_when_no_org_id_anywhere(
+        self,
+        settings_without_org: ConsoleAPISettings,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "pynetappfoundry.clients.console.api.APIWrapper",
+            MagicMock(),
+        )
+        with pytest.raises(ValueError, match="org_id"):
+            Console(_make_config(settings_without_org, tmp_path))
+
+
+class TestConsoleDelegatesToClient:
+    """The facade thinly delegates to ConsoleAPIClient with its bound org_id."""
+
+    def test_get_organization_delegates_with_bound_org_id(
+        self,
+        settings_with_default_org: ConsoleAPISettings,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        wrapper_instance = MagicMock()
+        wrapper_instance.call_endpoint.return_value = {
+            "id": "org-default",
+            "name": "Default Org",
+            "resourceClass": "tenancyv4",
+            "resourceType": "organization",
+        }
+        monkeypatch.setattr(
+            "pynetappfoundry.clients.console.api.APIWrapper",
+            MagicMock(return_value=wrapper_instance),
+        )
+
+        console = Console(_make_config(settings_with_default_org, tmp_path))
+        org = console.get_organization()
+
+        assert isinstance(org, Organization)
+        assert org.id == "org-default"
+        wrapper_instance.call_endpoint.assert_called_once_with(
+            method="GET",
+            path_template="/organizations/{organization_id}",
+            path_params={"organization_id": "org-default"},
+        )

--- a/tests/unit/models/console/test_types.py
+++ b/tests/unit/models/console/test_types.py
@@ -1,0 +1,105 @@
+"""Tests for the hand-authored Console types (`models.console.types`).
+
+These types are intentionally *not* generated — they exist so the cache-side
+field types stay stable across codegen runs and the cached JSON stays small.
+"""
+
+from __future__ import annotations
+
+from pynetappfoundry.models.console.tenancyv4.get_organizations import (
+    Resource10GetResponseBody,
+)
+from pynetappfoundry.models.console.types import Organization
+
+
+class TestOrganization:
+    """Round-trip and alias behaviour for the compact Organization model."""
+
+    def test_minimal_fields_parse_from_snake_case(self) -> None:
+        org = Organization.model_validate(
+            {
+                "id": "org-abc",
+                "name": "Test Org",
+                "resource_class": "tenancyv4",
+                "resource_type": "organization",
+            }
+        )
+        assert org.id == "org-abc"
+        assert org.name == "Test Org"
+        assert org.resource_class == "tenancyv4"
+        assert org.resource_type == "organization"
+        assert org.owner_organization_id is None
+        assert org.parent_id is None
+        assert org.description is None
+        assert org.state is None
+
+    def test_minimal_fields_parse_from_camel_case_alias(self) -> None:
+        """populate_by_name=True allows both snake_case and camelCase keys."""
+        org = Organization.model_validate(
+            {
+                "id": "org-abc",
+                "name": "Test Org",
+                "resourceClass": "tenancyv4",
+                "resourceType": "organization",
+                "ownerOrganizationId": "owner-xyz",
+                "parentId": "parent-456",
+            }
+        )
+        assert org.resource_class == "tenancyv4"
+        assert org.resource_type == "organization"
+        assert org.owner_organization_id == "owner-xyz"
+        assert org.parent_id == "parent-456"
+
+    def test_round_trip_with_by_alias(self) -> None:
+        """model_dump(by_alias=True) emits camelCase for cache and wire use."""
+        org = Organization.model_validate(
+            {
+                "id": "org-abc",
+                "name": "Test Org",
+                "resourceClass": "tenancyv4",
+                "resourceType": "organization",
+            }
+        )
+        dumped = org.model_dump(by_alias=True)
+        assert dumped["resourceClass"] == "tenancyv4"
+        assert dumped["resourceType"] == "organization"
+
+        # And it round-trips back through model_validate
+        reparsed = Organization.model_validate(dumped)
+        assert reparsed == org
+
+    def test_from_resource_converts_generated_type(self) -> None:
+        """from_resource() reduces the generated Resource10GetResponseBody."""
+        resource = Resource10GetResponseBody.model_validate(
+            {
+                "id": "org-from-resource",
+                "name": "Generated Org",
+                "resourceClass": "tenancyv4",
+                "resourceType": "organization",
+                "type": "application/vnd.netapp.bxp.resource",
+                "version": "1.0",
+                "ownerOrganizationId": "owner-9",
+                "description": "Pulled from the generator",
+                "state": "active",
+            }
+        )
+        org = Organization.from_resource(resource)
+        assert org.id == "org-from-resource"
+        assert org.name == "Generated Org"
+        assert org.resource_class == "tenancyv4"
+        assert org.resource_type == "organization"
+        assert org.owner_organization_id == "owner-9"
+        assert org.description == "Pulled from the generator"
+        assert org.state == "active"
+
+    def test_required_field_missing_raises(self) -> None:
+        import pydantic
+
+        try:
+            Organization.model_validate(
+                {"id": "org-x", "name": "X"}
+            )  # missing resource_class / resource_type
+        except pydantic.ValidationError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("expected ValidationError for missing required fields")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -8,6 +8,7 @@ import pytest
 
 from pynetappfoundry.core.config import Config, ConfigurationError
 from pynetappfoundry.core.models import (
+    ConsoleAPISettings,
     DIIAPISettings,
     LicensingSettings,
     ONTAPAPISettings,
@@ -635,6 +636,98 @@ key = "value"
             with pytest.raises(ConfigurationError) as exc_info:
                 config.get_dii_api_settings()
             assert "diiapi" in str(exc_info.value) or "Missing configuration" in str(exc_info.value)
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestGetConsoleApiSettings:
+    """Tests for get_console_api_settings accessor method."""
+
+    def test_get_console_api_settings_success(self, temp_config_dir: Path, tmp_path: Path) -> None:
+        """get_console_api_settings returns a populated ConsoleAPISettings."""
+        consoleapi_toml = temp_config_dir / "consoleapi.toml"
+        consoleapi_toml.write_text("""
+[general]
+user_token = "user-jwt"
+service_token = "service-jwt"
+base_url = "https://api.bluexp.netapp.com"
+base_api_path = "/"
+org_id = "org-abc"
+timeout = 15.0
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            result = config.get_console_api_settings()
+            assert isinstance(result, ConsoleAPISettings)
+            assert result.user_token == "user-jwt"
+            assert result.service_token == "service-jwt"
+            assert result.base_url == "https://api.bluexp.netapp.com"
+            assert result.org_id == "org-abc"
+            assert result.timeout == 15.0
+        finally:
+            os.chdir(original_cwd)
+
+    def test_get_console_api_settings_service_token_optional(
+        self, temp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """service_token may be omitted; defaults to None."""
+        consoleapi_toml = temp_config_dir / "consoleapi.toml"
+        consoleapi_toml.write_text("""
+[general]
+user_token = "user-jwt"
+base_url = "https://api.bluexp.netapp.com"
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            result = config.get_console_api_settings()
+            assert result.service_token is None
+            assert result.org_id is None
+        finally:
+            os.chdir(original_cwd)
+
+    def test_get_console_api_settings_missing_raises(
+        self, temp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """get_console_api_settings raises ConfigurationError when not configured."""
+        settings_file = temp_config_dir / "settings.toml"
+        settings_file.write_text("""
+[other]
+key = "value"
+""")
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            output_dir = tmp_path / "output"
+            output_dir.mkdir(exist_ok=True)
+            config = Config(
+                config_dir=str(temp_config_dir),
+                output_dir=str(output_dir),
+                script_name="test_script",
+            )
+            with pytest.raises(ConfigurationError):
+                config.get_console_api_settings()
         finally:
             os.chdir(original_cwd)
 


### PR DESCRIPTION
## Description

Delivers the v1 Console SaaS (BlueXP) runtime client per ADR-0019. Callers can now reach the Console API via an org-scoped `Console` facade; the first concrete consumer stores the organization in `CachedClusterMetadata.console` via a new `consoleinfo` cache table. ADR-0019 is flipped from Proposed to Accepted.

## Related Issue

Addresses #713

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

**New modules:**

- `src/pynetappfoundry/clients/console/` — `ConsoleAPIClient` with two internal `APIWrapper` instances (one per `x-token-type`). `service_token` is optional; missing it when calling a service-typed endpoint raises `ConsoleServiceTokenMissingError`. The `APIWrapper` contract is untouched.
- `src/pynetappfoundry/console/` — `Console(config, org_id=...)` org-scoped facade with `get_organization()` and `list_organizations()`.
- `src/pynetappfoundry/models/console/types.py` — hand-authored `Organization` Pydantic model (compact; not a re-export of the generated `Resource10GetResponseBody`).

**Modified source:**

- `src/pynetappfoundry/cache/_metadata.py` — new top-level `CachedClusterMetadata.console: ConsoleInfo` field mirroring the `NetworkInfo`/`StorageInfo` pattern.
- `src/pynetappfoundry/cache/_lazy.py` — lazy-loading support for `console`.
- `src/pynetappfoundry/cache/db.py` — schema v5 → v6; new `consoleinfo` table created idempotently via `_upgrade_to_v6()`. Existing v4→v5 and v2→v3 migration tests updated to assert against `ClusterMetadataDB.SCHEMA_VERSION` (not a hard-coded `5`) so they survive future version bumps.
- `src/pynetappfoundry/core/config.py` — `get_console_api_settings()` accessor.
- `src/pynetappfoundry/core/models.py` — `ConsoleAPISettings` Pydantic model.

**Documentation:**

- `docs/decisions/0019-...md` — status flipped Proposed → Accepted; implementation references updated.
- `docs/decisions/README.md` — index row updated to Accepted.
- `docs/example-config/apis/console/consoleapi.toml` — new example config file.
- `docs/example-config/apis/console/notes.txt` — setup and quick-start instructions.
- `docs/reference/config-schema.md` — added `consoleapi.toml` section (fields, defaults, description) and updated the directory structure overview.

**Out of scope (ADR-0019 and plan):**

- OAuth refresh-token flow — v1 static tokens only.
- `ClusterEntry.console` accessor — no concrete per-cluster consumer yet.
- Other cluster-scoped Console fields (subscription / folder / project / connector).
- Generated typed client surface — hand-authored at v1; codegen when >~10 endpoints.
- Console parser v2 / agentsMgmt.

## Testing

- [ ] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

**New tests (22 total across 5 files):**

| File | Count | Covers |
|------|-------|--------|
| `tests/unit/models/console/test_types.py` | 5 | `Organization` model parsing, field defaults, round-trip |
| `tests/unit/clients/console/` | 7 | `ConsoleAPIClient` construction, `get_organization`, `list_organizations`, missing service token error |
| `tests/unit/console/` | 4 | `Console` facade, org_id override, config delegation |
| `tests/unit/test_config.py` | 3 | `get_console_api_settings()` accessor |
| `tests/unit/cache/test_db.py` | 1 new + 2 updated | v5→v6 migration, updated v4→v5 and v2→v3 tests to use `SCHEMA_VERSION` constant |

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

ADR-0019 documents the two key architectural choices made here:

1. **Org-scoped primary access** — `Console(config, org_id=...)` is the entry point, not `ClusterEntry.console`. Console SaaS's natural domain is the organization; forcing per-cluster shape would cause category mismatch (one subscription per org, not per cluster).

2. **Two-wrapper isolation** — `ConsoleAPIClient` holds two private `APIWrapper` instances, one per `x-token-type` (`user` / `service`). This keeps the `APIWrapper` contract untouched and prevents the "wrong token type" footgun by design. The plausible alternative (one wrapper with per-call header swap) would have propagated a contract change to all existing clients (DII, ONTAP, AIQUM).

Cache migration note: the `consoleinfo` table is created idempotently. Existing databases at v5 are migrated forward; downgrade is unsupported per ADR-0018.
