### PR TITLE
docs: refresh cache.md SQLite schema section to reflect v6

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -199,7 +199,7 @@ The cache is rebuild-tolerant: destructive migrations are allowed, and
 
 In addition to the `cache_version` stamped into each snapshot,
 `ClusterMetadataDB` tracks the **on-disk SQLite schema** version through the
-shared `SQLiteDB` base class. The current value is `SCHEMA_VERSION = 4`, and
+shared `SQLiteDB` base class. The current value is `SCHEMA_VERSION = 6`, and
 the DB applies the following upgrades on open:
 
 | DB schema | Migration | What it does |
@@ -207,6 +207,8 @@ the DB applies the following upgrades on open:
 | `v1` → `v2` | `_upgrade_to_v2` | Reads the old `metadata_json` blob, decomposes each cluster into per-model tables (ADR-0009), then drops the JSON column from the envelope table. |
 | `v2` → `v3` | `_upgrade_to_v3` | Drops the unused `_uuid_index` table. UUID resolution moved to the in-memory `CachedClusterMetadata.uuid_index` cached property (ADR-0005). |
 | `v3` → `v4` | `_upgrade_to_v4` | Drops and recreates every per-model table to switch column names from the old flat naming (`ip_address`) to the new nested-model layout (`ip` stored as JSON), per ADR-0011. The envelope is cleared so callers detect a missing snapshot and trigger a fresh collection. |
+| `v4` → `v5` | `_upgrade_to_v5` | Adds the `vm_name` column to the `cloudmetadata` table via idempotent `ALTER TABLE … ADD COLUMN` (additive-column path from ADR-0018). Introduced with PR #582. |
+| `v5` → `v6` | `_upgrade_to_v6` | Creates the `consoleinfo` table to back `CachedClusterMetadata.console: ConsoleInfo` for cluster-scoped Console SaaS data (ADR-0019). Idempotent via `sqlite_master` check. Introduced with #713. |
 
 !!! warning "v3 → v4 is destructive"
     The v4 migration deletes existing cached rows. After upgrading,


### PR DESCRIPTION
## Description

Refreshes the "SQLite database schema versioning" section of `docs/reference/cache.md` to match the current source of truth in `src/pynetappfoundry/cache/db.py`. The doc had drifted two versions: it still reported `SCHEMA_VERSION = 4` and its migration table stopped at `v3 → v4`.

## Related Issue

Addresses #696

## Type of Change

- [x] Documentation update

## Changes Made

- Update `SCHEMA_VERSION = 4` → `SCHEMA_VERSION = 6` (line 202 of `docs/reference/cache.md`).
- Add a `v4 → v5` migration-table row for `_upgrade_to_v5` (adds `vm_name` column to `cloudmetadata`; additive-column path per ADR-0018; PR #582).
- Add a `v5 → v6` migration-table row for `_upgrade_to_v6` (creates the `consoleinfo` table for `CachedClusterMetadata.console: ConsoleInfo` per ADR-0019; #713).
- Left the existing `v3 → v4 is destructive` warning in place; v5/v6 are both additive/idempotent and don't warrant parallel warnings.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes (format, lint, type-check, security, audit, spell-check, tests). No code changes → no test impact. Migration-row content cross-checked against `_upgrade_to_v5` / `_upgrade_to_v6` docstrings in `src/pynetappfoundry/cache/db.py`.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

ADR-0018 already codifies the cache-schema versioning policy; this PR is a factual content refresh, not a policy change, so no new or updated ADR is required. CHANGELOG left untouched — internal doc correction, no user-visible behavior change.
