### PR TITLE
chore: tighten AI-agent verification discipline in AGENTS.md and CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -378,6 +378,8 @@ The label and approval are independent checks - both must pass. The label serves
 - Update your fork with the latest changes
 - Close any related issues with comment "Addressed in PR #XXX"
 
+**Closing tracking / epic issues:** Before closing any tracking, epic, or phase issue, ensure every "Deferred", "Out of scope", or "Future work" item in the issue body or comments has its own filed follow-up issue. Reference the follow-up issue numbers in the tracking issue's closing comment. Closed-issue audit comments are not a substitute for filed follow-ups — a future reader searching `gh issue list --state open` for `<topic>` must find the deferred work as a discrete ticket.
+
 ## Release Process
 
 This section documents how to publish releases to TestPyPI and PyPI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,9 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 | **New Dependency** | `.github/CONTRIBUTING.md` (Dependencies) | "Ask First" policy. |
 | **Creating Code** | `.claude/CLAUDE.md` (TodoWrite) | Plan -> Test -> Code loop. |
 | **Generating new code** | `docs/development/ai/architectural-conventions.md` | Layering rules and anti-patterns to avoid before writing code. |
-| **Architectural Decision** | `docs/decisions/README.md` | Check for related ADRs to update. |
+| **Architectural Decision** | `docs/decisions/README.md` | Read for context before deciding; check for related ADRs to update. |
+| **Refactor / migration proposal** | `docs/decisions/`, `docs/usage/`, `gh issue list --state all --search "<topic>"` | Verify the model, method, or prior phase issue actually exists before recommending; closed phase issues often gate the work. |
+| **Filing an issue** | `gh issue list --state all --search "<topic>"` | Closed phase issues often document deferrals and reasoning; their audit comments may be the authoritative record. |
 
 ### 6. Decision Framework
 
@@ -363,6 +365,7 @@ Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the r
 - **PRs:** Use `doit pr` to create PRs and `doit pr_merge` to merge with proper commit format. Issues are not automatically closed. Ask the user if they would like the related issue closed — pass `--auto-close` to `doit pr_merge` to close linked issues in one step.
 - **The Merge Gate action:** is a manual action for the user to add to a PR. It requires the ready-to-merge label and should never be added by automation. Exception: the dependabot auto-merge workflow (`.github/workflows/dependabot-automerge.yml`) applies the `ready-to-merge` label to qualifying dependabot PRs only.
 - **Issues:** Use `doit issue --type=<type>` to create issues (types: feature, bug, refactor, docs, chore). Labels are auto-applied. Manually close after PR merge with comment "Addressed in PR #XXX". Issues are not closed automatically when PRs are merged.
+- **Tracking-issue deferrals:** If a tracking or epic issue defers work to "later", "future", or "out of scope", file a separate follow-up issue and link it from the tracker **before** closing the tracker. Closed tracking issues must never be the sole record of work that still needs doing — `gh issue list --state open` must surface deferred work as a discrete ticket.
 - **ADRs:** When implementing architectural decisions (typically `feat` or `refactor`, rarely `fix`), update related ADRs in `docs/decisions/` to add the issue link. Create new ADRs for significant decisions using `doit adr`. Every ADR must link to the documentation in `docs/` that describes the implementation. Doc and chore issues do not need ADRs. Issues with the `needs-adr` label require an ADR before the PR can be merged.
 
 ## Workflow Commands (for AI agents)


### PR DESCRIPTION
## Description

Two complementary protocol additions that tighten AI-agent verification discipline:

- **AGENTS.md "Pre-Action Checks" table** gains two rows (refactor/migration proposals; filing an issue) that force a verification read of `docs/decisions/`, `docs/usage/`, and closed-issue history before recommending architectural changes. The existing "Architectural Decision" row is also tightened to make clear ADRs are a *read* target, not just a *write* target.
- **AGENTS.md "Critical Reminders"** gains a "Tracking-issue deferrals" bullet, mirrored in **`.github/CONTRIBUTING.md` "After Merge"**: deferred work must produce a filed follow-up issue *before* the tracker is closed, so deferrals remain searchable via `gh issue list --state open`.

Both additions reach all four supported AI agents (Claude, Gemini, Copilot, Codex) via the single `AGENTS.md` import shared by each agent's config dir.

## Related Issue

Addresses #743
Addresses #745

## Type of Change

- [x] Documentation update

## Changes Made

- `AGENTS.md` — three edits in the "Mandatory Protocols" → "Pre-Action Checks" table and one new bullet in "Critical Reminders":
  - Tightened wording of the "Architectural Decision" row (ADRs are a read target before deciding, not just a write target after).
  - Added "Refactor / migration proposal" row pointing to `docs/decisions/`, `docs/usage/`, and `gh issue list --state all --search "<topic>"`.
  - Added "Filing an issue" row that surfaces closed phase issues and their audit-comment deferrals.
  - Added "Tracking-issue deferrals" bullet under Critical Reminders.
- `.github/CONTRIBUTING.md` — added a paragraph in the "After Merge" section explaining the tracking-issue closing discipline (deferred items must produce filed follow-up issues; closed-issue audit comments are not a substitute).

## Testing

- [x] All existing tests pass (`doit check` passes clean — format, lint, mypy, bandit, pip-audit, codespell, all green)
- [x] No code changes; protocol/docs-only edits
- [x] Manually verified Markdown table alignment and link targets

## Motivation

Both additions are driven by the **#510 incident** uncovered in the recent DataSource-migration audit:

- #510 ("Phase 3f — migrate remaining CLI commands to DataSource") was closed with `nf events get` and `nf events save-azure` documented as "deferred" only in an audit comment. The deferral reasoning ("SSH-bound, out of scope for DataSource v1") was **incorrect** (`HostConnection` from upstream `netapp_ontap` is REST, not SSH), and the deferred work sat invisible to `gh issue list --state open` for months. The error only surfaced when someone investigating bug #740 traced back to find #510.
- The root cause was reasoning from plausibility without a forced verification read of `docs/decisions/`, `docs/usage/`, and the closed-issue history (#743), combined with a tracking issue closed without filed follow-ups for its deferred items (#745).

Putting both fixes in `AGENTS.md` (with the deferral discipline mirrored in `CONTRIBUTING.md` for human contributors) is the right home per the four rule-dir READMEs (`.claude/rules/`, `.gemini/rules/`, `.github/instructions/`, `.agents/skills/`), which explicitly say: *"They are not a second copy of `AGENTS.md`. `AGENTS.md` carries broad workflow and architectural rules for the whole project."*

## Out of Scope

- Per-agent rule files in `.claude/rules/` etc. — reserved for genuinely agent-specific footguns per the rule-dir READMEs.
- `UserPromptSubmit` hooks that inject these reminders on prompts mentioning "migrate" / "refactor" / "tracking issue" — higher leverage but more invasive; can be evaluated as a follow-up if the protocol text alone proves insufficient.
- A `doit audit_deferrals` tool that scans recently-closed tracking issues for unfiled deferrals — out of scope per #745's "Out of Scope" section.

## Related Issues

- #510 — closed Phase 3f tracking issue whose stale, unfiled deferral motivated both additions
- #741 — events migration filed retroactively to correct #510's missed deferral
- #742 — sibling docs correction (demote `netapp_ontap` SDK from "preferred pattern")
- #744 — sibling tooling fix (the `doit audit_legacy` task that surfaces drift directly; merged in PR #746)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable — protocol/docs-only edits)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (this PR *is* the documentation update)
- [ ] I have updated the CHANGELOG.md (not applicable — project's CHANGELOG is managed by release tooling)
- [x] My changes generate no new warnings
