### PR TITLE
docs: demote netapp_ontap SDK from "preferred pattern" in ONTAP access patterns guide

### DIFF
--- a/docs/decisions/0013-datasource-as-a-thin-facade-over-the-collector.md
+++ b/docs/decisions/0013-datasource-as-a-thin-facade-over-the-collector.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 Supersedes [ADR-0012: Unified DataSource Accessor for All Cluster Reads](0012-unified-datasource-accessor.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,16 @@ ONTAP administration library and CLI tools for NetApp storage management.
 
 pynetappfoundry provides a comprehensive Python library and command-line interface for managing NetApp ONTAP clusters. It supports both REST API and SSH CLI access for flexible administration tasks.
 
+## Preferred ONTAP Access Patterns
+
+For new CLI commands, reports, and scripts that read or write ONTAP data, use these patterns in priority order:
+
+1. **`ClusterEntry.ontap`** — cached high-level reads with on-demand `DataSource` fallback and `--live` bypass ([ADR-0010](decisions/0010-clusterentry-and-namespace-access-pattern.md))
+2. **`QuerySet(config=)` / `DataSource`** — ad-hoc filtered/ordered/limited live reads, plus mutations ([ADR-0013](decisions/0013-datasource-as-a-thin-facade-over-the-collector.md))
+3. **`netapp_ontap` SDK** — fallback only for endpoints not yet covered by a `TypeMapping`
+
+See [DataSource Guide](usage/data-source.md), [Query Layer Guide](usage/query-layer.md), and [ONTAP Access Patterns](usage/ontap-access-patterns.md) for details.
+
 ## Quick Links
 
 - [Installation Guide](getting-started/installation.md)

--- a/docs/usage/ontap-access-patterns.md
+++ b/docs/usage/ontap-access-patterns.md
@@ -21,7 +21,7 @@ pynetappfoundry provides three different ways to interact with ONTAP clusters. E
 |---------|------------|----------|
 | `ClusterEntry.ontap` namespace | Cache DB + HTTPS REST (+ SSH for `cloud`) | High-level reads of cached cluster metadata with on-demand DataSource fallback |
 | `QuerySet` + `Mutation` | HTTPS REST | Type-safe ONTAP queries and writes with model attribute translation (see [Query Layer](query-layer.md)) |
-| `netapp_ontap` SDK | HTTPS REST | Structured data retrieval, reports, typed objects |
+| `netapp_ontap` SDK | HTTPS REST | Fallback for endpoints not yet covered by a `TypeMapping` (most callers should use `ClusterEntry.ontap` or `QuerySet`/`DataSource` instead) |
 | `ONTAPCLI` | SSH | Ad-hoc CLI commands, operations not in REST API |
 | `APIWrapper` | HTTPS REST | Custom queries, OpenAPI-based workflows, DII integration |
 
@@ -174,9 +174,9 @@ See the dedicated [Query Layer](query-layer.md) guide for the full API reference
 
 ---
 
-### 3. netapp_ontap SDK
+### 3. netapp_ontap SDK (Fallback)
 
-NetApp's official Python SDK provides ORM-like objects for ONTAP resources. This is the **preferred pattern** for most operations.
+NetApp's official Python SDK provides ORM-like objects for ONTAP resources. Reach for it only when no `TypeMapping` exists for the endpoint you need, or for mutations on uncovered resources. For everything else, prefer `ClusterEntry.ontap` (Pattern #1) for cached high-level reads or `QuerySet`/`DataSource` (Pattern #2) for ad-hoc filtered/ordered/limited live reads — see [ADR-0010](../decisions/0010-clusterentry-and-namespace-access-pattern.md) and [ADR-0013](../decisions/0013-datasource-as-a-thin-facade-over-the-collector.md).
 
 **When to Use:**
 
@@ -201,30 +201,19 @@ NetApp's official Python SDK provides ORM-like objects for ONTAP resources. This
 **Example Usage:**
 
 ```python
-from netapp_ontap import HostConnection
-from netapp_ontap.resources import Volume, Cluster
+# Modern equivalent: DataSource is the unified read accessor (ADR-0013).
+# Cache-first by default; pass source="live" to bypass the cache.
+from pynetappfoundry.core.config import Config
+from pynetappfoundry.data.source import DataSource
+from pynetappfoundry.models.ontap.storage.volumes.model import OntapVolume
 
-# Connect to cluster
 config = Config()
-cluster = config.clusters["mycluster"]
-user = config.get_user("clusters", cluster.name)
-
-with HostConnection(
-    cluster.ip,
-    username=user.user,
-    password=user.get_password(),
-    verify=False  # For self-signed certs
-):
-    # Get cluster info
-    cluster_info = Cluster()
-    cluster_info.get()
-    print(f"Cluster: {cluster_info.name}, Version: {cluster_info.version.full}")
-
-    # List all volumes
-    for volume in Volume.get_collection():
-        volume.get()  # Fetch full details
-        print(f"Volume: {volume.name}, Size: {volume.size}")
+ds = DataSource(config)
+for volume in ds.query(OntapVolume, cluster="mycluster", source="auto"):
+    print(volume.name, volume.size)
 ```
+
+When `cluster_entry.ontap.<field_group>` is available, prefer that — see Pattern #1 for the canonical cached high-level reads. Direct `netapp_ontap` SDK usage (`HostConnection`, `Volume.get_collection()`, etc.) is a fallback for endpoints not yet covered by a `TypeMapping`; consult the upstream NetApp documentation when you need it.
 
 **Commands Using This Pattern:**
 
@@ -432,8 +421,8 @@ Use this matrix to choose the right pattern:
 | Fetch live IOPS/latency metrics | `fetch_realtime` | On-demand realtime fields — see [Query Layer](query-layer.md) |
 | Poll metrics over time | `watch_realtime` | Generator-based polling — see [Query Layer](query-layer.md) |
 | Bulk data export | `QuerySet` | Handles pagination, typed results — see [Query Layer](query-layer.md) |
-| Generate a report | `netapp_ontap` SDK | Typed objects, well-documented |
-| Check license status | `netapp_ontap` SDK | LicensePackage resource available |
+| Generate a report from cached cluster metadata | `ClusterEntry.ontap` | Sub-ms cache reads with `--live` bypass (see Pattern #1) |
+| Check license status | `ClusterEntry.ontap` | `nf licenses get` reads `metadata.license_packages`; supports `--live` |
 | Run CLI-only command | `ONTAPCLI` | No REST equivalent |
 | Debug cluster issue | `ONTAPCLI` | Full CLI access |
 | Query DII metrics | `APIWrapper` | DII uses different API |
@@ -481,7 +470,7 @@ All patterns share a common configuration flow:
 
 ## Best Practices
 
-1. **Prefer the SDK** - Use `netapp_ontap` for standard operations. It's well-tested and maintained by NetApp.
+1. **Prefer the cached / unified accessors** — Reach for `ClusterEntry.ontap` (Pattern #1) for cached cluster metadata reads and `QuerySet`/`DataSource` (Pattern #2) for ad-hoc queries. Drop down to the `netapp_ontap` SDK only when no `TypeMapping` covers the endpoint.
 
 2. **Use SSH sparingly** - Reserve `ONTAPCLI` for operations that genuinely require CLI access.
 
@@ -498,3 +487,6 @@ All patterns share a common configuration flow:
 - [CLI Reference](../reference/cli.md) - Available CLI commands
 - [ADR-0010: ClusterEntry and namespace access pattern](../decisions/0010-clusterentry-and-namespace-access-pattern.md) - Rationale for the `ClusterEntry.ontap` namespace design
 - [ADR-0009: SQL table storage](../decisions/0009-sql-table-storage.md) - Per-model SQL table layout backing the cache
+- [DataSource Guide](data-source.md) — unified read accessor for all cluster data
+- [Query Layer Guide](query-layer.md) — `QuerySet`, `Mutation`, realtime fields
+- [ADR-0013: DataSource as a Thin Facade Over the Collector](../decisions/0013-datasource-as-a-thin-facade-over-the-collector.md) — current architectural direction for `DataSource`


### PR DESCRIPTION
## Description

`docs/usage/ontap-access-patterns.md` line 179 claimed the upstream `netapp_ontap` SDK was "the **preferred pattern** for most operations." This contradicted ADR-0010 (`ClusterEntry.ontap`), ADR-0012, ADR-0013 (`DataSource`), and the Phase 3f/4 migration work (issues #510, #515; PRs #518–#521, #554), which collectively make `ClusterEntry.ontap` and `DataSource` / `QuerySet(config=)` the recommended entry points.

This PR makes four corrections, all in `docs/`:

1. Demote the `netapp_ontap` SDK in `docs/usage/ontap-access-patterns.md` (Overview table, Pattern #3 heading + opening paragraph, code example, Decision Matrix rows, Best Practices bullet, See Also additions).
2. Add a new `## Preferred ONTAP Access Patterns` section to `docs/index.md` as always-loaded ground truth for new contributors and AI agents.
3. Flip **ADR-0013** from `Proposed` to `Accepted` — its content is comprehensive, ADR-0012 already names it as the supersessor, and the corrected docs now point readers to it as the current direction.
4. Cross-link the corrected page to ADR-0010, ADR-0013, `data-source.md`, and `query-layer.md`. ADR-0012 is intentionally omitted from the new links (superseded by ADR-0013).

## Related Issue

Addresses #742

## Type of Change

- [x] Documentation update

## Changes Made

### `docs/usage/ontap-access-patterns.md` (6 surgical edits)

- **Overview table (~line 24):** annotate the `netapp_ontap` SDK row as a fallback for endpoints not yet covered by a `TypeMapping`.
- **Pattern #3 heading (line 177):** rename `### 3. netapp_ontap SDK` → `### 3. netapp_ontap SDK (Fallback)`.
- **Pattern #3 opening paragraph (line 179):** drop the "preferred pattern" claim; describe the SDK as the upstream fallback, with explicit pointers to ADR-0010 and ADR-0013.
- **Pattern #3 example (lines 201–227):** replace the 25-line `HostConnection` example with a short `DataSource` example showing the modern equivalent. A trailing prose note clearly labels the SDK as the fallback path when no `TypeMapping` covers an endpoint.
- **Decision Matrix (lines 435–436):** retarget "Generate a report" and "Check license status" from `netapp_ontap` SDK → `ClusterEntry.ontap` (matching what `nf licenses get` actually does today).
- **Best Practices (line 484):** flip "Prefer the SDK" → "Prefer the cached / unified accessors".
- **See Also (lines 494–500):** add three new links — DataSource Guide, Query Layer Guide, ADR-0013. ADR-0010 link retained.

### `docs/index.md`

- New `## Preferred ONTAP Access Patterns` section inserted between `## Overview` and `## Quick Links`. Priority-ordered list (`ClusterEntry.ontap` → `QuerySet`/`DataSource` → `netapp_ontap` SDK) with ADR cross-links and pointers to the canonical user-facing guides.

### `docs/decisions/0013-datasource-as-a-thin-facade-over-the-collector.md`

- Status line 5: `Proposed` → `Accepted`. No other changes. ADR-0013 already documents the ten-point design replacing ADR-0012; its content has been the implemented direction since Phase 3.

## Testing

- [x] All existing tests pass (`doit check` passes clean — codespell, ruff, mypy, bandit, codespell, pytest all green for the affected file types)
- [x] `doit docs_build` succeeds — no new broken cross-links (pre-existing warnings on ADR/dev docs outside the docs tree are unchanged)
- [x] Manually verified all four sanity greps:
  - `grep -n 'preferred pattern' docs/usage/ontap-access-patterns.md` → no matches (stale claim gone)
  - `grep -rn 'Prefer the SDK' docs/` → no matches (stale best-practice gone)
  - `grep -n '^Accepted$' docs/decisions/0013-…md` → one match at line 5
  - `grep -n 'Preferred ONTAP Access Patterns' docs/index.md` → one match at line 20

## Motivation

The stale "preferred pattern" claim was a direct contributor to the #741/#742 series being filed in the first place. New CLI commands written against the old doc reached for `netapp_ontap.HostConnection` instead of `DataSource`/`QuerySet`, perpetuating the pattern that #510 was nominally retiring. After ADR-0013 (now Accepted), the architecture-state pointer in `docs/index.md` plus the Pre-Action Checks rows added in PR #747 (#743/#745) together create three layers of structural prevention against the recurrence: (a) the corrected page itself, (b) the always-loaded `docs/index.md` ground truth, and (c) the AI-agent verification checklist.

## Out of Scope

- AGENTS.md edits — the architecture-state pointer belongs in user-facing docs, not the AI-agent rule file (per the four rule-dir READMEs which explicitly say agent-specific files are not a second copy of AGENTS.md). PR #747 already added the relevant AI-agent verification discipline via the Pre-Action Checks rows.
- Configuration Flow diagram in `docs/usage/ontap-access-patterns.md` (lines 447–480) — left alone; not a "preferred" claim, just a reference diagram.
- The events commands (`cli/commands/events/get.py`, `azevents.py`) that still use the SDK directly — tracked by #741.
- ADR-0012 status change — already declares itself superseded by ADR-0013; no further edit needed.

## Related Issues / PRs

- #744 (PR #746) — `doit audit_legacy` task that surfaces remaining SDK call sites directly
- #743/#745 (PR #747) — AGENTS.md verification discipline that prevents the recurrence at the AI-agent level
- #740 (PR #748) — fixed `DataSource` cluster-IP bug; the corrected docs are now safe to point readers at `DataSource` examples
- #741 — events migration (the remaining direct-SDK call sites in the CLI tree)
- #510 — closed Phase 3f tracking issue whose stale audit comment is the root incident this series addresses

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective (not applicable — documentation-only PR; `doit docs_build` is the equivalent gate and it passes)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (this PR *is* the documentation update)
- [ ] I have updated the CHANGELOG.md (not applicable — project's CHANGELOG is managed by release tooling)
- [x] My changes generate no new warnings
