### PR TITLE
chore: add doit audit_legacy task to surface non-DataSource call sites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,7 @@ The tool hierarchy (prefer higher over lower):
 | Format code | `doit format` | `ruff format` directly |
 | Type-check | `doit type_check` | `mypy` directly |
 | Security audit | `doit audit` | `pip-audit` directly |
+| Audit legacy data-access patterns | `doit audit_legacy` | manual grep |
 | Create issues | `doit issue --type=<type>` | `gh issue create` |
 | Create PRs | `doit pr` | `gh pr create` |
 | Merge PRs | `doit pr_merge` | `gh pr merge` |

--- a/tests/template/test_doit_audit_legacy.py
+++ b/tests/template/test_doit_audit_legacy.py
@@ -1,0 +1,519 @@
+"""Tests for tools/doit/audit_legacy.py.
+
+Covers:
+- Pattern detection on synthetic files (A-E)
+- Comment-line guard (B/C/D)
+- Multi-line paren-balanced config= suppression (C/D)
+- Allowlist behaviour and path normalisation
+- Output / flag semantics (_run_audit, render_json, task_audit_legacy)
+- Live-tree regression anchor (scan_tree(_SRC_ROOT))
+
+Tests call the module functions directly — no subprocess.
+Match style of tests/template/test_doit_quality.py.
+"""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from tools.doit.audit_legacy import (
+    _ALLOWLIST,
+    _PATTERNS,
+    _SRC_ROOT,
+    LegacyMatch,
+    _has_config_within_call,
+    _run_audit,
+    render_json,
+    scan_file,
+    scan_tree,
+    task_audit_legacy,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, rel: str, content: str) -> Path:
+    """Write *content* to *tmp_path*/*rel* and return the absolute Path."""
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+# ---------------------------------------------------------------------------
+# _has_config_within_call
+# ---------------------------------------------------------------------------
+
+
+class TestHasConfigWithinCall:
+    """Unit tests for the paren-balanced config= forward-window."""
+
+    def test_single_line_with_config(self) -> None:
+        lines = ["    client = ONTAPAPIClient(cluster=x, config=c)"]
+        assert _has_config_within_call(lines, 0) is True
+
+    def test_single_line_without_config(self) -> None:
+        lines = ["    client = ONTAPAPIClient(cluster=x)"]
+        assert _has_config_within_call(lines, 0) is False
+
+    def test_multi_line_config_on_later_line(self) -> None:
+        lines = [
+            "    client = ONTAPAPIClient(",
+            "        cluster=x,",
+            "        config=cfg,",
+            "    )",
+        ]
+        assert _has_config_within_call(lines, 0) is True
+
+    def test_multi_line_without_config(self) -> None:
+        lines = [
+            "    client = ONTAPAPIClient(",
+            "        cluster=x,",
+            "    )",
+        ]
+        assert _has_config_within_call(lines, 0) is False
+
+    def test_nested_parens_with_config(self) -> None:
+        lines = [
+            "    client = ONTAPAPIClient(",
+            "        cluster=Cluster(ip),",
+            "        config=cfg,",
+            "    )",
+        ]
+        assert _has_config_within_call(lines, 0) is True
+
+    def test_config_after_close_not_matched(self) -> None:
+        lines = [
+            "    client = ONTAPAPIClient(cluster=x)",
+            "    config = something",
+        ]
+        # config= appears after the call closes — must return False
+        assert _has_config_within_call(lines, 0) is False
+
+
+# ---------------------------------------------------------------------------
+# Pattern A — Legacy SDK import
+# ---------------------------------------------------------------------------
+
+
+class TestPatternA:
+    """Pattern A: from/import netapp_ontap at top-level or indented."""
+
+    def test_top_level_from_import(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "foo.py", "from netapp_ontap.x import Y\n")
+        matches = scan_file(p)
+        assert len(matches) == 1
+        assert matches[0].pattern == "A"
+        assert matches[0].line == 1
+
+    def test_top_level_bare_import(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "foo.py", "import netapp_ontap.error\n")
+        matches = scan_file(p)
+        assert len(matches) == 1
+        assert matches[0].pattern == "A"
+
+    def test_indented_from_import_matches(self, tmp_path: Path) -> None:
+        """Indented imports (inside functions) must still be detected."""
+        content = "def f():\n    from netapp_ontap import X\n"
+        p = _write(tmp_path, "foo.py", content)
+        matches = scan_file(p)
+        assert len(matches) == 1
+        assert matches[0].pattern == "A"
+        assert matches[0].line == 2
+
+    def test_non_netapp_import_not_matched(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "foo.py", "from netapp_other import X\n")
+        matches = scan_file(p)
+        assert matches == []
+
+
+# ---------------------------------------------------------------------------
+# Pattern B — HostConnection( call
+# ---------------------------------------------------------------------------
+
+
+class TestPatternB:
+    """Pattern B: HostConnection( with comment-line guard."""
+
+    def test_detected(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "foo.py", "    with HostConnection(\n")
+        matches = scan_file(p)
+        pat_b = [m for m in matches if m.pattern == "B"]
+        assert len(pat_b) == 1
+        assert pat_b[0].line == 1
+
+    def test_comment_line_suppressed(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "foo.py", "    # HostConnection(host, user)\n")
+        matches = scan_file(p)
+        pat_b = [m for m in matches if m.pattern == "B"]
+        assert pat_b == []
+
+    def test_no_paren_not_matched(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "foo.py", "    conn = HostConnection\n")
+        matches = scan_file(p)
+        pat_b = [m for m in matches if m.pattern == "B"]
+        assert pat_b == []
+
+
+# ---------------------------------------------------------------------------
+# Pattern C — ONTAPAPIClient( without config=
+# ---------------------------------------------------------------------------
+
+
+class TestPatternC:
+    """Pattern C: ONTAPAPIClient( with config= suppression."""
+
+    def test_single_line_with_config_suppressed(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "foo.py", "    c = ONTAPAPIClient(cluster=x, config=cfg)\n")
+        matches = scan_file(p)
+        pat_c = [m for m in matches if m.pattern == "C"]
+        assert pat_c == []
+
+    def test_multi_line_with_config_suppressed(self, tmp_path: Path) -> None:
+        content = "    c = ONTAPAPIClient(\n        cluster=x,\n        config=cfg,\n    )\n"
+        p = _write(tmp_path, "foo.py", content)
+        matches = scan_file(p)
+        pat_c = [m for m in matches if m.pattern == "C"]
+        assert pat_c == []
+
+    def test_single_line_without_config_flagged(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "foo.py", "    c = ONTAPAPIClient(cluster=x)\n")
+        matches = scan_file(p)
+        pat_c = [m for m in matches if m.pattern == "C"]
+        assert len(pat_c) == 1
+        assert pat_c[0].line == 1
+
+    def test_comment_line_suppressed(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "foo.py", "    # ONTAPAPIClient(cluster=x)\n")
+        matches = scan_file(p)
+        pat_c = [m for m in matches if m.pattern == "C"]
+        assert pat_c == []
+
+    def test_real_inspect_multi_line_pattern(self, tmp_path: Path) -> None:
+        """Reproduces inspect.py:332 multi-line call — must be suppressed."""
+        content = (
+            "    api_client = ONTAPAPIClient(\n"
+            "        cluster=_ClusterObj(cluster, ip),\n"
+            "        config=config,\n"
+            "    )\n"
+        )
+        p = _write(tmp_path, "foo.py", content)
+        matches = scan_file(p)
+        pat_c = [m for m in matches if m.pattern == "C"]
+        assert pat_c == []
+
+    def test_class_definition_not_flagged(self, tmp_path: Path) -> None:
+        """`class ONTAPAPIClient(APIWrapper):` is a declaration, not a call."""
+        p = _write(tmp_path, "foo.py", "class ONTAPAPIClient(APIWrapper):\n    pass\n")
+        matches = scan_file(p)
+        assert [m for m in matches if m.pattern == "C"] == []
+
+    def test_subclass_of_target_not_flagged(self, tmp_path: Path) -> None:
+        """`class Foo(QuerySet):` is a subclass declaration, not a constructor call."""
+        p = _write(tmp_path, "foo.py", "class Foo(QuerySet):\n    pass\n")
+        matches = scan_file(p)
+        assert [m for m in matches if m.pattern == "D"] == []
+
+
+# ---------------------------------------------------------------------------
+# Pattern D — QuerySet( without config=
+# ---------------------------------------------------------------------------
+
+
+class TestPatternD:
+    """Pattern D: QuerySet( with config= suppression — mirrors C tests."""
+
+    def test_single_line_with_config_suppressed(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "foo.py", "    qs = QuerySet(Model, client, config=cfg)\n")
+        matches = scan_file(p)
+        pat_d = [m for m in matches if m.pattern == "D"]
+        assert pat_d == []
+
+    def test_multi_line_with_config_suppressed(self, tmp_path: Path) -> None:
+        content = (
+            "    qs = QuerySet(\n        Model,\n        client,\n        config=cfg,\n    )\n"
+        )
+        p = _write(tmp_path, "foo.py", content)
+        matches = scan_file(p)
+        pat_d = [m for m in matches if m.pattern == "D"]
+        assert pat_d == []
+
+    def test_single_line_without_config_flagged(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "foo.py", "    qs = QuerySet(Model, client)\n")
+        matches = scan_file(p)
+        pat_d = [m for m in matches if m.pattern == "D"]
+        assert len(pat_d) == 1
+
+    def test_comment_line_suppressed(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "foo.py", "    # QuerySet(Model, client)\n")
+        matches = scan_file(p)
+        pat_d = [m for m in matches if m.pattern == "D"]
+        assert pat_d == []
+
+
+# ---------------------------------------------------------------------------
+# Pattern E — Legacy cache fetch in CLI
+# ---------------------------------------------------------------------------
+
+
+class TestPatternE:
+    """Pattern E: only fires under cli/ subtree."""
+
+    def test_detected_under_cli(self, tmp_path: Path) -> None:
+        """Pattern E fires when the file is under cli/."""
+        # scan_file uses the path to derive rel; we need to place it under
+        # a parent that looks like _SRC_ROOT / cli/
+        src = tmp_path / "pynetappfoundry"
+        p = _write(src, "cli/commands/foo.py", "from pynetappfoundry.cache import fetch\n")
+        # Temporarily patch _SRC_ROOT so scan_file resolves the rel path correctly
+        with patch("tools.doit.audit_legacy._SRC_ROOT", src):
+            matches = scan_file(p)
+        pat_e = [m for m in matches if m.pattern == "E"]
+        assert len(pat_e) == 1
+
+    def test_not_detected_outside_cli(self, tmp_path: Path) -> None:
+        """Pattern E must NOT fire outside cli/."""
+        src = tmp_path / "pynetappfoundry"
+        p = _write(src, "data/foo.py", "from pynetappfoundry.cache import fetch\n")
+        with patch("tools.doit.audit_legacy._SRC_ROOT", src):
+            matches = scan_file(p)
+        pat_e = [m for m in matches if m.pattern == "E"]
+        assert pat_e == []
+
+
+# ---------------------------------------------------------------------------
+# Allowlist behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlist:
+    """scan_tree splits hits into candidates vs legitimate by allowlist."""
+
+    def test_allowlisted_file_in_legitimate(self, tmp_path: Path) -> None:
+        src = tmp_path / "pynetappfoundry"
+        # Use a path that IS in the allowlist
+        _write(src, "clients/ontap/cli.py", "from netapp_ontap import HostConnection\n")
+        with patch("tools.doit.audit_legacy._SRC_ROOT", src):
+            candidates, legitimate = scan_tree(src)
+        assert any(m.file == "clients/ontap/cli.py" for m in legitimate)
+        assert not any(m.file == "clients/ontap/cli.py" for m in candidates)
+
+    def test_non_allowlisted_file_in_candidates(self, tmp_path: Path) -> None:
+        src = tmp_path / "pynetappfoundry"
+        _write(src, "cli/commands/events/get.py", "from netapp_ontap.x import Y\n")
+        with patch("tools.doit.audit_legacy._SRC_ROOT", src):
+            candidates, _ = scan_tree(src)
+        assert any(m.file == "cli/commands/events/get.py" for m in candidates)
+
+    def test_allowlist_path_normalisation(self, tmp_path: Path) -> None:
+        """Paths must be posix-form relative to _SRC_ROOT in the returned matches."""
+        src = tmp_path / "pynetappfoundry"
+        _write(src, "cli/commands/events/get.py", "from netapp_ontap.x import Y\n")
+        with patch("tools.doit.audit_legacy._SRC_ROOT", src):
+            candidates, _ = scan_tree(src)
+        # All file fields must be posix-relative strings (no abs path, no backslash)
+        for m in candidates:
+            assert not m.file.startswith("/"), f"Absolute path leaked: {m.file}"
+            assert "\\" not in m.file, f"Backslash in path: {m.file}"
+
+
+# ---------------------------------------------------------------------------
+# _run_audit return-value semantics
+# ---------------------------------------------------------------------------
+
+
+class TestRunAudit:
+    """_run_audit return-value and strict-mode semantics."""
+
+    def _make_matches(self) -> list[LegacyMatch]:
+        return [LegacyMatch(file="x.py", line=1, pattern="A", match="from netapp_ontap...")]
+
+    def test_strict_false_always_returns_true(self) -> None:
+        with (
+            patch("tools.doit.audit_legacy.scan_tree") as mock_scan,
+            patch("tools.doit.audit_legacy.render_table"),
+        ):
+            mock_scan.return_value = (self._make_matches(), [])
+            result = _run_audit(strict=False, json_output=False)
+        assert result is True
+
+    def test_strict_true_with_candidates_returns_false(self) -> None:
+        with (
+            patch("tools.doit.audit_legacy.scan_tree") as mock_scan,
+            patch("tools.doit.audit_legacy.render_table"),
+        ):
+            mock_scan.return_value = (self._make_matches(), [])
+            result = _run_audit(strict=True, json_output=False)
+        assert result is False
+
+    def test_strict_true_no_candidates_returns_true(self) -> None:
+        with (
+            patch("tools.doit.audit_legacy.scan_tree") as mock_scan,
+            patch("tools.doit.audit_legacy.render_table"),
+        ):
+            mock_scan.return_value = ([], [])
+            result = _run_audit(strict=True, json_output=False)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# render_json schema
+# ---------------------------------------------------------------------------
+
+
+class TestRenderJson:
+    """render_json must emit valid JSON with the documented schema."""
+
+    def _run_render(
+        self,
+        candidates: list[LegacyMatch],
+        legitimate: list[LegacyMatch],
+        strict: bool = False,
+    ) -> dict[str, Any]:
+        buf = StringIO()
+        with patch("builtins.print", side_effect=lambda s: buf.write(s + "\n")):
+            render_json(candidates, legitimate, strict)
+        return json.loads(buf.getvalue())
+
+    def test_top_level_keys(self) -> None:
+        data = self._run_render([], [])
+        assert "schema_version" in data
+        assert "strict" in data
+        assert "candidates" in data
+        assert "legitimate" in data
+        assert "summary" in data
+
+    def test_schema_version_is_1(self) -> None:
+        data = self._run_render([], [])
+        assert data["schema_version"] == 1
+
+    def test_strict_flag_reflected(self) -> None:
+        assert self._run_render([], [], strict=True)["strict"] is True
+        assert self._run_render([], [], strict=False)["strict"] is False
+
+    def test_summary_counts_correct(self) -> None:
+        c = [LegacyMatch("a.py", 1, "A", "x"), LegacyMatch("b.py", 2, "B", "y")]
+        leg = [LegacyMatch("c.py", 3, "A", "z")]
+        summary = self._run_render(c, leg)["summary"]
+        assert summary["candidate_count"] == 2
+        assert summary["legitimate_count"] == 1
+        assert summary["allowlist_count"] == len(_ALLOWLIST)
+
+    def test_summary_patterns_has_all_ids(self) -> None:
+        patterns = self._run_render([], [])["summary"]["patterns"]
+        expected_ids = {pid for pid, _, _ in _PATTERNS}
+        assert set(patterns.keys()) == expected_ids
+
+    def test_pattern_counts_in_summary(self) -> None:
+        c = [
+            LegacyMatch("a.py", 1, "A", "x"),
+            LegacyMatch("b.py", 2, "A", "y"),
+            LegacyMatch("c.py", 3, "B", "z"),
+        ]
+        patterns = self._run_render(c, [])["summary"]["patterns"]
+        assert patterns["A"] == 2
+        assert patterns["B"] == 1
+        assert patterns["C"] == 0
+
+
+# ---------------------------------------------------------------------------
+# task_audit_legacy structure
+# ---------------------------------------------------------------------------
+
+
+class TestTaskAuditLegacy:
+    """task_audit_legacy must return the expected doit task dict shape."""
+
+    def test_has_required_keys(self) -> None:
+        task = task_audit_legacy()
+        assert "actions" in task
+        assert "params" in task
+        assert "verbosity" in task
+
+    def test_params_has_strict_flag(self) -> None:
+        params = task_audit_legacy()["params"]
+        names = [p["name"] for p in params]
+        assert "strict" in names
+
+    def test_params_has_json_flag(self) -> None:
+        params = task_audit_legacy()["params"]
+        names = [p["name"] for p in params]
+        assert "json_output" in names
+
+    def test_params_strict_uses_long_flag(self) -> None:
+        params = task_audit_legacy()["params"]
+        strict_param = next(p for p in params if p["name"] == "strict")
+        assert strict_param["long"] == "strict"
+        assert strict_param["type"] is bool
+        assert strict_param["default"] is False
+
+    def test_params_json_uses_long_flag(self) -> None:
+        params = task_audit_legacy()["params"]
+        json_param = next(p for p in params if p["name"] == "json_output")
+        assert json_param["long"] == "json"
+        assert json_param["type"] is bool
+        assert json_param["default"] is False
+
+
+# ---------------------------------------------------------------------------
+# Live-tree regression anchor
+# ---------------------------------------------------------------------------
+
+
+class TestLiveTreeRegression:
+    """Regression anchor: scan_tree(_SRC_ROOT) must match manual ground truth.
+
+    Ground truth from #741 / #742:
+    - cli/commands/events/get.py lines 10, 11, 146     (A, A, B)
+    - cli/commands/events/azevents.py lines 263, 264, 265, 277  (A, A, A, B)
+    Total: 7 candidate match lines, all under cli/commands/events/.
+
+    If a future migration PR removes these files, this test will fail
+    intentionally — update the expected count after verifying the migration.
+    """
+
+    def test_exactly_7_candidates(self) -> None:
+        candidates, _ = scan_tree(_SRC_ROOT)
+        assert len(candidates) == 7, (
+            f"Expected 7 candidates, got {len(candidates)}. "
+            f"Candidates: {[(m.file, m.line, m.pattern) for m in candidates]}"
+        )
+
+    def test_all_candidates_under_events(self) -> None:
+        candidates, _ = scan_tree(_SRC_ROOT)
+        for m in candidates:
+            assert m.file.startswith("cli/commands/events/"), (
+                f"Unexpected candidate outside events/: {m.file}:{m.line}"
+            )
+
+    def test_exactly_3_legitimate_hits(self) -> None:
+        """clients/ontap/cli.py has 2 pattern-A imports (lines 13, 14) and 1
+        pattern-B HostConnection( call (line 437). The class definition at
+        clients/ontap/api.py:20 is excluded by the class-line guard."""
+        _, legitimate = scan_tree(_SRC_ROOT)
+        assert len(legitimate) == 3, (
+            f"Expected 3 legitimate hits, got {len(legitimate)}: "
+            f"{[(m.file, m.line, m.pattern) for m in legitimate]}"
+        )
+
+    def test_pattern_a_count_is_5(self) -> None:
+        candidates, _ = scan_tree(_SRC_ROOT)
+        a_count = sum(1 for m in candidates if m.pattern == "A")
+        assert a_count == 5, f"Expected 5 pattern-A candidates, got {a_count}"
+
+    def test_pattern_b_count_is_2(self) -> None:
+        candidates, _ = scan_tree(_SRC_ROOT)
+        b_count = sum(1 for m in candidates if m.pattern == "B")
+        assert b_count == 2, f"Expected 2 pattern-B candidates, got {b_count}"
+
+    def test_patterns_c_d_e_are_zero(self) -> None:
+        candidates, _ = scan_tree(_SRC_ROOT)
+        for pid in ("C", "D", "E"):
+            count = sum(1 for m in candidates if m.pattern == pid)
+            assert count == 0, f"Expected 0 pattern-{pid} candidates, got {count}"

