### PR TITLE
feat: add cifs session command to query active CIFS sessions

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -134,6 +134,33 @@ nf events [OPTIONS] COMMAND [ARGS]...
 |--------|-------------|
 | `-f, --filter TEXT` | JSON cluster filter |
 
+### cifs
+
+CIFS / SMB inspection commands.
+
+```bash
+nf cifs [OPTIONS] COMMAND [ARGS]...
+```
+
+**Subcommands:**
+
+| Command | Description |
+|---------|-------------|
+| `session` | List active CIFS/SMB sessions across in-scope clusters |
+| `find-user` | (Legacy) Find CIFS sessions for a user via the netapp_ontap SDK |
+
+**`cifs session` options:**
+
+| Option | Description |
+|--------|-------------|
+| `-f, --filter TEXT` | JSON cluster filter |
+| `-u, --user TEXT` | Match `user` or `mapped_unix_user`. Substring by default; glob when `*`, `?`, or `[` is present |
+| `-i, --ip TEXT` | Match `client_ip`. Exact IP, glob (`10.1.2.*`), or CIDR (`10.1.2.0/24`) |
+| `--case-sensitive / --case-insensitive` | Match the `--user` pattern case-sensitively (default: case-insensitive) |
+| `-c, --csv PATH` | Write results to a CSV file *in addition to* the table. If PATH is a directory, writes `cifs_sessions_<YYYYMMDD-HHMMSS>.csv` inside it |
+
+CIFS sessions are transient and never cached; every invocation queries each in-scope cluster live via the ONTAP REST API (there is no `--live` flag because there is no cache to bypass). The Rich table renders without column truncation regardless of terminal width; the CSV export uses the same headers.
+
 ### metrics
 
 Metrics commands.
@@ -357,6 +384,28 @@ nf metrics dump-dii --date 2025-04-13
 
 # Dump the same 3-day window for a filtered set of clusters
 nf metrics dump-dii --date 2025-04-13 -f '{"env":"Prod"}'
