### PR TITLE
fix: look up cluster IP from config in OntapBackend._get_api_client

### DIFF
--- a/src/pynetappfoundry/data/backends.py
+++ b/src/pynetappfoundry/data/backends.py
@@ -159,7 +159,8 @@ class OntapBackend(Backend):
             from pynetappfoundry.clients.ontap.api import ONTAPAPIClient
             from pynetappfoundry.core.models import ClusterConfig
 
-            cluster_obj = ClusterConfig(name=cluster, ip=cluster)
+            cluster_data = self._config.data.get("clusters", {}).get(cluster, {})
+            cluster_obj = ClusterConfig(name=cluster, ip=cluster_data.get("ip", cluster))
             self._api_clients[cluster] = ONTAPAPIClient(cluster=cluster_obj, config=self._config)
         return self._api_clients[cluster]
 

--- a/tests/unit/data/test_backends.py
+++ b/tests/unit/data/test_backends.py
@@ -1494,3 +1494,48 @@ class TestOntapBackendCliDispatch:
             )
 
         assert results == []
+
+
+# ---------------------------------------------------------------------------
+# _get_api_client IP resolution (#740)
+# ---------------------------------------------------------------------------
+
+
+class TestGetApiClient:
+    """Tests for :meth:`OntapBackend._get_api_client` IP resolution.
+
+    Verifies that the client is constructed with the configured IP address
+    rather than the cluster name, mirroring the pattern in ``_get_cli_client``.
+    """
+
+    def test_uses_configured_ip(self, mock_config: Any) -> None:
+        """ClusterConfig.ip uses the ``ip`` key from the clusters config."""
+        mock_config.data = {"clusters": {"cl1": {"ip": "10.0.0.5"}}}
+        backend = _make_backend(mock_config)
+
+        with patch(
+            "pynetappfoundry.clients.ontap.api.ONTAPAPIClient.__init__",
+            return_value=None,
+        ) as mock_init:
+            backend._get_api_client("cl1")
+
+        mock_init.assert_called_once()
+        cluster_arg = mock_init.call_args.kwargs["cluster"]
+        assert cluster_arg.name == "cl1"
+        assert cluster_arg.ip == "10.0.0.5"
+
+    def test_falls_back_to_cluster_name_when_ip_absent(self, mock_config: Any) -> None:
+        """ClusterConfig.ip falls back to the cluster name when no ``ip`` key is present."""
+        mock_config.data = {"clusters": {"cl1": {}}}
+        backend = _make_backend(mock_config)
+
+        with patch(
+            "pynetappfoundry.clients.ontap.api.ONTAPAPIClient.__init__",
+            return_value=None,
+        ) as mock_init:
+            backend._get_api_client("cl1")
+
+        mock_init.assert_called_once()
+        cluster_arg = mock_init.call_args.kwargs["cluster"]
+        assert cluster_arg.name == "cl1"
+        assert cluster_arg.ip == "cl1"


### PR DESCRIPTION
## Description

`OntapBackend._get_api_client` constructed `ClusterConfig` with the cluster **name** in the IP slot (`ClusterConfig(name=cluster, ip=cluster)`). The downstream `ONTAPAPIClient` builds `base_url=f"https://{cluster.ip}"`, so every live API request resolved to `https://<cluster_name>/...` and failed with `NameResolutionError` whenever the cluster name wasn't a resolvable DNS hostname — the standard production case where clusters are configured by IP in `clusters.yml`.

The fix mirrors the sibling `_get_cli_client` method in the same file, which already looks the IP up from `Config.data["clusters"][cluster]["ip"]` with the cluster name as a fallback.

## Related Issue

Addresses #740

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/pynetappfoundry/data/backends.py` — two-line fix in `_get_api_client`:
  - Look up `cluster_data = self._config.data.get("clusters", {}).get(cluster, {})` (matching the existing `_get_cli_client` pattern).
  - Change `ClusterConfig(name=cluster, ip=cluster)` → `ClusterConfig(name=cluster, ip=cluster_data.get("ip", cluster))`. Fallback to the cluster name preserves prior behavior when no `ip` is configured.
- `tests/unit/data/test_backends.py` — new `TestGetApiClient` class with 2 tests covering the method's internals (existing tests patched `_get_api_client` out; these are the first to exercise it):
  - `test_uses_configured_ip` — given `clusters: {cl1: {ip: "10.0.0.5"}}`, the constructed `ClusterConfig.ip == "10.0.0.5"`.
  - `test_falls_back_to_cluster_name_when_ip_absent` — given `clusters: {cl1: {}}`, the constructed `ClusterConfig.ip == "cl1"` (regression guard for the fallback case).

## Testing

- [x] All existing tests pass (`doit check` passes clean)
- [x] Added new tests for the regression (2 tests, both pass)
- [x] Manually verified the buggy line is gone (`grep -n "ip=cluster," src/pynetappfoundry/data/backends.py` returns no matches)

## Why This Bug Stayed Invisible

Cache-backed reads (`source="cache"`) bypass this client entirely. The lazy metadata loader in `cache/_lazy.py` hardcodes `source="cache"` even when `Config(no_cache=True)` is set (the `licenses get --live` path), so the live-API code path was never exercised end-to-end through `DataSource.query`. The bug only surfaces when someone first attempts `DataSource.query(model_class, cluster=..., source="live")` on a cluster whose name isn't a DNS hostname.

## Impact

Fixes `DataSource.query(..., source="live")` for any deployment that addresses clusters by IP rather than DNS-resolvable hostname. Required prerequisite for the `cifs find-user` work referenced in the issue body, and for any future live-DataSource caller.

## Out of Scope

- Refactoring `_get_api_client` and `_get_cli_client` to share their common cluster-lookup logic. The duplication is small (two lines each), and consolidating it would obscure the diff for this bug fix. File separately if the duplication grows.
- Tests covering the broader `OntapBackend` constructor / caching behavior. Existing tests cover those by patching `_get_api_client` out.

## Related Issues

- #744 — `doit audit_legacy` task (merged in PR #746) helps prevent similar drift going forward
- #741 — events migration that motivated the DataSource investigation surfacing this bug
- #710-series — `DataSource` architecture (this fix is on the critical path for live queries)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly (not applicable — internal bug fix, no public API change)
- [ ] I have updated the CHANGELOG.md (not applicable — project's CHANGELOG is managed by release tooling)
- [x] My changes generate no new warnings