--- a/tools/doit/audit_legacy.py
+++ b/tools/doit/audit_legacy.py
@@ -1,0 +1,364 @@
+"""Audit src/pynetappfoundry/ for legacy netapp_ontap / HostConnection call sites.
+
+Scans for five pattern categories and classifies each hit as either a
+``candidate`` (must be migrated) or ``legitimate`` (file is in the allowlist).
+
+Usage::
+
+    doit audit_legacy           # print Rich table (informational)
+    doit audit_legacy --strict  # non-zero exit when any candidate exists
+    doit audit_legacy --json    # machine-readable JSON
+
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_SRC_ROOT = _PROJECT_ROOT / "src" / "pynetappfoundry"
+
+# Files whose legacy hits are known-intentional.  Paths are posix-form
+# relative to _SRC_ROOT (e.g. "clients/ontap/cli.py").
+_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "cli/commands/cache/refresh.py",
+        "cli/commands/cache/inspect.py",
+        "cli/commands/utils/run_cmd.py",
+        "cli/commands/utils/validate.py",
+        "clients/ontap/api.py",
+        "clients/ontap/cli.py",
+        "query/queryset.py",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Pattern catalogue
+# (id, label, compiled regex)
+# ---------------------------------------------------------------------------
+
+_PATTERNS: list[tuple[str, str, re.Pattern[str]]] = [
+    (
+        "A",
+        "Legacy SDK import",
+        re.compile(r"(?:from netapp_ontap\b|import netapp_ontap\b)"),
+    ),
+    (
+        "B",
+        "HostConnection( call",
+        re.compile(r"\bHostConnection\s*\("),
+    ),
+    (
+        "C",
+        "ONTAPAPIClient( without config=",
+        re.compile(r"\bONTAPAPIClient\s*\("),
+    ),
+    (
+        "D",
+        "QuerySet( without config=",
+        re.compile(r"\bQuerySet\s*\("),
+    ),
+    (
+        "E",
+        "Legacy cache fetch in CLI",
+        re.compile(r"^from pynetappfoundry\.cache\s+import\s+\bfetch\b"),
+    ),
+]
+
+# IDs where the comment-line guard applies (first non-whitespace char is '#')
+_COMMENT_GUARDED = frozenset({"B", "C", "D"})
+
+# IDs where the forward-window config= check applies
+_CONFIG_GUARDED = frozenset({"C", "D"})
+
+# IDs that are restricted to the cli/ subtree
+_CLI_ONLY = frozenset({"E"})
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LegacyMatch:
+    """A single regex hit from the source scan."""
+
+    file: str  # posix-form path relative to _SRC_ROOT
+    line: int  # 1-based
+    pattern: str  # pattern ID ("A" … "E")
+    match: str  # the matched line text (stripped)
+
+
+# ---------------------------------------------------------------------------
+# Multi-line paren-balanced config= checker
+# ---------------------------------------------------------------------------
+
+
+def _has_config_within_call(lines: list[str], start_idx: int) -> bool:
+    """Return True if ``config=`` appears inside the call starting at *start_idx*.
+
+    Walks forward from *start_idx* line by line, counting ``(`` and ``)`` to
+    track paren depth.  For each line, if ``config=`` appears on the line AND
+    the depth is > 0 at any point on that line, return True.  Return False once
+    depth reaches 0 (end of call) without having found ``config=``.
+
+    Parameters
+    ----------
+    lines:
+        All lines of the file (0-indexed list, already split).
+    start_idx:
+        0-based index of the line containing the opening ``(``.
+    """
+    depth = 0
+    for i in range(start_idx, len(lines)):
+        text = lines[i]
+        # Check config= presence on this line before draining depth to 0.
+        # We scan character-by-character but track whether config= was seen
+        # while still inside the call.
+        line_had_open = False
+        for ch in text:
+            if ch == "(":
+                depth += 1
+                line_had_open = True
+            elif ch == ")":
+                if depth > 0:
+                    depth -= 1
+                if depth == 0 and (line_had_open or i > start_idx):
+                    # Call closed on this line — check if config= was on it
+                    return bool(re.search(r"\bconfig\s*=", text))
+        # Line did not close the call — check for config= while still open
+        if depth > 0 and re.search(r"\bconfig\s*=", text):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Core scanning
+# ---------------------------------------------------------------------------
+
+
+def scan_file(path: Path) -> list[LegacyMatch]:
+    """Scan *path* for legacy patterns.  Returns a list of :class:`LegacyMatch`.
+
+    Pure function — only I/O is ``path.read_text()``.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    lines = text.splitlines()
+    # posix path relative to _SRC_ROOT for allowlist checks
+    try:
+        rel = path.relative_to(_SRC_ROOT).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+
+    # cli/ sub-tree flag (needed for pattern E)
+    is_cli = rel.startswith("cli/")
+
+    results: list[LegacyMatch] = []
+
+    for idx, raw_line in enumerate(lines):
+        line_no = idx + 1
+
+        for pat_id, _, regex in _PATTERNS:
+            # Pattern E only applies under cli/
+            if pat_id in _CLI_ONLY and not is_cli:
+                continue
+
+            # Comment-line and class-definition guard for B/C/D.
+            # Class definitions (e.g. `class ONTAPAPIClient(APIWrapper):` or
+            # subclass declarations like `class Foo(QuerySet):`) are not
+            # constructor calls and should not be flagged.
+            if pat_id in _COMMENT_GUARDED:
+                stripped = raw_line.lstrip()
+                if stripped.startswith("#") or stripped.startswith("class "):
+                    continue
+
+            if not regex.search(raw_line):
+                continue
+
+            # Forward-window config= suppression for C/D
+            if pat_id in _CONFIG_GUARDED and _has_config_within_call(lines, idx):
+                continue
+
+            results.append(
+                LegacyMatch(
+                    file=rel,
+                    line=line_no,
+                    pattern=pat_id,
+                    match=raw_line.strip(),
+                )
+            )
+
+    return results
+
+
+def scan_tree(root: Path) -> tuple[list[LegacyMatch], list[LegacyMatch]]:
+    """Recursively scan *root* and split hits into (candidates, legitimate).
+
+    A hit is *legitimate* when its file path (posix-form relative to
+    ``_SRC_ROOT``) is in :data:`_ALLOWLIST`.  Otherwise it is a *candidate*.
+    """
+    candidates: list[LegacyMatch] = []
+    legitimate: list[LegacyMatch] = []
+
+    for py_file in sorted(root.rglob("*.py")):
+        if "__pycache__" in py_file.parts:
+            continue
+
+        for match in scan_file(py_file):
+            # Normalise path for allowlist lookup — must be posix-form
+            # relative to _SRC_ROOT regardless of how scan_file produced it.
+            try:
+                norm = py_file.relative_to(_SRC_ROOT).as_posix()
+            except ValueError:
+                norm = match.file
+
+            if norm in _ALLOWLIST:
+                legitimate.append(match)
+            else:
+                candidates.append(match)
+
+    return candidates, legitimate
+
+
+# ---------------------------------------------------------------------------
+# Output renderers
+# ---------------------------------------------------------------------------
+
+
+def render_table(
+    candidates: list[LegacyMatch],
+    legitimate: list[LegacyMatch],
+    console: Console,
+) -> None:
+    """Print a Rich table summarising audit results to *console*."""
+    table = Table(title="Legacy Pattern Audit", show_lines=True)
+    table.add_column("Status", style="bold", width=12)
+    table.add_column("File", style="cyan")
+    table.add_column("Line", justify="right", width=6)
+    table.add_column("Pat", width=4)
+    table.add_column("Match")
+
+    for m in sorted(candidates, key=lambda x: (x.file, x.line)):
+        table.add_row("[red]CANDIDATE[/red]", m.file, str(m.line), m.pattern, m.match)
+
+    for m in sorted(legitimate, key=lambda x: (x.file, x.line)):
+        table.add_row("[green]OK[/green]", m.file, str(m.line), m.pattern, m.match)
+
+    console.print()
+    console.print(table)
+    console.print()
+
+    if candidates:
+        console.print(
+            f"[bold red]CANDIDATES:[/bold red] {len(candidates)} non-allowlisted "
+            f"legacy hit(s) across "
+            f"{len({m.file for m in candidates})} file(s)."
+        )
+    else:
+        console.print("[bold green]No non-allowlisted legacy hits found.[/bold green]")
+    console.print()
+
+
+def render_json(
+    candidates: list[LegacyMatch],
+    legitimate: list[LegacyMatch],
+    strict: bool,
+) -> None:
+    """Emit machine-readable JSON to stdout."""
+    # Count per-pattern
+    pattern_counts: dict[str, int] = {pid: 0 for pid, _, _ in _PATTERNS}
+    for m in candidates:
+        pattern_counts[m.pattern] = pattern_counts.get(m.pattern, 0) + 1
+
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "strict": strict,
+        "candidates": [
+            {"file": m.file, "line": m.line, "pattern": m.pattern, "match": m.match}
+            for m in sorted(candidates, key=lambda x: (x.file, x.line))
+        ],
+        "legitimate": [
+            {"file": m.file, "line": m.line, "pattern": m.pattern, "match": m.match}
+            for m in sorted(legitimate, key=lambda x: (x.file, x.line))
+        ],
+        "summary": {
+            "candidate_count": len(candidates),
+            "legitimate_count": len(legitimate),
+            "allowlist_count": len(_ALLOWLIST),
+            "patterns": pattern_counts,
+        },
+    }
+    print(json.dumps(payload, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Task action
+# ---------------------------------------------------------------------------
+
+
+def _run_audit(strict: bool = False, json_output: bool = False) -> bool:
+    """Scan the source tree and report legacy hits.
+
+    Parameters
+    ----------
+    strict:
+        Return ``False`` (non-zero exit) when any candidate is found.
+    json_output:
+        Emit JSON to stdout instead of the Rich table.
+
+    Returns
+    -------
+    bool
+        ``True`` on success (strict=False always; strict=True only when no
+        candidates).
+    """
+    candidates, legitimate = scan_tree(_SRC_ROOT)
+
+    if json_output:
+        render_json(candidates, legitimate, strict)
+    else:
+        console = Console(file=sys.stdout)
+        render_table(candidates, legitimate, console)
+
+    return not (strict and bool(candidates))
+
+
+def task_audit_legacy() -> dict[str, Any]:
+    """Scan source tree for legacy netapp_ontap / HostConnection call sites."""
+    return {
+        "actions": [_run_audit],
+        "params": [
+            {
+                "name": "strict",
+                "long": "strict",
+                "type": bool,
+                "default": False,
+                "help": "Exit non-zero if any non-allowlisted candidate is found",
+            },
+            {
+                "name": "json_output",
+                "long": "json",
+                "type": bool,
+                "default": False,
+                "help": "Emit machine-readable JSON instead of the Rich table",
+            },
+        ],
+        "verbosity": 2,
+    }


### PR DESCRIPTION
## Description

Adds a `doit audit_legacy` task that scans `src/pynetappfoundry/` for five legacy-pattern signatures (legacy `netapp_ontap` SDK imports, raw `HostConnection(` construction, raw client/queryset construction missing `config=`, and the pre-DataSource `cache.fetch` import in CLI). Each hit is categorized as a migration `candidate` or `legitimate` (in an in-source allowlist). Output is a Rich table by default; `--json` produces machine-readable output and `--strict` exits non-zero when any non-allowlisted candidate is found.

## Related Issue

Addresses #744

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `tools/doit/audit_legacy.py` (NEW, ~365 lines) — auto-discovered `doit` task
  - **Pattern A** — `from netapp_ontap` / `import netapp_ontap` (legacy SDK)
  - **Pattern B** — `HostConnection(` call (legacy SDK auth)
  - **Pattern C** — `ONTAPAPIClient(` without `config=` (paren-balanced forward-window check handles multi-line calls)
  - **Pattern D** — `QuerySet(` without `config=` (same multi-line guard)
  - **Pattern E** — `from pynetappfoundry.cache import fetch` in `cli/` (pre-DataSource bypass)
  - Comment-line guard (`#`) and class-definition guard (`class `) suppress false positives in B/C/D
  - In-source `_ALLOWLIST` (7 paths) for files that legitimately need direct client access
  - `--strict` flag exits non-zero on any non-allowlisted candidate
  - `--json` flag emits a documented schema (`schema_version: 1`, `strict`, `candidates`, `legitimate`, `summary`)
- `tests/template/test_doit_audit_legacy.py` (NEW, ~480 lines) — 49 tests
  - Per-pattern positive/negative detection on synthetic files
  - Comment-line and class-definition suppression for B/C/D
  - Multi-line paren-balanced `config=` suppression for C/D (including a real-world reproduction of `cli/commands/cache/inspect.py:332`)
  - Allowlist behavior + posix-path normalization
  - `--strict` / `--json` semantics and schema validation
  - Live-tree regression anchor: asserts exactly 7 candidates / 3 legitimate hits against the current tree (matches the manual ground truth from #741 / #742)
- `AGENTS.md` — one row added to the "Tool Reference" table

## Testing

- [x] All existing tests pass (`doit check` passes clean)
- [x] Added new tests for new functionality (49 tests)
- [x] Manually tested `doit audit_legacy`, `--json`, `--strict`, and `doit help audit_legacy`

## Manual Verification

```
$ doit audit_legacy --json | jq '.summary'
{
  "candidate_count": 7,
  "legitimate_count": 3,
  "allowlist_count": 7,
  "patterns": {"A": 5, "B": 2, "C": 0, "D": 0, "E": 0}
}

$ doit audit_legacy --strict; echo "exit=$?"
... 7 candidates listed under cli/commands/events/ ...
exit=1
```

The 7 candidates are the legacy `from netapp_ontap` imports and `HostConnection(` calls in `cli/commands/events/get.py` and `azevents.py` — the manual ground truth from #741 / #742. Patterns C/D/E currently yield zero candidates (Phase 4 made `config=` required; the legacy `cache.fetch` import doesn't exist anywhere). They are included for forward drift detection.

## Motivation

Closed phase issues like #510 captured audit snapshots as comments, but those snapshots age out the moment subsequent migration PRs land. The structural gap: there was no single command to re-run the audit. Anyone — agent or human — investigating "what's still on the legacy pattern" had to re-derive it from scratch (multi-step grep + judgment + cross-referencing closed issues). In #510's case, an incorrect SSH-vs-REST deferral sat unnoticed for months. This task closes that gap: the answer is now one command away, machine-readable, and always reflects the current tree. `--strict` is the future hook for CI gating once the events migration (#741) lands.

## Out of Scope

- CI wiring of `--strict` mode (file separately if/when the audit is stable)
- Auto-fixing candidates (this is a reporter, not a refactorer)
- Audits beyond ONTAP legacy patterns (DII, Console SaaS) — extend later if drift develops there

## Related Issues

- #741 — events migration (the audit's primary motivation)
- #742 — docs correction: demote `netapp_ontap` SDK from "preferred pattern"
- #743 — AGENTS.md pre-action checks for refactor / migration proposals
- #510 — closed Phase 3f tracking issue whose stale audit comment motivated this structural fix

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (AGENTS.md Tool Reference row)
- [ ] I have updated the CHANGELOG.md (not applicable — project's CHANGELOG is managed by release tooling)
- [x] My changes generate no new warnings