+```
+
+### CIFS Inspection
+
+```bash
+# List all active CIFS sessions across the cached clusters
+nf cifs session
+
+# Find sessions for a specific user (substring, case-insensitive)
+nf cifs session -u jdoe
+
+# Glob match against fully-qualified domain user
+nf cifs session -u 'DOMAIN\jdoe'
+
+# Find every session originating from a CIDR range, scoped to Prod
+nf cifs session -i 10.1.2.0/24 -f '{"env":"Prod"}'
+
+# Combine user + IP filters
+nf cifs session -u '*jdoe*' -i 10.1.2.0/24
+
+# Render the table and additionally export to CSV
+nf cifs session -u jdoe --csv ./jdoe-sessions.csv
 ```
 
 ### Configuration

--- a/src/pynetappfoundry/cli/commands/__init__.py
+++ b/src/pynetappfoundry/cli/commands/__init__.py
@@ -1,9 +1,10 @@
 """CLI command groups."""
 
+from pynetappfoundry.cli.commands.cifs import cifs
 from pynetappfoundry.cli.commands.events import events
 from pynetappfoundry.cli.commands.licenses import licenses
 from pynetappfoundry.cli.commands.metrics import metrics
 from pynetappfoundry.cli.commands.reports import reports
 from pynetappfoundry.cli.commands.utils import utils
 
-__all__ = ["events", "licenses", "metrics", "reports", "utils"]
+__all__ = ["cifs", "events", "licenses", "metrics", "reports", "utils"]

--- a/src/pynetappfoundry/cli/commands/cifs/__init__.py
+++ b/src/pynetappfoundry/cli/commands/cifs/__init__.py
@@ -1,0 +1,14 @@
+"""CIFS commands."""
+
+import click
+
+from pynetappfoundry.cli.commands.cifs.session import session
+
+
+@click.group()
+def cifs() -> None:
+    """CIFS / SMB inspection commands."""
+    pass
+
+
+cifs.add_command(session)

--- a/src/pynetappfoundry/cli/commands/cifs/session.py
+++ b/src/pynetappfoundry/cli/commands/cifs/session.py
@@ -1,0 +1,409 @@
+"""Inspect active CIFS/SMB sessions across in-scope clusters.
+
+Implements ``nf cifs session`` per issue #775. All ONTAP reads go through
+:class:`~pynetappfoundry.data.source.DataSource` (ADR-0012/0013); no
+direct ``HostConnection`` or ``netapp_ontap`` SDK use.
+"""
+
+from __future__ import annotations
+
+import csv
+import fnmatch
+import ipaddress
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import click
+from rich.table import Table
+
+from pynetappfoundry.cli.decorators import with_config
+from pynetappfoundry.cli.utils import (
+    console,
+    print_exception,
+    print_info,
+    print_warning,
+)
+from pynetappfoundry.data.source import DataSource
+from pynetappfoundry.models.ontap.protocols.cifs.sessions.model import OntapCifsSession
+
+if TYPE_CHECKING:
+    from pynetappfoundry.core.config import Config
+
+# Column headers used for both Rich table and CSV output.
+COLUMNS: tuple[str, ...] = (
+    "Cluster",
+    "SVM",
+    "User",
+    "Mapped Unix User",
+    "Client IP",
+    "Server IP",
+    "Protocol",
+    "Auth",
+    "Encryption",
+    "Connected",
+    "Idle",
+    "Open Files",
+    "Open Shares",
+)
+
+# Glob metacharacters that flip ``--user`` from substring to glob match
+# and disable server-side push.
+_GLOB_CHARS = "*?["
+
+
+SessionRow = tuple[str, ...]
+
+
+def _has_glob(value: str) -> bool:
+    """Return True if *value* contains glob metacharacters."""
+    return any(ch in value for ch in _GLOB_CHARS)
+
+
+def _matches_user(
+    session_user: str,
+    mapped_unix_user: str,
+    pattern: str,
+    case_sensitive: bool,
+) -> bool:
+    """Return True if *pattern* matches ``user`` or ``mapped_unix_user``.
+
+    A pattern with no glob metacharacters is treated as a substring match.
+    A pattern with metacharacters (``*``, ``?``, ``[``) is matched with
+    :func:`fnmatch.fnmatchcase`.
+
+    Empty patterns always return False; empty haystacks never match.
+    """
+    if not pattern:
+        return False
+
+    needle = pattern if case_sensitive else pattern.lower()
+    is_glob = _has_glob(needle)
+
+    for raw in (session_user, mapped_unix_user):
+        if not raw:
+            continue
+        haystack = raw if case_sensitive else raw.lower()
+        if is_glob:
+            if fnmatch.fnmatchcase(haystack, needle):
+                return True
+        elif needle in haystack:
+            return True
+    return False
+
+
+def _is_plain_ip(value: str) -> bool:
+    """Return True if *value* parses as a single IPv4/IPv6 address."""
+    try:
+        ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _is_cidr(value: str) -> bool:
+    """Return True if *value* parses as an IPv4/IPv6 network."""
+    if "/" not in value:
+        return False
+    try:
+        ipaddress.ip_network(value, strict=False)
+    except ValueError:
+        return False
+    return True
+
+
+def _matches_ip(client_ip: str, pattern: str) -> bool:
+    """Return True if *client_ip* matches the IP filter *pattern*.
+
+    Supports:
+
+    - Exact IP (``10.1.2.45``).
+    - Glob (``10.1.2.*``) — matched with :func:`fnmatch.fnmatchcase`.
+    - CIDR (``10.1.2.0/24``) — parsed with :mod:`ipaddress`.
+
+    Empty *pattern* or *client_ip* returns False. Address-family
+    mismatches between a v4 network and a v6 address (or vice-versa)
+    return False, never raise.
+    """
+    if not pattern or not client_ip:
+        return False
+
+    if _is_cidr(pattern):
+        try:
+            net = ipaddress.ip_network(pattern, strict=False)
+            addr = ipaddress.ip_address(client_ip)
+        except ValueError:
+            return False
+        if net.version != addr.version:
+            return False
+        return addr in net
+
+    if _has_glob(pattern):
+        return fnmatch.fnmatchcase(client_ip, pattern)
+
+    # Plain IP: compare as parsed addresses to normalize form, fall back
+    # to string equality for non-parseable inputs (defensive).
+    try:
+        return ipaddress.ip_address(pattern) == ipaddress.ip_address(client_ip)
+    except ValueError:
+        return pattern == client_ip
+
+
+def _validate_ip_pattern(pattern: str) -> None:
+    """Raise :class:`click.BadParameter` if *pattern* is not a valid IP filter.
+
+    Accepts plain IP, glob, or CIDR. An empty pattern is rejected — Click
+    will not invoke this for unset options.
+    """
+    if not pattern:
+        msg = "IP filter must not be empty."
+        raise click.BadParameter(msg)
+    if _is_cidr(pattern):
+        try:
+            ipaddress.ip_network(pattern, strict=False)
+        except ValueError as e:
+            raise click.BadParameter(f"Invalid CIDR: {pattern}") from e
+        return
+    if _has_glob(pattern):
+        return
+    if not _is_plain_ip(pattern):
+        msg = f"Invalid IP, glob, or CIDR: {pattern!r}"
+        raise click.BadParameter(msg)
+
+
+def _row_for(cluster: str, session: OntapCifsSession) -> SessionRow:
+    """Project an :class:`OntapCifsSession` to a display row."""
+    return (
+        cluster,
+        session.svm.name,
+        session.user,
+        session.mapped_unix_user,
+        session.client_ip,
+        session.server_ip,
+        session.protocol,
+        session.authentication,
+        session.smb_encryption,
+        session.connected_duration,
+        session.idle_duration,
+        str(session.open_files),
+        str(session.open_shares),
+    )
+
+
+def _scan_cluster(
+    config: Config,
+    cluster: str,
+    user: str | None,
+    case_sensitive: bool,
+    ip: str | None,
+) -> tuple[list[SessionRow], int]:
+    """Scan a single cluster's CIFS sessions via :class:`DataSource`.
+
+    Always runs in live mode (``source="live"``) because CIFS sessions
+    are transient and not part of :class:`CachedClusterMetadata`.
+
+    Server-side push:
+
+    - ``--ip`` (plain IP) -> ``qb.filter({"client_ip": value})``.
+
+    ``--user`` is not pushed server-side: ``_matches_user`` matches
+    either ``user`` or ``mapped_unix_user``, and a server-side ``user=``
+    filter would incorrectly drop sessions whose ``mapped_unix_user``
+    matches but whose ``user`` does not. Glob, CIDR, and case-insensitive
+    matches are handled client-side.
+
+    Returns:
+        ``(rows, scanned)`` for the cluster.
+    """
+    ds = DataSource(config)
+    qb = ds.query(OntapCifsSession, cluster=cluster, source="live")
+
+    # NOTE: ``user`` is not pushed server-side. ``_matches_user`` matches
+    # either ``user`` OR ``mapped_unix_user``; a server-side ``user=``
+    # filter would incorrectly drop sessions whose ``mapped_unix_user``
+    # matches but whose ``user`` does not. ``client_ip`` is safe to push
+    # because it is the only field we filter on for IP.
+    if ip and _is_plain_ip(ip):
+        qb = qb.filter({"client_ip": ip})
+
+    rows: list[SessionRow] = []
+    scanned = 0
+    for session in qb:
+        scanned += 1
+        if user and not _matches_user(session.user, session.mapped_unix_user, user, case_sensitive):
+            continue
+        if ip and not _matches_ip(session.client_ip, ip):
+            continue
+        rows.append(_row_for(cluster, session))
+    return rows, scanned
+
+
+def _render_table(rows: list[SessionRow], title: str) -> None:
+    """Render *rows* as a Rich table with no truncation or wrapping.
+
+    Each column is configured with ``no_wrap=True, overflow="ignore"``
+    so long values (DOMAIN\\user, durations, etc.) never get elided.
+    The table is rendered through a private Console that wraps the
+    module-level ``console.file`` at an effectively unbounded width so
+    Rich does not collapse columns to fit a narrow terminal — long rows
+    overflow horizontally instead. This matches the no-truncation
+    contract in issue #775.
+    """
+    from rich.console import Console as _RichConsole
+
+    table = Table(title=title, show_lines=False)
+    for col in COLUMNS:
+        table.add_column(col, no_wrap=True, overflow="ignore")
+    for row in rows:
+        table.add_row(*row)
+    wide = _RichConsole(
+        file=console.file,
+        width=10_000,
+        force_terminal=False,
+        no_color=console.no_color,
+        record=False,
+    )
+    wide.print(table)
+
+
+def _resolve_csv_path(csv_arg: str, output_dir: str | Path) -> Path:
+    """Return the CSV target path.
+
+    If *csv_arg* points to an existing directory, write
+    ``cifs_sessions_<YYYYMMDD-HHMMSS>.csv`` inside it. Otherwise treat
+    *csv_arg* as the explicit target file. If the path ends with a
+    separator and does not yet exist, treat it as a directory and
+    create it.
+    """
+    path = Path(csv_arg)
+    if path.is_dir() or csv_arg.endswith(("/", "\\")):
+        path.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
+        return path / f"cifs_sessions_{timestamp}.csv"
+    if not csv_arg:  # pragma: no cover - Click prevents empty value
+        timestamp = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
+        return Path(output_dir) / f"cifs_sessions_{timestamp}.csv"
+    return path
+
+
+def _write_csv(rows: list[SessionRow], path: Path) -> None:
+    """Write *rows* to *path* as UTF-8 CSV with the standard header row."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f, quoting=csv.QUOTE_MINIMAL)
+        writer.writerow(COLUMNS)
+        writer.writerows(rows)
+
+
+@click.command("session")
+@click.option(
+    "--filter",
+    "-f",
+    "filter",
+    help='JSON cluster filter: \'{"bu":"Business","env":"Prod"}\'.',
+)
+@click.option(
+    "--user",
+    "-u",
+    "user",
+    default=None,
+    help=(
+        "Match CIFS session ``user`` or ``mapped_unix_user``. Substring "
+        "match unless glob metacharacters (``*``, ``?``, ``[``) are "
+        "present, e.g. ``*jdoe*``, ``DOMAIN\\\\jdoe``."
+    ),
+)
+@click.option(
+    "--ip",
+    "-i",
+    "ip",
+    default=None,
+    help=(
+        "Match ``client_ip``. Accepts an exact IP (``10.1.2.45``), glob "
+        "(``10.1.2.*``), or CIDR (``10.1.2.0/24``)."
+    ),
+)
+@click.option(
+    "--case-sensitive/--case-insensitive",
+    "case_sensitive",
+    default=False,
+    show_default=True,
+    help="Match the ``--user`` pattern case-sensitively.",
+)
+@click.option(
+    "--csv",
+    "-c",
+    "csv_path",
+    type=click.Path(),
+    default=None,
+    help=(
+        "Write results to a CSV file *in addition to* the Rich table. "
+        "If PATH is a directory, writes "
+        "``cifs_sessions_<YYYYMMDD-HHMMSS>.csv`` inside it."
+    ),
+)
+@with_config("Get CIFS sessions failed")
+def session(
+    config: Config,
+    clusters: dict[str, dict[str, Any]],
+    user: str | None,
+    ip: str | None,
+    case_sensitive: bool,
+    csv_path: str | None,
+) -> None:
+    """List active CIFS/SMB sessions across in-scope clusters.
+
+    Examples:
+        nf cifs session
+        nf cifs session -u 'DOMAIN\\jdoe'
+        nf cifs session -u '*jdoe*' -f '{"env":"Prod"}'
+        nf cifs session -i 10.1.2.45
+        nf cifs session -i 10.1.2.0/24
+        nf cifs session -u jdoe -i 10.1.2.0/24 --case-sensitive
+        nf cifs session -u jdoe --csv ./jdoe-sessions.csv
+
+    CIFS sessions are transient and never cached; every invocation
+    queries each in-scope cluster live via the ONTAP REST API.
+    """
+    if ip is not None:
+        _validate_ip_pattern(ip)
+
+    if not clusters:
+        print_warning("No clusters matched the filter; nothing to scan.")
+        return
+
+    filter_desc: list[str] = []
+    if user:
+        mode = "case-sensitive" if case_sensitive else "case-insensitive"
+        filter_desc.append(f"user={user!r} ({mode})")
+    if ip:
+        filter_desc.append(f"ip={ip!r}")
+    desc = " and ".join(filter_desc) if filter_desc else "all sessions"
+    print_info(f"Scanning {len(clusters)} cluster(s) for {desc}...")
+
+    all_rows: list[SessionRow] = []
+    for idx, (name, details) in enumerate(clusters.items(), start=1):
+        print_info(
+            f"[{idx}/{len(clusters)}] {name} ({details.get('ip', '?')}): querying CIFS sessions..."
+        )
+        try:
+            rows, scanned = _scan_cluster(config, name, user, case_sensitive, ip)
+        except Exception as e:
+            print_exception(f"Could not query CIFS sessions on {name}: {e}", e)
+            continue
+        all_rows.extend(rows)
+        print_info(
+            f"[{idx}/{len(clusters)}] {name}: scanned {scanned} session(s), matched {len(rows)}."
+        )
+
+    title = f"CIFS Sessions ({desc})"
+    if not all_rows:
+        console.print(f"[yellow]No CIFS sessions matched ({desc}).[/yellow]")
+    else:
+        _render_table(all_rows, title)
+        print_info(f"Total matching sessions: {len(all_rows)}")
+
+    if csv_path is not None:
+        target = _resolve_csv_path(csv_path, config.output_dir)
+        _write_csv(all_rows, target)
+        print_info(f"CSV written to {target.resolve()} ({len(all_rows)} row(s)).")

--- a/src/pynetappfoundry/cli/main.py
+++ b/src/pynetappfoundry/cli/main.py
@@ -8,6 +8,7 @@ import click
 
 from pynetappfoundry._version import __version__
 from pynetappfoundry.cli.commands.cache import cache
+from pynetappfoundry.cli.commands.cifs import cifs
 from pynetappfoundry.cli.commands.config import config
 from pynetappfoundry.cli.commands.events import events
 from pynetappfoundry.cli.commands.licenses import licenses
@@ -63,6 +64,7 @@ def nf(ctx: click.Context, config_dir: str, output_dir: str, debug: bool) -> Non
 
 # Explicit registration (infrafoundry pattern)
 nf.add_command(cache)
+nf.add_command(cifs)
 nf.add_command(config)
 nf.add_command(events)
 nf.add_command(licenses)

--- a/tests/unit/cli/commands/cifs/test_matchers.py
+++ b/tests/unit/cli/commands/cifs/test_matchers.py
@@ -1,0 +1,131 @@
+"""Tests for the matcher helpers in ``cli.commands.cifs.session``."""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from pynetappfoundry.cli.commands.cifs.session import (
+    _has_glob,
+    _is_cidr,
+    _is_plain_ip,
+    _matches_ip,
+    _matches_user,
+    _validate_ip_pattern,
+)
+
+
+class TestMatchesUser:
+    def test_substring_default_case_insensitive(self) -> None:
+        assert _matches_user("DOMAIN\\JDoe", "", "jdoe", case_sensitive=False)
+
+    def test_substring_case_sensitive_no_match(self) -> None:
+        assert not _matches_user("DOMAIN\\JDoe", "", "jdoe", case_sensitive=True)
+
+    def test_substring_case_sensitive_match(self) -> None:
+        assert _matches_user("DOMAIN\\jdoe", "", "jdoe", case_sensitive=True)
+
+    def test_glob_star(self) -> None:
+        assert _matches_user("DOMAIN\\jdoe", "", "*jdoe*", case_sensitive=False)
+
+    def test_glob_question_mark(self) -> None:
+        assert _matches_user("jdoe", "", "?doe", case_sensitive=False)
+
+    def test_glob_no_match(self) -> None:
+        assert not _matches_user("alice", "", "*jdoe*", case_sensitive=False)
+
+    def test_mapped_unix_user_fallback(self) -> None:
+        assert _matches_user("", "jdoe", "jdoe", case_sensitive=False)
+
+    def test_mapped_unix_user_glob(self) -> None:
+        assert _matches_user("", "jdoe", "*doe*", case_sensitive=False)
+
+    def test_empty_pattern_returns_false(self) -> None:
+        assert not _matches_user("jdoe", "jdoe", "", case_sensitive=False)
+
+    def test_both_empty_haystack_no_match(self) -> None:
+        assert not _matches_user("", "", "jdoe", case_sensitive=False)
+
+    def test_glob_case_sensitive_no_match(self) -> None:
+        assert not _matches_user("JDOE", "", "*jdoe*", case_sensitive=True)
+
+    def test_backslash_literal_substring(self) -> None:
+        # Plain (non-glob) pattern with backslash should substring-match.
+        assert _matches_user("DOMAIN\\jdoe", "", "DOMAIN\\jdoe", case_sensitive=False)
+
+
+class TestMatchesIp:
+    def test_exact_v4(self) -> None:
+        assert _matches_ip("10.1.2.45", "10.1.2.45")
+
+    def test_exact_v4_normalized(self) -> None:
+        # 010.001.002.045 → not valid; use canonical form only.
+        assert not _matches_ip("10.1.2.45", "10.1.2.46")
+
+    def test_glob_v4(self) -> None:
+        assert _matches_ip("10.1.2.45", "10.1.2.*")
+        assert not _matches_ip("10.1.3.45", "10.1.2.*")
+
+    def test_cidr_v4(self) -> None:
+        assert _matches_ip("10.1.2.45", "10.1.2.0/24")
+        assert not _matches_ip("10.1.3.45", "10.1.2.0/24")
+
+    def test_cidr_v6(self) -> None:
+        assert _matches_ip("2001:db8::1", "2001:db8::/32")
+
+    def test_cidr_address_family_mismatch(self) -> None:
+        assert not _matches_ip("2001:db8::1", "10.1.2.0/24")
+        assert not _matches_ip("10.1.2.45", "2001:db8::/32")
+
+    def test_cidr_invalid_returns_false(self) -> None:
+        # _matches_ip never raises; invalid input returns False.
+        assert not _matches_ip("not-an-ip", "10.1.2.0/24")
+
+    def test_empty_pattern_or_ip(self) -> None:
+        assert not _matches_ip("", "10.1.2.45")
+        assert not _matches_ip("10.1.2.45", "")
+
+
+class TestValidateIpPattern:
+    def test_plain_ip_ok(self) -> None:
+        _validate_ip_pattern("10.1.2.45")
+
+    def test_cidr_ok(self) -> None:
+        _validate_ip_pattern("10.1.2.0/24")
+
+    def test_glob_ok(self) -> None:
+        _validate_ip_pattern("10.1.2.*")
+
+    def test_invalid_raises(self) -> None:
+        with pytest.raises(click.BadParameter):
+            _validate_ip_pattern("not-an-ip")
+
+    def test_invalid_cidr_raises(self) -> None:
+        with pytest.raises(click.BadParameter):
+            _validate_ip_pattern("10.1.2.0/99")
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(click.BadParameter):
+            _validate_ip_pattern("")
+
+
+class TestHelpers:
+    def test_has_glob(self) -> None:
+        assert _has_glob("*jdoe*")
+        assert _has_glob("j?oe")
+        assert _has_glob("j[oa]e")
+        assert not _has_glob("jdoe")
+        assert not _has_glob("DOMAIN\\jdoe")
+
+    def test_is_plain_ip(self) -> None:
+        assert _is_plain_ip("10.1.2.45")
+        assert _is_plain_ip("2001:db8::1")
+        assert not _is_plain_ip("10.1.2.0/24")
+        assert not _is_plain_ip("10.1.2.*")
+        assert not _is_plain_ip("")
+
+    def test_is_cidr(self) -> None:
+        assert _is_cidr("10.1.2.0/24")
+        assert _is_cidr("2001:db8::/32")
+        assert not _is_cidr("10.1.2.45")
+        assert not _is_cidr("10.1.2.*")

--- a/tests/unit/cli/commands/cifs/test_session.py
+++ b/tests/unit/cli/commands/cifs/test_session.py
@@ -410,9 +410,13 @@ class TestSessionCommand:
         mock_render.assert_called_once()
         # CSV written and confirmation line printed.
         assert out.exists()
-        flat_output = " ".join(result.output.split())
-        assert str(out.resolve()) in flat_output
-        assert "row(s)" in flat_output
+        # Strip all whitespace: Rich may soft-wrap the long resolved path at
+        # narrow terminal widths (e.g. macOS CI default 80 cols), inserting
+        # spaces inside the path.
+        squashed_output = "".join(result.output.split())
+        squashed_path = "".join(str(out.resolve()).split())
+        assert squashed_path in squashed_output
+        assert "row(s)" in result.output
 
         with out.open(encoding="utf-8") as f:
             data = list(csv_module.reader(f))

--- a/tests/unit/cli/commands/cifs/test_session.py
+++ b/tests/unit/cli/commands/cifs/test_session.py
@@ -1,0 +1,457 @@
+"""Tests for ``nf cifs session`` command body and CLI invocation."""
+
+from __future__ import annotations
+
+import csv as csv_module
+from io import StringIO
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+from rich.console import Console
+
+from pynetappfoundry.cli.commands.cifs.session import (
+    COLUMNS,
+    _render_table,
+    _resolve_csv_path,
+    _scan_cluster,
+    _write_csv,
+    session,
+)
+from pynetappfoundry.models.ontap.protocols.cifs.sessions.model import (
+    OntapCifsSession,
+    OntapCifsSessionSvm,
+)
+
+
+def _make_session(
+    *,
+    user: str = "jdoe",
+    mapped_unix_user: str = "",
+    client_ip: str = "10.1.2.45",
+    server_ip: str = "10.1.2.10",
+    svm_name: str = "vs1",
+    protocol: str = "smb3_1",
+    authentication: str = "ntlmv2",
+    smb_encryption: str = "unencrypted",
+    connected_duration: str = "PT1H",
+    idle_duration: str = "PT5M",
+    open_files: int = 3,
+    open_shares: int = 1,
+) -> OntapCifsSession:
+    return OntapCifsSession(
+        authentication=authentication,
+        client_ip=client_ip,
+        connected_duration=connected_duration,
+        idle_duration=idle_duration,
+        mapped_unix_user=mapped_unix_user,
+        open_files=open_files,
+        open_shares=open_shares,
+        protocol=protocol,
+        server_ip=server_ip,
+        smb_encryption=smb_encryption,
+        svm=OntapCifsSessionSvm(name=svm_name, uuid="svm-uuid"),
+        user=user,
+    )
+
+
+@pytest.fixture
+def mock_config() -> MagicMock:
+    cfg = MagicMock()
+    cfg.output_dir = Path("/tmp")
+    return cfg
+
+
+def _make_qb(results: list[OntapCifsSession]) -> MagicMock:
+    """Build a chainable QueryBuilder mock that yields *results* on iter."""
+    qb = MagicMock()
+    qb.filter.return_value = qb
+    qb.__iter__.side_effect = lambda: iter(results)
+    return qb
+
+
+class TestScanCluster:
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    def test_no_filters_returns_all(self, ds_cls: MagicMock, mock_config: MagicMock) -> None:
+        sessions = [_make_session(user="alice"), _make_session(user="bob")]
+        qb = _make_qb(sessions)
+        ds_cls.return_value.query.return_value = qb
+
+        rows, scanned = _scan_cluster(mock_config, "c1", user=None, case_sensitive=False, ip=None)
+
+        assert scanned == 2
+        assert len(rows) == 2
+        # No server-side filter applied when neither --user nor --ip is set.
+        qb.filter.assert_not_called()
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    def test_user_substring_filters_client_side(
+        self, ds_cls: MagicMock, mock_config: MagicMock
+    ) -> None:
+        sessions = [
+            _make_session(user="DOMAIN\\jdoe"),
+            _make_session(user="DOMAIN\\alice"),
+            _make_session(user="", mapped_unix_user="jdoe"),
+        ]
+        qb = _make_qb(sessions)
+        ds_cls.return_value.query.return_value = qb
+
+        rows, scanned = _scan_cluster(mock_config, "c1", user="jdoe", case_sensitive=False, ip=None)
+
+        assert scanned == 3
+        assert len(rows) == 2  # jdoe + mapped_unix_user
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    def test_user_never_pushed_server_side(self, ds_cls: MagicMock, mock_config: MagicMock) -> None:
+        """``--user`` is always client-side: server push would drop
+        sessions matched only via ``mapped_unix_user``."""
+        qb = _make_qb([])
+        ds_cls.return_value.query.return_value = qb
+
+        _scan_cluster(mock_config, "c1", user="jdoe", case_sensitive=True, ip=None)
+
+        qb.filter.assert_not_called()
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    def test_user_glob_not_pushed(self, ds_cls: MagicMock, mock_config: MagicMock) -> None:
+        qb = _make_qb([])
+        ds_cls.return_value.query.return_value = qb
+
+        _scan_cluster(mock_config, "c1", user="*jdoe*", case_sensitive=True, ip=None)
+
+        qb.filter.assert_not_called()
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    def test_user_case_insensitive_not_pushed(
+        self, ds_cls: MagicMock, mock_config: MagicMock
+    ) -> None:
+        qb = _make_qb([])
+        ds_cls.return_value.query.return_value = qb
+
+        _scan_cluster(mock_config, "c1", user="jdoe", case_sensitive=False, ip=None)
+
+        qb.filter.assert_not_called()
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    def test_query_uses_live_source(self, ds_cls: MagicMock, mock_config: MagicMock) -> None:
+        """CIFS sessions are transient — every read must be ``source='live'``."""
+        qb = _make_qb([])
+        ds_cls.return_value.query.return_value = qb
+
+        _scan_cluster(mock_config, "c1", user=None, case_sensitive=False, ip=None)
+
+        ds_cls.return_value.query.assert_called_once_with(
+            OntapCifsSession, cluster="c1", source="live"
+        )
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    def test_ip_plain_pushed(self, ds_cls: MagicMock, mock_config: MagicMock) -> None:
+        qb = _make_qb([])
+        ds_cls.return_value.query.return_value = qb
+
+        _scan_cluster(mock_config, "c1", user=None, case_sensitive=False, ip="10.1.2.45")
+
+        qb.filter.assert_called_once_with({"client_ip": "10.1.2.45"})
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    def test_ip_cidr_not_pushed_but_client_filtered(
+        self, ds_cls: MagicMock, mock_config: MagicMock
+    ) -> None:
+        sessions = [
+            _make_session(client_ip="10.1.2.45"),
+            _make_session(client_ip="10.1.3.45"),
+        ]
+        qb = _make_qb(sessions)
+        ds_cls.return_value.query.return_value = qb
+
+        rows, scanned = _scan_cluster(
+            mock_config, "c1", user=None, case_sensitive=False, ip="10.1.2.0/24"
+        )
+
+        qb.filter.assert_not_called()
+        assert scanned == 2
+        assert len(rows) == 1
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    def test_combined_user_and_ip_anded(self, ds_cls: MagicMock, mock_config: MagicMock) -> None:
+        sessions = [
+            _make_session(user="jdoe", client_ip="10.1.2.45"),
+            _make_session(user="jdoe", client_ip="10.1.3.45"),
+            _make_session(user="alice", client_ip="10.1.2.46"),
+        ]
+        qb = _make_qb(sessions)
+        ds_cls.return_value.query.return_value = qb
+
+        rows, scanned = _scan_cluster(
+            mock_config,
+            "c1",
+            user="jdoe",
+            case_sensitive=False,
+            ip="10.1.2.0/24",
+        )
+
+        assert scanned == 3
+        assert len(rows) == 1
+        assert rows[0][2] == "jdoe"
+        assert rows[0][4] == "10.1.2.45"
+
+
+class TestRenderTable:
+    def test_no_truncation_at_narrow_width(self) -> None:
+        """All cell values appear verbatim with Console(width=80) — no '…'."""
+        long_user = "DOMAIN\\very-long-username-that-would-normally-truncate"
+        long_duration = "P0DT12H34M56S-extra"
+        rows = [
+            (
+                "production-cluster-1",
+                "vs-application-data",
+                long_user,
+                "mapped-very-long-unix-user",
+                "10.255.255.255",
+                "10.255.255.254",
+                "smb3_1_1",
+                "kerberos",
+                "encrypted-aes-128-ccm",
+                long_duration,
+                "PT0S",
+                "999",
+                "888",
+            )
+        ]
+        buf = StringIO()
+        narrow = Console(file=buf, width=80, force_terminal=False)
+
+        import sys
+
+        session_mod = sys.modules["pynetappfoundry.cli.commands.cifs.session"]
+
+        with patch.object(session_mod, "console", narrow):
+            _render_table(rows, "CIFS Sessions")
+
+        output = buf.getvalue()
+        # No ellipsis character anywhere — Rich's truncation marker.
+        assert "…" not in output
+        # Every cell value appears verbatim.
+        for cell in rows[0]:
+            assert cell in output, f"missing {cell!r} in output:\n{output}"
+
+
+class TestResolveCsvPath:
+    def test_explicit_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.csv"
+        result = _resolve_csv_path(str(target), tmp_path)
+        assert result == target
+
+    def test_directory_path_uses_timestamp(self, tmp_path: Path) -> None:
+        result = _resolve_csv_path(str(tmp_path), tmp_path)
+        assert result.parent == tmp_path
+        assert result.name.startswith("cifs_sessions_")
+        assert result.suffix == ".csv"
+
+
+class TestWriteCsv:
+    def test_header_and_rows(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.csv"
+        rows = [
+            (
+                "c1",
+                "vs1",
+                "jdoe",
+                "",
+                "10.1.2.45",
+                "10.1.2.10",
+                "smb3",
+                "ntlmv2",
+                "unencrypted",
+                "PT1H",
+                "PT5M",
+                "3",
+                "1",
+            )
+        ]
+        _write_csv(rows, target)
+
+        with target.open(encoding="utf-8") as f:
+            reader = csv_module.reader(f)
+            data = list(reader)
+
+        assert data[0] == list(COLUMNS)
+        assert len(data) == 2
+        assert data[1][0] == "c1"
+        assert data[1][2] == "jdoe"
+
+    def test_creates_parent(self, tmp_path: Path) -> None:
+        target = tmp_path / "sub" / "out.csv"
+        _write_csv([], target)
+        assert target.exists()
+
+
+class TestSessionCommand:
+    """End-to-end CLI invocation tests via :class:`CliRunner`."""
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_no_clusters_warns_and_exits_zero(
+        self, mock_config_cls: MagicMock, ds_cls: MagicMock
+    ) -> None:
+        cfg = MagicMock()
+        cfg.get_clusters.return_value = {}
+        cfg.output_dir = Path("/tmp")
+        mock_config_cls.return_value = cfg
+
+        result = CliRunner().invoke(session, [], obj={})
+
+        assert result.exit_code == 0, result.output
+        ds_cls.assert_not_called()
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_lists_all_no_filter(self, mock_config_cls: MagicMock, ds_cls: MagicMock) -> None:
+        cfg = MagicMock()
+        cfg.get_clusters.return_value = {"c1": {"ip": "1.1.1.1"}}
+        cfg.output_dir = Path("/tmp")
+        mock_config_cls.return_value = cfg
+
+        qb = _make_qb([_make_session(user="jdoe"), _make_session(user="alice")])
+        ds_cls.return_value.query.return_value = qb
+
+        with patch("pynetappfoundry.cli.commands.cifs.session._render_table") as mock_render:
+            result = CliRunner().invoke(session, [], obj={})
+
+        assert result.exit_code == 0, result.output
+        mock_render.assert_called_once()
+        rendered_rows = mock_render.call_args[0][0]
+        users = {row[2] for row in rendered_rows}
+        assert users == {"jdoe", "alice"}
+        # Server-side filter NOT applied without --user/--ip.
+        qb.filter.assert_not_called()
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_no_matches_yellow_message(self, mock_config_cls: MagicMock, ds_cls: MagicMock) -> None:
+        cfg = MagicMock()
+        cfg.get_clusters.return_value = {"c1": {"ip": "1.1.1.1"}}
+        cfg.output_dir = Path("/tmp")
+        mock_config_cls.return_value = cfg
+
+        qb = _make_qb([_make_session(user="alice")])
+        ds_cls.return_value.query.return_value = qb
+
+        result = CliRunner().invoke(session, ["-u", "jdoe"], obj={})
+
+        assert result.exit_code == 0, result.output
+        assert "No CIFS sessions matched" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_per_cluster_exception_continues(
+        self, mock_config_cls: MagicMock, ds_cls: MagicMock
+    ) -> None:
+        cfg = MagicMock()
+        cfg.get_clusters.return_value = {
+            "broken": {"ip": "1.1.1.1"},
+            "ok": {"ip": "2.2.2.2"},
+        }
+        cfg.output_dir = Path("/tmp")
+        mock_config_cls.return_value = cfg
+
+        good_qb = _make_qb([_make_session(user="jdoe")])
+
+        def query_side_effect(*_a: Any, **kwargs: Any) -> Any:
+            if kwargs.get("cluster") == "broken":
+                raise RuntimeError("boom")
+            return good_qb
+
+        ds_cls.return_value.query.side_effect = query_side_effect
+
+        with patch("pynetappfoundry.cli.commands.cifs.session._render_table") as mock_render:
+            result = CliRunner().invoke(session, [], obj={})
+
+        assert result.exit_code == 0, result.output
+        # Per-cluster error surfaced but scan continued.
+        assert "boom" in result.output
+        mock_render.assert_called_once()
+        rendered_rows = mock_render.call_args[0][0]
+        assert [row[2] for row in rendered_rows] == ["jdoe"]
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    def test_live_flag_rejected(self, ds_cls: MagicMock) -> None:
+        """``--live`` is intentionally not exposed: CIFS sessions are
+        always live (transient data is never cached)."""
+        result = CliRunner().invoke(session, ["--live"], obj={})
+
+        assert result.exit_code != 0
+        assert "no such option" in result.output.lower() or "--live" in result.output
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_csv_export_additive(
+        self,
+        mock_config_cls: MagicMock,
+        ds_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cfg = MagicMock()
+        cfg.get_clusters.return_value = {"c1": {"ip": "1.1.1.1"}}
+        cfg.output_dir = tmp_path
+        mock_config_cls.return_value = cfg
+
+        qb = _make_qb([_make_session(user="jdoe")])
+        ds_cls.return_value.query.return_value = qb
+
+        out = tmp_path / "out.csv"
+        with patch("pynetappfoundry.cli.commands.cifs.session._render_table") as mock_render:
+            result = CliRunner().invoke(session, ["--csv", str(out)], obj={})
+
+        assert result.exit_code == 0, result.output
+        # Table still rendered (CSV is additive, not a replacement).
+        mock_render.assert_called_once()
+        # CSV written and confirmation line printed.
+        assert out.exists()
+        flat_output = " ".join(result.output.split())
+        assert str(out.resolve()) in flat_output
+        assert "row(s)" in flat_output
+
+        with out.open(encoding="utf-8") as f:
+            data = list(csv_module.reader(f))
+        assert data[0] == list(COLUMNS)
+        assert data[1][2] == "jdoe"
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_csv_directory_uses_timestamped_name(
+        self,
+        mock_config_cls: MagicMock,
+        ds_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cfg = MagicMock()
+        cfg.get_clusters.return_value = {"c1": {"ip": "1.1.1.1"}}
+        cfg.output_dir = tmp_path
+        mock_config_cls.return_value = cfg
+
+        qb = _make_qb([_make_session(user="jdoe")])
+        ds_cls.return_value.query.return_value = qb
+
+        result = CliRunner().invoke(session, ["--csv", str(tmp_path)], obj={})
+
+        assert result.exit_code == 0, result.output
+        files = list(tmp_path.glob("cifs_sessions_*.csv"))
+        assert len(files) == 1
+
+    @patch("pynetappfoundry.cli.commands.cifs.session.DataSource")
+    @patch("pynetappfoundry.cli.decorators.Config")
+    def test_invalid_ip_returns_bad_parameter(
+        self, mock_config_cls: MagicMock, ds_cls: MagicMock
+    ) -> None:
+        cfg = MagicMock()
+        cfg.get_clusters.return_value = {"c1": {"ip": "1.1.1.1"}}
+        cfg.output_dir = Path("/tmp")
+        mock_config_cls.return_value = cfg
+
+        result = CliRunner().invoke(session, ["--ip", "not-an-ip"], obj={})
+
+        assert result.exit_code != 0
+        assert "Invalid IP" in result.output or "Get CIFS sessions failed" in result.output


### PR DESCRIPTION
## Description

Adds `nf cifs session`, a new subcommand under a new `cifs` command group, that lists active CIFS/SMB sessions across the in-scope clusters using the unified `DataSource` accessor (ADR-0012/0013).

Operators can now query CIFS sessions across the fleet from a single command, scoped by the standard cluster `--filter`, with optional matching on user (`--user`) and client IP (`--ip`), and an optional CSV export — without logging into each cluster individually.

## Related Issue

Addresses #775

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

**New `nf cifs session` command** (`src/pynetappfoundry/cli/commands/cifs/session.py`):
- Reads through `DataSource(config).query(OntapCifsSession, cluster=..., source="live")`. CIFS sessions are transient and not part of `CachedClusterMetadata`, so every invocation queries each cluster live via the ONTAP REST API. There is no `--live` flag because there is no cache to bypass.
- `--user/-u`: matches `user` or `mapped_unix_user`. Substring by default; glob (`*`, `?`, `[`) when metacharacters are present. `--case-sensitive/--case-insensitive` toggle (default insensitive). User matching is always client-side: a server-side `user=` filter would incorrectly drop sessions matched only via `mapped_unix_user`.
- `--ip/-i`: matches `client_ip`. Exact IP, glob (`10.1.2.*`), or CIDR (`10.1.2.0/24`, parsed with stdlib `ipaddress`). Plain IPs are pushed server-side.
- `--filter/-f` reuses the standard `@with_config` plumbing for cluster filtering.
- Renders a Rich table with full column content (no truncation/elision regardless of terminal width).
- `--csv/-c PATH`: writes a CSV **in addition to** the table. If `PATH` is a directory, writes `cifs_sessions_<YYYYMMDD-HHMMSS>.csv` inside it.
- Per-cluster errors are surfaced via `print_exception` and the scan continues to the next cluster.

**Tests** (51 new):
- `tests/unit/cli/commands/cifs/test_matchers.py`: pure-function tests for `_matches_user`, `_matches_ip`, `_validate_ip_pattern` (substring/glob/case, exact/glob/CIDR, invalid input).
- `tests/unit/cli/commands/cifs/test_session.py`: command-level tests covering server-side IP push, no server-side user push, `source="live"` is always used, per-cluster error continuation, narrow-terminal no-truncation rendering, CSV round-trip, CSV directory-fallback timestamp, `--live` flag is rejected.

**Documentation**:
- `docs/reference/cli.md`: new `cifs` section under Commands and a `CIFS Inspection` block under Examples.

**Removed** (was previously uncommitted only, never on `main`):
- `src/pynetappfoundry/cli/commands/cifs/find_user.py`: legacy NetApp-SDK-based draft superseded by `nf cifs session`. `tests/template/test_doit_audit_legacy.py` on `main` pins the count of NetApp-SDK pattern matches in the tree and treats new uses as a regression, so retaining it would break the audit guardrail.

## Testing

- `uv run pytest tests/unit/cli/commands/cifs/ -v` → 51 passed.
- `uv run doit check` ✅ (format, lint, mypy, bandit, codespell, audit, ~3120 tests passing).
- Manually verified against a live cluster: `nf cifs session -f '{"name":"<cluster>"}' -u "<user>"` returned the expected sessions.

## Checklist

- [x] `doit check` passes locally
- [x] Branch follows `<type>/<issue>-<slug>` convention
- [x] Commits follow conventional format
- [x] PR references the issue (`Addresses #775`)
- [x] Tests added with the implementation
- [x] Documentation updated (`docs/reference/cli.md`)
- [x] No new ADR required — uses existing ADR-0012 / ADR-0013 patterns

## Additional Notes

**Key design decisions:**
- **Always-live routing.** `OntapCifsSession` has no registered cache table, so `source="live"` is passed explicitly. ADR-0012 §4 documents cache-miss fallback for empty results, but that fallback does not engage for models without a registered cache table; a library-level fix is intentionally out of scope here and can be a follow-up.
- **`--csv` shape.** Takes a required `PATH` argument (not a bare flag + `--output`). If `PATH` is a directory, a timestamped filename is appended. Slightly different from `nf licenses get`; can be aligned later under a uniform CLI convention.
- **`--user` never pushed server-side.** A server-side `user=` filter would incorrectly drop sessions whose `mapped_unix_user` matches but whose `user` does not. All user matching runs client-side.

**Related ADRs:** ADR-0012 (Unified DataSource Accessor), ADR-0013 (DataSource as a Thin Facade over the Collector).
