### PR TITLE
chore: resolve doit audit vulnerabilities (idna, pymdown-extensions)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -697,11 +697,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -1905,15 +1905,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

`doit audit` (pip-audit) reported two known vulnerabilities in transitive dependencies, both with fix versions available. This upgrades the locked versions to non-vulnerable releases. Lockfile-only change — no `pyproject.toml` constraint changes (both are transitive deps).

| Package | Was | Now | CVE |
| :--- | :--- | :--- | :--- |
| `idna` | 3.11 | 3.16 | CVE-2026-45409 |
| `pymdown-extensions` | 10.21.2 | 10.21.3 | CVE-2026-46338 |

## Related Issue

Addresses #759

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue) — resolves two security vulnerabilities

## Changes Made

- Upgrade `idna` 3.11 → 3.16 in `uv.lock` (resolves CVE-2026-45409; pulled in via `requests` / `jsonschema` / `netapp-ontap`)
- Upgrade `pymdown-extensions` 10.21.2 → 10.21.3 in `uv.lock` (resolves CVE-2026-46338; pulled in via `mkdocs-material` / `mkdocstrings`)
- No `pyproject.toml` changes — parent packages already accept these versions

## Testing

- [x] All existing tests pass (`doit check` → all checks passed)
- [x] Manually tested: `doit audit` now reports "No known vulnerabilities found, 1 ignored" (the pre-existing ignored `GHSA-r374-rxx8-8654`)

## Checklist

- [x] My code follows the code style of this project (ran `doit check`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Notes

- Lockfile-only change; no new tests apply.
- CHANGELOG is auto-generated from conventional commits at release time (per CONTRIBUTING.md), so no manual CHANGELOG edit.
- Verified `git diff uv.lock` is scoped to exactly these two packages; no packages added or removed.
- These are nested transitive deps, so Dependabot does not raise direct-bump PRs for them — the lockfile had to be upgraded explicitly.
